### PR TITLE
fix(backend): remove leading blank lines in service account E2E tests

### DIFF
--- a/backend/src/api_client/README.md
+++ b/backend/src/api_client/README.md
@@ -56,7 +56,11 @@ client = AuthenticatedClient(
 You can also disable certificate validation altogether, but beware that **this is a security risk**.
 
 ```python
-client = AuthenticatedClient(base_url="https://internal_api.example.com", token="SuperSecretToken", verify_ssl=False)
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com",
+    token="SuperSecretToken",
+    verify_ssl=False
+)
 ```
 
 Things to know:
@@ -77,15 +81,12 @@ There are more settings on the generated `Client` class which let you control mo
 ```python
 from syntara_api_client import Client
 
-
 def log_request(request):
     print(f"Request event hook: {request.method} {request.url} - Waiting for response")
-
 
 def log_response(response):
     request = response.request
     print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
-
 
 client = Client(
     base_url="https://api.example.com",

--- a/backend/tests/e2e/service_accounts/test_client_credentials_grant.py
+++ b/backend/tests/e2e/service_accounts/test_client_credentials_grant.py
@@ -1,6 +1,5 @@
 """E2E tests for the OAuth 2.0 client credentials grant token endpoint (API-9 through API-15, API-33, API-39).
 
-
 Covers:
   API-9:  Client credentials grant — happy path (JWT issuance, ES256, claims)
   API-10: Client credentials grant — HTTP Basic auth header

--- a/backend/tests/e2e/service_accounts/test_full_lifecycle.py
+++ b/backend/tests/e2e/service_accounts/test_full_lifecycle.py
@@ -1,6 +1,5 @@
 """E2E tests for full service account lifecycle flows (API-24, API-35).
 
-
 Covers:
   API-24: Cross-project delegation — full flow
           (create in Project A, grant to Project B admin, authenticate,

--- a/backend/tests/e2e/service_accounts/test_secret_rotation.py
+++ b/backend/tests/e2e/service_accounts/test_secret_rotation.py
@@ -1,6 +1,5 @@
 """E2E tests for client secret rotation with grace period (API-19, API-20).
 
-
 Covers:
   API-19: Secret rotation — grace period (both old and new secrets valid during grace window)
   API-20: Secret rotation — old secret rejected after grace period expires

--- a/backend/tests/e2e/service_accounts/test_token_revocation.py
+++ b/backend/tests/e2e/service_accounts/test_token_revocation.py
@@ -1,6 +1,5 @@
 """E2E tests for service account token revocation on disable/delete (API-21,22,23).
 
-
 Covers:
   API-21: Disable — immediate token invalidation (outstanding tokens rejected)
   API-22: Delete — immediate token invalidation (outstanding tokens rejected)

--- a/backend/tests/e2e/service_accounts/test_token_validation_middleware.py
+++ b/backend/tests/e2e/service_accounts/test_token_validation_middleware.py
@@ -1,6 +1,5 @@
 """E2E tests for service account token validation via auth middleware (API-16,17,18,32,37,38).
 
-
 Covers:
   API-16: Token validation — authorized API access (Bearer token grants access)
   API-17: Token validation — unauthorized returns 403 (insufficient permissions)


### PR DESCRIPTION
## Description

Ruff check flagged 5 test files with a leading blank line before the module docstring, causing the pre-commit hook to fail in CI. This PR should address those 5 test files.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [ ] List the specific changes made
- [ ] Include any new dependencies or configuration changes
