### PR TITLE
chore: re-add sanitized test names

### DIFF
--- a/backend/src/api_client/README.md
+++ b/backend/src/api_client/README.md
@@ -56,11 +56,7 @@ client = AuthenticatedClient(
 You can also disable certificate validation altogether, but beware that **this is a security risk**.
 
 ```python
-client = AuthenticatedClient(
-    base_url="https://internal_api.example.com",
-    token="SuperSecretToken",
-    verify_ssl=False
-)
+client = AuthenticatedClient(base_url="https://internal_api.example.com", token="SuperSecretToken", verify_ssl=False)
 ```
 
 Things to know:
@@ -81,12 +77,15 @@ There are more settings on the generated `Client` class which let you control mo
 ```python
 from syntara_api_client import Client
 
+
 def log_request(request):
     print(f"Request event hook: {request.method} {request.url} - Waiting for response")
+
 
 def log_response(response):
     request = response.request
     print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
+
 
 client = Client(
     base_url="https://api.example.com",

--- a/backend/src/api_client/syntara_api_client/models/test_execution_create.py
+++ b/backend/src/api_client/syntara_api_client/models/test_execution_create.py
@@ -9,7 +9,7 @@ from attrs import field as _attrs_field
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
-    from ..models.***REMOVED*** import TestExecutionCreatePreResolvedNodes
+    from ..models.test_execution_create_pre_resolved_nodes import TestExecutionCreatePreResolvedNodes
     from ..models.test_execution_create_trigger_inputs import TestExecutionCreateTriggerInputs
 
 
@@ -72,7 +72,7 @@ class TestExecutionCreate:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.***REMOVED*** import TestExecutionCreatePreResolvedNodes
+        from ..models.test_execution_create_pre_resolved_nodes import TestExecutionCreatePreResolvedNodes
         from ..models.test_execution_create_trigger_inputs import TestExecutionCreateTriggerInputs
 
         d = dict(src_dict)

--- a/backend/src/api_client/syntara_api_client/models/test_execution_create_pre_resolved_nodes.py
+++ b/backend/src/api_client/syntara_api_client/models/test_execution_create_pre_resolved_nodes.py
@@ -31,7 +31,7 @@ class TestExecutionCreatePreResolvedNodes:
         from ..models.pre_resolved_node_output import PreResolvedNodeOutput
 
         d = dict(src_dict)
-        ***REMOVED*** = cls()
+        test_execution_create_pre_resolved_nodes = cls()
 
         additional_properties = {}
         for prop_name, prop_dict in d.items():
@@ -39,8 +39,8 @@ class TestExecutionCreatePreResolvedNodes:
 
             additional_properties[prop_name] = additional_property
 
-        ***REMOVED***.additional_properties = additional_properties
-        return ***REMOVED***
+        test_execution_create_pre_resolved_nodes.additional_properties = additional_properties
+        return test_execution_create_pre_resolved_nodes
 
     @property
     def additional_keys(self) -> list[str]:

--- a/backend/src/nexus/workflows/workflow_engine/services/activity_sync_service.py
+++ b/backend/src/nexus/workflows/workflow_engine/services/activity_sync_service.py
@@ -1752,7 +1752,7 @@ class ActivitySyncService:
             # retry the query. This handles the case where Temporal emits the
             # ACTIVITY_TASK_COMPLETED event before the workflow's async loop
             # stores the result in the resolver namespace.
-            
+
             # (e.g., workflow signal after output is stored).
             if activity_data["status"] == ActivityStatus.COMPLETED and queried_output is None:
                 max_retries = _OUTPUT_QUERY_MAX_RETRIES

--- a/backend/src/nexus/workflows/workflow_engine/services/activity_sync_service.py
+++ b/backend/src/nexus/workflows/workflow_engine/services/activity_sync_service.py
@@ -684,7 +684,7 @@ class ActivitySyncService:
 
     @staticmethod
     def _extract_heartbeat_data(
-        pa: Any,  # noqa: ANN401 — PendingActivityInfo from protobuf
+        pa: Any,
     ) -> dict[str, Any] | None:
         """Decode the latest heartbeat payload from a pending activity.
 
@@ -730,7 +730,7 @@ class ActivitySyncService:
         queue: asyncio.Queue[_QueueItem],
         activity_id: str,
         scheduled_event_id: int,
-        pa: Any,  # noqa: ANN401 — PendingActivityInfo from protobuf
+        pa: Any,
     ) -> bool:
         """Check heartbeat data for STOP_MONITOR signal and push partial output.
 
@@ -1276,7 +1276,7 @@ class ActivitySyncService:
             metadata.pending_sync_event_ids.add(scheduled_id)
             metadata.terminal_activity_ids.add(update["activity_id"])
 
-    def _extract_execution_status_from_event(self, event: HistoryEvent) -> tuple[ExecutionStatus, datetime, str | None]:  # noqa: C901
+    def _extract_execution_status_from_event(self, event: HistoryEvent) -> tuple[ExecutionStatus, datetime, str | None]:
         """Extract execution status, completion time, and error from workflow completion event.
 
         Args:
@@ -1310,7 +1310,7 @@ class ActivitySyncService:
                         elif inner_status == "completed_with_errors":
                             status = ExecutionStatus.COMPLETED_WITH_ERRORS
                             error_details = self._extract_failed_activity_errors(result_data)
-                except Exception:  # noqa: BLE001
+                except Exception:
                     logger.warning("Failed to parse workflow result for failure detection", exc_info=True)
         elif event_type == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
             status = ExecutionStatus.FAILED
@@ -1372,7 +1372,7 @@ class ActivitySyncService:
                 fa = result_data.get("failed_activities", {})
                 if isinstance(fa, dict):
                     return fa
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.debug("Could not parse failed_activities from workflow result", exc_info=True)
         return {}
 
@@ -1789,7 +1789,7 @@ class ActivitySyncService:
         return input_data, output_data
 
     @staticmethod
-    def _scrub_data(data: Any) -> dict[str, Any] | None:  # noqa: ANN401
+    def _scrub_data(data: Any) -> dict[str, Any] | None:
         """Scrub credentials from data, wrapping non-dict values.
 
         Args:

--- a/backend/src/nexus/workflows/workflow_engine/services/activity_sync_service.py
+++ b/backend/src/nexus/workflows/workflow_engine/services/activity_sync_service.py
@@ -684,7 +684,7 @@ class ActivitySyncService:
 
     @staticmethod
     def _extract_heartbeat_data(
-        pa: Any,
+        pa: Any,  # noqa: ANN401 — PendingActivityInfo from protobuf
     ) -> dict[str, Any] | None:
         """Decode the latest heartbeat payload from a pending activity.
 
@@ -730,7 +730,7 @@ class ActivitySyncService:
         queue: asyncio.Queue[_QueueItem],
         activity_id: str,
         scheduled_event_id: int,
-        pa: Any,
+        pa: Any,  # noqa: ANN401 — PendingActivityInfo from protobuf
     ) -> bool:
         """Check heartbeat data for STOP_MONITOR signal and push partial output.
 
@@ -1276,7 +1276,7 @@ class ActivitySyncService:
             metadata.pending_sync_event_ids.add(scheduled_id)
             metadata.terminal_activity_ids.add(update["activity_id"])
 
-    def _extract_execution_status_from_event(self, event: HistoryEvent) -> tuple[ExecutionStatus, datetime, str | None]:
+    def _extract_execution_status_from_event(self, event: HistoryEvent) -> tuple[ExecutionStatus, datetime, str | None]:  # noqa: C901
         """Extract execution status, completion time, and error from workflow completion event.
 
         Args:
@@ -1310,7 +1310,7 @@ class ActivitySyncService:
                         elif inner_status == "completed_with_errors":
                             status = ExecutionStatus.COMPLETED_WITH_ERRORS
                             error_details = self._extract_failed_activity_errors(result_data)
-                except Exception:
+                except Exception:  # noqa: BLE001
                     logger.warning("Failed to parse workflow result for failure detection", exc_info=True)
         elif event_type == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
             status = ExecutionStatus.FAILED
@@ -1372,7 +1372,7 @@ class ActivitySyncService:
                 fa = result_data.get("failed_activities", {})
                 if isinstance(fa, dict):
                     return fa
-        except Exception:
+        except Exception:  # noqa: BLE001
             logger.debug("Could not parse failed_activities from workflow result", exc_info=True)
         return {}
 
@@ -1789,7 +1789,7 @@ class ActivitySyncService:
         return input_data, output_data
 
     @staticmethod
-    def _scrub_data(data: Any) -> dict[str, Any] | None:
+    def _scrub_data(data: Any) -> dict[str, Any] | None:  # noqa: ANN401
         """Scrub credentials from data, wrapping non-dict values.
 
         Args:

--- a/backend/tests/e2e/credentials/test_credential_endpoints.py
+++ b/backend/tests/e2e/credentials/test_credential_endpoints.py
@@ -570,7 +570,7 @@ class TestRbacAuditorReadOnly:
 class TestRbacProjectScopedVisibility:
     """Credentials with project_id are only visible to users with project access."""
 
-    def ***REMOVED***(self, nexus_api: SyntaraApiRegistry) -> None:
+    def test_org_level_credential_visible_to_all(self, nexus_api: SyntaraApiRegistry) -> None:
         """Credential with project_id=NULL is visible to all authorized users."""
         # ANSTRAT-1901: implement when workflow+credential wiring is available
         # 1. Create org-level credential (project_id=NULL — if supported)

--- a/backend/tests/e2e/workflows/test_execution_retry.py
+++ b/backend/tests/e2e/workflows/test_execution_retry.py
@@ -13,7 +13,7 @@ import pytest
 from orchestrator_test_sdk.e2e import unique_name
 from orchestrator_test_sdk.e2e.helpers import create_and_run_workflow, poll_execution_until_complete
 from syntara_api_client.models.test_execution_create import TestExecutionCreate
-from syntara_api_client.models.***REMOVED*** import TestExecutionCreatePreResolvedNodes
+from syntara_api_client.models.test_execution_create_pre_resolved_nodes import TestExecutionCreatePreResolvedNodes
 from syntara_api_client.models.workflow_create import WorkflowCreate
 from syntara_api_client.models.workflow_definition import WorkflowDefinition
 

--- a/backend/tests/e2e/workflows/test_workflow_test_node.py
+++ b/backend/tests/e2e/workflows/test_workflow_test_node.py
@@ -13,7 +13,7 @@ from orchestrator_test_sdk.e2e import unique_name
 from orchestrator_test_sdk.e2e.helpers import connected_definition, poll_execution_until_complete
 from syntara_api_client.models.publish_version_request import PublishVersionRequest
 from syntara_api_client.models.test_execution_create import TestExecutionCreate
-from syntara_api_client.models.***REMOVED*** import TestExecutionCreatePreResolvedNodes
+from syntara_api_client.models.test_execution_create_pre_resolved_nodes import TestExecutionCreatePreResolvedNodes
 from syntara_api_client.models.workflow_create import WorkflowCreate
 from syntara_api_client.models.workflow_definition import WorkflowDefinition
 

--- a/backend/tests/e2e/workflows/test_workflow_version_operations.py
+++ b/backend/tests/e2e/workflows/test_workflow_version_operations.py
@@ -146,7 +146,7 @@ class TestWorkflowVersionRestore:
         assert by_ver[2].status == "draft"
         assert by_ver[3].status == "draft"
 
-    def ***REMOVED***(
+    def test_version_list_status_after_republish(
         self, nexus_api: SyntaraApiRegistry, cleanup_workflows: list[UUID], first_project_id: UUID
     ) -> None:
         """After publishing a different version, the pointer switches.

--- a/backend/tests/integration/agent_orchestrator/context_manager/retriever_service/test_integration.py
+++ b/backend/tests/integration/agent_orchestrator/context_manager/retriever_service/test_integration.py
@@ -203,7 +203,7 @@ async def test_file_upload_creates_db_records(
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_callback_url_stored_in_context_data(
     auth_client_with_mocked_llm, test_user, test_db_session, test_project_id
 ) -> None:
     """Verify callback_url in context_data is preserved in invocation."""

--- a/backend/tests/integration/agent_orchestrator/context_manager/test_assembler_session_lifecycle.py
+++ b/backend/tests/integration/agent_orchestrator/context_manager/test_assembler_session_lifecycle.py
@@ -63,7 +63,7 @@ class TestSessionLifecycle:
     """Tests for session lifecycle management in AssemblerService."""
 
     @pytest.mark.usefixtures("test_user_low_token_config")
-    async def ***REMOVED***(
+    async def test_session_released_before_compression(
         self,
         test_db_session,
         test_db_session_factory,

--- a/backend/tests/integration/api/test_group_members.py
+++ b/backend/tests/integration/api/test_group_members.py
@@ -537,7 +537,7 @@ class TestSetUserGroups:
         assert response.status_code == 401
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_set_user_groups_non_admin_forbidden(
         self,
         base_client: AsyncClient,
         user_factory: Callable[..., Awaitable[User]],

--- a/backend/tests/integration/api/test_integration_project_assignment.py
+++ b/backend/tests/integration/api/test_integration_project_assignment.py
@@ -200,7 +200,7 @@ class TestProjectAssignmentLifecycle:
 class TestProjectAssignmentScopeErrors:
     """Scope enforcement: cannot assign projects to global-scoped integrations."""
 
-    async def ***REMOVED***(
+    async def test_assign_to_global_scoped_returns_422(
         self,
         auth_client: AsyncClient,
         test_db_session: AsyncSession,

--- a/backend/tests/integration/api/test_integrations_get.py
+++ b/backend/tests/integration/api/test_integrations_get.py
@@ -65,7 +65,7 @@ class TestIntegrationsGet:
         response = await auth_client.get(f"{BASE_URL}/not-a-uuid")
         assert response.status_code == 422
 
-    async def ***REMOVED***(
+    async def test_get_deleted_integration_returns_404(
         self,
         auth_client: AsyncClient,
         test_db_session: AsyncSession,

--- a/backend/tests/integration/api/test_invocations_api.py
+++ b/backend/tests/integration/api/test_invocations_api.py
@@ -173,7 +173,7 @@ async def test_list_invocations_response_schema(auth_client: AsyncClient, test_u
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_list_invocations_with_status_filter(
     auth_client_with_mocked_llm: AsyncClient, test_user, test_project_id: str
 ) -> None:
     """Test filtering invocations by status."""
@@ -555,7 +555,7 @@ async def test_list_invocations_sort_by_non_sortable_field(auth_client: AsyncCli
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_list_invocations_default_sort_order(
     auth_client_with_mocked_llm: AsyncClient, test_user, test_project_id: str
 ) -> None:
     """Test that default sort order is -created_at (descending)."""
@@ -633,7 +633,7 @@ async def test_list_invocations_invalid_status(auth_client: AsyncClient, test_us
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_invoke_response_includes_all_fields(
     auth_client_with_mocked_llm: AsyncClient, test_user, test_project_id: str
 ) -> None:
     """Test that POST response includes all expected fields including inherited ones."""

--- a/backend/tests/integration/api/test_list_workflows.py
+++ b/backend/tests/integration/api/test_list_workflows.py
@@ -146,7 +146,7 @@ async def test_lw2_user_with_multiple_projects_sees_workflows_from_all(
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_lw3_global_admin_sees_all_workflows(
     auth_client: AsyncClient,
     test_db_session: AsyncSession,
     test_user: User,

--- a/backend/tests/integration/api/test_roles.py
+++ b/backend/tests/integration/api/test_roles.py
@@ -328,7 +328,7 @@ async def test_list_roles_filter_by_policy_name_contains(
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_list_builtin_roles_with_in_operator(
     auth_client: AsyncClient,
     test_db_session: AsyncSession,
     test_user: User,

--- a/backend/tests/integration/api/test_tools_authz.py
+++ b/backend/tests/integration/api/test_tools_authz.py
@@ -443,7 +443,7 @@ class TestIntegrationScopedGetToolAuthz:
 class TestIntegrationScopedUpdateToolAuthz:
     """RBAC for PATCH /integrations/{integration_id}/tools/{tool_id}."""
 
-    async def ***REMOVED***(
+    async def test_user_cannot_update_integration_tool(
         self,
         auth_client: AsyncClient,
         test_tool: Tool,

--- a/backend/tests/integration/api/test_tools_bulk_update.py
+++ b/backend/tests/integration/api/test_tools_bulk_update.py
@@ -94,7 +94,7 @@ class TestToolsBulkUpdateContract:
         assert data["skipped_count"] == 2  # Two non-existent tools
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_bulk_update_empty_tool_ids_contract(
         self, jwt_client: AsyncClient, multiple_tools_for_bulk: list[Tool]
     ) -> None:
         """Test bulk update with empty tool_ids list returns 422."""
@@ -113,7 +113,7 @@ class TestToolsBulkUpdateContract:
         assert isinstance(data["detail"], list) or "cannot be empty" in str(data["detail"])
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_bulk_update_too_many_tools_contract(
         self, jwt_client: AsyncClient, multiple_tools_for_bulk: list[Tool]
     ) -> None:
         """Test bulk update with more than 50 tools returns 422."""

--- a/backend/tests/integration/api/test_workflows_post.py
+++ b/backend/tests/integration/api/test_workflows_post.py
@@ -278,7 +278,7 @@ async def test_post_workflow_with_labels_not_strings(jwt_client: AsyncClient, te
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(jwt_client: AsyncClient, test_project_id: str) -> None:
+async def test_post_workflow_with_long_description(jwt_client: AsyncClient, test_project_id: str) -> None:
     """Test creating a workflow with a long description. The field limit is 2,000 characters.
 
     Expected: 422 Unprocessable

--- a/backend/tests/integration/api/test_workflows_test_node.py
+++ b/backend/tests/integration/api/test_workflows_test_node.py
@@ -263,7 +263,7 @@ async def test_test_workflow_node_invalid_workflow_id(
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_test_node_with_execute_target_false(
     auth_client: AsyncClient,
     test_db_session: AsyncSession,
     test_user: User,

--- a/backend/tests/integration/api/v1/test_files.py
+++ b/backend/tests/integration/api/v1/test_files.py
@@ -438,7 +438,7 @@ class TestFilesAPIMetadata:
         assert returned_ids == {str(fm1.id), str(fm2.id)}
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_metadata_empty_file_ids_returns_422(
         self,
         auth_client: AsyncClient,
     ) -> None:

--- a/backend/tests/integration/core/tls/test_mtls_directions.py
+++ b/backend/tests/integration/core/tls/test_mtls_directions.py
@@ -86,7 +86,7 @@ class TestMTLS1TemporalTLSConfig:
         assert tls_config is not None
         assert tls_config.client_cert == mtls_certs["backend_cert"].read_bytes()
 
-    def ***REMOVED***(
+    def test_client_private_key_matches_key_file(
         self,
         mtls_certs: dict[str, Path],
         override_settings: Callable[..., AbstractContextManager[object]],

--- a/backend/tests/integration/core/utils/test_filter_parser_sqlalchemy.py
+++ b/backend/tests/integration/core/utils/test_filter_parser_sqlalchemy.py
@@ -544,7 +544,7 @@ class TestIsNullFiltering:
         assert len(result) == len(expected)
         assert {u.username for u in result} == {u.username for u in expected}
 
-    async def ***REMOVED***(
+    async def test_isnull_end_to_end_from_query_params(
         self, test_users: list[User], test_db_session: AsyncSession
     ) -> None:
         """End-to-end: parse ``?last_name[isnull]=false`` and apply to query."""

--- a/backend/tests/integration/core/websocket/test_json_validation.py
+++ b/backend/tests/integration/core/websocket/test_json_validation.py
@@ -47,7 +47,7 @@ class TestWebSocketJsonValidation:
             assert timestamp.tzinfo is not None
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_non_json_text_input_coffee_endpoint(self, example_app_server: tuple[Path, FastAPI]) -> None:
         """Test that non-JSON text input returns validation error on coffee endpoint."""
         _ = example_app_server
         async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/coffee") as websocket:

--- a/backend/tests/integration/files/models/test_file_metadata.py
+++ b/backend/tests/integration/files/models/test_file_metadata.py
@@ -147,7 +147,7 @@ async def test_file_metadata_with_converted_content(test_db_session: AsyncSessio
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(test_db_session: AsyncSession, test_project_id: str) -> None:
+async def test_file_metadata_with_conversion_error(test_db_session: AsyncSession, test_project_id: str) -> None:
     """Test FileMetadata with conversion failure and error message."""
     error_message = "Failed to parse PDF: corrupted file"
 
@@ -215,7 +215,7 @@ async def test_file_metadata_update_status(test_db_session: AsyncSession, test_p
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(test_db_session: AsyncSession, test_project_id: str) -> None:
+async def test_file_metadata_content_hash_nullable(test_db_session: AsyncSession, test_project_id: str) -> None:
     """Test that content_hash defaults to None and accepts a SHA-256 value."""
     file_metadata = FileMetadata(
         filename="test.pdf",

--- a/backend/tests/integration/integrations/test_integration_discover.py
+++ b/backend/tests/integration/integrations/test_integration_discover.py
@@ -115,7 +115,7 @@ class TestIntegrationDiscoverContract:
         )
         assert response.status_code == 422
 
-    async def ***REMOVED***(
+    async def test_unauthenticated_request_returns_401(
         self, base_client: AsyncClient, test_db_session: AsyncSession, test_user: User
     ) -> None:
         """Request without authentication returns 401."""

--- a/backend/tests/integration/integrations/test_integration_service.py
+++ b/backend/tests/integration/integrations/test_integration_service.py
@@ -450,7 +450,7 @@ class TestUpdateValidationStatus:
         assert result.validation_status == IntegrationStatus.AVAILABLE
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_update_status_to_error_with_message(
         self, test_db_session: AsyncSession, integration_service: IntegrationService
     ) -> None:
         created = await integration_service.create_integration(_mcp_create())

--- a/backend/tests/integration/invocations/models/test_invocation_models.py
+++ b/backend/tests/integration/invocations/models/test_invocation_models.py
@@ -634,7 +634,7 @@ async def test_invocation_indexes_exist(test_db_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_invocation_timestamp_timezone_aware(
     test_db_session: AsyncSession, test_user: User, test_project_id
 ) -> None:
     """Test that timestamp fields preserve timezone information."""

--- a/backend/tests/integration/invocations/test_invocation_backward_compatibility.py
+++ b/backend/tests/integration/invocations/test_invocation_backward_compatibility.py
@@ -16,7 +16,7 @@ from nexus.core.constants import CONTEXT_KEY, CONTEXT_KEY_FILE_IDS
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_json_request_without_files_succeeds(
     auth_client_with_mocked_llm: AsyncClient, test_user, test_project_id
 ) -> None:
     """Test that application/json requests still work without files.
@@ -117,7 +117,7 @@ async def test_json_request_with_existing_context_data(
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_multipart_rejected_by_json_endpoint(
     auth_client_with_mocked_llm: AsyncClient, test_user, test_project_id
 ) -> None:
     """Test that POST /invocations rejects multipart/form-data requests.

--- a/backend/tests/integration/invocations/test_invocation_file_errors.py
+++ b/backend/tests/integration/invocations/test_invocation_file_errors.py
@@ -174,7 +174,7 @@ async def test_validation_error_no_invocation_created(
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(
+async def test_error_response_structure_consistent(
     auth_client_with_mocked_llm: AsyncClient, test_user, test_project_id
 ) -> None:
     """Test that POST /invocations/chat file error responses follow consistent RFC 9457 structure.

--- a/backend/tests/integration/projects/services/test_project_service.py
+++ b/backend/tests/integration/projects/services/test_project_service.py
@@ -625,7 +625,7 @@ async def test_delete_builtin_project_raises(seeded_db: AsyncSession, test_user:
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(seeded_db: AsyncSession, test_user: User) -> None:
+async def test_update_non_builtin_project_succeeds(seeded_db: AsyncSession, test_user: User) -> None:
     """Updating a non-builtin project succeeds normally."""
     svc = ProjectService(seeded_db, test_user)
     project = await svc.create_project(name="normal-project")
@@ -634,7 +634,7 @@ async def ***REMOVED***(seeded_db: AsyncSession, test_user: User) -> None:
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(seeded_db: AsyncSession, test_user: User) -> None:
+async def test_delete_non_builtin_project_succeeds(seeded_db: AsyncSession, test_user: User) -> None:
     """Deleting a non-builtin project succeeds normally."""
     svc = ProjectService(seeded_db, test_user)
     project = await svc.create_project(name="deletable-project")

--- a/backend/tests/integration/telemetry/test_periodic_analytics.py
+++ b/backend/tests/integration/telemetry/test_periodic_analytics.py
@@ -458,7 +458,7 @@ class TestQueryModelUsageRealDB:
 
         assert result == []
 
-    async def ***REMOVED***(
+    async def test_excludes_records_without_model_name(
         self, test_db_session: AsyncSession, test_user: User, test_project_id
     ):
         """Invocations without a model_name are excluded from aggregation."""

--- a/backend/tests/integration/workflows/services/test_workflow_service.py
+++ b/backend/tests/integration/workflows/services/test_workflow_service.py
@@ -468,7 +468,7 @@ class TestWorkflowServiceCreateWorkflow(TestWorkflowServiceBase):
             assert val_result.warning_count > 0
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_create_workflow_errors_always_saves(
         self, test_db_session: AsyncSession, test_user: User, test_project_id: UUID
     ) -> None:
         """Test workflow creation with errors saves successfully and reports issues."""
@@ -1747,7 +1747,7 @@ class TestUnpublishWorkflow(TestWorkflowServiceBase):
         assert result.is_enabled is False
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_unpublish_when_not_published_raises(
         self, test_db_session: AsyncSession, test_user: User, test_project_id: UUID
     ) -> None:
         """Test unpublishing when no version is published raises error."""
@@ -1904,7 +1904,7 @@ class TestRestoreWorkflowVersion(TestWorkflowServiceBase):
             await service.restore_workflow_version(workflow_id=workflow.id, version=99)
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, test_db_session: AsyncSession, test_user: User) -> None:
+    async def test_restore_nonexistent_workflow_raises(self, test_db_session: AsyncSession, test_user: User) -> None:
         """Test restoring from a nonexistent workflow raises error."""
         service = WorkflowService(test_db_session, test_user)
         fake_id = uuid4()

--- a/backend/tests/integration/workflows/test_background_queue_routing.py
+++ b/backend/tests/integration/workflows/test_background_queue_routing.py
@@ -289,7 +289,7 @@ class TestQueueDepthMetricLabels:
         )
         assert "orchestrator-workflow-queue" in task_queues
 
-    def ***REMOVED***(self) -> None:
+    def test_background_queue_depth_metric_value(self) -> None:
         """Background queue depth metric reflects the correct value."""
         from prometheus_client import CollectorRegistry
 

--- a/backend/tests/integration/workflows/test_manual_trigger_schema.py
+++ b/backend/tests/integration/workflows/test_manual_trigger_schema.py
@@ -78,7 +78,7 @@ async def test_manual_trigger_in_workflow_definition_schema() -> None:
     assert len(manual_entries) == 1
 
 
-async def ***REMOVED***() -> None:
+async def test_manual_trigger_in_node_type_catalog() -> None:
     """Manual trigger should be listed in the node type catalog."""
     catalog_path = SCHEMA_DIR.parent / "catalog" / "node_type_catalog.json"
     with catalog_path.open() as f:

--- a/backend/tests/integration/workflows/test_worker_metrics_server.py
+++ b/backend/tests/integration/workflows/test_worker_metrics_server.py
@@ -90,7 +90,7 @@ class TestWorkerMetricsServer:
             server.shutdown()
             thread.join(timeout=2)
 
-    def ***REMOVED***(self) -> None:
+    def test_metrics_server_uses_configured_port(self) -> None:
         """The metrics server port is read from settings.metrics_worker_port."""
         settings = get_settings()
         assert isinstance(settings.metrics_worker_port, int)

--- a/backend/tests/integration/workflows/test_workflow_v2_contract.py
+++ b/backend/tests/integration/workflows/test_workflow_v2_contract.py
@@ -644,7 +644,7 @@ class TestNodeSettingsValidation:
         # Should not raise
         self.validator.validate_workflow_definition(defn)
 
-    def ***REMOVED***(self) -> None:
+    def test_rejects_retry_policy_on_script_node(self) -> None:
         """Script nodes (NoRetry tier) should reject retry_policy."""
         defn = {
             "schema_version": "2.0.0",

--- a/backend/tests/unit/agent_orchestrator/context_manager/test_model_profile_service.py
+++ b/backend/tests/unit/agent_orchestrator/context_manager/test_model_profile_service.py
@@ -254,7 +254,7 @@ class TestFallbackBehavior:
         assert budget.source == "fallback"
 
     @pytest.mark.anyio
-    async def ***REMOVED***(self) -> None:
+    async def test_missing_package_degrades_gracefully(self) -> None:
         """If a LangChain provider package is not installed, still return fallback."""
         service = ModelProfileService()
 
@@ -267,7 +267,7 @@ class TestFallbackBehavior:
         assert budget.source == "fallback"
 
     @pytest.mark.anyio
-    async def ***REMOVED***(self) -> None:
+    async def test_attribute_error_degrades_gracefully(self) -> None:
         """If _PROFILES is removed in a future LangChain update, degrade gracefully."""
         service = ModelProfileService()
 

--- a/backend/tests/unit/agent_orchestrator/tool_manager/test_tool_discovery.py
+++ b/backend/tests/unit/agent_orchestrator/tool_manager/test_tool_discovery.py
@@ -130,7 +130,7 @@ class TestMCPIntegrationDiscovery:
         with pytest.raises(httpx.ConnectError):
             await client.get_all_mcp_integrations()
 
-    async def ***REMOVED***(self, client: ToolManagerClient) -> None:
+    async def test_get_all_mcp_integrations_pagination(self, client: ToolManagerClient) -> None:
         """Test handling of paginated integration responses."""
         page1 = [_make_integration_response("integration_1")]
         page2 = [_make_integration_response("integration_2")]

--- a/backend/tests/unit/agent_orchestrator/utils/test_keyword_association.py
+++ b/backend/tests/unit/agent_orchestrator/utils/test_keyword_association.py
@@ -198,7 +198,7 @@ class TestAnnotateToolsWithRelevance:
 
         assert result[0].name == "search_repos"
 
-    def ***REMOVED***(self) -> None:
+    def test_deterministic_alphabetical_tiebreak(self) -> None:
         """Equal-score tools sorted alphabetically by name."""
         tools = [
             _make_tool("zebra_search", "Search for data"),

--- a/backend/tests/unit/api/compliance/test_crud_endpoint_discovery.py
+++ b/backend/tests/unit/api/compliance/test_crud_endpoint_discovery.py
@@ -78,7 +78,7 @@ class TestReadDiscovery:
 class TestCreateDiscovery:
     """Tests for resource-creation POST endpoint discovery."""
 
-    def ***REMOVED***(self, create_endpoints) -> None:
+    def test_discovers_standard_create_endpoints(self, create_endpoints) -> None:
         """Discovers create_ prefixed endpoints."""
         operation_ids = {ep.operation_id for ep in create_endpoints}
 
@@ -194,7 +194,7 @@ class TestHelperFunctions:
         }
         assert _resolve_response_properties(operation, {}, "200") == {}
 
-    def ***REMOVED***(self) -> None:
+    def test_resolve_success_response_properties(self) -> None:
         """Finds the first 2xx response with properties."""
         operation: dict[str, Any] = {
             "responses": {
@@ -206,7 +206,7 @@ class TestHelperFunctions:
         props = _resolve_success_response_properties(operation, schemas)
         assert "id" in props
 
-    def ***REMOVED***_empty(self) -> None:
+    def test_resolve_success_response_properties_empty_empty(self) -> None:
         """Returns empty dict when no 2xx responses have properties."""
         operation: dict[str, Any] = {"responses": {"400": {}, "500": {}}}
         assert _resolve_success_response_properties(operation, {}) == {}

--- a/backend/tests/unit/api/compliance/test_list_endpoint_compliance.py
+++ b/backend/tests/unit/api/compliance/test_list_endpoint_compliance.py
@@ -95,7 +95,7 @@ class TestListEndpointCompliance:
             if isinstance(p, dict) and "name" in p and p.get("in") != "path"
         }
 
-    def ***REMOVED***(self, endpoint: EndpointInfo, openapi_spec: dict[str, Any]):
+    def test_response_declares_pagination_fields(self, endpoint: EndpointInfo, openapi_spec: dict[str, Any]):
         """Validates response schema declares all pagination fields.
 
         Validates that the response schema declares all fields from ResourcesResponse[T]:
@@ -248,7 +248,7 @@ class TestListEndpointCompliance:
                 f"{missing_operators}. Should declare: {required_operators}"
             )
 
-    def ***REMOVED***(self, endpoint: EndpointInfo, openapi_spec: dict[str, Any]):
+    def test_filterable_fields_declare_operators(self, endpoint: EndpointInfo, openapi_spec: dict[str, Any]):
         """Validates filterable fields declare appropriate filter operators.
 
         Dynamically discovers filter parameters from the OpenAPI spec (any query
@@ -361,10 +361,10 @@ class TestExclusionListMaintenance:
 
         # Define all compliance checks to run
         compliance_checks = [
-            test_instance.***REMOVED***,
+            test_instance.test_response_declares_pagination_fields,
             test_instance.test_declares_pagination_parameters,
             test_instance.test_sort_parameter_constrains_values,
-            test_instance.***REMOVED***,
+            test_instance.test_filterable_fields_declare_operators,
         ]
 
         for endpoint in excluded_endpoints:

--- a/backend/tests/unit/api/test_docs_endpoints.py
+++ b/backend/tests/unit/api/test_docs_endpoints.py
@@ -272,7 +272,7 @@ class TestDocsEnabledWiring:
             object.__setattr__(main_module._settings, "enable_api_docs", original)
             main_module.app.dependency_overrides.pop(get_current_user, None)
 
-    def ***REMOVED***(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_docs_routes_registered_when_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import importlib
 
         import nexus.api.main as main_module

--- a/backend/tests/unit/approvals/test_approval_authorization.py
+++ b/backend/tests/unit/approvals/test_approval_authorization.py
@@ -297,7 +297,7 @@ class TestApprovalServiceIsUserAuthorizedApprover(TestApprovalAuthorizationBase)
         assert is_authorized is False
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_user_matches_either_users_or_groups(
         self, test_db_session: AsyncSession, users: dict[str, User], executions_factory: ExecutionsFactory
     ) -> None:
         """Test that user authorized if they match either approver_users OR approver_groups."""
@@ -577,7 +577,7 @@ class TestApprovalServiceEvaluatorAuthorization(TestApprovalAuthorizationBase):
         assert is_authorized is False
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_opa_allows_with_approver_list_check(
         self,
         test_db_session: AsyncSession,
         users: dict[str, User],
@@ -624,7 +624,7 @@ class TestApprovalServiceEvaluatorAuthorization(TestApprovalAuthorizationBase):
         assert is_authorized is True
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_opa_allows_but_not_in_approver_list(
         self,
         test_db_session: AsyncSession,
         users: dict[str, User],
@@ -672,7 +672,7 @@ class TestApprovalServiceEvaluatorAuthorization(TestApprovalAuthorizationBase):
         assert is_authorized is False
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_opa_allows_with_empty_approver_list(
         self,
         test_db_session: AsyncSession,
         users: dict[str, User],

--- a/backend/tests/unit/audit/outbox/test_session.py
+++ b/backend/tests/unit/audit/outbox/test_session.py
@@ -32,7 +32,7 @@ def test_audit_worker_pool_size() -> None:
     assert worker_pool_size > 0, "Worker pool should have at least 1 connection"
 
 
-def ***REMOVED***() -> None:
+def test_audit_worker_session_factory_exists() -> None:
     """Audit worker session factory should be properly configured."""
     assert AuditWorkerAsyncSessionLocal is not None
     assert callable(AuditWorkerAsyncSessionLocal)

--- a/backend/tests/unit/audit/outbox/test_worker_adaptive.py
+++ b/backend/tests/unit/audit/outbox/test_worker_adaptive.py
@@ -62,7 +62,7 @@ class TestAdaptiveCallback:
             assert worker._adaptive_sm.current_batch_size == 130
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_adaptive_callback_skips_on_db_error(
         self, test_session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
         """DB error (None from _get_pending_outbox_count) skips adjustment, preserves params."""
@@ -128,7 +128,7 @@ class TestAdaptiveCallback:
             assert worker._adaptive_sm.current_batch_size == 100
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_adaptive_callback_shrinking_backlog(
         self, test_session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
         """Shrinking backlog slows down interval and decreases batch size."""

--- a/backend/tests/unit/auth/test_client_credentials.py
+++ b/backend/tests/unit/auth/test_client_credentials.py
@@ -278,7 +278,7 @@ class TestTokenEndpoint:
         assert isinstance(exc_info.value, AuthenticationRequiredError)
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, mock_db: AsyncMock) -> None:
+    async def test_deleted_service_account_returns_401(self, mock_db: AsyncMock) -> None:
         """AC8: Hard-deleted service account (credential gone) returns 401."""
         self._setup_db_result(mock_db, None)
 

--- a/backend/tests/unit/authz/test_credential_use_engine.py
+++ b/backend/tests/unit/authz/test_credential_use_engine.py
@@ -74,7 +74,7 @@ class TestHasDirectSystemCredentialUse:  # noqa: D101
         assert await _has_direct_system_credential_use(db, uuid4()) is False
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self) -> None:
+    async def test_mixed_roles_with_admin_returns_true(self) -> None:
         db = _mock_db(["auditor", "admin"])
         assert await _has_direct_system_credential_use(db, uuid4()) is True
 

--- a/backend/tests/unit/core/auth/audit/test_oidc_flow.py
+++ b/backend/tests/unit/core/auth/audit/test_oidc_flow.py
@@ -117,7 +117,7 @@ class TestOIDCFlowHandler:
         assert result.resource_urn == "urn:syntara:user:testuser"
         assert result.resource_name == "testuser"
 
-    def ***REMOVED***(self) -> None:
+    def test_resource_fields_fallback_to_user_id(self) -> None:
         """Resource fields fall back to user_id when username is None."""
         uid = uuid4()
         event = OIDCFlowEvent(provider_id=None, stage=OIDCStage.CALLBACK, user_id=uid, username=None)

--- a/backend/tests/unit/core/auth/test_idp_group_sync.py
+++ b/backend/tests/unit/core/auth/test_idp_group_sync.py
@@ -835,7 +835,7 @@ class TestAapRoleMapping:
         assert result is True
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self):
+    async def test_issuer_match_without_trailing_slash(self):
         """Issuer comparison tolerates missing trailing slash in the iss claim."""
         user = _make_user()
         provider_id = uuid4()

--- a/backend/tests/unit/core/auth/test_stale_token_middleware.py
+++ b/backend/tests/unit/core/auth/test_stale_token_middleware.py
@@ -493,7 +493,7 @@ class TestStaleTokenMiddlewareSA:
         _user_status_cache.clear()
         _cred_status_cache.clear()
 
-    def ***REMOVED***(self) -> None:
+    def test_active_sa_with_current_token_passes(self) -> None:
         """Active SA with matching token_ver and active credential passes through."""
         app = _build_app()
         payload = _make_sa_payload(sub="sa-456", token_version=1, credential_id="cred-001")

--- a/backend/tests/unit/core/utils/test_api_client_filters.py
+++ b/backend/tests/unit/core/utils/test_api_client_filters.py
@@ -148,7 +148,7 @@ class TestEdgeCasesFieldNames:
         result = build_filters(**{"created-at__gte": "2025-01-01"})
         assert result == {"created-at[gte]": "2025-01-01"}
 
-    def ***REMOVED***(self) -> None:
+    def test_field_name_that_looks_like_operator(self) -> None:
         """Field name 'contains' without operator works."""
         result = build_filters(contains="some-value")
         assert result == {"contains": "some-value"}

--- a/backend/tests/unit/core/websocket/test_endpoint_factory.py
+++ b/backend/tests/unit/core/websocket/test_endpoint_factory.py
@@ -786,7 +786,7 @@ class TestCheckWebSocketAuthorization:
         assert authz_request.resource_type == "invocation"
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self) -> None:
+    async def test_unknown_resource_type_returns_false(self) -> None:
         resource_id = str(uuid4())
         ws = MagicMock()
         ws.path_params = {"task_id": resource_id}

--- a/backend/tests/unit/files/retrievers/test_s3_retriever.py
+++ b/backend/tests/unit/files/retrievers/test_s3_retriever.py
@@ -233,7 +233,7 @@ class TestS3VerifySSL:
             S3FileRetriever(endpoint_url=None, bucket_name=BUCKET_NAME, region_name=REGION, verify_ssl=False)
             assert mock_client.call_args.kwargs["verify"] is False
 
-    def ***REMOVED***(self) -> None:
+    def test_ca_bundle_used_when_verify_ssl_true(self) -> None:
         with mock_aws(), patch("nexus.files.retrievers.s3.boto3.client", wraps=boto3.client) as mock_client:
             S3FileRetriever(
                 endpoint_url=None,

--- a/backend/tests/unit/files/test_file_detail_endpoint.py
+++ b/backend/tests/unit/files/test_file_detail_endpoint.py
@@ -104,7 +104,7 @@ class TestFileDetailEndpoint:
         assert response.conversion_error == "The file appears to be corrupted"
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self) -> None:
+    async def test_get_file_details_pending_conversion(self) -> None:
         """Test response for a file still pending conversion."""
         file_id = uuid4()
         metadata = FileMetadata(

--- a/backend/tests/unit/files/test_file_manager.py
+++ b/backend/tests/unit/files/test_file_manager.py
@@ -35,7 +35,7 @@ def test_file_manager_unconfigured_when_no_s3_env() -> None:
     assert fm._retriever is None
 
 
-def ***REMOVED***(
+def test_file_manager_configured_when_s3_set(
     override_settings: Callable[..., AbstractContextManager[object]],
 ) -> None:
     """FileManager registers S3 retriever when endpoint is configured."""
@@ -439,7 +439,7 @@ async def test_update_file_status_with_error() -> None:
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***() -> None:
+async def test_update_file_status_not_found_raises() -> None:
     """update_file_status raises SafeValueError when file not found."""
     from uuid import uuid4
 

--- a/backend/tests/unit/integrations/adapters/providers/test_anthropic.py
+++ b/backend/tests/unit/integrations/adapters/providers/test_anthropic.py
@@ -47,7 +47,7 @@ class TestAnthropicProvider:
         assert models[1].id == "claude-sonnet-4-6"
         assert models[1].name == "Claude Sonnet 4.6"
 
-    def ***REMOVED***_to_id(self) -> None:
+    def test_parse_models_response_fallback_name_to_id_to_id(self) -> None:
         """If display_name is missing, falls back to id."""
         provider = AnthropicProvider()
         models = provider.parse_models_response({"data": [{"id": "claude-4"}]})

--- a/backend/tests/unit/integrations/adapters/providers/test_google.py
+++ b/backend/tests/unit/integrations/adapters/providers/test_google.py
@@ -44,7 +44,7 @@ class TestGoogleProvider:
         assert models[1].id == "gemini-2.0-pro"
         assert models[1].name == "Gemini 2.0 Pro"
 
-    def ***REMOVED***(self) -> None:
+    def test_parse_models_response_fallback_name(self) -> None:
         """If displayName is missing, falls back to name."""
         provider = GoogleProvider()
         models = provider.parse_models_response({"models": [{"name": "models/gemini-flash"}]})

--- a/backend/tests/unit/integrations/audit/test_integration_validate.py
+++ b/backend/tests/unit/integrations/audit/test_integration_validate.py
@@ -71,7 +71,7 @@ class TestIntegrationValidateHandler:
         assert "timeout" in audit_event.event_message
         assert audit_event.structured_data.timeout is True  # type: ignore[attr-defined]
 
-    def ***REMOVED***(self) -> None:
+    def test_resource_fields_with_integration_id(self) -> None:
         """Should set resource URN when integration_id is present."""
         handler = IntegrationValidateHandler()
         integration_id = uuid4()

--- a/backend/tests/unit/integrations/services/test_integration_project_assignment.py
+++ b/backend/tests/unit/integrations/services/test_integration_project_assignment.py
@@ -220,7 +220,7 @@ class TestListAssignedProjects:
         assert len(result.resources) == 0
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_list_nonexistent_integration_raises(
         self, test_db_session: AsyncSession, integration_service: IntegrationService
     ) -> None:
         fake_integration_id = uuid4()

--- a/backend/tests/unit/integrations/services/test_integration_service.py
+++ b/backend/tests/unit/integrations/services/test_integration_service.py
@@ -610,7 +610,7 @@ class TestUpdateValidationStatus:
         assert result.validation_status == IntegrationStatus.AVAILABLE
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_update_status_to_error_with_message(
         self, test_db_session: AsyncSession, integration_service: IntegrationService
     ) -> None:
         created = await integration_service.create_integration(_mcp_create())

--- a/backend/tests/unit/integrations/services/test_llm_model_service.py
+++ b/backend/tests/unit/integrations/services/test_llm_model_service.py
@@ -105,7 +105,7 @@ class TestListModels:
     """Tests for LLMModelService.list_models."""
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_list_returns_models_for_integration(
         self,
         test_db_session: AsyncSession,
         model_service: LLMModelService,

--- a/backend/tests/unit/integrations/services/test_model_profile_lookup.py
+++ b/backend/tests/unit/integrations/services/test_model_profile_lookup.py
@@ -87,7 +87,7 @@ def test_openrouter_prefixed_ids_resolve(model_id: str, expected_name: str) -> N
     assert profile["name"] == expected_name
 
 
-def ***REMOVED***() -> None:
+def test_unknown_prefixed_model_returns_none() -> None:
     """A prefixed model not in any registry returns None."""
     assert lookup_model_profile("deepseek/deepseek-chat-v99") is None
 

--- a/backend/tests/unit/integrations/test_health_check_adapter.py
+++ b/backend/tests/unit/integrations/test_health_check_adapter.py
@@ -279,7 +279,7 @@ class TestAdapterFactory:
         assert isinstance(adapter, IntegrationAdapter)
         assert adapter.config == config
 
-    def ***REMOVED***(self) -> None:
+    def test_create_raises_for_unregistered_type(self) -> None:
         config = LLMProviderConfiguration(base_url="https://api.openai.com", provider_hint="openai")
 
         with pytest.raises(AdapterNotRegisteredError, match="No health check adapter registered"):

--- a/backend/tests/unit/integrations/test_llm_provider_health_check.py
+++ b/backend/tests/unit/integrations/test_llm_provider_health_check.py
@@ -665,7 +665,7 @@ class TestLLMProviderLogging:
         assert "LLM request timed out" in caplog.text
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_validate_http_error_logs_error_type(self, caplog: pytest.LogCaptureFixture) -> None:
         """HTTP error logs at WARNING with error_type."""
         import logging
 
@@ -825,7 +825,7 @@ class TestLLMProviderDiscoverPagination:
         assert second_call.kwargs["params"] == {"after": "claude-opus-4"}
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self) -> None:
+    async def test_google_discover_paginates_two_pages(self) -> None:
         adapter = LLMProviderAdapter(_make_config("gemini", base_url=None))
         page1 = _mock_response(
             {

--- a/backend/tests/unit/integrations/test_mcp_health_check.py
+++ b/backend/tests/unit/integrations/test_mcp_health_check.py
@@ -460,7 +460,7 @@ class TestMCPServerDiscoverErrors:
         mock_provider.close.assert_called_once()
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, mcp_config: MCPServerConfiguration) -> None:
+    async def test_http_401_classified_as_auth_failure(self, mcp_config: MCPServerConfiguration) -> None:
         """HTTP 401 returns AUTH_FAILURE error type."""
         adapter = MCPServerAdapter(mcp_config)
 
@@ -479,7 +479,7 @@ class TestMCPServerDiscoverErrors:
         assert "401" in (result.error or "")
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, mcp_config: MCPServerConfiguration) -> None:
+    async def test_http_403_classified_as_auth_failure(self, mcp_config: MCPServerConfiguration) -> None:
         """HTTP 403 returns AUTH_FAILURE error type."""
         adapter = MCPServerAdapter(mcp_config)
 

--- a/backend/tests/unit/metrics/test_authz_metrics.py
+++ b/backend/tests/unit/metrics/test_authz_metrics.py
@@ -337,7 +337,7 @@ class TestExistingMetricsNotRegressed:
         results = list(recorder.query(metric_types={MetricType.ERROR}))
         assert len(results) == 1
 
-    def ***REMOVED***(self, recorder: MetricsRecorder) -> None:
+    def test_database_query_metric_still_records(self, recorder: MetricsRecorder) -> None:
         """DATABASE_QUERY_RESPONSE_TIME metric continues to work."""
         recorder.record(
             MetricType.DATABASE_QUERY_RESPONSE_TIME,

--- a/backend/tests/unit/metrics/test_prometheus.py
+++ b/backend/tests/unit/metrics/test_prometheus.py
@@ -224,7 +224,7 @@ class TestToolInstruments:
 class TestInterfaceLabelInPrometheusOutput:
     """Verify the interface label appears in scraped Prometheus output."""
 
-    def ***REMOVED***(self, prom: OrchestratorPrometheusMetrics) -> None:
+    def test_request_duration_includes_interface(self, prom: OrchestratorPrometheusMetrics) -> None:
         """orchestrator_request_duration_seconds samples include interface label."""
         prom.request_duration_seconds.labels(endpoint="/api/v1/test", method="GET", interface="ui").observe(0.1)
 

--- a/backend/tests/unit/projects/test_project_workflow_list.py
+++ b/backend/tests/unit/projects/test_project_workflow_list.py
@@ -15,7 +15,7 @@ class TestListProjectWorkflows:
     """Tests for the list_project_workflows endpoint."""
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self) -> None:
+    async def test_populates_published_version_numbers(self) -> None:
         """Verify endpoint calls populate_published_version_numbers on result."""
         project_id = uuid4()
         mock_service = AsyncMock()

--- a/backend/tests/unit/rate_limiting/test_settings.py
+++ b/backend/tests/unit/rate_limiting/test_settings.py
@@ -54,7 +54,7 @@ class TestGetRateLimitConfig:
         assert result == (100, 120)
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, mock_settings_cache: AsyncMock) -> None:
+    async def test_enabled_with_catalog_default_window(self, mock_settings_cache: AsyncMock) -> None:
         async def side_effect(key: str) -> int | None:
             if key == RATE_LIMIT_REQUESTS_PER_WINDOW:
                 return 50

--- a/backend/tests/unit/telemetry/handlers/test_api_call_handler.py
+++ b/backend/tests/unit/telemetry/handlers/test_api_call_handler.py
@@ -150,7 +150,7 @@ class TestRecordUsage:
         snapshot = fresh_accumulator.drain()
         assert snapshot.callers_by_interface == {"ui": 1}
 
-    def ***REMOVED***(self, mock_registry: MagicMock):
+    def test_does_not_raise_on_accumulator_error(self, mock_registry: MagicMock):
         event = _make_event(actor_id=uuid4(), actor_type=PrincipalType.USER)
 
         mock_acc = MagicMock()

--- a/backend/tests/unit/telemetry/test_segment_live_reload.py
+++ b/backend/tests/unit/telemetry/test_segment_live_reload.py
@@ -35,7 +35,7 @@ class TestResolveTelemetryConfig:
         assert host == "http://runtime:9999"
 
     @patch("nexus.telemetry.client.get_settings")
-    def ***REMOVED***(self, mock_get_settings: MagicMock) -> None:
+    def test_empty_override_falls_back_to_static(self, mock_get_settings: MagicMock) -> None:
         mock_settings = MagicMock()
         mock_settings.segment_write_key.get_secret_value.return_value = "static-key"
         mock_get_settings.return_value = mock_settings
@@ -191,7 +191,7 @@ class TestReinitializeFromRuntime:
     @patch("nexus.telemetry.client.get_telemetry_registry")
     @patch("nexus.telemetry.client.get_settings")
     @patch("nexus.settings.cache.settings_cache.get_runtime_settings")
-    def ***REMOVED***(
+    def test_no_keys_anywhere_disables_telemetry(
         self,
         mock_get_runtime: MagicMock,
         mock_get_settings: MagicMock,

--- a/backend/tests/unit/workflows/activities/test_aap_common_poll.py
+++ b/backend/tests/unit/workflows/activities/test_aap_common_poll.py
@@ -60,7 +60,7 @@ class TestIsTransientPollError:
         exc = httpx.ReadTimeout("Read timed out")
         assert _is_transient_poll_error(exc) is True
 
-    def ***REMOVED***(self) -> None:
+    def test_generic_http_error_is_not_transient(self) -> None:
         exc = httpx.HTTPError("Some other error")
         assert _is_transient_poll_error(exc) is False
 

--- a/backend/tests/unit/workflows/activities/test_aap_job_template_activity.py
+++ b/backend/tests/unit/workflows/activities/test_aap_job_template_activity.py
@@ -1661,7 +1661,7 @@ class TestAuditEventIntegration:
             mock_dispatcher.dispatch.assert_not_called()
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, mock_activity_context: object) -> None:
+    async def test_unexpected_error_emits_failed_event(self, mock_activity_context: object) -> None:
         launch_response = create_http_response(200, {"id": 123, "url": "/api/v2/jobs/123/"})
         activity_config = build_activity_config(job_template_id=42)
 

--- a/backend/tests/unit/workflows/activities/test_aap_workflow_job_template_activity.py
+++ b/backend/tests/unit/workflows/activities/test_aap_workflow_job_template_activity.py
@@ -1048,7 +1048,7 @@ class TestWorkflowAuditEventIntegration:
             mock_dispatcher.dispatch.assert_not_called()
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, mock_activity_context: object) -> None:
+    async def test_unexpected_error_emits_failed_event(self, mock_activity_context: object) -> None:
         launch_response = create_http_response(200, {"id": 123, "url": "/api/v2/workflow_jobs/123/"})
         activity_config = build_activity_config(workflow_job_template_id=42)
 

--- a/backend/tests/unit/workflows/activities/test_credential_resolution_activity.py
+++ b/backend/tests/unit/workflows/activities/test_credential_resolution_activity.py
@@ -171,7 +171,7 @@ class TestResolveWorkflowCredentials:
     @pytest.mark.asyncio
     @patch("nexus.workflows.workflow_engine.activities.credential_resolution_activity._session_factory")
     @patch("nexus.workflows.workflow_engine.activities.credential_resolution_activity.create_secret_service")
-    async def ***REMOVED***(
+    async def test_secret_values_excludes_short_values(
         self,
         mock_create_ss: MagicMock,
         mock_session_local: MagicMock,

--- a/backend/tests/unit/workflows/activities/test_expire_approval_activity.py
+++ b/backend/tests/unit/workflows/activities/test_expire_approval_activity.py
@@ -108,7 +108,7 @@ async def test_expire_filters_by_node_id(execution_id: str, node_id: str) -> Non
 
 
 @pytest.mark.asyncio
-async def ***REMOVED***(execution_id: str, node_id: str) -> None:
+async def test_expire_api_error_returns_gracefully(execution_id: str, node_id: str) -> None:
     """API errors are caught and returned as error info, not raised."""
     from nexus.workflows.clients.approvals_client import ApprovalsApiClientError
 

--- a/backend/tests/unit/workflows/activities/test_integration_resolution_activity.py
+++ b/backend/tests/unit/workflows/activities/test_integration_resolution_activity.py
@@ -85,7 +85,7 @@ class TestResolveIntegration:
             await _resolve_integration(session, "missing-id")
 
     @pytest.mark.anyio
-    async def ***REMOVED***(self) -> None:
+    async def test_wrong_type_raises_application_error(self) -> None:
         integration = _make_integration(integration_type="llm_provider")
         session = AsyncMock()
         result_mock = MagicMock()

--- a/backend/tests/unit/workflows/audit/test_workflow_execution.py
+++ b/backend/tests/unit/workflows/audit/test_workflow_execution.py
@@ -169,7 +169,7 @@ class TestWorkflowExecutionErrorHandler:
         assert audit_event.resource_urn == f"urn:syntara:workflow:{WORKFLOW_ID}"
         assert audit_event.resource_name is None
 
-    def ***REMOVED***(self) -> None:
+    def test_resource_fields_without_workflow_id(self) -> None:
         """Resource URN is None when workflow_id is None."""
         event = WorkflowExecutionErrorEvent(
             execution_id=EXECUTION_ID,

--- a/backend/tests/unit/workflows/models/test_agentic_config_validation.py
+++ b/backend/tests/unit/workflows/models/test_agentic_config_validation.py
@@ -238,7 +238,7 @@ class TestErrorMessageQuality:
         assert "bad-value" in error_text
         assert "tool_selections" in error_text
 
-    def ***REMOVED***(self) -> None:
+    def test_cross_field_error_names_both_fields(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             AgenticExecutorParameters(
                 prompt="test",

--- a/backend/tests/unit/workflows/models/test_model_field_coverage.py
+++ b/backend/tests/unit/workflows/models/test_model_field_coverage.py
@@ -27,7 +27,7 @@ class TestWorkflowPublishEventFields:
         event = WorkflowPublishEvent.model_construct(version_id=vid)
         assert event.__dict__["version_id"] == vid
 
-    def ***REMOVED***(self) -> None:
+    def test_model_construct_sets_action_in_dict(self) -> None:
         event = WorkflowPublishEvent.model_construct(action=PublishAction.PUBLISHED)
         assert event.__dict__["action"] == PublishAction.PUBLISHED
 

--- a/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
+++ b/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
@@ -147,7 +147,7 @@ class TestMissedSchedulePolicy:
 class TestRequiredFieldValidation:
     """Tests for conditional required field validation."""
 
-    async def ***REMOVED***(self) -> None:
+    async def test_interval_required_for_interval_type(self) -> None:
         """Interval field is required when schedule_type is 'interval'."""
         with pytest.raises((ValidationError, ValueError)):
             ScheduledTriggerConfig(schedule_type=ScheduleType.INTERVAL)
@@ -157,7 +157,7 @@ class TestRequiredFieldValidation:
         with pytest.raises((ValidationError, ValueError)):
             ScheduledTriggerConfig(schedule_type=ScheduleType.CRON)
 
-    async def ***REMOVED***(self) -> None:
+    async def test_interval_not_required_for_cron_type(self) -> None:
         """Interval field should not be required for cron type."""
         config = ScheduledTriggerConfig(
             schedule_type=ScheduleType.CRON,
@@ -165,7 +165,7 @@ class TestRequiredFieldValidation:
         )
         assert config.interval is None
 
-    async def ***REMOVED***(self) -> None:
+    async def test_cron_not_required_for_interval_type(self) -> None:
         """Cron field should not be required for interval type."""
         config = ScheduledTriggerConfig(
             schedule_type=ScheduleType.INTERVAL,

--- a/backend/tests/unit/workflows/models/test_version_status_models.py
+++ b/backend/tests/unit/workflows/models/test_version_status_models.py
@@ -83,7 +83,7 @@ class TestWorkflowReadFields:
         read = self._make_workflow_read()
         assert read.published_version_number is None
 
-    def ***REMOVED***(self) -> None:
+    def test_published_version_number_can_be_set(self) -> None:
         read = self._make_workflow_read(published_version_number=3)
         assert read.published_version_number == 3
 
@@ -141,7 +141,7 @@ class TestWorkflowVersionReadFields:
         )
         assert read.status == "published"
 
-    def ***REMOVED***(self) -> None:
+    def test_status_literal_previously_published(self) -> None:
         read = WorkflowVersionRead(
             id=uuid4(),
             workflow_id=uuid4(),

--- a/backend/tests/unit/workflows/models/test_workflow_version_update.py
+++ b/backend/tests/unit/workflows/models/test_workflow_version_update.py
@@ -56,7 +56,7 @@ class TestWorkflowVersionUpdate:
         assert update.change_description is not None
         assert len(update.change_description) == 1024
 
-    def ***REMOVED***(self) -> None:
+    def test_model_fields_set_tracks_sent_fields(self) -> None:
         update = WorkflowVersionUpdate.model_validate({"name": "Name"})
         assert "name" in update.model_fields_set
         assert "change_description" not in update.model_fields_set

--- a/backend/tests/unit/workflows/services/test_scheduled_trigger_service.py
+++ b/backend/tests/unit/workflows/services/test_scheduled_trigger_service.py
@@ -233,7 +233,7 @@ class TestSyncScheduledTriggers:
         client.create_schedule.assert_called_once()
         handle.update.assert_called_once()
 
-    async def ***REMOVED***(self) -> None:
+    async def test_sync_ignores_non_scheduled_triggers(self) -> None:
         """Non-scheduled trigger nodes should be ignored."""
         client = _make_mock_client()
         service = ScheduledTriggerService(temporal_client=client)
@@ -453,7 +453,7 @@ class TestDeleteTriggersForWorkflow:
         assert deleted == 2
         assert handle.delete.call_count == 2
 
-    async def ***REMOVED***(self) -> None:
+    async def test_delete_handles_nonexistent_schedule(self) -> None:
         """Should handle case where schedule doesn't exist."""
         client = _make_mock_client()
         client.list_schedules = AsyncMock(
@@ -747,7 +747,7 @@ class TestSearchAttributeRegistration:
         assert result is True
         assert _mod._search_attr_available is True
 
-    async def ***REMOVED***(self) -> None:
+    async def test_add_non_connection_error_falls_back(self) -> None:
         """Non-connection error from add_search_attributes should fall back to prefix scan."""
         client = _make_mock_client(search_attr_available=False)
         client.operator_service = _make_mock_operator_service(

--- a/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
+++ b/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
@@ -89,7 +89,7 @@ class TestPublishEmptyWorkflow:
         assert workflow == mock_workflow
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, mock_service: WorkflowService) -> None:
+    async def test_publish_sets_name_and_creates_event(self, mock_service: WorkflowService) -> None:
         workflow_id = uuid4()
         mock_workflow = MagicMock()
         mock_workflow.id = workflow_id

--- a/backend/tests/unit/workflows/services/test_workflow_service_uncovered.py
+++ b/backend/tests/unit/workflows/services/test_workflow_service_uncovered.py
@@ -99,7 +99,7 @@ class TestGetWebhookSyncDefinition:
         assert definition == {"nodes": [{"id": "published"}]}
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, mock_service: WorkflowService) -> None:
+    async def test_returns_fallback_when_not_published(self, mock_service: WorkflowService) -> None:
         """Return fallback definition when published_version_id is None."""
         workflow = MagicMock()
         workflow.published_version_id = None
@@ -225,7 +225,7 @@ class TestRestoreWorkflowVersionSourceLabel:
         assert "Release v1" in call_kwargs.kwargs["change_description"]
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, mock_service: WorkflowService) -> None:
+    async def test_source_label_uses_date_when_no_name(self, mock_service: WorkflowService) -> None:
         """Verify change_description contains ISO date when name is None."""
         workflow_id = uuid4()
         mock_workflow = MagicMock()

--- a/backend/tests/unit/workflows/services/test_workflow_version_context.py
+++ b/backend/tests/unit/workflows/services/test_workflow_version_context.py
@@ -122,7 +122,7 @@ class TestListWorkflowVersionsCursor:
         mock_exec.assert_not_called()
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self, mock_service: WorkflowService) -> None:
+    async def test_populate_callback_queries_usernames(self, mock_service: WorkflowService) -> None:
         """populate_version_context queries User for usernames used by convert_version."""
         workflow_id = uuid4()
         user_id_1 = uuid4()

--- a/backend/tests/unit/workflows/test_json_schema_validation.py
+++ b/backend/tests/unit/workflows/test_json_schema_validation.py
@@ -272,7 +272,7 @@ class TestApplySchemaDefaults:
         apply_schema_defaults(data, self.SCHEMA)
         assert data == {"version": "latest", "timeout": 30}
 
-    def ***REMOVED***(self) -> None:
+    def test_partial_input_gets_missing_defaults(self) -> None:
         data = {"version": "1.0"}
         apply_schema_defaults(data, self.SCHEMA)
         assert data == {"version": "1.0", "timeout": 30}

--- a/backend/tests/unit/workflows/validators/test_template_expression_validation.py
+++ b/backend/tests/unit/workflows/validators/test_template_expression_validation.py
@@ -557,7 +557,7 @@ class TestTriggerExpressions:
         assert len(errors) == 1
         assert "ghost" in errors[0].message
 
-    def ***REMOVED***(self) -> None:
+    def test_valid_builtin_expression_in_trigger(self) -> None:
         defn = _base_definition(
             triggers=[
                 {
@@ -573,7 +573,7 @@ class TestTriggerExpressions:
         errors = check_template_expressions(defn, node_ids)
         assert errors == []
 
-    def ***REMOVED***(self) -> None:
+    def test_empty_workflow_produces_no_findings(self) -> None:
         defn = _base_definition(nodes=[], edges=[])
         errors = check_template_expressions(defn, {"t1"})
         assert errors == []

--- a/backend/tests/unit/workflows/validators/test_workflow_definition_validator.py
+++ b/backend/tests/unit/workflows/validators/test_workflow_definition_validator.py
@@ -798,7 +798,7 @@ class TestConvergeNodeValidation:
         schema_errors = [f for f in result.findings if f.category == ValidationCategory.schema_violation]
         assert any("minimum" in f.message.lower() or "0" in f.message for f in schema_errors)
 
-    def ***REMOVED***(self, validator: WorkflowValidator) -> None:
+    def test_multiple_converge_nodes_independent(self, validator: WorkflowValidator) -> None:
         """Only the misconfigured converge gets findings."""
         definition: dict[str, Any] = {
             "schema_version": "2.0.0",

--- a/backend/tests/unit/workflows/workflow_engine/activities/test_http_request_activity.py
+++ b/backend/tests/unit/workflows/workflow_engine/activities/test_http_request_activity.py
@@ -451,7 +451,7 @@ class TestSecretUrlCredential:
             await execute_http_request_activity(config, None)
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self) -> None:
+    async def test_url_credential_redacts_url_in_error(self) -> None:
         resp = _mock_response(401)
         secret_url = "https://hooks.slack.com/services/T/B/supersecret"  # noqa: S105
         config = {

--- a/backend/tests/unit/workflows/workflow_engine/models/test_node_output_models.py
+++ b/backend/tests/unit/workflows/workflow_engine/models/test_node_output_models.py
@@ -35,7 +35,7 @@ from nexus.workflows.workflow_engine.models.workflow_definition import (
 class TestApprovalOutputFieldNaming:
     """Verify ApprovalOutput uses the domain convention field names."""
 
-    def ***REMOVED***(self) -> None:
+    def test_field_names_match_domain_convention(self) -> None:
         """ApprovalOutput fields use decided_by/decided_at/decision_notes, not approver/timestamp/comments."""
         field_names = set(ApprovalOutput.model_fields.keys())
         assert "decided_by" in field_names

--- a/backend/tests/unit/workflows/workflow_engine/services/test_activity_sync_service.py
+++ b/backend/tests/unit/workflows/workflow_engine/services/test_activity_sync_service.py
@@ -3582,7 +3582,7 @@ class TestPendingSyncEventIds:
 class TestUpdateNonTerminalActivitiesOnCancel:
     """Test _update_non_terminal_activities_on_cancel method."""
 
-    def ***REMOVED***(self) -> None:
+    def test_in_flight_cancelled_pending_skipped(self) -> None:
         """In-flight activities (RUNNING, WAITING) are CANCELLED; PENDING is SKIPPED."""
         mock_client = Mock()
         mock_session_factory = Mock()
@@ -3754,7 +3754,7 @@ class TestUpdateNonTerminalActivitiesOnCancel:
         assert completed_activity.status == ActivityStatus.COMPLETED
         assert failed_activity.status == ActivityStatus.FAILED
 
-    def ***REMOVED***(self) -> None:
+    def test_only_pending_activities_all_skipped(self) -> None:
         """When all non-terminal activities are PENDING, all are SKIPPED."""
         mock_client = Mock()
         mock_session_factory = Mock()
@@ -4152,7 +4152,7 @@ class TestUpdateApprovalPendingFlag:
         assert result is True
         assert execution.approval_pending is True
 
-    def ***REMOVED***(self) -> None:
+    def test_all_approvals_completed_clears_flag(self) -> None:
         """Flag should clear when all approval activities complete."""
         execution = self._make_execution(approval_pending=True)
         activities = [
@@ -4395,7 +4395,7 @@ class TestReconcileStaleExecutions:
         mock_session.commit.assert_awaited()
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(self) -> None:
+    async def test_generic_exception_continues_to_next(self) -> None:
         """A non-Temporal exception on one execution doesn't block others."""
         service, mock_session, mock_client = self._make_service()
         exec_bad = self._make_stale_execution()

--- a/backend/tests/unit/workflows/workflow_engine/services/test_approver_resolution.py
+++ b/backend/tests/unit/workflows/workflow_engine/services/test_approver_resolution.py
@@ -169,7 +169,7 @@ class TestResolveUsernamesToIds:
         assert alice.id in result
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_all_usernames_successfully_resolved(
         self, service: ApproverResolutionService, test_users: dict[str, User]
     ):
         """Test that all valid usernames are successfully resolved."""
@@ -209,7 +209,7 @@ class TestResolveGroupNamesToIds:
         assert result == []
 
     @pytest.mark.asyncio
-    async def ***REMOVED***(
+    async def test_nonexistent_group_name_filtered_out(
         self, service: ApproverResolutionService, test_groups: dict[str, Group]
     ):
         """Test that non-existent group names are silently filtered out."""

--- a/backend/tests/unit/workflows/workflow_engine/test_dynamic_workflow.py
+++ b/backend/tests/unit/workflows/workflow_engine/test_dynamic_workflow.py
@@ -709,7 +709,7 @@ class TestFanInConverge:
 
         mock_ct.assert_not_called()
 
-    def ***REMOVED***(self, mock_timeout_workflow: MagicMock) -> None:
+    def test_converge_timeout_handler_no_timeout(self, mock_timeout_workflow: MagicMock) -> None:
         """When predecessors complete before timeout, no failure occurs."""
         mock_timeout_workflow.wait_condition = AsyncMock()
         wf = _make_workflow()
@@ -1436,7 +1436,7 @@ class TestConvergeIntermediateFailure:
 class TestDetachInFlightPredecessors:
     """Test that _detach_in_flight_predecessors correctly marks in-flight predecessors as detached."""
 
-    def ***REMOVED***(self) -> None:
+    def test_in_flight_predecessors_are_detached(self) -> None:
         """Predecessors in pending_tasks with no resolver namespace are added to _detached_nodes."""
         wf = _make_workflow()
         graph = _build_fanin_graph()


### PR DESCRIPTION
## Description

Readds test names accidentally sanitized. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [ ] List the specific changes made
- [ ] Include any new dependencies or configuration changes

## Out of Scope

<!-- What this PR intentionally does NOT include, to set reviewer expectations -->

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## How to Test

<!-- Manual testing directions, for example:
1. Log in as an admin
2. Go to the `/workflows` route
3. Click on a thing
4. Validate that something changed
-->

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [ ] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [ ] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->
