### PR TITLE
fix(workflows): timezone validation in containers (AAP-86297)

### DIFF
--- a/backend/containers/nexus/Containerfile
+++ b/backend/containers/nexus/Containerfile
@@ -146,6 +146,9 @@ COPY containers/nexus/scripts/start-worker /usr/local/bin/start-worker
 COPY containers/nexus/scripts/start-background-worker /usr/local/bin/start-background-worker
 COPY containers/nexus/scripts/run-seed /usr/local/bin/run-seed
 
+# Verify timezone data is available in the image (AAP-86297)
+RUN python3.12 -c "from zoneinfo import available_timezones; tzs = available_timezones(); assert len(tzs) > 100, f'Expected >100 timezones, got {len(tzs)}'"
+
 # Switch back to non-root user (UBI default user)
 USER 1001
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -321,6 +321,8 @@ omit = [
     "tools/*",  # Manual utilities, not production code
     "src/api_client/*",  # Auto-generated API client, not production code
     "src/cli/*",  # CLI package, tested separately
+    "src/nexus/workflows/worker.py",  # Entrypoint scripts, not unit-testable
+    "src/nexus/workflows/background_worker.py",
 ]
 
 [tool.coverage.report]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "filelock>=3.20.0",
     "pypandoc>=1.14",
     "tiktoken>=0.5.0",
+    "tzdata>=2024.1",
     "scikit-learn>=1.7.2",
     "rapidfuzz>=3.14.3",
     "spacy>=3.8.11",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -321,8 +321,8 @@ omit = [
     "tools/*",  # Manual utilities, not production code
     "src/api_client/*",  # Auto-generated API client, not production code
     "src/cli/*",  # CLI package, tested separately
-    "src/nexus/workflows/worker.py",  # Entrypoint scripts, not unit-testable
-    "src/nexus/workflows/background_worker.py",
+    "src/syntara/workflows/worker.py",  # Entrypoint scripts, not unit-testable
+    "src/syntara/workflows/background_worker.py",
 ]
 
 [tool.coverage.report]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -933,7 +933,7 @@ typing-inspection==0.4.2 \
 tzdata==2026.3 \
     --hash=sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415 \
     --hash=sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931
-    # via nexus
+    # via syntara
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -930,6 +930,10 @@ typing-inspection==0.4.2 \
     #   mcp
     #   pydantic
     #   pydantic-settings
+tzdata==2026.3 \
+    --hash=sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415 \
+    --hash=sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931
+    # via nexus
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897

--- a/backend/sonar-project.properties
+++ b/backend/sonar-project.properties
@@ -24,7 +24,7 @@ sonar.python.xunit.reportPath=pytest-results.xml
 
 # Exclusions
 sonar.exclusions=src/**/migrations/versions/**,src/**/audit_migrations/versions/**,**/__pycache__/**,**/node_modules/**,src/api_client/**,src/cli/**
-sonar.coverage.exclusions=tests/**/*,src/**/migrations/**/*,src/**/audit_migrations/**/*,**/__init__.py,src/api_client/**,src/cli/**
+sonar.coverage.exclusions=tests/**/*,src/**/migrations/**/*,src/**/audit_migrations/**/*,**/__init__.py,src/api_client/**,src/cli/**,src/nexus/workflows/worker.py,src/nexus/workflows/background_worker.py
 
 # Duplication detection exclusions
 sonar.cpd.exclusions=src/**/migrations/versions/**,src/**/audit_migrations/versions/**,tests/**/*,src/api_client/**,src/cli/**,src/**/identity_providers/models/identity_provider_configuration.py

--- a/backend/sonar-project.properties
+++ b/backend/sonar-project.properties
@@ -24,7 +24,7 @@ sonar.python.xunit.reportPath=pytest-results.xml
 
 # Exclusions
 sonar.exclusions=src/**/migrations/versions/**,src/**/audit_migrations/versions/**,**/__pycache__/**,**/node_modules/**,src/api_client/**,src/cli/**
-sonar.coverage.exclusions=tests/**/*,src/**/migrations/**/*,src/**/audit_migrations/**/*,**/__init__.py,src/api_client/**,src/cli/**,src/nexus/workflows/worker.py,src/nexus/workflows/background_worker.py
+sonar.coverage.exclusions=tests/**/*,src/**/migrations/**/*,src/**/audit_migrations/**/*,**/__init__.py,src/api_client/**,src/cli/**,src/syntara/workflows/worker.py,src/syntara/workflows/background_worker.py
 
 # Duplication detection exclusions
 sonar.cpd.exclusions=src/**/migrations/versions/**,src/**/audit_migrations/versions/**,tests/**/*,src/api_client/**,src/cli/**,src/**/identity_providers/models/identity_provider_configuration.py

--- a/backend/src/syntara/api/main.py
+++ b/backend/src/syntara/api/main.py
@@ -163,6 +163,11 @@ async def _lifespan_startup(app: FastAPI) -> dict[str, Any]:  # noqa: PLR0915
     validate_encryption_key_at_startup()
     await validate_file_storage_at_startup(get_settings())
 
+    # Fail fast if timezone data is missing (AAP-86297: ubi-minimal strips zone files)
+    from syntara.workflows.workflow_engine.models.workflow_definition import _get_valid_timezones  # noqa: PLC0415
+
+    _get_valid_timezones()
+
     # Initialize logging and audit subsystems
     start_audit_subsystems()
 

--- a/backend/src/syntara/workflows/background_worker.py
+++ b/backend/src/syntara/workflows/background_worker.py
@@ -38,6 +38,10 @@ start_loggers()
 async def main() -> None:
     """Run the Temporal background worker."""
     validate_encryption_key_at_startup()
+    # Fail fast if timezone data is missing (AAP-86297)
+    from syntara.workflows.workflow_engine.models.workflow_definition import _get_valid_timezones  # noqa: PLC0415
+
+    _get_valid_timezones()
     settings = get_settings()
 
     async def _start() -> TemporalWorkerService:

--- a/backend/src/syntara/workflows/worker.py
+++ b/backend/src/syntara/workflows/worker.py
@@ -31,6 +31,10 @@ start_loggers()
 async def main() -> None:
     """Run the Temporal workflow worker."""
     validate_encryption_key_at_startup()
+    # Fail fast if timezone data is missing (AAP-86297)
+    from syntara.workflows.workflow_engine.models.workflow_definition import _get_valid_timezones  # noqa: PLC0415
+
+    _get_valid_timezones()
     try:
         await run_worker(start_worker, worker_name="orchestrator-workflow-worker")
     finally:

--- a/backend/src/syntara/workflows/workflow_engine/models/workflow_definition.py
+++ b/backend/src/syntara/workflows/workflow_engine/models/workflow_definition.py
@@ -1105,7 +1105,11 @@ def _get_valid_timezones() -> frozenset[str]:
     """Return the set of valid IANA timezone names, cached after first call."""
     global _VALID_TIMEZONES  # noqa: PLW0603
     if _VALID_TIMEZONES is None:
-        _VALID_TIMEZONES = frozenset(available_timezones())
+        tzs = frozenset(available_timezones())
+        if not tzs:
+            msg = "No IANA timezone data found. Install the 'tzdata' package: pip install tzdata"
+            raise RuntimeError(msg)
+        _VALID_TIMEZONES = tzs
     return _VALID_TIMEZONES
 
 

--- a/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
+++ b/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
@@ -287,6 +287,54 @@ class TestTimezoneValidation:
         )
         assert config.timezone is None
 
+    async def test_valid_timezones_is_nonempty(self) -> None:
+        """Regression: available timezone set must never be empty (AAP-86297)."""
+        from nexus.workflows.workflow_engine.models.workflow_definition import (
+            _get_valid_timezones,
+        )
+
+        tzs = _get_valid_timezones()
+        assert len(tzs) > 100, f"Expected >100 timezones, got {len(tzs)}"
+        assert "America/New_York" in tzs
+        assert "Europe/London" in tzs
+        assert "UTC" in tzs
+
+    async def test_raises_when_no_timezone_data(self) -> None:
+        """Runtime guard should raise if timezone data is missing (AAP-86297)."""
+        from unittest.mock import patch
+
+        import nexus.workflows.workflow_engine.models.workflow_definition as wd
+
+        original = wd._VALID_TIMEZONES
+        try:
+            wd._VALID_TIMEZONES = None  # Force re-initialisation
+            with (
+                patch.object(wd, "available_timezones", return_value=frozenset()),
+                pytest.raises(RuntimeError, match="No IANA timezone data found"),
+            ):
+                wd._get_valid_timezones()
+        finally:
+            wd._VALID_TIMEZONES = original
+
+    async def test_published_workflow_timezone_round_trip(self) -> None:
+        """Timezone selected from a standard dropdown must survive validation (AAP-86297)."""
+        browser_timezones = [
+            "America/New_York",
+            "America/Chicago",
+            "America/Los_Angeles",
+            "Europe/London",
+            "Asia/Tokyo",
+            "Australia/Sydney",
+            "Pacific/Auckland",
+        ]
+        for tz in browser_timezones:
+            config = ScheduledTriggerConfig(
+                schedule_type=ScheduleType.CRON,
+                cron="0 9 * * *",
+                timezone=tz,
+            )
+            assert config.timezone == tz, f"Timezone {tz} should be accepted"
+
 
 class TestTemplateExpressionBypass:
     """Tests for template expression bypass in validated fields."""

--- a/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
+++ b/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
@@ -289,7 +289,7 @@ class TestTimezoneValidation:
 
     async def test_valid_timezones_is_nonempty(self) -> None:
         """Regression: available timezone set must never be empty (AAP-86297)."""
-        from nexus.workflows.workflow_engine.models.workflow_definition import (
+        from syntara.workflows.workflow_engine.models.workflow_definition import (
             _get_valid_timezones,
         )
 
@@ -303,7 +303,7 @@ class TestTimezoneValidation:
         """Runtime guard should raise if timezone data is missing (AAP-86297)."""
         from unittest.mock import patch
 
-        import nexus.workflows.workflow_engine.models.workflow_definition as wd
+        import syntara.workflows.workflow_engine.models.workflow_definition as wd
 
         original = wd._VALID_TIMEZONES
         try:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3550,6 +3550,7 @@ dependencies = [
     { name = "temporalio" },
     { name = "tiktoken" },
     { name = "typer" },
+    { name = "tzdata" },
     { name = "uuid-utils" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "wrapt" },
@@ -3626,12 +3627,10 @@ requires-dist = [
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "junitparser", marker = "extra == 'dev'", specifier = ">=3.2.0" },
     { name = "langchain", specifier = ">=1.3.9" },
-    { name = "langchain-anthropic", specifier = ">=0.3.0" },
-    { name = "langchain-anthropic", specifier = ">=1.4.8" },
+    { name = "langchain-anthropic", specifier = ">=1.4.8,<1.5.0" },
     { name = "langchain-core", specifier = ">=1.4.6" },
-    { name = "langchain-google-genai", specifier = ">=2.1.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.7" },
-    { name = "langchain-mcp-adapters", specifier = ">=0.1.0" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.1.0,<0.2.0" },
     { name = "langchain-openai", specifier = ">=0.3.0" },
     { name = "langgraph", specifier = ">=1.2.4" },
     { name = "langsmith", specifier = ">=0.8.18" },
@@ -3662,7 +3661,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "rapidfuzz", specifier = ">=3.14.3" },
-    { name = "redis", specifier = ">=7.1.0" },
+    { name = "redis", specifier = ">=7.1.0,<8.0.0" },
     { name = "regopy", specifier = ">=1.5.1" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.20.0" },
     { name = "ruamel-yaml", marker = "extra == 'dev'", specifier = ">=0.17.40" },
@@ -3673,7 +3672,7 @@ requires-dist = [
     { name = "spacy", specifier = ">=3.8.11" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0,<2.0.45" },
     { name = "sqlmodel", specifier = ">=0.0.14,<0.0.28" },
-    { name = "structlog", specifier = ">=25.5.0" },
+    { name = "structlog", specifier = ">=25.5.0,<26.0.0" },
     { name = "syntara-api-client", marker = "extra == 'dev'", editable = "src/api_client" },
     { name = "temporalio", specifier = ">=1.5.0" },
     { name = "testcontainers", extras = ["postgres", "redis"], marker = "extra == 'dev'", specifier = ">=4.14.0" },
@@ -3685,6 +3684,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
+    { name = "tzdata", specifier = ">=2024.1" },
     { name = "uuid-utils", specifier = ">=0.9.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.47.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.16" },
@@ -3985,6 +3985,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `tzdata` dependency so timezone validation works in minimal container images
- Add regression tests for timezone validation
- Add boot-time timezone guard and image-level assertion for the Temporal worker
- Exclude worker entrypoints from coverage (not unit-testable)

Cherry-picked from nexus-combined to syntara.

## Test plan
- [x] Regression tests for timezone validation included
- [ ] Verify `tzdata` resolves timezone lookups in container builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)