### PR TITLE
chore(ci): switch Tekton UI-tests pipeline resolver from bundles to git

### DIFF
--- a/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
@@ -37,16 +37,22 @@ spec:
     - name: pipeline-github-pr-number
       value: '{{pull_request_number}}'
   pipelineRef:
+    resolver: git
     params:
-      - name: name
-        value: ao-ui-tests
-      - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:946bc72c83a3d831f3e45ccabd81bc4395fc65a08a7e50e7182ca7c4ef84cd7f
-      - name: kind
-        value: pipeline
-      - name: secret
-        value: quay-aap-ci-viewer
-    resolver: bundles
+      - name: org
+        value: ansible-automation-platform
+      - name: repo
+        value: aap-konflux-pipelines
+      - name: revision
+        value: fix/deploy-ao-symlink-syntara-ui
+      - name: pathInRepo
+        value: pipelines/test/ao-ui-tests/0.1/pipeline.yaml
+      - name: token
+        value: github-aap-org-secret
+      - name: tokenKey
+        value: password
+      - name: scmType
+        value: github
 
   taskRunTemplate:
     serviceAccountName: konflux-integration-runner


### PR DESCRIPTION
## Summary

- Replaces the pinned OCI bundle resolver (`quay.io/aap-ci/tekton-catalog/...`) with a `git` resolver pointing to `ansible-automation-platform/aap-konflux-pipelines`
- Pipeline definition is now pulled from the `fix/deploy-ao-symlink-syntara-ui` revision of that repo, eliminating the need to update a bundle SHA on every pipeline change

## Test plan

- [ ] Konflux PR pipeline triggers and resolves the pipeline definition from the git source successfully
- [ ] UI tests complete as expected against the `devel` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)