### PR TITLE
feat(access): add Select All to role policy pickers

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPolicySelect.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPolicySelect.test.tsx
@@ -318,7 +318,7 @@ describe('ProjectPolicySelect', () => {
 
       await openDropdown(user)
 
-      expect(screen.getByRole('option', { name: 'Select All' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Select all' })).toBeInTheDocument()
     })
 
     it('fetches all project policies when Select All is clicked', async () => {
@@ -326,7 +326,7 @@ describe('ProjectPolicySelect', () => {
       renderSelect()
 
       await openDropdown(user)
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
       await waitFor(() => {
         expect(fetchAllProjectPoliciesForSelect).toHaveBeenCalledWith('proj-1', undefined)
@@ -346,7 +346,7 @@ describe('ProjectPolicySelect', () => {
       renderSelect()
 
       await openDropdown(user)
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith(['read-policy', 'write-policy', 'admin-policy', 'extra-policy'])
@@ -358,7 +358,7 @@ describe('ProjectPolicySelect', () => {
       renderSelect(['read-policy'])
 
       await openDropdown(user)
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith(['read-policy', 'write-policy', 'admin-policy'])
@@ -373,7 +373,7 @@ describe('ProjectPolicySelect', () => {
       await openDropdown(user)
       const input = screen.getByRole('textbox', { name: /type to filter/i })
       await user.type(input, 'read')
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
       await waitFor(() => {
         expect(fetchAllProjectPoliciesForSelect).toHaveBeenCalledWith('proj-1', 'read')
@@ -390,7 +390,7 @@ describe('ProjectPolicySelect', () => {
 
       await openDropdown(user)
 
-      expect(screen.queryByRole('option', { name: 'Select All' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('option', { name: 'Select all' })).not.toBeInTheDocument()
     })
 
     it('disables Select All while policies are being fetched', async () => {
@@ -405,9 +405,9 @@ describe('ProjectPolicySelect', () => {
       renderSelect()
 
       await openDropdown(user)
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
-      expect(screen.getByRole('option', { name: 'Select All' })).toBeDisabled()
+      expect(screen.getByRole('option', { name: /Selecting all/i })).toBeDisabled()
     })
 
     it('shows an error alert when Select All fetch fails', async () => {
@@ -417,7 +417,7 @@ describe('ProjectPolicySelect', () => {
       renderSelect()
 
       await openDropdown(user)
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
       await waitFor(() => {
         expect(mockShowError).toHaveBeenCalledWith(SELECT_ALL_LOAD_ERROR)

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPolicySelect.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPolicySelect.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,6 +7,8 @@ import { axe } from 'vitest-axe'
 
 import { AlertProvider } from '../../../providers/alerts'
 import { accessClient } from '../../access/accessClient'
+import { fetchAllProjectPoliciesForSelect } from '../../access/fetchAllPoliciesForSelect'
+import { SELECT_ALL_LOAD_ERROR } from '../../access/policySelectConstants'
 
 import { ProjectPolicySelect } from './ProjectPolicySelect'
 
@@ -17,10 +19,32 @@ vi.mock('../../access/accessClient', () => ({
   },
 }))
 
+vi.mock('../../access/fetchAllPoliciesForSelect', () => ({
+  fetchAllProjectPoliciesForSelect: vi.fn(),
+}))
+
 vi.mock('../../../client', () => ({
   authMiddleware: { onRequest: vi.fn() },
   interfaceTagMiddleware: { onRequest: vi.fn() },
 }))
+
+const mockShowError = vi.fn()
+
+vi.mock('../../../providers/alerts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../providers/alerts')>()
+  return {
+    ...actual,
+    useAlerts: () => ({
+      showAlert: vi.fn(),
+      showSuccess: vi.fn(),
+      showError: mockShowError,
+      showWarning: vi.fn(),
+      showInfo: vi.fn(),
+      dismissAlert: vi.fn(),
+      clearAllAlerts: vi.fn(),
+    }),
+  }
+})
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
@@ -59,6 +83,7 @@ describe('ProjectPolicySelect', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     setupMocks()
+    vi.mocked(fetchAllProjectPoliciesForSelect).mockResolvedValue(mockPolicies as never)
   })
 
   function renderSelect(selected: string[] = [], hasError = false) {
@@ -284,5 +309,119 @@ describe('ProjectPolicySelect', () => {
 
     const unselectedCheckbox = screen.getByRole('checkbox', { name: /write-policy/i })
     expect(unselectedCheckbox).not.toBeChecked()
+  })
+
+  describe('Select all', () => {
+    it('shows Select All option when policies are available', async () => {
+      const user = userEvent.setup()
+      renderSelect()
+
+      await openDropdown(user)
+
+      expect(screen.getByRole('option', { name: 'Select All' })).toBeInTheDocument()
+    })
+
+    it('fetches all project policies when Select All is clicked', async () => {
+      const user = userEvent.setup()
+      renderSelect()
+
+      await openDropdown(user)
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      await waitFor(() => {
+        expect(fetchAllProjectPoliciesForSelect).toHaveBeenCalledWith('proj-1', undefined)
+      })
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(['read-policy', 'write-policy', 'admin-policy'])
+      })
+    })
+
+    it('includes policies beyond the first page when Select All is clicked', async () => {
+      vi.mocked(fetchAllProjectPoliciesForSelect).mockResolvedValue([
+        ...mockPolicies,
+        { id: 'p4', name: 'extra-policy', description: 'Extra access' },
+      ] as never)
+
+      const user = userEvent.setup()
+      renderSelect()
+
+      await openDropdown(user)
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(['read-policy', 'write-policy', 'admin-policy', 'extra-policy'])
+      })
+    })
+
+    it('merges with existing selection when Select All is clicked', async () => {
+      const user = userEvent.setup()
+      renderSelect(['read-policy'])
+
+      await openDropdown(user)
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(['read-policy', 'write-policy', 'admin-policy'])
+      })
+    })
+
+    it('fetches and filters policies when a filter is active', async () => {
+      vi.mocked(fetchAllProjectPoliciesForSelect).mockResolvedValue([mockPolicies[0]] as never)
+      const user = userEvent.setup()
+      renderSelect()
+
+      await openDropdown(user)
+      const input = screen.getByRole('textbox', { name: /type to filter/i })
+      await user.type(input, 'read')
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      await waitFor(() => {
+        expect(fetchAllProjectPoliciesForSelect).toHaveBeenCalledWith('proj-1', 'read')
+      })
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(['read-policy'])
+      })
+    })
+
+    it('does not show Select All when no policies are available', async () => {
+      setupMocks({ policies: [] })
+      const user = userEvent.setup()
+      renderSelect()
+
+      await openDropdown(user)
+
+      expect(screen.queryByRole('option', { name: 'Select All' })).not.toBeInTheDocument()
+    })
+
+    it('disables Select All while policies are being fetched', async () => {
+      vi.mocked(fetchAllProjectPoliciesForSelect).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve(mockPolicies as never), 100)
+          })
+      )
+
+      const user = userEvent.setup()
+      renderSelect()
+
+      await openDropdown(user)
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      expect(screen.getByRole('option', { name: 'Select All' })).toBeDisabled()
+    })
+
+    it('shows an error alert when Select All fetch fails', async () => {
+      vi.mocked(fetchAllProjectPoliciesForSelect).mockRejectedValue(new Error('network'))
+
+      const user = userEvent.setup()
+      renderSelect()
+
+      await openDropdown(user)
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      await waitFor(() => {
+        expect(mockShowError).toHaveBeenCalledWith(SELECT_ALL_LOAD_ERROR)
+      })
+    })
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPolicySelect.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPolicySelect.tsx
@@ -1,15 +1,9 @@
-import { type Ref, useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 
-import { LONG_SELECT_MAX_MENU_HEIGHT, longSelectMenuPopperProps } from '../../../components/longSelectMenu'
-import longSelectMenuStyles from '../../../components/longSelectMenu.module.css'
-import { NxSelect } from '../../../components/NxSelect'
-import { useAlerts } from '../../../providers/alerts'
 import { accessClient } from '../../access/accessClient'
 import { fetchAllProjectPoliciesForSelect } from '../../access/fetchAllPoliciesForSelect'
-import { SELECT_ALL_VALUE } from '../../access/policySelectConstants'
-import { PolicySelectOptionsList } from '../../access/PolicySelectOptionsList'
-import { PolicySelectToggle } from '../../access/PolicySelectToggle'
-import { usePolicySelectAll } from '../../access/usePolicySelectAll'
+import { PolicySelectField } from '../../access/PolicySelectDropdown'
+import { buildPolicyOptionList, filterPolicyOptionsByTerm, usePolicySelectField } from '../../access/policySelectShared'
 
 type ProjectPolicySelectProps = {
   projectId: string
@@ -21,10 +15,22 @@ type ProjectPolicySelectProps = {
 const PAGE_SIZE = 50
 
 export function ProjectPolicySelect({ projectId, selected, onChange, hasError }: Readonly<ProjectPolicySelectProps>) {
-  const [isOpen, setIsOpen] = useState(false)
-  const [filterValue, setFilterValue] = useState('')
-  const inputRef = useRef<HTMLInputElement>(null)
-  const { showError } = useAlerts()
+  const filterValueRef = useRef('')
+
+  const fetchAllMatchingPolicies = useCallback(
+    () => fetchAllProjectPoliciesForSelect(projectId, filterValueRef.current || undefined),
+    [projectId]
+  )
+
+  const field = usePolicySelectField({
+    selected,
+    onChange,
+    fetchPolicies: fetchAllMatchingPolicies,
+  })
+
+  useEffect(() => {
+    filterValueRef.current = field.filterValue
+  }, [field.filterValue])
 
   const policiesQuery = accessClient.useQuery(
     'get',
@@ -35,126 +41,43 @@ export function ProjectPolicySelect({ projectId, selected, onChange, hasError }:
         query: { sort: 'name', limit: PAGE_SIZE },
       },
     },
-    { enabled: isOpen }
+    { enabled: field.isOpen }
   )
 
-  const policyOptions = useMemo(() => {
-    const fetched = policiesQuery.data?.resources ?? []
-    const fetchedNames = new Set(fetched.map((p) => p.name))
-    const selectedOnly = selected.filter((name) => !fetchedNames.has(name))
-    return [
-      ...fetched.map((p) => ({ name: p.name, description: p.description ?? null })),
-      ...selectedOnly.map((name) => ({ name, description: null })),
-    ]
-  }, [policiesQuery.data?.resources, selected])
-
-  const filteredOptions = useMemo(() => {
-    if (filterValue) {
-      const term = filterValue.toLowerCase()
-      return policyOptions.filter((p) => p.name.toLowerCase().includes(term))
-    }
-    return policyOptions
-  }, [policyOptions, filterValue])
-
-  const fetchAllMatchingPolicies = useCallback(
-    () => fetchAllProjectPoliciesForSelect(projectId, filterValue || undefined),
-    [projectId, filterValue]
+  const policyOptions = useMemo(
+    () => buildPolicyOptionList(policiesQuery.data?.resources ?? [], selected),
+    [policiesQuery.data?.resources, selected]
   )
 
-  const { isSelectingAll, runSelectAll } = usePolicySelectAll({
-    selected,
-    onChange,
-    fetchPolicies: fetchAllMatchingPolicies,
-    showError,
-    onAfterSelect: () => {
-      setFilterValue('')
-      inputRef.current?.focus()
-    },
-  })
-
-  const onSelect = useCallback(
-    (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
-      if (value === SELECT_ALL_VALUE) {
-        runSelectAll()
-        return
-      }
-
-      const policyName = value as string
-      if (selected.includes(policyName)) {
-        onChange(selected.filter((p) => p !== policyName))
-      } else {
-        onChange([...selected, policyName])
-      }
-      setFilterValue('')
-      inputRef.current?.focus()
-    },
-    [selected, onChange, runSelectAll]
+  const filteredOptions = useMemo(
+    () => filterPolicyOptionsByTerm(policyOptions, field.filterValue),
+    [policyOptions, field.filterValue]
   )
-
-  const removePolicy = useCallback(
-    (policyName: string) => {
-      onChange(selected.filter((p) => p !== policyName))
-    },
-    [selected, onChange]
-  )
-
-  const clearAll = useCallback(() => {
-    onChange([])
-    setFilterValue('')
-  }, [onChange])
 
   const isLoading = policiesQuery.isLoading || policiesQuery.isFetching
 
-  const handleOpenChange = useCallback((open: boolean) => {
-    setIsOpen(open)
-    if (!open) setFilterValue('')
-  }, [])
-
-  const openDropdown = useCallback(() => {
-    if (!isOpen) setIsOpen(true)
-  }, [isOpen])
-
-  const toggle = (toggleRef: Ref<HTMLButtonElement>) => (
-    <PolicySelectToggle
-      toggleRef={toggleRef}
-      isOpen={isOpen}
-      onToggle={() => setIsOpen(!isOpen)}
-      filterValue={filterValue}
-      onFilterChange={(val) => {
-        setFilterValue(val)
-        openDropdown()
-      }}
-      onFilterFocus={openDropdown}
-      selected={selected}
-      onRemovePolicy={removePolicy}
-      onClearAll={clearAll}
-      inputRef={inputRef}
-      hasError={hasError}
-      toggleTestId="policy-select-toggle"
-    />
-  )
-
   return (
-    <NxSelect
+    <PolicySelectField
       id="project-role-policies"
-      aria-label="Policies"
-      isOpen={isOpen}
-      onOpenChange={handleOpenChange}
-      onSelect={onSelect}
       selected={selected}
-      toggle={toggle}
-      isScrollable
-      maxMenuHeight={LONG_SELECT_MAX_MENU_HEIGHT}
-      popperProps={longSelectMenuPopperProps}
-      className={longSelectMenuStyles.containScroll}
-    >
-      <PolicySelectOptionsList
-        isLoading={isLoading}
-        filterValue={filterValue}
-        filteredOptions={filteredOptions}
-        selected={selected}
-        isSelectingAll={isSelectingAll}
-      />
-    </NxSelect>
+      filteredOptions={filteredOptions}
+      filterValue={field.filterValue}
+      isOpen={field.isOpen}
+      isLoading={isLoading}
+      isSelectingAll={field.isSelectingAll}
+      hasError={hasError}
+      inputRef={field.inputRef}
+      toggleTestId="policy-select-toggle"
+      onOpenChange={field.handleOpenChange}
+      onSelect={field.onSelect}
+      onFilterChange={(value: string) => {
+        field.setFilterValue(value)
+        field.openDropdown()
+      }}
+      onFilterFocus={field.openDropdown}
+      onRemovePolicy={field.removePolicy}
+      onClearAll={field.clearAll}
+      onToggle={() => field.handleOpenChange(!field.isOpen)}
+    />
   )
 }

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPolicySelect.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPolicySelect.tsx
@@ -1,20 +1,15 @@
-import {
-  Button,
-  Label,
-  LabelGroup,
-  MenuToggle,
-  SelectList,
-  SelectOption,
-  Spinner,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
-} from '@patternfly/react-core'
-import { RhUiCloseIcon } from '@patternfly/react-icons'
 import { type Ref, useCallback, useMemo, useRef, useState } from 'react'
 
+import { LONG_SELECT_MAX_MENU_HEIGHT, longSelectMenuPopperProps } from '../../../components/longSelectMenu'
+import longSelectMenuStyles from '../../../components/longSelectMenu.module.css'
 import { NxSelect } from '../../../components/NxSelect'
+import { useAlerts } from '../../../providers/alerts'
 import { accessClient } from '../../access/accessClient'
+import { fetchAllProjectPoliciesForSelect } from '../../access/fetchAllPoliciesForSelect'
+import { SELECT_ALL_VALUE } from '../../access/policySelectConstants'
+import { PolicySelectOptionsList } from '../../access/PolicySelectOptionsList'
+import { PolicySelectToggle } from '../../access/PolicySelectToggle'
+import { usePolicySelectAll } from '../../access/usePolicySelectAll'
 
 type ProjectPolicySelectProps = {
   projectId: string
@@ -29,6 +24,7 @@ export function ProjectPolicySelect({ projectId, selected, onChange, hasError }:
   const [isOpen, setIsOpen] = useState(false)
   const [filterValue, setFilterValue] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
+  const { showError } = useAlerts()
 
   const policiesQuery = accessClient.useQuery(
     'get',
@@ -42,17 +38,15 @@ export function ProjectPolicySelect({ projectId, selected, onChange, hasError }:
     { enabled: isOpen }
   )
 
-  const policies = policiesQuery.data?.resources
-
   const policyOptions = useMemo(() => {
-    const fetched = policies ?? []
+    const fetched = policiesQuery.data?.resources ?? []
     const fetchedNames = new Set(fetched.map((p) => p.name))
     const selectedOnly = selected.filter((name) => !fetchedNames.has(name))
     return [
-      ...fetched.map((p) => ({ name: p.name, description: p.description })),
+      ...fetched.map((p) => ({ name: p.name, description: p.description ?? null })),
       ...selectedOnly.map((name) => ({ name, description: null })),
     ]
-  }, [policies, selected])
+  }, [policiesQuery.data?.resources, selected])
 
   const filteredOptions = useMemo(() => {
     if (filterValue) {
@@ -62,8 +56,29 @@ export function ProjectPolicySelect({ projectId, selected, onChange, hasError }:
     return policyOptions
   }, [policyOptions, filterValue])
 
+  const fetchAllMatchingPolicies = useCallback(
+    () => fetchAllProjectPoliciesForSelect(projectId, filterValue || undefined),
+    [projectId, filterValue]
+  )
+
+  const { isSelectingAll, runSelectAll } = usePolicySelectAll({
+    selected,
+    onChange,
+    fetchPolicies: fetchAllMatchingPolicies,
+    showError,
+    onAfterSelect: () => {
+      setFilterValue('')
+      inputRef.current?.focus()
+    },
+  })
+
   const onSelect = useCallback(
     (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
+      if (value === SELECT_ALL_VALUE) {
+        runSelectAll()
+        return
+      }
+
       const policyName = value as string
       if (selected.includes(policyName)) {
         onChange(selected.filter((p) => p !== policyName))
@@ -73,7 +88,7 @@ export function ProjectPolicySelect({ projectId, selected, onChange, hasError }:
       setFilterValue('')
       inputRef.current?.focus()
     },
-    [selected, onChange]
+    [selected, onChange, runSelectAll]
   )
 
   const removePolicy = useCallback(
@@ -90,69 +105,34 @@ export function ProjectPolicySelect({ projectId, selected, onChange, hasError }:
 
   const isLoading = policiesQuery.isLoading || policiesQuery.isFetching
 
-  const toggle = (toggleRef: Ref<HTMLButtonElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      data-testid="policy-select-toggle"
-      variant="typeahead"
-      onClick={() => setIsOpen(!isOpen)}
-      isExpanded={isOpen}
-      isFullWidth
-      status={hasError ? 'danger' : undefined}
-    >
-      <TextInputGroup isPlain>
-        <TextInputGroupMain
-          value={filterValue}
-          onChange={(_e, val) => {
-            setFilterValue(val)
-            if (!isOpen) setIsOpen(true)
-          }}
-          onClick={() => {
-            if (!isOpen) setIsOpen(true)
-          }}
-          placeholder={selected.length === 0 ? 'Select policies...' : ''}
-          autoComplete="off"
-          innerRef={inputRef}
-        >
-          {selected.length > 0 && (
-            <LabelGroup>
-              {selected.map((name) => (
-                <Label
-                  key={name}
-                  color="blue"
-                  onClose={(e) => {
-                    e.stopPropagation()
-                    removePolicy(name)
-                  }}
-                >
-                  {name}
-                </Label>
-              ))}
-            </LabelGroup>
-          )}
-        </TextInputGroupMain>
-        {selected.length > 0 && (
-          <TextInputGroupUtilities>
-            <Button
-              variant="plain"
-              onClick={(e) => {
-                e.stopPropagation()
-                clearAll()
-              }}
-              aria-label="Clear all selected policies"
-            >
-              <RhUiCloseIcon />
-            </Button>
-          </TextInputGroupUtilities>
-        )}
-      </TextInputGroup>
-    </MenuToggle>
-  )
-
   const handleOpenChange = useCallback((open: boolean) => {
     setIsOpen(open)
     if (!open) setFilterValue('')
   }, [])
+
+  const openDropdown = useCallback(() => {
+    if (!isOpen) setIsOpen(true)
+  }, [isOpen])
+
+  const toggle = (toggleRef: Ref<HTMLButtonElement>) => (
+    <PolicySelectToggle
+      toggleRef={toggleRef}
+      isOpen={isOpen}
+      onToggle={() => setIsOpen(!isOpen)}
+      filterValue={filterValue}
+      onFilterChange={(val) => {
+        setFilterValue(val)
+        openDropdown()
+      }}
+      onFilterFocus={openDropdown}
+      selected={selected}
+      onRemovePolicy={removePolicy}
+      onClearAll={clearAll}
+      inputRef={inputRef}
+      hasError={hasError}
+      toggleTestId="policy-select-toggle"
+    />
+  )
 
   return (
     <NxSelect
@@ -163,31 +143,18 @@ export function ProjectPolicySelect({ projectId, selected, onChange, hasError }:
       onSelect={onSelect}
       selected={selected}
       toggle={toggle}
+      isScrollable
+      maxMenuHeight={LONG_SELECT_MAX_MENU_HEIGHT}
+      popperProps={longSelectMenuPopperProps}
+      className={longSelectMenuStyles.containScroll}
     >
-      <SelectList style={{ maxHeight: '200px', overflow: 'auto' }}>
-        {isLoading && (
-          <SelectOption isDisabled>
-            <Spinner size="sm" /> Loading policies...
-          </SelectOption>
-        )}
-        {!isLoading && filteredOptions.length === 0 && (
-          <SelectOption isDisabled>
-            {filterValue ? `No policies match "${filterValue}"` : 'No policies available'}
-          </SelectOption>
-        )}
-        {!isLoading &&
-          filteredOptions.map((policy) => (
-            <SelectOption
-              key={policy.name}
-              value={policy.name}
-              hasCheckbox
-              isSelected={selected.includes(policy.name)}
-              description={policy.description ?? undefined}
-            >
-              {policy.name}
-            </SelectOption>
-          ))}
-      </SelectList>
+      <PolicySelectOptionsList
+        isLoading={isLoading}
+        filterValue={filterValue}
+        filteredOptions={filteredOptions}
+        selected={selected}
+        isSelectingAll={isSelectingAll}
+      />
     </NxSelect>
   )
 }

--- a/frontend/packages/syntara-ui/src/routes/access/AddRoleDialog.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/AddRoleDialog.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor, act, within } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
@@ -11,6 +11,43 @@ import { accessClient } from './accessClient'
 import { POLICIES_HELP, SCOPE_HELP } from './accessControlFieldHelpText'
 import { AddRoleDialog } from './AddRoleDialog'
 import { useSelectableProjects } from './useAllProjects'
+
+const { mockPolicySelect } = vi.hoisted(() => ({
+  mockPolicySelect: vi.fn(
+    ({
+      selected,
+      onChange,
+      scopeProjectId,
+      projectEligible,
+      isDisabled,
+    }: {
+      selected: string[]
+      onChange: (policies: string[]) => void
+      scopeProjectId?: string | null
+      projectEligible?: boolean
+      isDisabled?: boolean
+    }) => (
+      <div
+        data-testid="policy-select"
+        data-scope-project-id={scopeProjectId ?? ''}
+        data-project-eligible={String(projectEligible ?? false)}
+        data-disabled={String(isDisabled ?? false)}
+      >
+        <input
+          placeholder="Select policies..."
+          readOnly
+          disabled={isDisabled}
+          value={selected.join(', ')}
+          onClick={() => onChange(['workflow-admin'])}
+        />
+      </div>
+    )
+  ),
+}))
+
+vi.mock('./PolicySelect', () => ({
+  PolicySelect: mockPolicySelect,
+}))
 
 vi.mock('../../client', () => ({
   authMiddleware: { onRequest: vi.fn() },
@@ -130,6 +167,10 @@ describe('AddRoleDialog', () => {
     return render(<AddRoleDialog onClose={mockOnClose} onSuccess={mockOnSuccess} {...props} />, { wrapper })
   }
 
+  function selectPolicy(user: ReturnType<typeof userEvent.setup>) {
+    return user.click(screen.getByPlaceholderText('Select policies...'))
+  }
+
   describe('Accessibility', () => {
     it('has no accessibility violations', async () => {
       const { container } = renderDialog()
@@ -239,11 +280,8 @@ describe('AddRoleDialog', () => {
       // Fill in description
       await user.type(screen.getByRole('textbox', { name: /role description/i }), 'A test role')
 
-      // Select a policy by opening the dropdown and clicking
-      const policyInput = screen.getByPlaceholderText('Select policies...')
-      await user.click(policyInput)
-      const menuitem1 = screen.getByRole('menuitem', { name: /workflow-admin/i })
-      await user.click(within(menuitem1).getByText('workflow-admin'))
+      // Select a policy
+      await selectPolicy(user)
 
       // Submit the form
       await user.click(screen.getByRole('button', { name: 'Create role' }))
@@ -269,10 +307,7 @@ describe('AddRoleDialog', () => {
       await user.type(screen.getByRole('textbox', { name: /role name/i }), 'my-role')
 
       // Select a policy
-      const policyInput = screen.getByPlaceholderText('Select policies...')
-      await user.click(policyInput)
-      const menuitem2 = screen.getByRole('menuitem', { name: /workflow-admin/i })
-      await user.click(within(menuitem2).getByText('workflow-admin'))
+      await selectPolicy(user)
 
       await user.click(screen.getByRole('button', { name: 'Create role' }))
 
@@ -296,10 +331,7 @@ describe('AddRoleDialog', () => {
 
       await user.type(screen.getByRole('textbox', { name: /role name/i }), 'my-role')
 
-      const policyInput = screen.getByPlaceholderText('Select policies...')
-      await user.click(policyInput)
-      const menuitem3 = screen.getByRole('menuitem', { name: /workflow-admin/i })
-      await user.click(within(menuitem3).getByText('workflow-admin'))
+      await selectPolicy(user)
 
       await user.click(screen.getByRole('button', { name: 'Create role' }))
 
@@ -324,10 +356,7 @@ describe('AddRoleDialog', () => {
 
       await user.type(screen.getByRole('textbox', { name: /role name/i }), 'my-role')
 
-      const policyInput = screen.getByPlaceholderText('Select policies...')
-      await user.click(policyInput)
-      const menuitem4 = screen.getByRole('menuitem', { name: /workflow-admin/i })
-      await user.click(within(menuitem4).getByText('workflow-admin'))
+      await selectPolicy(user)
 
       await user.click(screen.getByRole('button', { name: 'Create role' }))
 
@@ -345,10 +374,7 @@ describe('AddRoleDialog', () => {
 
       await user.type(screen.getByRole('textbox', { name: /role name/i }), 'proj-role')
 
-      const policyInput = screen.getByPlaceholderText('Select policies...')
-      await user.click(policyInput)
-      const menuitem = screen.getByRole('menuitem', { name: /workflow-admin/i })
-      await user.click(within(menuitem).getByText('workflow-admin'))
+      await selectPolicy(user)
 
       await user.click(screen.getByRole('button', { name: 'Create role' }))
 
@@ -369,6 +395,50 @@ describe('AddRoleDialog', () => {
         description: undefined,
         policies: ['workflow-admin'],
       })
+    })
+  })
+
+  describe('PolicySelect scope', () => {
+    it('passes null scopeProjectId for system scope by default', () => {
+      renderDialog()
+
+      expect(mockPolicySelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scopeProjectId: null,
+          projectEligible: false,
+        }),
+        undefined
+      )
+    })
+
+    it('passes project scopeProjectId when defaultScope is project', () => {
+      renderDialog({ defaultScope: 'project', defaultProjectId: 'proj-1' })
+
+      expect(mockPolicySelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scopeProjectId: 'proj-1',
+          projectEligible: true,
+          isDisabled: false,
+        }),
+        undefined
+      )
+    })
+
+    it('disables PolicySelect until a project is chosen in project scope', async () => {
+      const user = userEvent.setup()
+      renderDialog()
+
+      await user.click(screen.getByRole('button', { name: 'Role scope' }))
+      await user.click(screen.getByRole('option', { name: 'Project' }))
+
+      expect(mockPolicySelect).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          scopeProjectId: null,
+          projectEligible: true,
+          isDisabled: true,
+        }),
+        undefined
+      )
     })
   })
 

--- a/frontend/packages/syntara-ui/src/routes/access/AddRoleDialog.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/AddRoleDialog.tsx
@@ -180,6 +180,7 @@ function AddRoleFormFields({
               selected={field.value}
               onChange={field.onChange}
               hasError={!!errors.policies}
+              scopeProjectId={scope === 'project' ? projectId || null : null}
               projectEligible={scope === 'project'}
               isDisabled={scope === 'project' && !projectId}
             />

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelect.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelect.test.tsx
@@ -5,8 +5,12 @@ import type { ReactNode } from 'react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { axe } from 'vitest-axe'
 
+import { AlertProvider } from '../../providers/alerts'
+
 import { accessClient } from './accessClient'
+import { fetchAllPoliciesForSelect } from './fetchAllPoliciesForSelect'
 import { PolicySelect } from './PolicySelect'
+import { SELECT_ALL_LOAD_ERROR } from './policySelectConstants'
 
 vi.mock('../../client', () => ({
   authMiddleware: { onRequest: vi.fn() },
@@ -23,18 +27,42 @@ vi.mock('./accessClient', () => ({
   },
 }))
 
+vi.mock('./fetchAllPoliciesForSelect', () => ({
+  fetchAllPoliciesForSelect: vi.fn(),
+}))
+
+const mockShowError = vi.fn()
+
+vi.mock('../../providers/alerts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../providers/alerts')>()
+  return {
+    ...actual,
+    useAlerts: () => ({
+      showAlert: vi.fn(),
+      showSuccess: vi.fn(),
+      showError: mockShowError,
+      showWarning: vi.fn(),
+      showInfo: vi.fn(),
+      dismissAlert: vi.fn(),
+      clearAllAlerts: vi.fn(),
+    }),
+  }
+})
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper = ({ children }: { children: ReactNode }) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={queryClient}>
+    <AlertProvider>{children}</AlertProvider>
+  </QueryClientProvider>
 )
 
 const mockPolicies = [
-  { id: 'p1', name: 'workflow-admin', description: 'Manage workflows' },
-  { id: 'p2', name: 'project-viewer', description: 'View projects' },
-  { id: 'p3', name: 'execution-runner', description: null },
+  { id: 'p1', name: 'workflow-admin', description: 'Manage workflows', is_project_eligible: false },
+  { id: 'p2', name: 'project-viewer', description: 'View projects', is_project_eligible: false },
+  { id: 'p3', name: 'execution-runner', description: null, is_project_eligible: false },
 ]
 
 function renderPolicySelect(overrides: Partial<React.ComponentProps<typeof PolicySelect>> = {}) {
@@ -54,6 +82,7 @@ function getInput() {
 
 describe('PolicySelect', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     vi.mocked(accessClient.useQuery).mockReturnValue({
       data: { resources: mockPolicies },
       isPending: false,
@@ -63,6 +92,7 @@ describe('PolicySelect', () => {
       isLoading: false,
       refetch: vi.fn(),
     } as never)
+    vi.mocked(fetchAllPoliciesForSelect).mockResolvedValue(mockPolicies as never)
   })
 
   describe('Accessibility', () => {
@@ -221,6 +251,166 @@ describe('PolicySelect', () => {
       await waitFor(() => {
         expect(screen.getByRole('menuitem', { name: /workflow-admin/i })).toBeInTheDocument()
         expect(screen.queryByRole('menuitem', { name: /project-viewer/i })).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Select all', () => {
+    it('shows Select All option when policies are available', async () => {
+      const user = userEvent.setup()
+      renderPolicySelect()
+
+      await user.click(getInput())
+
+      expect(screen.getByRole('option', { name: 'Select All' })).toBeInTheDocument()
+    })
+
+    it('fetches all policies when Select All is clicked', async () => {
+      const user = userEvent.setup()
+      const { onChange } = renderPolicySelect()
+
+      await user.click(getInput())
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      await waitFor(() => {
+        expect(fetchAllPoliciesForSelect).toHaveBeenCalledWith({
+          scopeProjectId: undefined,
+          projectEligible: undefined,
+          nameContains: undefined,
+        })
+      })
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(['workflow-admin', 'project-viewer', 'execution-runner'])
+      })
+    })
+
+    it('includes policies beyond the first page when Select All is clicked', async () => {
+      vi.mocked(fetchAllPoliciesForSelect).mockResolvedValue([
+        ...mockPolicies,
+        { id: 'p4', name: 'extra-policy', description: 'Extra access' },
+      ] as never)
+
+      const user = userEvent.setup()
+      const { onChange } = renderPolicySelect()
+
+      await user.click(getInput())
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith([
+          'workflow-admin',
+          'project-viewer',
+          'execution-runner',
+          'extra-policy',
+        ])
+      })
+    })
+
+    it('merges with existing selection when Select All is clicked', async () => {
+      const user = userEvent.setup()
+      const { onChange } = renderPolicySelect({ selected: ['workflow-admin'] })
+
+      await user.click(getInput())
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(['workflow-admin', 'project-viewer', 'execution-runner'])
+      })
+    })
+
+    it('fetches only matching policies when a filter is active', async () => {
+      const user = userEvent.setup()
+      const { onChange } = renderPolicySelect()
+      vi.mocked(fetchAllPoliciesForSelect).mockResolvedValue([mockPolicies[0]] as never)
+
+      await user.click(getInput())
+      await user.type(getInput(), 'workflow')
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      await waitFor(() => {
+        expect(fetchAllPoliciesForSelect).toHaveBeenCalledWith({
+          scopeProjectId: undefined,
+          projectEligible: undefined,
+          nameContains: 'workflow',
+        })
+      })
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(['workflow-admin'])
+      })
+    })
+
+    it('does not show Select All when no policies are available', async () => {
+      vi.mocked(accessClient.useQuery).mockReturnValue({
+        data: { resources: [] },
+        isPending: false,
+        isError: false,
+        error: null,
+        isFetching: false,
+        isLoading: false,
+        refetch: vi.fn(),
+      } as never)
+
+      const user = userEvent.setup()
+      renderPolicySelect()
+
+      await user.click(getInput())
+
+      expect(screen.queryByRole('option', { name: 'Select All' })).not.toBeInTheDocument()
+    })
+
+    it('does not show project-only policies in the dropdown for global roles', async () => {
+      vi.mocked(accessClient.useQuery).mockReturnValue({
+        data: {
+          resources: [
+            ...mockPolicies,
+            { id: 'p4', name: 'policy:update:project', description: 'Project policy', is_project_eligible: true },
+          ],
+        },
+        isPending: false,
+        isError: false,
+        error: null,
+        isFetching: false,
+        isLoading: false,
+        refetch: vi.fn(),
+      } as never)
+
+      const user = userEvent.setup()
+      renderPolicySelect()
+
+      await user.click(getInput())
+
+      expect(screen.getByRole('menuitem', { name: /workflow-admin/i })).toBeInTheDocument()
+      expect(screen.queryByRole('menuitem', { name: /policy:update:project/i })).not.toBeInTheDocument()
+    })
+
+    it('disables Select All while policies are being fetched', async () => {
+      vi.mocked(fetchAllPoliciesForSelect).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve(mockPolicies as never), 100)
+          })
+      )
+
+      const user = userEvent.setup()
+      renderPolicySelect()
+
+      await user.click(getInput())
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      expect(screen.getByRole('option', { name: 'Select All' })).toBeDisabled()
+    })
+
+    it('shows an error alert when Select All fetch fails', async () => {
+      vi.mocked(fetchAllPoliciesForSelect).mockRejectedValue(new Error('network'))
+
+      const user = userEvent.setup()
+      renderPolicySelect()
+
+      await user.click(getInput())
+      await user.click(screen.getByRole('option', { name: 'Select All' }))
+
+      await waitFor(() => {
+        expect(mockShowError).toHaveBeenCalledWith(SELECT_ALL_LOAD_ERROR)
       })
     })
   })

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelect.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelect.test.tsx
@@ -262,7 +262,7 @@ describe('PolicySelect', () => {
 
       await user.click(getInput())
 
-      expect(screen.getByRole('option', { name: 'Select All' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Select all' })).toBeInTheDocument()
     })
 
     it('fetches all policies when Select All is clicked', async () => {
@@ -270,7 +270,7 @@ describe('PolicySelect', () => {
       const { onChange } = renderPolicySelect()
 
       await user.click(getInput())
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
       await waitFor(() => {
         expect(fetchAllPoliciesForSelect).toHaveBeenCalledWith({
@@ -294,15 +294,10 @@ describe('PolicySelect', () => {
       const { onChange } = renderPolicySelect()
 
       await user.click(getInput())
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
       await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith([
-          'workflow-admin',
-          'project-viewer',
-          'execution-runner',
-          'extra-policy',
-        ])
+        expect(onChange).toHaveBeenCalledWith(['workflow-admin', 'project-viewer', 'execution-runner', 'extra-policy'])
       })
     })
 
@@ -311,7 +306,7 @@ describe('PolicySelect', () => {
       const { onChange } = renderPolicySelect({ selected: ['workflow-admin'] })
 
       await user.click(getInput())
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
       await waitFor(() => {
         expect(onChange).toHaveBeenCalledWith(['workflow-admin', 'project-viewer', 'execution-runner'])
@@ -325,7 +320,7 @@ describe('PolicySelect', () => {
 
       await user.click(getInput())
       await user.type(getInput(), 'workflow')
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
       await waitFor(() => {
         expect(fetchAllPoliciesForSelect).toHaveBeenCalledWith({
@@ -355,7 +350,7 @@ describe('PolicySelect', () => {
 
       await user.click(getInput())
 
-      expect(screen.queryByRole('option', { name: 'Select All' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('option', { name: 'Select all' })).not.toBeInTheDocument()
     })
 
     it('does not show project-only policies in the dropdown for global roles', async () => {
@@ -395,9 +390,9 @@ describe('PolicySelect', () => {
       renderPolicySelect()
 
       await user.click(getInput())
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
-      expect(screen.getByRole('option', { name: 'Select All' })).toBeDisabled()
+      expect(screen.getByRole('option', { name: /Selecting all/i })).toBeDisabled()
     })
 
     it('shows an error alert when Select All fetch fails', async () => {
@@ -407,7 +402,7 @@ describe('PolicySelect', () => {
       renderPolicySelect()
 
       await user.click(getInput())
-      await user.click(screen.getByRole('option', { name: 'Select All' }))
+      await user.click(screen.getByRole('option', { name: 'Select all' }))
 
       await waitFor(() => {
         expect(mockShowError).toHaveBeenCalledWith(SELECT_ALL_LOAD_ERROR)

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelect.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelect.tsx
@@ -1,21 +1,16 @@
-import {
-  Button,
-  Label,
-  LabelGroup,
-  MenuToggle,
-  SelectList,
-  SelectOption,
-  Spinner,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
-} from '@patternfly/react-core'
-import { RhUiCloseIcon } from '@patternfly/react-icons'
 import { type Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { LONG_SELECT_MAX_MENU_HEIGHT, longSelectMenuPopperProps } from '../../components/longSelectMenu'
+import longSelectMenuStyles from '../../components/longSelectMenu.module.css'
 import { NxSelect } from '../../components/NxSelect'
+import { useAlerts } from '../../providers/alerts'
 
 import { accessClient } from './accessClient'
+import { fetchAllPoliciesForSelect } from './fetchAllPoliciesForSelect'
+import { filterPoliciesForRoleSelect, SELECT_ALL_VALUE } from './policySelectConstants'
+import { PolicySelectOptionsList } from './PolicySelectOptionsList'
+import { PolicySelectToggle } from './PolicySelectToggle'
+import { usePolicySelectAll } from './usePolicySelectAll'
 
 type PolicySelectProps = {
   selected: string[]
@@ -45,8 +40,8 @@ export function PolicySelect({
   const [debouncedFilter, setDebouncedFilter] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const { showError } = useAlerts()
 
-  // Debounce filter value for API calls
   useEffect(() => {
     debounceRef.current = setTimeout(() => {
       setDebouncedFilter(filterValue)
@@ -71,21 +66,21 @@ export function PolicySelect({
     { enabled: isOpen }
   )
 
-  const policies = policiesQuery.data?.resources
+  const scopedPolicies = useMemo(
+    () => filterPoliciesForRoleSelect(policiesQuery.data?.resources ?? [], { scopeProjectId, projectEligible }),
+    [policiesQuery.data?.resources, scopeProjectId, projectEligible]
+  )
 
-  // Merge fetched policies with selected names so selected items always appear
   const policyOptions = useMemo(() => {
-    const fetched = policies ?? []
-    const fetchedNames = new Set(fetched.map((p) => p.name))
+    const fetchedNames = new Set(scopedPolicies.map((p) => p.name))
     const selectedOnly = selected.filter((name) => !fetchedNames.has(name))
     return [
-      ...fetched.map((p) => ({ name: p.name, description: p.description })),
+      ...scopedPolicies.map((p) => ({ name: p.name, description: p.description ?? null })),
       ...selectedOnly.map((name) => ({ name, description: null })),
     ]
-  }, [policies, selected])
+  }, [scopedPolicies, selected])
 
   const filteredOptions = useMemo(() => {
-    // Client-side filter for instant feedback while debounce hasn't fired yet
     if (filterValue && filterValue !== debouncedFilter) {
       const term = filterValue.toLowerCase()
       return policyOptions.filter((p) => p.name.toLowerCase().includes(term))
@@ -93,8 +88,34 @@ export function PolicySelect({
     return policyOptions
   }, [policyOptions, filterValue, debouncedFilter])
 
+  const fetchAllMatchingPolicies = useCallback(
+    () =>
+      fetchAllPoliciesForSelect({
+        scopeProjectId,
+        projectEligible,
+        nameContains: filterValue || debouncedFilter || undefined,
+      }),
+    [scopeProjectId, projectEligible, filterValue, debouncedFilter]
+  )
+
+  const { isSelectingAll, runSelectAll } = usePolicySelectAll({
+    selected,
+    onChange,
+    fetchPolicies: fetchAllMatchingPolicies,
+    showError,
+    onAfterSelect: () => {
+      setFilterValue('')
+      inputRef.current?.focus()
+    },
+  })
+
   const onSelect = useCallback(
     (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
+      if (value === SELECT_ALL_VALUE) {
+        runSelectAll()
+        return
+      }
+
       const policyName = value as string
       if (selected.includes(policyName)) {
         onChange(selected.filter((p) => p !== policyName))
@@ -104,7 +125,7 @@ export function PolicySelect({
       setFilterValue('')
       inputRef.current?.focus()
     },
-    [selected, onChange]
+    [selected, onChange, runSelectAll]
   )
 
   const removePolicy = useCallback(
@@ -121,69 +142,34 @@ export function PolicySelect({
 
   const isLoading = policiesQuery.isLoading || policiesQuery.isFetching
 
-  const toggle = (toggleRef: Ref<HTMLButtonElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      variant="typeahead"
-      onClick={() => setIsOpen(!isOpen)}
-      isExpanded={isOpen}
-      isFullWidth
-      isDisabled={isDisabled}
-      status={hasError ? 'danger' : undefined}
-    >
-      <TextInputGroup isPlain isDisabled={isDisabled}>
-        <TextInputGroupMain
-          value={filterValue}
-          onChange={(_e, val) => {
-            setFilterValue(val)
-            if (!isOpen) setIsOpen(true)
-          }}
-          onClick={() => {
-            if (!isOpen) setIsOpen(true)
-          }}
-          placeholder={selected.length === 0 ? 'Select policies...' : ''}
-          autoComplete="off"
-          innerRef={inputRef}
-        >
-          {selected.length > 0 && (
-            <LabelGroup>
-              {selected.map((name) => (
-                <Label
-                  key={name}
-                  color="blue"
-                  onClose={(e) => {
-                    e.stopPropagation()
-                    removePolicy(name)
-                  }}
-                >
-                  {name}
-                </Label>
-              ))}
-            </LabelGroup>
-          )}
-        </TextInputGroupMain>
-        {selected.length > 0 && (
-          <TextInputGroupUtilities>
-            <Button
-              variant="plain"
-              onClick={(e) => {
-                e.stopPropagation()
-                clearAll()
-              }}
-              aria-label="Clear all selected policies"
-            >
-              <RhUiCloseIcon />
-            </Button>
-          </TextInputGroupUtilities>
-        )}
-      </TextInputGroup>
-    </MenuToggle>
-  )
-
   const handleOpenChange = useCallback((open: boolean) => {
     setIsOpen(open)
     if (!open) setFilterValue('')
   }, [])
+
+  const openDropdown = useCallback(() => {
+    if (!isOpen) setIsOpen(true)
+  }, [isOpen])
+
+  const toggle = (toggleRef: Ref<HTMLButtonElement>) => (
+    <PolicySelectToggle
+      toggleRef={toggleRef}
+      isOpen={isOpen}
+      onToggle={() => setIsOpen(!isOpen)}
+      filterValue={filterValue}
+      onFilterChange={(val) => {
+        setFilterValue(val)
+        openDropdown()
+      }}
+      onFilterFocus={openDropdown}
+      selected={selected}
+      onRemovePolicy={removePolicy}
+      onClearAll={clearAll}
+      inputRef={inputRef}
+      isDisabled={isDisabled}
+      hasError={hasError}
+    />
+  )
 
   return (
     <NxSelect
@@ -194,31 +180,18 @@ export function PolicySelect({
       onSelect={onSelect}
       selected={selected}
       toggle={toggle}
+      isScrollable
+      maxMenuHeight={LONG_SELECT_MAX_MENU_HEIGHT}
+      popperProps={longSelectMenuPopperProps}
+      className={longSelectMenuStyles.containScroll}
     >
-      <SelectList style={{ maxHeight: '200px', overflow: 'auto' }}>
-        {isLoading && (
-          <SelectOption isDisabled>
-            <Spinner size="sm" /> Loading policies...
-          </SelectOption>
-        )}
-        {!isLoading && filteredOptions.length === 0 && (
-          <SelectOption isDisabled>
-            {filterValue ? `No policies match "${filterValue}"` : 'No policies available'}
-          </SelectOption>
-        )}
-        {!isLoading &&
-          filteredOptions.map((policy) => (
-            <SelectOption
-              key={policy.name}
-              value={policy.name}
-              hasCheckbox
-              isSelected={selected.includes(policy.name)}
-              description={policy.description ?? undefined}
-            >
-              {policy.name}
-            </SelectOption>
-          ))}
-      </SelectList>
+      <PolicySelectOptionsList
+        isLoading={isLoading}
+        filterValue={filterValue}
+        filteredOptions={filteredOptions}
+        selected={selected}
+        isSelectingAll={isSelectingAll}
+      />
     </NxSelect>
   )
 }

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelect.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelect.tsx
@@ -1,16 +1,10 @@
-import { type Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-
-import { LONG_SELECT_MAX_MENU_HEIGHT, longSelectMenuPopperProps } from '../../components/longSelectMenu'
-import longSelectMenuStyles from '../../components/longSelectMenu.module.css'
-import { NxSelect } from '../../components/NxSelect'
-import { useAlerts } from '../../providers/alerts'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { accessClient } from './accessClient'
 import { fetchAllPoliciesForSelect } from './fetchAllPoliciesForSelect'
-import { filterPoliciesForRoleSelect, SELECT_ALL_VALUE } from './policySelectConstants'
-import { PolicySelectOptionsList } from './PolicySelectOptionsList'
-import { PolicySelectToggle } from './PolicySelectToggle'
-import { usePolicySelectAll } from './usePolicySelectAll'
+import { filterPoliciesForRoleSelect } from './policySelectConstants'
+import { PolicySelectField } from './PolicySelectDropdown'
+import { buildPolicyOptionList, filterPolicyOptionsByTerm, usePolicySelectField } from './policySelectShared'
 
 type PolicySelectProps = {
   selected: string[]
@@ -35,19 +29,41 @@ export function PolicySelect({
   projectEligible,
   isDisabled,
 }: Readonly<PolicySelectProps>) {
-  const [isOpen, setIsOpen] = useState(false)
-  const [filterValue, setFilterValue] = useState('')
   const [debouncedFilter, setDebouncedFilter] = useState('')
-  const inputRef = useRef<HTMLInputElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
-  const { showError } = useAlerts()
+  const filterValueRef = useRef('')
+  const debouncedFilterRef = useRef('')
+
+  const fetchAllMatchingPolicies = useCallback(
+    () =>
+      fetchAllPoliciesForSelect({
+        scopeProjectId,
+        projectEligible,
+        nameContains: filterValueRef.current || debouncedFilterRef.current || undefined,
+      }),
+    [scopeProjectId, projectEligible]
+  )
+
+  const field = usePolicySelectField({
+    selected,
+    onChange,
+    fetchPolicies: fetchAllMatchingPolicies,
+  })
+
+  useEffect(() => {
+    filterValueRef.current = field.filterValue
+  }, [field.filterValue])
+
+  useEffect(() => {
+    debouncedFilterRef.current = debouncedFilter
+  }, [debouncedFilter])
 
   useEffect(() => {
     debounceRef.current = setTimeout(() => {
-      setDebouncedFilter(filterValue)
+      setDebouncedFilter(field.filterValue)
     }, DEBOUNCE_MS)
     return () => clearTimeout(debounceRef.current)
-  }, [filterValue])
+  }, [field.filterValue])
 
   const policiesQuery = accessClient.useQuery(
     'get',
@@ -63,7 +79,7 @@ export function PolicySelect({
         },
       },
     },
-    { enabled: isOpen }
+    { enabled: field.isOpen }
   )
 
   const scopedPolicies = useMemo(
@@ -71,127 +87,39 @@ export function PolicySelect({
     [policiesQuery.data?.resources, scopeProjectId, projectEligible]
   )
 
-  const policyOptions = useMemo(() => {
-    const fetchedNames = new Set(scopedPolicies.map((p) => p.name))
-    const selectedOnly = selected.filter((name) => !fetchedNames.has(name))
-    return [
-      ...scopedPolicies.map((p) => ({ name: p.name, description: p.description ?? null })),
-      ...selectedOnly.map((name) => ({ name, description: null })),
-    ]
-  }, [scopedPolicies, selected])
+  const policyOptions = useMemo(() => buildPolicyOptionList(scopedPolicies, selected), [scopedPolicies, selected])
 
   const filteredOptions = useMemo(() => {
-    if (filterValue && filterValue !== debouncedFilter) {
-      const term = filterValue.toLowerCase()
-      return policyOptions.filter((p) => p.name.toLowerCase().includes(term))
+    if (field.filterValue && field.filterValue !== debouncedFilter) {
+      return filterPolicyOptionsByTerm(policyOptions, field.filterValue)
     }
     return policyOptions
-  }, [policyOptions, filterValue, debouncedFilter])
-
-  const fetchAllMatchingPolicies = useCallback(
-    () =>
-      fetchAllPoliciesForSelect({
-        scopeProjectId,
-        projectEligible,
-        nameContains: filterValue || debouncedFilter || undefined,
-      }),
-    [scopeProjectId, projectEligible, filterValue, debouncedFilter]
-  )
-
-  const { isSelectingAll, runSelectAll } = usePolicySelectAll({
-    selected,
-    onChange,
-    fetchPolicies: fetchAllMatchingPolicies,
-    showError,
-    onAfterSelect: () => {
-      setFilterValue('')
-      inputRef.current?.focus()
-    },
-  })
-
-  const onSelect = useCallback(
-    (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
-      if (value === SELECT_ALL_VALUE) {
-        runSelectAll()
-        return
-      }
-
-      const policyName = value as string
-      if (selected.includes(policyName)) {
-        onChange(selected.filter((p) => p !== policyName))
-      } else {
-        onChange([...selected, policyName])
-      }
-      setFilterValue('')
-      inputRef.current?.focus()
-    },
-    [selected, onChange, runSelectAll]
-  )
-
-  const removePolicy = useCallback(
-    (policyName: string) => {
-      onChange(selected.filter((p) => p !== policyName))
-    },
-    [selected, onChange]
-  )
-
-  const clearAll = useCallback(() => {
-    onChange([])
-    setFilterValue('')
-  }, [onChange])
+  }, [policyOptions, field.filterValue, debouncedFilter])
 
   const isLoading = policiesQuery.isLoading || policiesQuery.isFetching
 
-  const handleOpenChange = useCallback((open: boolean) => {
-    setIsOpen(open)
-    if (!open) setFilterValue('')
-  }, [])
-
-  const openDropdown = useCallback(() => {
-    if (!isOpen) setIsOpen(true)
-  }, [isOpen])
-
-  const toggle = (toggleRef: Ref<HTMLButtonElement>) => (
-    <PolicySelectToggle
-      toggleRef={toggleRef}
-      isOpen={isOpen}
-      onToggle={() => setIsOpen(!isOpen)}
-      filterValue={filterValue}
-      onFilterChange={(val) => {
-        setFilterValue(val)
-        openDropdown()
-      }}
-      onFilterFocus={openDropdown}
-      selected={selected}
-      onRemovePolicy={removePolicy}
-      onClearAll={clearAll}
-      inputRef={inputRef}
-      isDisabled={isDisabled}
-      hasError={hasError}
-    />
-  )
-
   return (
-    <NxSelect
+    <PolicySelectField
       id="role-policies"
-      aria-label="Policies"
-      isOpen={isOpen}
-      onOpenChange={handleOpenChange}
-      onSelect={onSelect}
       selected={selected}
-      toggle={toggle}
-      isScrollable
-      maxMenuHeight={LONG_SELECT_MAX_MENU_HEIGHT}
-      popperProps={longSelectMenuPopperProps}
-      className={longSelectMenuStyles.containScroll}
-    >
-      <PolicySelectOptionsList
-        isLoading={isLoading}
-        filterValue={filterValue}
-        filteredOptions={filteredOptions}
-        selected={selected}
-        isSelectingAll={isSelectingAll}
-      />
-    </NxSelect>
+      filteredOptions={filteredOptions}
+      filterValue={field.filterValue}
+      isOpen={field.isOpen}
+      isLoading={isLoading}
+      isSelectingAll={field.isSelectingAll}
+      hasError={hasError}
+      isDisabled={isDisabled}
+      inputRef={field.inputRef}
+      onOpenChange={field.handleOpenChange}
+      onSelect={field.onSelect}
+      onFilterChange={(value: string) => {
+        field.setFilterValue(value)
+        field.openDropdown()
+      }}
+      onFilterFocus={field.openDropdown}
+      onRemovePolicy={field.removePolicy}
+      onClearAll={field.clearAll}
+      onToggle={() => field.handleOpenChange(!field.isOpen)}
+    />
   )
 }

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelectDropdown.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelectDropdown.tsx
@@ -1,0 +1,94 @@
+import { type Ref } from 'react'
+
+import { LONG_SELECT_MAX_MENU_HEIGHT, longSelectMenuPopperProps } from '../../components/longSelectMenu'
+import longSelectMenuStyles from '../../components/longSelectMenu.module.css'
+import { NxSelect } from '../../components/NxSelect'
+
+import { PolicySelectOptionsList } from './PolicySelectOptionsList'
+import type { PolicySelectOption } from './policySelectShared'
+import { PolicySelectToggle } from './PolicySelectToggle'
+
+type PolicySelectFieldProps = {
+  id: string
+  selected: string[]
+  filteredOptions: PolicySelectOption[]
+  filterValue: string
+  isOpen: boolean
+  isLoading: boolean
+  isSelectingAll: boolean
+  hasError?: boolean
+  isDisabled?: boolean
+  toggleTestId?: string
+  inputRef: React.RefObject<HTMLInputElement | null>
+  onOpenChange: (open: boolean) => void
+  onSelect: (event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => void
+  onFilterChange: (value: string) => void
+  onFilterFocus: () => void
+  onRemovePolicy: (name: string) => void
+  onClearAll: () => void
+  onToggle: () => void
+}
+
+export function PolicySelectField({
+  id,
+  selected,
+  filteredOptions,
+  filterValue,
+  isOpen,
+  isLoading,
+  isSelectingAll,
+  hasError,
+  isDisabled,
+  toggleTestId,
+  inputRef,
+  onOpenChange,
+  onSelect,
+  onFilterChange,
+  onFilterFocus,
+  onRemovePolicy,
+  onClearAll,
+  onToggle,
+}: Readonly<PolicySelectFieldProps>) {
+  const toggle = (toggleRef: Ref<HTMLButtonElement>) => (
+    <PolicySelectToggle
+      toggleRef={toggleRef}
+      isOpen={isOpen}
+      onToggle={onToggle}
+      filterValue={filterValue}
+      onFilterChange={onFilterChange}
+      onFilterFocus={onFilterFocus}
+      selected={selected}
+      onRemovePolicy={onRemovePolicy}
+      onClearAll={onClearAll}
+      inputRef={inputRef}
+      isDisabled={isDisabled}
+      hasError={hasError}
+      toggleTestId={toggleTestId}
+    />
+  )
+
+  return (
+    <NxSelect
+      id={id}
+      aria-label="Policies"
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      onSelect={onSelect}
+      selected={selected}
+      toggle={toggle}
+      shouldFocusToggleOnSelect={false}
+      isScrollable
+      maxMenuHeight={LONG_SELECT_MAX_MENU_HEIGHT}
+      popperProps={longSelectMenuPopperProps}
+      className={longSelectMenuStyles.containScroll}
+    >
+      <PolicySelectOptionsList
+        isLoading={isLoading}
+        filterValue={filterValue}
+        filteredOptions={filteredOptions}
+        selected={selected}
+        isSelectingAll={isSelectingAll}
+      />
+    </NxSelect>
+  )
+}

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelectOptionsList.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelectOptionsList.test.tsx
@@ -26,13 +26,7 @@ describe('PolicySelectOptionsList', () => {
 
   it('has no accessibility violations while loading', async () => {
     const { container } = render(
-      <PolicySelectOptionsList
-        isLoading
-        filterValue=""
-        filteredOptions={[]}
-        selected={[]}
-        isSelectingAll={false}
-      />
+      <PolicySelectOptionsList isLoading filterValue="" filteredOptions={[]} selected={[]} isSelectingAll={false} />
     )
     const results = await axe(container)
     expect(results).toHaveNoViolations()
@@ -49,10 +43,10 @@ describe('PolicySelectOptionsList', () => {
       />
     )
 
-    expect(screen.getByRole('menuitem', { name: 'Select All' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Select all' })).toBeInTheDocument()
   })
 
-  it('disables Select All while selection is in progress', () => {
+  it('disables Select All and shows progress while selection is in progress', () => {
     render(
       <PolicySelectOptionsList
         isLoading={false}
@@ -63,6 +57,6 @@ describe('PolicySelectOptionsList', () => {
       />
     )
 
-    expect(screen.getByRole('menuitem', { name: 'Select All' })).toBeDisabled()
+    expect(screen.getByRole('menuitem', { name: /Selecting all/i })).toBeDisabled()
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelectOptionsList.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelectOptionsList.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { PolicySelectOptionsList } from './PolicySelectOptionsList'
+
+describe('PolicySelectOptionsList', () => {
+  const options = [
+    { name: 'workflow-admin', description: 'Manage workflows' },
+    { name: 'project-viewer', description: null },
+  ]
+
+  it('has no accessibility violations when options are available', async () => {
+    const { container } = render(
+      <PolicySelectOptionsList
+        isLoading={false}
+        filterValue=""
+        filteredOptions={options}
+        selected={['workflow-admin']}
+        isSelectingAll={false}
+      />
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no accessibility violations while loading', async () => {
+    const { container } = render(
+      <PolicySelectOptionsList
+        isLoading
+        filterValue=""
+        filteredOptions={[]}
+        selected={[]}
+        isSelectingAll={false}
+      />
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('renders Select All when options exist', () => {
+    render(
+      <PolicySelectOptionsList
+        isLoading={false}
+        filterValue=""
+        filteredOptions={options}
+        selected={[]}
+        isSelectingAll={false}
+      />
+    )
+
+    expect(screen.getByRole('menuitem', { name: 'Select All' })).toBeInTheDocument()
+  })
+
+  it('disables Select All while selection is in progress', () => {
+    render(
+      <PolicySelectOptionsList
+        isLoading={false}
+        filterValue=""
+        filteredOptions={options}
+        selected={[]}
+        isSelectingAll
+      />
+    )
+
+    expect(screen.getByRole('menuitem', { name: 'Select All' })).toBeDisabled()
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelectOptionsList.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelectOptionsList.tsx
@@ -1,0 +1,59 @@
+import { Divider, SelectList, SelectOption, Spinner } from '@patternfly/react-core'
+
+import { SELECT_ALL_LABEL, SELECT_ALL_VALUE } from './policySelectConstants'
+
+type PolicySelectOption = {
+  name: string
+  description: string | null
+}
+
+type PolicySelectOptionsListProps = {
+  isLoading: boolean
+  filterValue: string
+  filteredOptions: PolicySelectOption[]
+  selected: string[]
+  isSelectingAll: boolean
+}
+
+export function PolicySelectOptionsList({
+  isLoading,
+  filterValue,
+  filteredOptions,
+  selected,
+  isSelectingAll,
+}: Readonly<PolicySelectOptionsListProps>) {
+  return (
+    <SelectList>
+      {isLoading && (
+        <SelectOption isDisabled>
+          <Spinner size="sm" /> Loading policies...
+        </SelectOption>
+      )}
+      {!isLoading && filteredOptions.length === 0 && (
+        <SelectOption isDisabled>
+          {filterValue ? `No policies match "${filterValue}"` : 'No policies available'}
+        </SelectOption>
+      )}
+      {!isLoading && filteredOptions.length > 0 && (
+        <>
+          <SelectOption value={SELECT_ALL_VALUE} isDisabled={isSelectingAll}>
+            {SELECT_ALL_LABEL}
+          </SelectOption>
+          <Divider component="li" />
+        </>
+      )}
+      {!isLoading &&
+        filteredOptions.map((policy) => (
+          <SelectOption
+            key={policy.name}
+            value={policy.name}
+            hasCheckbox
+            isSelected={selected.includes(policy.name)}
+            description={policy.description ?? undefined}
+          >
+            {policy.name}
+          </SelectOption>
+        ))}
+    </SelectList>
+  )
+}

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelectOptionsList.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelectOptionsList.tsx
@@ -1,11 +1,7 @@
 import { Divider, SelectList, SelectOption, Spinner } from '@patternfly/react-core'
 
 import { SELECT_ALL_LABEL, SELECT_ALL_VALUE } from './policySelectConstants'
-
-type PolicySelectOption = {
-  name: string
-  description: string | null
-}
+import type { PolicySelectOption } from './policySelectShared'
 
 type PolicySelectOptionsListProps = {
   isLoading: boolean
@@ -37,7 +33,13 @@ export function PolicySelectOptionsList({
       {!isLoading && filteredOptions.length > 0 && (
         <>
           <SelectOption value={SELECT_ALL_VALUE} isDisabled={isSelectingAll}>
-            {SELECT_ALL_LABEL}
+            {isSelectingAll ? (
+              <>
+                <Spinner size="sm" /> Selecting all...
+              </>
+            ) : (
+              SELECT_ALL_LABEL
+            )}
           </SelectOption>
           <Divider component="li" />
         </>

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelectToggle.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelectToggle.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createRef } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { PolicySelectToggle } from './PolicySelectToggle'
+
+describe('PolicySelectToggle', () => {
+  const defaultProps = {
+    toggleRef: createRef<HTMLButtonElement>(),
+    isOpen: false,
+    onToggle: vi.fn(),
+    filterValue: '',
+    onFilterChange: vi.fn(),
+    onFilterFocus: vi.fn(),
+    selected: [] as string[],
+    onRemovePolicy: vi.fn(),
+    onClearAll: vi.fn(),
+    inputRef: createRef<HTMLInputElement>(),
+  }
+
+  it('has no accessibility violations in default state', async () => {
+    const { container } = render(<PolicySelectToggle {...defaultProps} />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no accessibility violations with selected policy chips', async () => {
+    const { container } = render(
+      <PolicySelectToggle {...defaultProps} selected={['workflow-admin', 'project-viewer']} />
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('renders selected policies as NxLabel chips', () => {
+    render(<PolicySelectToggle {...defaultProps} selected={['workflow-admin']} />)
+    expect(screen.getByText('workflow-admin')).toBeInTheDocument()
+  })
+
+  it('calls onClearAll when the clear button is clicked', async () => {
+    const user = userEvent.setup()
+    const onClearAll = vi.fn()
+    render(<PolicySelectToggle {...defaultProps} selected={['workflow-admin']} onClearAll={onClearAll} />)
+
+    await user.click(screen.getByRole('button', { name: 'Clear all selected policies' }))
+
+    expect(onClearAll).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelectToggle.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelectToggle.tsx
@@ -1,0 +1,99 @@
+import {
+  Button,
+  LabelGroup,
+  MenuToggle,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+} from '@patternfly/react-core'
+import { RhUiCloseIcon } from '@patternfly/react-icons'
+import type { Ref, RefObject } from 'react'
+
+import { NxLabel } from '../../components/labels/NxLabel'
+
+type PolicySelectToggleProps = {
+  toggleRef: Ref<HTMLButtonElement>
+  isOpen: boolean
+  onToggle: () => void
+  filterValue: string
+  onFilterChange: (value: string) => void
+  onFilterFocus: () => void
+  selected: string[]
+  onRemovePolicy: (name: string) => void
+  onClearAll: () => void
+  inputRef: RefObject<HTMLInputElement | null>
+  isDisabled?: boolean
+  hasError?: boolean
+  toggleTestId?: string
+}
+
+export function PolicySelectToggle({
+  toggleRef,
+  isOpen,
+  onToggle,
+  filterValue,
+  onFilterChange,
+  onFilterFocus,
+  selected,
+  onRemovePolicy,
+  onClearAll,
+  inputRef,
+  isDisabled,
+  hasError,
+  toggleTestId,
+}: Readonly<PolicySelectToggleProps>) {
+  return (
+    <MenuToggle
+      ref={toggleRef}
+      data-testid={toggleTestId}
+      variant="typeahead"
+      onClick={onToggle}
+      isExpanded={isOpen}
+      isFullWidth
+      isDisabled={isDisabled}
+      status={hasError ? 'danger' : undefined}
+    >
+      <TextInputGroup isPlain isDisabled={isDisabled}>
+        <TextInputGroupMain
+          value={filterValue}
+          onChange={(_e, val) => onFilterChange(val)}
+          onClick={onFilterFocus}
+          placeholder={selected.length === 0 ? 'Select policies...' : ''}
+          autoComplete="off"
+          innerRef={inputRef}
+        >
+          {selected.length > 0 && (
+            <LabelGroup>
+              {selected.map((name) => (
+                <NxLabel
+                  key={name}
+                  color="blue"
+                  onClose={(e) => {
+                    e.stopPropagation()
+                    onRemovePolicy(name)
+                  }}
+                >
+                  {name}
+                </NxLabel>
+              ))}
+            </LabelGroup>
+          )}
+        </TextInputGroupMain>
+        {selected.length > 0 && (
+          <TextInputGroupUtilities>
+            <Button
+              variant="plain"
+              onClick={(e) => {
+                e.stopPropagation()
+                onClearAll()
+              }}
+              aria-label="Clear all selected policies"
+            >
+              <RhUiCloseIcon />
+            </Button>
+          </TextInputGroupUtilities>
+        )}
+      </TextInputGroup>
+    </MenuToggle>
+  )
+}

--- a/frontend/packages/syntara-ui/src/routes/access/fetchAllPoliciesForSelect.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/fetchAllPoliciesForSelect.test.ts
@@ -37,7 +37,7 @@ describe('fetchAllPoliciesForSelect', () => {
     } as never)
     vi.mocked(fetchAllPages).mockImplementation(async (fetchPage): Promise<PolicySelectListItem[]> => {
       const page = (await fetchPage(undefined)) as FetchPageResult<PolicySelectListItem>
-      if (page.error) throw page.error
+      if (page.error) throw new Error(JSON.stringify(page.error))
       if (!page.data) throw new Error('Empty response')
       return [...(page.data.resources ?? [])]
     })

--- a/frontend/packages/syntara-ui/src/routes/access/fetchAllPoliciesForSelect.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/fetchAllPoliciesForSelect.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchAllPages, type FetchPageResult } from '../../utils/fetchAllPages'
+
+import { accessFetchClient } from './accessClient'
+import { fetchAllPoliciesForSelect, fetchAllProjectPoliciesForSelect } from './fetchAllPoliciesForSelect'
+import { filterPoliciesForRoleSelect, type PolicySelectListItem } from './policySelectConstants'
+
+vi.mock('../../utils/fetchAllPages', () => ({
+  fetchAllPages: vi.fn(),
+  MAX_PAGE_SIZE: 100,
+}))
+
+vi.mock('./accessClient', () => ({
+  accessFetchClient: {
+    GET: vi.fn(),
+  },
+}))
+
+vi.mock('./policySelectConstants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./policySelectConstants')>()
+  return {
+    ...actual,
+    filterPoliciesForRoleSelect: vi.fn(actual.filterPoliciesForRoleSelect),
+  }
+})
+
+describe('fetchAllPoliciesForSelect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('delegates to fetchAllPages with scoped query params', async () => {
+    const policies = [{ name: 'policy-a', is_project_eligible: true }]
+    vi.mocked(accessFetchClient.GET).mockResolvedValue({
+      data: { resources: policies, next: null },
+    } as never)
+    vi.mocked(fetchAllPages).mockImplementation(async (fetchPage): Promise<PolicySelectListItem[]> => {
+      const page = (await fetchPage(undefined)) as FetchPageResult<PolicySelectListItem>
+      if (page.error) throw page.error
+      if (!page.data) throw new Error('Empty response')
+      return [...(page.data.resources ?? [])]
+    })
+
+    const result = await fetchAllPoliciesForSelect({
+      scopeProjectId: 'proj-1',
+      projectEligible: true,
+      nameContains: 'admin',
+    })
+
+    expect(result).toEqual(policies)
+    expect(accessFetchClient.GET).toHaveBeenCalledWith('/policies', {
+      params: {
+        query: {
+          sort: 'name',
+          limit: 100,
+          cursor: undefined,
+          'name[contains]': 'admin',
+          project_id: 'proj-1',
+          project_eligible: true,
+        },
+      },
+    })
+  })
+
+  it('filters out project-only policies for global role select-all', async () => {
+    const policies = [
+      { name: 'workflow-admin', is_project_eligible: false },
+      { name: 'policy:update:project', is_project_eligible: true },
+    ]
+    vi.mocked(fetchAllPages).mockResolvedValue(policies as never)
+
+    const result = await fetchAllPoliciesForSelect({})
+
+    expect(filterPoliciesForRoleSelect).toHaveBeenCalledWith(policies, {})
+    expect(result).toEqual([policies[0]])
+  })
+})
+
+describe('fetchAllProjectPoliciesForSelect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns all project policies when no filter is provided', async () => {
+    const policies = [
+      { id: '1', name: 'read-policy' },
+      { id: '2', name: 'write-policy' },
+    ]
+    vi.mocked(fetchAllPages).mockResolvedValue(policies as never)
+
+    const result = await fetchAllProjectPoliciesForSelect('proj-1')
+
+    expect(result).toEqual(policies)
+  })
+
+  it('filters project policies client-side when nameContains is provided', async () => {
+    vi.mocked(fetchAllPages).mockResolvedValue([
+      { id: '1', name: 'read-policy' },
+      { id: '2', name: 'write-policy' },
+      { id: '3', name: 'admin-policy' },
+    ] as never)
+
+    const result = await fetchAllProjectPoliciesForSelect('proj-1', 'read')
+
+    expect(result).toEqual([{ id: '1', name: 'read-policy' }])
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/access/fetchAllPoliciesForSelect.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/fetchAllPoliciesForSelect.ts
@@ -1,0 +1,61 @@
+import { fetchAllPages, MAX_PAGE_SIZE } from '../../utils/fetchAllPages'
+
+import { accessFetchClient } from './accessClient'
+import { toPolicySelectPageResult } from './policySelectApi'
+import {
+  filterPoliciesForRoleSelect,
+  type PolicySelectListItem,
+  type PolicySelectScopeParams,
+} from './policySelectConstants'
+
+export type FetchAllPoliciesParams = PolicySelectScopeParams & {
+  nameContains?: string
+}
+
+/** Fetch every policy matching the role-select query (all pages). */
+export async function fetchAllPoliciesForSelect({
+  scopeProjectId,
+  projectEligible,
+  nameContains,
+}: FetchAllPoliciesParams): Promise<PolicySelectListItem[]> {
+  const policies = await fetchAllPages<PolicySelectListItem>(async (cursor) =>
+    toPolicySelectPageResult(
+      await accessFetchClient.GET('/policies', {
+        params: {
+          query: {
+            sort: 'name',
+            limit: MAX_PAGE_SIZE,
+            cursor,
+            ...(nameContains ? { 'name[contains]': nameContains } : {}),
+            ...(scopeProjectId ? { project_id: scopeProjectId } : {}),
+            ...(projectEligible ? { project_eligible: true } : {}),
+          },
+        },
+      })
+    )
+  )
+
+  return filterPoliciesForRoleSelect(policies, { scopeProjectId, projectEligible })
+}
+
+/** Fetch every project policy, optionally narrowed by a client-side name filter. */
+export async function fetchAllProjectPoliciesForSelect(
+  projectId: string,
+  nameContains?: string
+): Promise<PolicySelectListItem[]> {
+  const allPolicies = await fetchAllPages<PolicySelectListItem>(async (cursor) =>
+    toPolicySelectPageResult(
+      await accessFetchClient.GET('/projects/{project_id}/policies', {
+        params: {
+          path: { project_id: projectId },
+          query: { sort: 'name', limit: MAX_PAGE_SIZE, cursor },
+        },
+      })
+    )
+  )
+
+  if (!nameContains) return allPolicies
+
+  const term = nameContains.toLowerCase()
+  return allPolicies.filter((policy) => policy.name.toLowerCase().includes(term))
+}

--- a/frontend/packages/syntara-ui/src/routes/access/policySelectApi.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/policySelectApi.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { toPolicySelectPageResult } from './policySelectApi'
+
+describe('toPolicySelectPageResult', () => {
+  it('maps policy list resources to PolicySelectListItem shape', () => {
+    const result = toPolicySelectPageResult({
+      data: {
+        resources: [
+          {
+            name: 'workflow-admin',
+            description: 'Manage workflows',
+            project_id: null,
+            is_project_eligible: false,
+          },
+        ],
+        next: 'cursor-2',
+      },
+    })
+
+    expect(result).toEqual({
+      data: {
+        next: 'cursor-2',
+        resources: [
+          {
+            name: 'workflow-admin',
+            description: 'Manage workflows',
+            project_id: null,
+            is_project_eligible: false,
+          },
+        ],
+      },
+    })
+  })
+
+  it('returns error when the fetch response includes an error', () => {
+    expect(toPolicySelectPageResult({ error: { detail: 'Unauthorized' } })).toEqual({
+      error: { detail: 'Unauthorized' },
+    })
+  })
+
+  it('returns error when data is missing', () => {
+    expect(toPolicySelectPageResult({})).toEqual({ error: 'Empty response' })
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/access/policySelectApi.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/policySelectApi.ts
@@ -1,0 +1,35 @@
+import type { FetchPageResult } from '../../utils/fetchAllPages'
+
+import type { PolicySelectListItem } from './policySelectConstants'
+
+type PolicyListPayload = {
+  resources?: readonly {
+    name: string
+    description?: string | null
+    project_id?: string | null
+    is_project_eligible: boolean
+  }[] | null
+  next?: string | null
+}
+
+/** Map an openapi-fetch list response to policy-select list items without unsafe casts. */
+export function toPolicySelectPageResult(result: {
+  data?: PolicyListPayload
+  error?: unknown
+}): FetchPageResult<PolicySelectListItem> {
+  const { data, error } = result
+  if (error) return { error }
+  if (!data) return { error: 'Empty response' }
+
+  return {
+    data: {
+      next: data.next,
+      resources: (data.resources ?? []).map((policy) => ({
+        name: policy.name,
+        description: policy.description,
+        project_id: policy.project_id,
+        is_project_eligible: policy.is_project_eligible,
+      })),
+    },
+  }
+}

--- a/frontend/packages/syntara-ui/src/routes/access/policySelectApi.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/policySelectApi.ts
@@ -3,12 +3,14 @@ import type { FetchPageResult } from '../../utils/fetchAllPages'
 import type { PolicySelectListItem } from './policySelectConstants'
 
 type PolicyListPayload = {
-  resources?: readonly {
-    name: string
-    description?: string | null
-    project_id?: string | null
-    is_project_eligible: boolean
-  }[] | null
+  resources?:
+    | readonly {
+        name: string
+        description?: string | null
+        project_id?: string | null
+        is_project_eligible: boolean
+      }[]
+    | null
   next?: string | null
 }
 

--- a/frontend/packages/syntara-ui/src/routes/access/policySelectConstants.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/policySelectConstants.test.ts
@@ -20,9 +20,9 @@ const projectCustomPolicy: PolicySelectListItem = {
 
 describe('filterPoliciesForRoleSelect', () => {
   it('returns only non-project-eligible policies for global roles', () => {
-    expect(
-      filterPoliciesForRoleSelect([globalPolicy, projectBuiltinPolicy, projectCustomPolicy], {})
-    ).toEqual([globalPolicy])
+    expect(filterPoliciesForRoleSelect([globalPolicy, projectBuiltinPolicy, projectCustomPolicy], {})).toEqual([
+      globalPolicy,
+    ])
   })
 
   it('returns only project-eligible policies when projectEligible is true', () => {

--- a/frontend/packages/syntara-ui/src/routes/access/policySelectConstants.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/policySelectConstants.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { filterPoliciesForRoleSelect, mergeSelectAll, type PolicySelectListItem } from './policySelectConstants'
+
+const globalPolicy: PolicySelectListItem = {
+  name: 'workflow-admin',
+  is_project_eligible: false,
+}
+
+const projectBuiltinPolicy: PolicySelectListItem = {
+  name: 'policy:update:project',
+  is_project_eligible: true,
+}
+
+const projectCustomPolicy: PolicySelectListItem = {
+  name: 'custom-project-policy',
+  project_id: 'proj-1',
+  is_project_eligible: true,
+}
+
+describe('filterPoliciesForRoleSelect', () => {
+  it('returns only non-project-eligible policies for global roles', () => {
+    expect(
+      filterPoliciesForRoleSelect([globalPolicy, projectBuiltinPolicy, projectCustomPolicy], {})
+    ).toEqual([globalPolicy])
+  })
+
+  it('returns only project-eligible policies when projectEligible is true', () => {
+    expect(
+      filterPoliciesForRoleSelect([globalPolicy, projectBuiltinPolicy, projectCustomPolicy], {
+        projectEligible: true,
+      })
+    ).toEqual([projectBuiltinPolicy, projectCustomPolicy])
+  })
+
+  it('returns policies for the selected project when scopeProjectId is set', () => {
+    expect(
+      filterPoliciesForRoleSelect([globalPolicy, projectBuiltinPolicy, projectCustomPolicy], {
+        scopeProjectId: 'proj-1',
+      })
+    ).toEqual([globalPolicy, projectBuiltinPolicy, projectCustomPolicy])
+  })
+})
+
+describe('mergeSelectAll', () => {
+  it('merges current selection with new option names without duplicates', () => {
+    expect(mergeSelectAll(['a', 'b'], ['b', 'c', 'd'])).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('returns only new names when nothing is selected', () => {
+    expect(mergeSelectAll([], ['x', 'y'])).toEqual(['x', 'y'])
+  })
+
+  it('preserves existing selection when option list is empty', () => {
+    expect(mergeSelectAll(['a'], [])).toEqual(['a'])
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/access/policySelectConstants.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/policySelectConstants.ts
@@ -10,7 +10,7 @@ export type PolicySelectListItem = {
 export const SELECT_ALL_VALUE = '__select_all__'
 
 /** Label for the select-all menu action (matches MultiSelectFilter). */
-export const SELECT_ALL_LABEL = 'Select All'
+export const SELECT_ALL_LABEL = 'Select all'
 
 export const SELECT_ALL_LOAD_ERROR = {
   title: 'Failed to load policies',

--- a/frontend/packages/syntara-ui/src/routes/access/policySelectConstants.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/policySelectConstants.ts
@@ -1,0 +1,44 @@
+/** Minimal policy fields used by role policy pickers and select-all fetching. */
+export type PolicySelectListItem = {
+  name: string
+  description?: string | null
+  project_id?: string | null
+  is_project_eligible: boolean
+}
+
+/** Sentinel value for the "Select All" action in policy multi-select dropdowns. */
+export const SELECT_ALL_VALUE = '__select_all__'
+
+/** Label for the select-all menu action (matches MultiSelectFilter). */
+export const SELECT_ALL_LABEL = 'Select All'
+
+export const SELECT_ALL_LOAD_ERROR = {
+  title: 'Failed to load policies',
+  description: 'Could not select all policies. Try again.',
+} as const
+
+export type PolicySelectScopeParams = {
+  scopeProjectId?: string | null
+  projectEligible?: boolean
+}
+
+/** Keep only policies assignable to the current role scope. */
+export function filterPoliciesForRoleSelect<T extends PolicySelectListItem>(
+  policies: T[],
+  { scopeProjectId, projectEligible }: PolicySelectScopeParams
+): T[] {
+  if (scopeProjectId) {
+    return policies.filter((policy) => policy.project_id == null || policy.project_id === scopeProjectId)
+  }
+
+  if (projectEligible) {
+    return policies.filter((policy) => policy.is_project_eligible)
+  }
+
+  return policies.filter((policy) => !policy.is_project_eligible)
+}
+
+/** Merge currently selected policy names with all option names (deduped). */
+export function mergeSelectAll(currentSelected: string[], optionNames: string[]): string[] {
+  return [...new Set([...currentSelected, ...optionNames])]
+}

--- a/frontend/packages/syntara-ui/src/routes/access/policySelectShared.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/policySelectShared.ts
@@ -1,0 +1,108 @@
+import { useCallback, useRef, useState } from 'react'
+
+import { useAlerts } from '../../providers/alerts'
+
+import { SELECT_ALL_VALUE, type PolicySelectListItem } from './policySelectConstants'
+import { usePolicySelectAll } from './usePolicySelectAll'
+
+export type PolicySelectOption = {
+  name: string
+  description: string | null
+}
+
+export function buildPolicyOptionList(
+  fetched: readonly { name: string; description?: string | null }[],
+  selected: string[]
+): PolicySelectOption[] {
+  const fetchedNames = new Set(fetched.map((policy) => policy.name))
+  const selectedOnly = selected.filter((name) => !fetchedNames.has(name))
+  return [
+    ...fetched.map((policy) => ({ name: policy.name, description: policy.description ?? null })),
+    ...selectedOnly.map((name) => ({ name, description: null })),
+  ]
+}
+
+export function filterPolicyOptionsByTerm(options: PolicySelectOption[], term: string): PolicySelectOption[] {
+  if (!term) return options
+  const lower = term.toLowerCase()
+  return options.filter((policy) => policy.name.toLowerCase().includes(lower))
+}
+
+type UsePolicySelectFieldParams = {
+  selected: string[]
+  onChange: (selected: string[]) => void
+  fetchPolicies: () => Promise<PolicySelectListItem[]>
+}
+
+export function usePolicySelectField({ selected, onChange, fetchPolicies }: UsePolicySelectFieldParams) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [filterValue, setFilterValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const { showError } = useAlerts()
+
+  const clearFilterAndFocus = useCallback(() => {
+    setFilterValue('')
+    inputRef.current?.focus()
+  }, [])
+
+  const { isSelectingAll, runSelectAll } = usePolicySelectAll({
+    selected,
+    onChange,
+    fetchPolicies,
+    showError,
+    onAfterSelect: clearFilterAndFocus,
+  })
+
+  const onSelect = useCallback(
+    (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
+      if (value === SELECT_ALL_VALUE) {
+        runSelectAll()
+        return
+      }
+
+      const policyName = value as string
+      if (selected.includes(policyName)) {
+        onChange(selected.filter((policy) => policy !== policyName))
+      } else {
+        onChange([...selected, policyName])
+      }
+      setFilterValue('')
+      inputRef.current?.focus()
+    },
+    [selected, onChange, runSelectAll]
+  )
+
+  const removePolicy = useCallback(
+    (policyName: string) => {
+      onChange(selected.filter((policy) => policy !== policyName))
+    },
+    [selected, onChange]
+  )
+
+  const clearAll = useCallback(() => {
+    onChange([])
+    setFilterValue('')
+  }, [onChange])
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    setIsOpen(open)
+    if (!open) setFilterValue('')
+  }, [])
+
+  const openDropdown = useCallback(() => {
+    if (!isOpen) setIsOpen(true)
+  }, [isOpen])
+
+  return {
+    isOpen,
+    filterValue,
+    setFilterValue,
+    inputRef,
+    isSelectingAll,
+    onSelect,
+    removePolicy,
+    clearAll,
+    handleOpenChange,
+    openDropdown,
+  }
+}

--- a/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.test.ts
@@ -86,4 +86,43 @@ describe('usePolicySelectAll', () => {
       expect(result.current.isSelectingAll).toBe(false)
     })
   })
+
+  it('merges against the latest selection when chips change during fetch', async () => {
+    let resolveFetch: (value: { name: string; is_project_eligible: boolean }[]) => void = () => undefined
+    const fetchPolicies = vi.fn(
+      () =>
+        new Promise<{ name: string; is_project_eligible: boolean }[]>((resolve) => {
+          resolveFetch = resolve
+        })
+    )
+    const onChange = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ selected }: { selected: string[] }) =>
+        usePolicySelectAll({
+          selected,
+          onChange,
+          fetchPolicies,
+          showError: vi.fn(),
+        }),
+      { initialProps: { selected: ['policy-a'] } }
+    )
+
+    act(() => {
+      result.current.runSelectAll()
+    })
+
+    rerender({ selected: ['policy-c'] })
+
+    act(() => {
+      resolveFetch([
+        { name: 'policy-a', is_project_eligible: false },
+        { name: 'policy-b', is_project_eligible: false },
+      ])
+    })
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(['policy-c', 'policy-a', 'policy-b'])
+    })
+  })
 })

--- a/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.test.ts
@@ -78,7 +78,7 @@ describe('usePolicySelectAll', () => {
     expect(fetchPolicies).toHaveBeenCalledTimes(1)
     expect(result.current.isSelectingAll).toBe(true)
 
-    await act(async () => {
+    act(() => {
       resolveFetch([{ name: 'policy-a', is_project_eligible: false }])
     })
 

--- a/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SELECT_ALL_LOAD_ERROR } from './policySelectConstants'
+import { usePolicySelectAll } from './usePolicySelectAll'
+
+describe('usePolicySelectAll', () => {
+  it('merges fetched policy names into the current selection', async () => {
+    const onChange = vi.fn()
+    const fetchPolicies = vi.fn().mockResolvedValue([
+      { name: 'policy-a', is_project_eligible: false },
+      { name: 'policy-b', is_project_eligible: false },
+    ])
+
+    const { result } = renderHook(() =>
+      usePolicySelectAll({
+        selected: ['policy-a'],
+        onChange,
+        fetchPolicies,
+        showError: vi.fn(),
+      })
+    )
+
+    act(() => {
+      result.current.runSelectAll()
+    })
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(['policy-a', 'policy-b'])
+    })
+  })
+
+  it('shows an error alert when fetching policies fails', async () => {
+    const showError = vi.fn()
+    const fetchPolicies = vi.fn().mockRejectedValue(new Error('network'))
+
+    const { result } = renderHook(() =>
+      usePolicySelectAll({
+        selected: [],
+        onChange: vi.fn(),
+        fetchPolicies,
+        showError,
+      })
+    )
+
+    act(() => {
+      result.current.runSelectAll()
+    })
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(SELECT_ALL_LOAD_ERROR)
+    })
+  })
+
+  it('ignores duplicate runSelectAll calls while a fetch is in progress', async () => {
+    let resolveFetch: (value: { name: string; is_project_eligible: boolean }[]) => void = () => undefined
+    const fetchPolicies = vi.fn(
+      () =>
+        new Promise<{ name: string; is_project_eligible: boolean }[]>((resolve) => {
+          resolveFetch = resolve
+        })
+    )
+
+    const { result } = renderHook(() =>
+      usePolicySelectAll({
+        selected: [],
+        onChange: vi.fn(),
+        fetchPolicies,
+        showError: vi.fn(),
+      })
+    )
+
+    act(() => {
+      result.current.runSelectAll()
+      result.current.runSelectAll()
+    })
+
+    expect(fetchPolicies).toHaveBeenCalledTimes(1)
+    expect(result.current.isSelectingAll).toBe(true)
+
+    await act(async () => {
+      resolveFetch([{ name: 'policy-a', is_project_eligible: false }])
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSelectingAll).toBe(false)
+    })
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.ts
@@ -1,0 +1,49 @@
+import { useCallback, useRef, useState } from 'react'
+
+import { detachPromise } from '../../utils/detachPromise'
+
+import { mergeSelectAll, SELECT_ALL_LOAD_ERROR, type PolicySelectListItem } from './policySelectConstants'
+
+type ShowError = (alert: { title: string; description?: string }) => void
+
+type UsePolicySelectAllParams = {
+  selected: string[]
+  onChange: (selected: string[]) => void
+  fetchPolicies: () => Promise<PolicySelectListItem[]>
+  showError: ShowError
+  onAfterSelect?: () => void
+}
+
+export function usePolicySelectAll({
+  selected,
+  onChange,
+  fetchPolicies,
+  showError,
+  onAfterSelect,
+}: UsePolicySelectAllParams) {
+  const [isSelectingAll, setIsSelectingAll] = useState(false)
+  const isSelectingAllRef = useRef(false)
+
+  const runSelectAll = useCallback(() => {
+    if (isSelectingAllRef.current) return
+
+    isSelectingAllRef.current = true
+    setIsSelectingAll(true)
+    detachPromise(
+      fetchPolicies()
+        .then((policies) => {
+          onChange(mergeSelectAll(selected, policies.map((policy) => policy.name)))
+          onAfterSelect?.()
+        })
+        .catch(() => {
+          showError(SELECT_ALL_LOAD_ERROR)
+        })
+        .finally(() => {
+          isSelectingAllRef.current = false
+          setIsSelectingAll(false)
+        })
+    )
+  }, [fetchPolicies, onAfterSelect, onChange, selected, showError])
+
+  return { isSelectingAll, runSelectAll }
+}

--- a/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.ts
@@ -23,6 +23,8 @@ export function usePolicySelectAll({
 }: UsePolicySelectAllParams) {
   const [isSelectingAll, setIsSelectingAll] = useState(false)
   const isSelectingAllRef = useRef(false)
+  const selectedRef = useRef(selected)
+  selectedRef.current = selected
 
   const runSelectAll = useCallback(() => {
     if (isSelectingAllRef.current) return
@@ -32,7 +34,12 @@ export function usePolicySelectAll({
     detachPromise(
       fetchPolicies()
         .then((policies) => {
-          onChange(mergeSelectAll(selected, policies.map((policy) => policy.name)))
+          onChange(
+            mergeSelectAll(
+              selectedRef.current,
+              policies.map((policy) => policy.name)
+            )
+          )
           onAfterSelect?.()
         })
         .catch(() => {
@@ -43,7 +50,7 @@ export function usePolicySelectAll({
           setIsSelectingAll(false)
         })
     )
-  }, [fetchPolicies, onAfterSelect, onChange, selected, showError])
+  }, [fetchPolicies, onAfterSelect, onChange, showError])
 
   return { isSelectingAll, runSelectAll }
 }

--- a/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/usePolicySelectAll.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { detachPromise } from '../../utils/detachPromise'
 
@@ -24,7 +24,9 @@ export function usePolicySelectAll({
   const [isSelectingAll, setIsSelectingAll] = useState(false)
   const isSelectingAllRef = useRef(false)
   const selectedRef = useRef(selected)
-  selectedRef.current = selected
+  useEffect(() => {
+    selectedRef.current = selected
+  })
 
   const runSelectAll = useCallback(() => {
     if (isSelectingAllRef.current) return


### PR DESCRIPTION
## Description

Adds a **Select All** option to the policy multi-select dropdowns used when creating and editing roles (global and project-scoped). Selecting all fetches every matching policy across paginated API results, not just the first page.

<img width="1512" height="822" alt="Screenshot 2026-08-11 at 11 22 49 AM" src="https://github.com/user-attachments/assets/0d89988b-74a6-4e6a-ae2c-72e9540d9691" />


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] Add **Select All** row to `PolicySelect` (global roles) and `ProjectPolicySelect` (project roles)
- [x] Fetch all policies via `fetchAllPages` for true select-all behavior
- [x] Filter policies by role scope so global roles exclude project-only policies
- [x] Extract shared UI (`PolicySelectToggle`, `PolicySelectOptionsList`) and logic (`usePolicySelectAll`, `policySelectConstants`)
- [x] Pass `scopeProjectId` from `AddRoleDialog` when project scope is selected
- [x] Unit tests for scope filtering, pagination fetch, select-all error/loading states, and dialog wiring

## Related Issues

Related to AAP-86303

## How to Test

1. Go to **Access Management → Roles** and create or edit a **system-scoped** role.
2. Open the **Policies** dropdown and confirm **Select All** appears above the policy list.
3. Click **Select All** and verify all assignable global policies are selected (including those beyond the first page).
4. Create or edit a **project-scoped** role and repeat; confirm project-eligible policies are selected.
5. Edit a global role and use **Select All** — confirm no project-only policies are included (no "Policies not available in global scope" error on save).


## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [x] Screenshots or screen recordings are attached for UI changes

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Additional Notes

Shared select-all logic follows the existing `MultiSelectFilter` pattern (sentinel value + divider). Policy chips use `NxLabel`; dropdown scrolling uses `longSelectMenu` on `NxSelect`.


Made with [Cursor](https://cursor.com)