### PR TITLE
fix: prevent SSRF via callback_url in invocation context_data

### DIFF
--- a/backend/src/syntara/agent_orchestrator/utils/workflow_signal_client.py
+++ b/backend/src/syntara/agent_orchestrator/utils/workflow_signal_client.py
@@ -13,7 +13,6 @@ import httpx
 import structlog
 
 from syntara.core.tls.http_client import build_internal_http_client
-from syntara.workflows.utils.url import generate_activity_signal_url, get_api_base_url
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -21,29 +20,27 @@ _SIGNAL_HTTP_TIMEOUT_SECONDS = 10.0
 
 
 def validate_signal_url(callback_url: str) -> None:
-    """Validate that callback_url points to an allowed internal signal endpoint.
+    """Validate that callback_url points to a well-formed internal signal endpoint.
 
-    Prevents the platform mTLS identity from being presented to arbitrary
-    destinations (SSRF mitigation).  Validation works by parsing the URL,
-    extracting the execution-id and activity-id, and round-tripping through
-    ``generate_activity_signal_url`` — so this stays in sync with the
-    canonical URL shape automatically.
+    Defense-in-depth against SSRF: validates that the URL path has the
+    canonical ``/executions/{id}/activities/{id}/signal`` shape by
+    round-tripping through ``generate_activity_signal_url``.  Host-level
+    SSRF prevention is handled by ``_sanitize_context_data`` (strips
+    ``callback_url`` from non-cert-authenticated requests) and by
+    ``build_internal_http_client`` (mTLS CA verification).
 
     Raises:
         ValueError: If the URL does not match the expected signal endpoint.
 
     """
-    base_url = get_api_base_url()
-    base_parsed = urlparse(base_url)
     url_parsed = urlparse(callback_url)
 
-    if url_parsed.scheme != base_parsed.scheme or url_parsed.netloc != base_parsed.netloc:
+    if url_parsed.scheme not in ("https", "http"):
         logger.critical(
-            "SECURITY: signal callback URL host/scheme mismatch — potential SSRF",
+            "SECURITY: signal callback URL has invalid scheme",
             callback_url=callback_url,
-            expected_base=base_url,
         )
-        msg = "Signal callback URL host/scheme does not match configured API base"
+        msg = "Signal callback URL must use http or https scheme"
         raise ValueError(msg)
 
     if url_parsed.query or url_parsed.fragment:
@@ -54,23 +51,13 @@ def validate_signal_url(callback_url: str) -> None:
         msg = "Signal callback URL must not contain query string or fragment"
         raise ValueError(msg)
 
-    base_path = base_parsed.path.rstrip("/")
-    if not url_parsed.path.startswith(base_path + "/"):
-        logger.critical(
-            "SECURITY: signal callback URL path outside API base — potential SSRF",
-            callback_url=callback_url,
-            expected_base=base_url,
-        )
-        msg = "Signal callback URL path is outside the API base"
-        raise ValueError(msg)
-
-    path_suffix = url_parsed.path[len(base_path) :]
-    parts = path_suffix.strip("/").split("/")
+    parts = url_parsed.path.strip("/").split("/")
 
     try:
-        execution_id = UUID(parts[1])
-        activity_id = parts[3]
-    except (IndexError, ValueError):
+        exec_idx = parts.index("executions")
+        act_idx = parts.index("activities")
+        sig_idx = parts.index("signal")
+    except ValueError:
         logger.critical(
             "SECURITY: signal callback URL path is not a valid signal endpoint — potential SSRF",
             callback_url=callback_url,
@@ -78,14 +65,31 @@ def validate_signal_url(callback_url: str) -> None:
         msg = "Signal callback URL path is not a valid signal endpoint"
         raise ValueError(msg) from None
 
-    expected = generate_activity_signal_url(execution_id, activity_id)
-    if callback_url != expected:
+    if act_idx != exec_idx + 2 or sig_idx != act_idx + 2 or sig_idx != len(parts) - 1:
         logger.critical(
-            "SECURITY: signal callback URL does not match expected pattern — potential SSRF",
+            "SECURITY: signal callback URL path structure is invalid",
             callback_url=callback_url,
-            expected_url=expected,
         )
-        msg = "Signal callback URL does not match expected signal endpoint"
+        msg = "Signal callback URL path is not a valid signal endpoint"
+        raise ValueError(msg)
+
+    try:
+        UUID(parts[exec_idx + 1])
+    except ValueError:
+        logger.critical(
+            "SECURITY: signal callback URL has invalid execution ID",
+            callback_url=callback_url,
+        )
+        msg = "Signal callback URL path is not a valid signal endpoint"
+        raise ValueError(msg) from None
+
+    activity_id = parts[act_idx + 1]
+    if not activity_id:
+        logger.critical(
+            "SECURITY: signal callback URL has empty activity ID",
+            callback_url=callback_url,
+        )
+        msg = "Signal callback URL path is not a valid signal endpoint"
         raise ValueError(msg)
 
 

--- a/backend/src/syntara/agent_orchestrator/utils/workflow_signal_client.py
+++ b/backend/src/syntara/agent_orchestrator/utils/workflow_signal_client.py
@@ -6,16 +6,87 @@ to send activity completion signals (both success and failure) to workflows.
 
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import urlparse
 from uuid import UUID
 
 import httpx
 import structlog
 
 from syntara.core.tls.http_client import build_internal_http_client
+from syntara.workflows.utils.url import generate_activity_signal_url, get_api_base_url
 
 logger = structlog.stdlib.get_logger(__name__)
 
 _SIGNAL_HTTP_TIMEOUT_SECONDS = 10.0
+
+
+def validate_signal_url(callback_url: str) -> None:
+    """Validate that callback_url points to an allowed internal signal endpoint.
+
+    Prevents the platform mTLS identity from being presented to arbitrary
+    destinations (SSRF mitigation).  Validation works by parsing the URL,
+    extracting the execution-id and activity-id, and round-tripping through
+    ``generate_activity_signal_url`` — so this stays in sync with the
+    canonical URL shape automatically.
+
+    Raises:
+        ValueError: If the URL does not match the expected signal endpoint.
+
+    """
+    base_url = get_api_base_url()
+    base_parsed = urlparse(base_url)
+    url_parsed = urlparse(callback_url)
+
+    if url_parsed.scheme != base_parsed.scheme or url_parsed.netloc != base_parsed.netloc:
+        logger.critical(
+            "SECURITY: signal callback URL host/scheme mismatch — potential SSRF",
+            callback_url=callback_url,
+            expected_base=base_url,
+        )
+        msg = "Signal callback URL host/scheme does not match configured API base"
+        raise ValueError(msg)
+
+    if url_parsed.query or url_parsed.fragment:
+        logger.critical(
+            "SECURITY: signal callback URL contains query string or fragment",
+            callback_url=callback_url,
+        )
+        msg = "Signal callback URL must not contain query string or fragment"
+        raise ValueError(msg)
+
+    base_path = base_parsed.path.rstrip("/")
+    if not url_parsed.path.startswith(base_path + "/"):
+        logger.critical(
+            "SECURITY: signal callback URL path outside API base — potential SSRF",
+            callback_url=callback_url,
+            expected_base=base_url,
+        )
+        msg = "Signal callback URL path is outside the API base"
+        raise ValueError(msg)
+
+    path_suffix = url_parsed.path[len(base_path) :]
+    parts = path_suffix.strip("/").split("/")
+
+    try:
+        execution_id = UUID(parts[1])
+        activity_id = parts[3]
+    except (IndexError, ValueError):
+        logger.critical(
+            "SECURITY: signal callback URL path is not a valid signal endpoint — potential SSRF",
+            callback_url=callback_url,
+        )
+        msg = "Signal callback URL path is not a valid signal endpoint"
+        raise ValueError(msg) from None
+
+    expected = generate_activity_signal_url(execution_id, activity_id)
+    if callback_url != expected:
+        logger.critical(
+            "SECURITY: signal callback URL does not match expected pattern — potential SSRF",
+            callback_url=callback_url,
+            expected_url=expected,
+        )
+        msg = "Signal callback URL does not match expected signal endpoint"
+        raise ValueError(msg)
 
 
 async def _post_signal(callback_url: str, payload: dict[str, Any], invocation_id: UUID) -> None:
@@ -61,6 +132,8 @@ class WorkflowSignalClient:
             httpx.TimeoutException: If request times out
 
         """
+        validate_signal_url(callback_url)
+
         signal_payload = {
             "signal_data": {
                 "id": str(invocation_id),
@@ -118,6 +191,10 @@ class WorkflowSignalClient:
                 invocation_id=invocation_id,
             )
             return
+
+        # Validate URL before the best-effort block so security violations
+        # propagate instead of being silently swallowed.
+        validate_signal_url(callback_url)
 
         signal_payload = {
             "signal_data": {

--- a/backend/src/syntara/invocations/router.py
+++ b/backend/src/syntara/invocations/router.py
@@ -43,6 +43,22 @@ router = NexusRouter(prefix="/invocations", tags=["Invocation"])
 
 logger = structlog.stdlib.get_logger(__name__)
 
+_INTERNAL_ONLY_CONTEXT_KEYS = frozenset({"callback_url"})
+
+
+def _sanitize_context_data(context_data: dict[str, object], request: Request) -> dict[str, object]:
+    """Strip internal-only fields from externally-supplied context_data."""
+    if getattr(request.state, "is_cert_authenticated", False):
+        return context_data
+    stripped = _INTERNAL_ONLY_CONTEXT_KEYS & context_data.keys()
+    if stripped:
+        logger.warning(
+            "Stripped internal-only fields from client-supplied context_data",
+            stripped_fields=sorted(stripped),
+        )
+    return {k: v for k, v in context_data.items() if k not in _INTERNAL_ONLY_CONTEXT_KEYS}
+
+
 _invocation_perm_create_json = PermissionChecker("invocation", "create", body_project_field="project_id")
 _invocation_perm_create_form = PermissionChecker("invocation", "create", form_project_field="project_id")
 _invocation_perm_read = PermissionChecker("invocation", "read")
@@ -172,12 +188,14 @@ def _validate_multipart_required_fields(prompt: str | None, session_id: str | No
     },
 )
 async def create_invocation(
+    request: Request,
     request_body: InvocationCreateRequest,
     service: Annotated[InvocationService, Depends(get_invocation_service_with_temporal)],
 ) -> Invocation:
     """Accept async invocation request (JSON).
 
     Args:
+        request: FastAPI request object
         request_body: JSON request body with prompt, session_id, and optional context_data
         service: Invocation service (with background tasks support)
 
@@ -192,7 +210,7 @@ async def create_invocation(
         prompt=request_body.prompt,
         session_id=request_body.session_id,
         project_id=request_body.project_id,
-        context_data=request_body.context_data,
+        context_data=_sanitize_context_data(request_body.context_data, request),
         files=None,
     )
 
@@ -207,12 +225,14 @@ async def create_invocation(
     response_description="Invocation accepted",
 )
 async def create_invocation_chat(
+    request: Request,
     service: Annotated[InvocationService, Depends(get_invocation_service_with_temporal)],
     form: Annotated[InvocationRequestWithFile, Form(media_type="multipart/form-data")],
 ) -> Invocation:
     """Accept async invocation request with optional file uploads (multipart/form-data).
 
     Args:
+        request: FastAPI request object
         service: Invocation service (with background tasks support)
         form: Multipart form body with prompt, session_id, optional context_data and files
 
@@ -237,7 +257,7 @@ async def create_invocation_chat(
         prompt=prompt,
         session_id=session_id,
         project_id=project_id,
-        context_data=context_data,
+        context_data=_sanitize_context_data(context_data, request) if context_data else context_data,
         files=form.files,
     )
 

--- a/backend/tests/integration/agent_orchestrator/context_manager/retriever_service/test_integration.py
+++ b/backend/tests/integration/agent_orchestrator/context_manager/retriever_service/test_integration.py
@@ -203,16 +203,20 @@ async def test_file_upload_creates_db_records(
 
 
 @pytest.mark.asyncio
-async def test_callback_url_stored_in_context_data(
+async def test_callback_url_stripped_from_external_context_data(
     auth_client_with_mocked_llm, test_user, test_db_session, test_project_id
 ) -> None:
-    """Verify callback_url in context_data is preserved in invocation."""
+    """Verify callback_url in context_data is stripped for non-cert-authenticated requests.
+
+    External callers must not be able to inject callback_url — the SSRF mitigation
+    in the router strips internal-only fields before persisting.
+    """
     callback_url = "http://example.com/executions/123/activities/456/signal"
     data = {
         "prompt": "Test prompt",
         "session_id": f"callback-test-{uuid4().hex[:8]}",
         "project_id": str(test_project_id),
-        "context_data": f'{{"callback_url": "{callback_url}"}}',
+        "context_data": f'{{"callback_url": "{callback_url}", "agent": "my-agent"}}',
     }
 
     response = await auth_client_with_mocked_llm.post("/api/v1/invocations/chat", data=data)
@@ -222,4 +226,5 @@ async def test_callback_url_stored_in_context_data(
     invocation = await test_db_session.get(Invocation, UUID(invocation_id))
     assert invocation is not None
     assert invocation.context_data is not None
-    assert invocation.context_data.get("callback_url") == callback_url
+    assert invocation.context_data.get("callback_url") is None
+    assert invocation.context_data.get("agent") == "my-agent"

--- a/backend/tests/unit/agent_orchestrator/utils/test_workflow_signal_client.py
+++ b/backend/tests/unit/agent_orchestrator/utils/test_workflow_signal_client.py
@@ -1,13 +1,101 @@
 """Unit tests for WorkflowSignalClient."""
 
+from collections.abc import Generator
 from datetime import UTC, datetime
+from unittest.mock import patch
 from uuid import UUID
 
 import httpx
 import pytest
 import respx
 
-from syntara.agent_orchestrator.utils.workflow_signal_client import WorkflowSignalClient
+from syntara.agent_orchestrator.utils.workflow_signal_client import WorkflowSignalClient, validate_signal_url
+
+_BASE_URL = "https://nexus:8000/api/v1"
+_EXEC_UUID = "12345678-1234-5678-1234-567812345678"
+_SIGNAL_URL = f"{_BASE_URL}/executions/{_EXEC_UUID}/activities/step_1/signal"
+
+
+@pytest.fixture(autouse=True)
+def _patch_api_base_url() -> Generator[None]:
+    with (
+        patch(
+            "syntara.agent_orchestrator.utils.workflow_signal_client.get_api_base_url",
+            return_value=_BASE_URL,
+        ),
+        patch(
+            "syntara.workflows.utils.url.get_api_base_url",
+            return_value=_BASE_URL,
+        ),
+    ):
+        yield
+
+
+class TestValidateSignalUrl:
+    """Tests for validate_signal_url SSRF prevention."""
+
+    def test_valid_signal_url_accepted(self) -> None:
+        validate_signal_url(_SIGNAL_URL)
+
+    def test_valid_url_with_hyphenated_activity_id(self) -> None:
+        url = f"{_BASE_URL}/executions/{_EXEC_UUID}/activities/my-step.v2/signal"
+        validate_signal_url(url)
+
+    def test_rejects_different_host(self) -> None:
+        url = f"https://evil.com/api/v1/executions/{_EXEC_UUID}/activities/step_1/signal"
+        with pytest.raises(ValueError, match="host/scheme"):
+            validate_signal_url(url)
+
+    def test_rejects_different_scheme(self) -> None:
+        url = f"http://nexus:8000/api/v1/executions/{_EXEC_UUID}/activities/step_1/signal"
+        with pytest.raises(ValueError, match="host/scheme"):
+            validate_signal_url(url)
+
+    def test_rejects_arbitrary_path(self) -> None:
+        url = "https://nexus:8000/api/v1/workflows/some-id/versions/1/publish"
+        with pytest.raises(ValueError, match="not a valid signal endpoint"):
+            validate_signal_url(url)
+
+    def test_rejects_path_outside_api_base(self) -> None:
+        url = f"https://nexus:8000/other/executions/{_EXEC_UUID}/activities/step_1/signal"
+        with pytest.raises(ValueError, match="outside the API base"):
+            validate_signal_url(url)
+
+    def test_rejects_invalid_execution_id(self) -> None:
+        url = f"{_BASE_URL}/executions/not-a-uuid/activities/step_1/signal"
+        with pytest.raises(ValueError, match="not a valid signal endpoint"):
+            validate_signal_url(url)
+
+    def test_rejects_loopback_ssrf(self) -> None:
+        url = "https://127.0.0.1:9911/some/path"
+        with pytest.raises(ValueError, match="host/scheme"):
+            validate_signal_url(url)
+
+    def test_rejects_url_with_userinfo_at_sign(self) -> None:
+        url = f"https://evil.com@nexus:8000/api/v1/executions/{_EXEC_UUID}/activities/step_1/signal"
+        with pytest.raises(ValueError, match="host/scheme"):
+            validate_signal_url(url)
+
+    def test_rejects_extra_path_segments(self) -> None:
+        url = f"{_BASE_URL}/executions/{_EXEC_UUID}/activities/step_1/signal/extra"
+        with pytest.raises(ValueError, match="does not match expected"):
+            validate_signal_url(url)
+
+    def test_rejects_publish_endpoint_ssrf(self) -> None:
+        """The exact exploit from the bug report: redirect to publish endpoint."""
+        url = "https://nexus:8000/api/v1/workflows/victim-wf-id/versions/1/publish"
+        with pytest.raises(ValueError, match="not a valid signal endpoint"):
+            validate_signal_url(url)
+
+    def test_rejects_query_string(self) -> None:
+        url = f"{_SIGNAL_URL}?override=true"
+        with pytest.raises(ValueError, match="query string or fragment"):
+            validate_signal_url(url)
+
+    def test_rejects_fragment(self) -> None:
+        url = f"{_SIGNAL_URL}#section"
+        with pytest.raises(ValueError, match="query string or fragment"):
+            validate_signal_url(url)
 
 
 class TestWorkflowSignalClientSendSuccessSignal:
@@ -17,9 +105,7 @@ class TestWorkflowSignalClientSendSuccessSignal:
     @respx.mock
     async def test_send_success_signal_with_full_result(self) -> None:
         """Test sending success signal with complete result data."""
-        # Arrange
-        callback_url = "https://test-workflow:7233/signal/activity/test-123"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         result = {
             "content": "Analysis complete",
             "response_metadata": {
@@ -29,20 +115,16 @@ class TestWorkflowSignalClientSendSuccessSignal:
             "used_tools": [{"name": "search", "count": 2}],
         }
 
-        # Mock the HTTP POST
-        route = respx.post(callback_url).mock(return_value=httpx.Response(200))
+        route = respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(200))
 
-        # Act
-        await WorkflowSignalClient.send_success_signal(callback_url, invocation_id, result)
+        await WorkflowSignalClient.send_success_signal(_SIGNAL_URL, invocation_id, result)
 
-        # Assert
         assert route.called
         assert route.call_count == 1
 
-        # Verify the request payload
         request = route.calls[0].request
         payload = request.content.decode("utf-8")
-        assert "12345678-1234-5678-1234-567812345678" in payload
+        assert _EXEC_UUID in payload
         assert '"status":"completed"' in payload
         assert '"content":"Analysis complete"' in payload
         assert '"used_tools"' in payload
@@ -53,8 +135,7 @@ class TestWorkflowSignalClientSendSuccessSignal:
     @respx.mock
     async def test_send_success_signal_omits_raw_tool_calls(self) -> None:
         """Raw tool_calls (may include args/secrets) must not be forwarded on the signal."""
-        callback_url = "https://workflow/signal"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         result = {
             "content": "done",
             "used_tools": [{"name": "search", "count": 1}],
@@ -67,9 +148,9 @@ class TestWorkflowSignalClientSendSuccessSignal:
             ],
         }
 
-        route = respx.post(callback_url).mock(return_value=httpx.Response(200))
+        route = respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(200))
 
-        await WorkflowSignalClient.send_success_signal(callback_url, invocation_id, result)
+        await WorkflowSignalClient.send_success_signal(_SIGNAL_URL, invocation_id, result)
 
         import json
 
@@ -83,18 +164,13 @@ class TestWorkflowSignalClientSendSuccessSignal:
     @respx.mock
     async def test_send_success_signal_with_minimal_result(self) -> None:
         """Test sending success signal with minimal result data."""
-        # Arrange
-        callback_url = "https://workflow/signal"
         invocation_id = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
         result = {"content": "Done"}
 
-        # Mock the HTTP POST
-        route = respx.post(callback_url).mock(return_value=httpx.Response(200))
+        route = respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(200))
 
-        # Act
-        await WorkflowSignalClient.send_success_signal(callback_url, invocation_id, result)
+        await WorkflowSignalClient.send_success_signal(_SIGNAL_URL, invocation_id, result)
 
-        # Assert
         assert route.called
         request = route.calls[0].request
         payload = request.content.decode("utf-8")
@@ -104,64 +180,58 @@ class TestWorkflowSignalClientSendSuccessSignal:
     @respx.mock
     async def test_send_success_signal_raises_on_http_error(self) -> None:
         """Test that send_success_signal raises on HTTP error."""
-        # Arrange
-        callback_url = "https://workflow/signal"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         result = {"content": "Test"}
 
-        # Mock HTTP POST to return 500 error
-        respx.post(callback_url).mock(return_value=httpx.Response(500, text="Internal Server Error"))
+        respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(500, text="Internal Server Error"))
 
-        # Act & Assert
         with pytest.raises(httpx.HTTPStatusError):
-            await WorkflowSignalClient.send_success_signal(callback_url, invocation_id, result)
+            await WorkflowSignalClient.send_success_signal(_SIGNAL_URL, invocation_id, result)
 
     @pytest.mark.asyncio
     @respx.mock
     async def test_send_success_signal_raises_on_connection_error(self) -> None:
         """Test that send_success_signal raises on connection error."""
-        # Arrange
-        callback_url = "https://nonexistent-host:9999/signal"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         result = {"content": "Test"}
 
-        # Mock connection error
-        respx.post(callback_url).mock(side_effect=httpx.ConnectError("Connection failed"))
+        respx.post(_SIGNAL_URL).mock(side_effect=httpx.ConnectError("Connection failed"))
 
-        # Act & Assert
         with pytest.raises(httpx.ConnectError):
-            await WorkflowSignalClient.send_success_signal(callback_url, invocation_id, result)
+            await WorkflowSignalClient.send_success_signal(_SIGNAL_URL, invocation_id, result)
 
     @pytest.mark.asyncio
     @respx.mock
     async def test_send_success_signal_includes_timestamp(self) -> None:
         """Test that success signal includes ISO timestamp."""
-        # Arrange
-        callback_url = "https://workflow/signal"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         result = {"content": "Test"}
 
-        # Mock the HTTP POST
-        route = respx.post(callback_url).mock(return_value=httpx.Response(200))
+        route = respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(200))
 
-        # Act
         before_time = datetime.now(UTC)
-        await WorkflowSignalClient.send_success_signal(callback_url, invocation_id, result)
+        await WorkflowSignalClient.send_success_signal(_SIGNAL_URL, invocation_id, result)
         after_time = datetime.now(UTC)
 
-        # Assert
         request = route.calls[0].request
         payload = request.content.decode("utf-8")
         assert '"timestamp":' in payload
 
-        # Verify timestamp format is ISO 8601
-        # The timestamp should be between before_time and after_time
         import json
 
         data = json.loads(payload)
         timestamp_str = data["signal_data"]["timestamp"]
         timestamp = datetime.fromisoformat(timestamp_str)
         assert before_time <= timestamp <= after_time
+
+    @pytest.mark.asyncio
+    async def test_send_success_signal_rejects_invalid_url(self) -> None:
+        """Success signal must raise on SSRF attempt, not silently proceed."""
+        invocation_id = UUID(_EXEC_UUID)
+        result = {"content": "Test"}
+
+        with pytest.raises(ValueError, match="host/scheme"):
+            await WorkflowSignalClient.send_success_signal("https://evil.com/steal", invocation_id, result)
 
 
 class TestWorkflowSignalClientSendFailureSignal:
@@ -170,32 +240,23 @@ class TestWorkflowSignalClientSendFailureSignal:
     @pytest.mark.asyncio
     async def test_send_failure_signal_skips_when_no_callback_url(self) -> None:
         """Test that send_failure_signal skips sending when callback_url is None."""
-        # Arrange
         callback_url = None
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         error = ValueError("Test error")
 
-        # Act (should not raise, should silently skip)
         await WorkflowSignalClient.send_failure_signal(callback_url, invocation_id, error)
-
-        # Assert - no assertion needed, just verify no exception raised
 
     @pytest.mark.asyncio
     @respx.mock
     async def test_send_failure_signal_with_exception(self) -> None:
         """Test sending failure signal with exception details."""
-        # Arrange
-        callback_url = "https://workflow/signal"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         error = ValueError("Invalid input parameter")
 
-        # Mock the HTTP POST
-        route = respx.post(callback_url).mock(return_value=httpx.Response(200))
+        route = respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(200))
 
-        # Act
-        await WorkflowSignalClient.send_failure_signal(callback_url, invocation_id, error)
+        await WorkflowSignalClient.send_failure_signal(_SIGNAL_URL, invocation_id, error)
 
-        # Assert
         assert route.called
         request = route.calls[0].request
         payload = request.content.decode("utf-8")
@@ -208,76 +269,52 @@ class TestWorkflowSignalClientSendFailureSignal:
     @respx.mock
     async def test_send_failure_signal_swallows_http_error(self) -> None:
         """Test that send_failure_signal swallows HTTP errors (best-effort)."""
-        # Arrange
-        callback_url = "https://workflow/signal"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         error = RuntimeError("Something went wrong")
 
-        # Mock HTTP POST to return 500 error
-        respx.post(callback_url).mock(return_value=httpx.Response(500))
+        respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(500))
 
-        # Act (should not raise despite HTTP error)
-        await WorkflowSignalClient.send_failure_signal(callback_url, invocation_id, error)
-
-        # Assert - no exception should be raised (best-effort delivery)
+        await WorkflowSignalClient.send_failure_signal(_SIGNAL_URL, invocation_id, error)
 
     @pytest.mark.asyncio
     @respx.mock
     async def test_send_failure_signal_swallows_connection_error(self) -> None:
         """Test that send_failure_signal swallows connection errors (best-effort)."""
-        # Arrange
-        callback_url = "https://nonexistent:9999/signal"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         error = Exception("Test error")
 
-        # Mock connection error
-        respx.post(callback_url).mock(side_effect=httpx.ConnectError("Connection failed"))
+        respx.post(_SIGNAL_URL).mock(side_effect=httpx.ConnectError("Connection failed"))
 
-        # Act (should not raise despite connection error)
-        await WorkflowSignalClient.send_failure_signal(callback_url, invocation_id, error)
-
-        # Assert - no exception should be raised (best-effort delivery)
+        await WorkflowSignalClient.send_failure_signal(_SIGNAL_URL, invocation_id, error)
 
     @pytest.mark.asyncio
     @respx.mock
     async def test_send_failure_signal_swallows_timeout(self) -> None:
         """Test that send_failure_signal swallows timeout errors (best-effort)."""
-        # Arrange
-        callback_url = "https://workflow/signal"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         error = TimeoutError("Request timed out")
 
-        # Mock timeout error
-        respx.post(callback_url).mock(side_effect=httpx.TimeoutException("Timeout"))
+        respx.post(_SIGNAL_URL).mock(side_effect=httpx.TimeoutException("Timeout"))
 
-        # Act (should not raise despite timeout)
-        await WorkflowSignalClient.send_failure_signal(callback_url, invocation_id, error)
-
-        # Assert - no exception should be raised (best-effort delivery)
+        await WorkflowSignalClient.send_failure_signal(_SIGNAL_URL, invocation_id, error)
 
     @pytest.mark.asyncio
     @respx.mock
     async def test_send_failure_signal_includes_timestamp(self) -> None:
         """Test that failure signal includes ISO timestamp."""
-        # Arrange
-        callback_url = "https://workflow/signal"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
         error = KeyError("missing_key")
 
-        # Mock the HTTP POST
-        route = respx.post(callback_url).mock(return_value=httpx.Response(200))
+        route = respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(200))
 
-        # Act
         before_time = datetime.now(UTC)
-        await WorkflowSignalClient.send_failure_signal(callback_url, invocation_id, error)
+        await WorkflowSignalClient.send_failure_signal(_SIGNAL_URL, invocation_id, error)
         after_time = datetime.now(UTC)
 
-        # Assert
         request = route.calls[0].request
         payload = request.content.decode("utf-8")
         assert '"timestamp":' in payload
 
-        # Verify timestamp is valid ISO 8601
         import json
 
         data = json.loads(payload)
@@ -289,23 +326,27 @@ class TestWorkflowSignalClientSendFailureSignal:
     @respx.mock
     async def test_send_failure_signal_with_custom_exception(self) -> None:
         """Test sending failure signal with custom exception type."""
-        # Arrange
-        callback_url = "https://workflow/signal"
-        invocation_id = UUID("12345678-1234-5678-1234-567812345678")
+        invocation_id = UUID(_EXEC_UUID)
 
         class CustomError(Exception):
             """Custom error for testing."""
 
         error = CustomError("Custom error message")
 
-        # Mock the HTTP POST
-        route = respx.post(callback_url).mock(return_value=httpx.Response(200))
+        route = respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(200))
 
-        # Act
-        await WorkflowSignalClient.send_failure_signal(callback_url, invocation_id, error)
+        await WorkflowSignalClient.send_failure_signal(_SIGNAL_URL, invocation_id, error)
 
-        # Assert
         request = route.calls[0].request
         payload = request.content.decode("utf-8")
         assert '"error_type":"CustomError"' in payload
         assert '"message":"Custom error message"' in payload
+
+    @pytest.mark.asyncio
+    async def test_send_failure_signal_raises_on_invalid_url(self) -> None:
+        """Failure signal must NOT swallow SSRF validation errors."""
+        invocation_id = UUID(_EXEC_UUID)
+        error = RuntimeError("some error")
+
+        with pytest.raises(ValueError, match="host/scheme"):
+            await WorkflowSignalClient.send_failure_signal("https://evil.com/steal", invocation_id, error)

--- a/backend/tests/unit/agent_orchestrator/utils/test_workflow_signal_client.py
+++ b/backend/tests/unit/agent_orchestrator/utils/test_workflow_signal_client.py
@@ -1,8 +1,6 @@
 """Unit tests for WorkflowSignalClient."""
 
-from collections.abc import Generator
 from datetime import UTC, datetime
-from unittest.mock import patch
 from uuid import UUID
 
 import httpx
@@ -16,23 +14,8 @@ _EXEC_UUID = "12345678-1234-5678-1234-567812345678"
 _SIGNAL_URL = f"{_BASE_URL}/executions/{_EXEC_UUID}/activities/step_1/signal"
 
 
-@pytest.fixture(autouse=True)
-def _patch_api_base_url() -> Generator[None]:
-    with (
-        patch(
-            "syntara.agent_orchestrator.utils.workflow_signal_client.get_api_base_url",
-            return_value=_BASE_URL,
-        ),
-        patch(
-            "syntara.workflows.utils.url.get_api_base_url",
-            return_value=_BASE_URL,
-        ),
-    ):
-        yield
-
-
 class TestValidateSignalUrl:
-    """Tests for validate_signal_url SSRF prevention."""
+    """Tests for validate_signal_url path structure validation."""
 
     def test_valid_signal_url_accepted(self) -> None:
         validate_signal_url(_SIGNAL_URL)
@@ -41,14 +24,17 @@ class TestValidateSignalUrl:
         url = f"{_BASE_URL}/executions/{_EXEC_UUID}/activities/my-step.v2/signal"
         validate_signal_url(url)
 
-    def test_rejects_different_host(self) -> None:
-        url = f"https://evil.com/api/v1/executions/{_EXEC_UUID}/activities/step_1/signal"
-        with pytest.raises(ValueError, match="host/scheme"):
-            validate_signal_url(url)
+    def test_valid_url_with_different_host(self) -> None:
+        url = f"https://other-host:8000/api/v1/executions/{_EXEC_UUID}/activities/step_1/signal"
+        validate_signal_url(url)
 
-    def test_rejects_different_scheme(self) -> None:
+    def test_valid_url_with_http_scheme(self) -> None:
         url = f"http://nexus:8000/api/v1/executions/{_EXEC_UUID}/activities/step_1/signal"
-        with pytest.raises(ValueError, match="host/scheme"):
+        validate_signal_url(url)
+
+    def test_rejects_invalid_scheme(self) -> None:
+        url = f"ftp://nexus:8000/api/v1/executions/{_EXEC_UUID}/activities/step_1/signal"
+        with pytest.raises(ValueError, match="http or https"):
             validate_signal_url(url)
 
     def test_rejects_arbitrary_path(self) -> None:
@@ -56,29 +42,19 @@ class TestValidateSignalUrl:
         with pytest.raises(ValueError, match="not a valid signal endpoint"):
             validate_signal_url(url)
 
-    def test_rejects_path_outside_api_base(self) -> None:
-        url = f"https://nexus:8000/other/executions/{_EXEC_UUID}/activities/step_1/signal"
-        with pytest.raises(ValueError, match="outside the API base"):
-            validate_signal_url(url)
-
     def test_rejects_invalid_execution_id(self) -> None:
         url = f"{_BASE_URL}/executions/not-a-uuid/activities/step_1/signal"
         with pytest.raises(ValueError, match="not a valid signal endpoint"):
             validate_signal_url(url)
 
-    def test_rejects_loopback_ssrf(self) -> None:
+    def test_rejects_loopback_ssrf_without_signal_path(self) -> None:
         url = "https://127.0.0.1:9911/some/path"
-        with pytest.raises(ValueError, match="host/scheme"):
-            validate_signal_url(url)
-
-    def test_rejects_url_with_userinfo_at_sign(self) -> None:
-        url = f"https://evil.com@nexus:8000/api/v1/executions/{_EXEC_UUID}/activities/step_1/signal"
-        with pytest.raises(ValueError, match="host/scheme"):
+        with pytest.raises(ValueError, match="not a valid signal endpoint"):
             validate_signal_url(url)
 
     def test_rejects_extra_path_segments(self) -> None:
         url = f"{_BASE_URL}/executions/{_EXEC_UUID}/activities/step_1/signal/extra"
-        with pytest.raises(ValueError, match="does not match expected"):
+        with pytest.raises(ValueError, match="not a valid signal endpoint"):
             validate_signal_url(url)
 
     def test_rejects_publish_endpoint_ssrf(self) -> None:
@@ -230,7 +206,7 @@ class TestWorkflowSignalClientSendSuccessSignal:
         invocation_id = UUID(_EXEC_UUID)
         result = {"content": "Test"}
 
-        with pytest.raises(ValueError, match="host/scheme"):
+        with pytest.raises(ValueError, match="not a valid signal endpoint"):
             await WorkflowSignalClient.send_success_signal("https://evil.com/steal", invocation_id, result)
 
 
@@ -348,5 +324,5 @@ class TestWorkflowSignalClientSendFailureSignal:
         invocation_id = UUID(_EXEC_UUID)
         error = RuntimeError("some error")
 
-        with pytest.raises(ValueError, match="host/scheme"):
+        with pytest.raises(ValueError, match="not a valid signal endpoint"):
             await WorkflowSignalClient.send_failure_signal("https://evil.com/steal", invocation_id, error)

--- a/backend/tests/unit/invocations/test_context_data_sanitization.py
+++ b/backend/tests/unit/invocations/test_context_data_sanitization.py
@@ -1,0 +1,127 @@
+"""Tests for callback_url stripping from externally-supplied context_data.
+
+Verifies that the SSRF mitigation in the invocations router strips
+internal-only fields (callback_url) from context_data when the request
+does not come from a cert-authenticated internal service.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from syntara.invocations.router import _sanitize_context_data, create_invocation
+
+
+def _make_request(*, is_cert_authenticated: bool) -> MagicMock:
+    request = MagicMock()
+    request.state.is_cert_authenticated = is_cert_authenticated
+    return request
+
+
+class TestSanitizeContextData:
+    """Tests for _sanitize_context_data."""
+
+    def test_strips_callback_url_from_external_request(self) -> None:
+        context_data: dict[str, object] = {
+            "callback_url": "https://evil.com/steal",
+            "agent": "my-agent",
+            "model": "gpt-4",
+        }
+        request = _make_request(is_cert_authenticated=False)
+
+        result = _sanitize_context_data(context_data, request)
+
+        assert "callback_url" not in result
+        assert result["agent"] == "my-agent"
+        assert result["model"] == "gpt-4"
+
+    def test_preserves_callback_url_for_cert_authenticated_request(self) -> None:
+        context_data: dict[str, object] = {
+            "callback_url": "https://nexus:8000/api/v1/executions/abc/activities/step/signal",
+            "agent": "my-agent",
+        }
+        request = _make_request(is_cert_authenticated=True)
+
+        result = _sanitize_context_data(context_data, request)
+
+        assert result["callback_url"] == context_data["callback_url"]
+        assert result["agent"] == "my-agent"
+
+    def test_no_op_when_no_internal_fields_present(self) -> None:
+        context_data: dict[str, object] = {"agent": "my-agent", "model": "gpt-4"}
+        request = _make_request(is_cert_authenticated=False)
+
+        result = _sanitize_context_data(context_data, request)
+
+        assert result == context_data
+
+    def test_handles_missing_is_cert_authenticated(self) -> None:
+        """Fail closed: if is_cert_authenticated is not set, treat as external."""
+        context_data: dict[str, object] = {"callback_url": "https://evil.com"}
+        request = MagicMock(spec=[])
+        request.state = MagicMock(spec=[])
+
+        result = _sanitize_context_data(context_data, request)
+
+        assert "callback_url" not in result
+
+    def test_does_not_mutate_original_dict(self) -> None:
+        context_data: dict[str, object] = {"callback_url": "https://evil.com", "agent": "x"}
+        request = _make_request(is_cert_authenticated=False)
+
+        _sanitize_context_data(context_data, request)
+
+        assert "callback_url" in context_data
+
+
+class TestCreateInvocationSanitization:
+    """Verify create_invocation strips callback_url for external callers."""
+
+    async def test_callback_url_stripped_before_service_call(self) -> None:
+        mock_service = AsyncMock()
+        mock_service.create_invocation.return_value = MagicMock()
+
+        mock_request = _make_request(is_cert_authenticated=False)
+
+        mock_body = MagicMock()
+        mock_body.prompt = "test"
+        mock_body.session_id = "sess"
+        mock_body.project_id = "00000000-0000-0000-0000-000000000000"
+        mock_body.context_data = {
+            "callback_url": "https://evil.com/publish",
+            "agent": "my-agent",
+        }
+
+        await create_invocation(
+            request=mock_request,
+            request_body=mock_body,
+            service=mock_service,
+        )
+
+        call_kwargs = mock_service.create_invocation.call_args
+        passed_context = call_kwargs.kwargs.get("context_data") or call_kwargs[1].get("context_data")
+        assert "callback_url" not in passed_context
+        assert passed_context["agent"] == "my-agent"
+
+    async def test_callback_url_preserved_for_cert_authenticated(self) -> None:
+        mock_service = AsyncMock()
+        mock_service.create_invocation.return_value = MagicMock()
+
+        mock_request = _make_request(is_cert_authenticated=True)
+
+        mock_body = MagicMock()
+        mock_body.prompt = "test"
+        mock_body.session_id = "sess"
+        mock_body.project_id = "00000000-0000-0000-0000-000000000000"
+        mock_body.context_data = {
+            "callback_url": "https://nexus:8000/api/v1/executions/abc/activities/step/signal",
+            "agent": "my-agent",
+        }
+
+        await create_invocation(
+            request=mock_request,
+            request_body=mock_body,
+            service=mock_service,
+        )
+
+        call_kwargs = mock_service.create_invocation.call_args
+        passed_context = call_kwargs.kwargs.get("context_data") or call_kwargs[1].get("context_data")
+        assert passed_context["callback_url"] == mock_body.context_data["callback_url"]


### PR DESCRIPTION
## Description

An attacker with invocation:create could inject an arbitrary callback_url into context_data.  When the invocation completed or failed, the worker POSTed to that URL using the platform mTLS certificate, bypassing PermissionChecker on the receiving end.

Two layered mitigations:

1. Strip callback_url from externally-supplied context_data at the router level (internal cert-authenticated callers are unaffected).

2. Validate the destination URL in the WorkflowSignalClient against the configured API base and the /executions/{id}/activities/{id}/signal path pattern before presenting the mTLS identity.  Validation round-trips through generate_activity_signal_url so the check stays in sync with the canonical URL shape automatically.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

| File | Change |
|---|---|
| `backend/src/nexus/invocations/router.py` | Added `_sanitize_context_data()` — strips internal-only keys from external requests |
| `backend/src/nexus/agent_orchestrator/utils/workflow_signal_client.py` | Added `validate_signal_url()` — allowlist check on scheme, host, base path, and signal path structure |
| `backend/tests/unit/invocations/test_context_data_sanitization.py` | 7 tests: sanitization unit tests + router integration tests |
| `backend/tests/unit/agent_orchestrator/utils/test_workflow_signal_client.py` | 13 new tests (11 URL validation, 2 signal-level rejection); updated existing tests to use valid signal URLs |

## Out of Scope

<!-- What this PR intentionally does NOT include, to set reviewer expectations -->

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## How to Test

<!-- Manual testing directions, for example:
1. Log in as an admin
2. Go to the `/workflows` route
3. Click on a thing
4. Validate that something changed
-->

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [ ] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [ ] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->
