### PR TITLE
fix(AAP-87139): user-friendly AI Agent orchestrator timeout message

### DIFF
--- a/backend/src/syntara/agent_orchestrator/agents/base_agent.py
+++ b/backend/src/syntara/agent_orchestrator/agents/base_agent.py
@@ -129,9 +129,13 @@ class BaseAgent(ABC):
             AgentOrchestratorError: For all other errors
 
         """
-        # Handle timeout errors
+        # Handle timeout errors (orchestrator/LLM timeout — distinct from Temporal StartToClose)
         if isinstance(error, TimeoutError):
-            msg = "Request timed out"
+            msg = (
+                "The AI Agent did not respond in time. Try again, increase the node "
+                "timeout, or simplify the prompt. If the agent may still be running, "
+                "check execution details before re-running."
+            )
             raise AgentTimeoutError(msg, str(invocation_id)) from error
 
         # Handle configuration and validation errors

--- a/backend/tests/unit/agent_orchestrator/agents/test_base_agent.py
+++ b/backend/tests/unit/agent_orchestrator/agents/test_base_agent.py
@@ -40,14 +40,21 @@ class TestBaseAgentErrorHandling:
     """Test BaseAgent error handling helper method."""
 
     def test_handle_execution_error_converts_timeout_error(self) -> None:
-        """Test that TimeoutError is converted to AgentTimeoutError."""
+        """Test that TimeoutError is converted to AgentTimeoutError with guidance."""
         agent = ConcreteAgent()
         invocation_id = uuid4()
         original_error = TimeoutError("Connection timed out")
+        expected_message = (
+            "The AI Agent did not respond in time. Try again, increase the node "
+            "timeout, or simplify the prompt. If the agent may still be running, "
+            "check execution details before re-running."
+        )
 
         with pytest.raises(AgentTimeoutError) as exc_info:
             agent._handle_execution_error(original_error, invocation_id)
 
+        assert str(exc_info.value) == expected_message
+        assert "Request timed out" not in str(exc_info.value)
         assert exc_info.value.invocation_id == str(invocation_id)
         assert exc_info.value.__cause__ == original_error
 

--- a/backend/tests/unit/agent_orchestrator/agents/test_generic_agent.py
+++ b/backend/tests/unit/agent_orchestrator/agents/test_generic_agent.py
@@ -189,6 +189,8 @@ class TestGenericAgentLLMIntegration:
             await agent.execute_as_node(state)
 
         assert exc_info.value.invocation_id == str(invocation_id)
+        assert "did not respond in time" in str(exc_info.value)
+        assert "Request timed out" not in str(exc_info.value)
 
 
 class TestGenericAgentContextInjection:


### PR DESCRIPTION
## Description

ai agent orchestrator timeouts were showing bare `Request timed out` with no remediation. this replaces that with the AGENT-12 target guidance so users know to retry, raise the node timeout, or simplify the prompt.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] replace bare `Request timed out` in `BaseAgent._handle_execution_error` with the AGENT-12 user-facing message
- [x] update unit tests in `test_base_agent.py` and `test_generic_agent.py` to assert the new copy

## Out of Scope

Temporal StartToClose timeout messaging ([AAP-87135](https://redhat.atlassian.net/browse/AAP-87135) / AGENT-07). that is a separate path.

## Related Issues

Fixes [AAP-87139](https://redhat.atlassian.net/browse/AAP-87139)

## How to Test

1. run an AI Agent step that hits an orchestrator/`TimeoutError` (not Temporal StartToClose)
2. confirm the surfaced error is the AGENT-12 guidance, not bare `Request timed out`
3. optional: `uv run pytest tests/unit/agent_orchestrator/agents/test_base_agent.py tests/unit/agent_orchestrator/agents/test_generic_agent.py -k timeout` from `backend/`

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->

