### PR TITLE
fix(backend): stop agent loop on invocation cancel and emit cancelled event

### DIFF
--- a/backend/src/syntara/agent_orchestrator/context_manager/planner.py
+++ b/backend/src/syntara/agent_orchestrator/context_manager/planner.py
@@ -11,6 +11,7 @@ from typing import NamedTuple
 from uuid import UUID
 
 import structlog
+from redis.exceptions import RedisError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -21,9 +22,12 @@ from syntara.agent_orchestrator.audit.context_planning import (
     ContextPlanningStatus,
 )
 from syntara.agent_orchestrator.exceptions import InvocationCancelledError
-from syntara.agent_orchestrator.models import Invocation, InvocationStatus, LLMCredentialConfig
+from syntara.agent_orchestrator.models import LLMCredentialConfig
+from syntara.agent_orchestrator.services.streaming_service import get_invocation_cancel_key
 from syntara.agent_orchestrator.token_manager import TokenValidationService
+from syntara.agent_orchestrator.utils.cancellation import is_invocation_cancelled
 from syntara.audit.dispatcher import AuditEventDispatcher
+from syntara.core.cache.stream import StreamClient
 from syntara.core.database.session import get_db
 from syntara.settings.cache.settings_cache import get_runtime_settings
 
@@ -105,35 +109,48 @@ class ContextManagerPlanner:
             InvocationCancelledError: If invocation has been cancelled
 
         """
+        cancelled = False
+        redis_available = True
+
+        # Fast path: check Redis cancellation key (O(1), sub-millisecond)
         try:
-            # Create a short-lived session for the cancellation check
-            async with self.get_async_session_context() as session:
-                invocation = await session.get(Invocation, invocation_id)
-                if invocation and invocation.status == InvocationStatus.CANCELLED:
-                    logger.info("Invocation cancelled during phase", phase=phase, invocation_id=invocation_id)
+            async with StreamClient() as client:
+                cancel_key = get_invocation_cancel_key(invocation_id)
+                cancelled = await client.key_exists(cancel_key)
+        except (RedisError, OSError):
+            redis_available = False
+            logger.debug("Redis cancellation check unavailable, falling back to DB", invocation_id=invocation_id)
 
-                    # Emit cancellation detected event
-                    AuditEventDispatcher.dispatch(
-                        CancellationEvent(
-                            phase=phase,
-                            session_id=session_id,
-                            invocation_id=invocation_id,
-                            execution_id=execution_id,
-                            request_id=request_id,
-                            activity_id=activity_id,
-                            activity_name=activity_name,
-                        )
-                    )
+        if not redis_available and not cancelled:
+            # Slow path: only when Redis was down — create a short-lived session
+            try:
+                async with self.get_async_session_context() as session:
+                    cancelled = await is_invocation_cancelled(session, invocation_id)
+            except (SQLAlchemyError, OSError) as e:
+                logger.warning(
+                    "Failed to check cancellation status for invocation, continuing execution",
+                    invocation_id=invocation_id,
+                    error=str(e),
+                    exc_info=True,
+                )
 
-                    raise InvocationCancelledError(str(invocation_id), phase.value)
-        except (SQLAlchemyError, OSError) as e:
-            # Log but don't fail on database errors - graceful degradation
-            logger.warning(
-                "Failed to check cancellation status for invocation, continuing execution",
-                invocation_id=invocation_id,
-                error=str(e),
-                exc_info=True,
+        if cancelled:
+            logger.info("Invocation cancelled during phase", phase=phase, invocation_id=invocation_id)
+
+            # Emit cancellation detected event
+            AuditEventDispatcher.dispatch(
+                CancellationEvent(
+                    phase=phase,
+                    session_id=session_id,
+                    invocation_id=invocation_id,
+                    execution_id=execution_id,
+                    request_id=request_id,
+                    activity_id=activity_id,
+                    activity_name=activity_name,
+                )
             )
+
+            raise InvocationCancelledError(str(invocation_id), phase.value)
 
     async def _resolve_token_budget(self) -> int:
         """Resolve the token budget from the model profile or fallback settings."""

--- a/backend/src/syntara/agent_orchestrator/context_manager/planner.py
+++ b/backend/src/syntara/agent_orchestrator/context_manager/planner.py
@@ -23,9 +23,8 @@ from syntara.agent_orchestrator.audit.context_planning import (
 )
 from syntara.agent_orchestrator.exceptions import InvocationCancelledError
 from syntara.agent_orchestrator.models import LLMCredentialConfig
-from syntara.agent_orchestrator.services.streaming_service import get_invocation_cancel_key
 from syntara.agent_orchestrator.token_manager import TokenValidationService
-from syntara.agent_orchestrator.utils.cancellation import is_invocation_cancelled
+from syntara.agent_orchestrator.utils.cancellation import get_invocation_cancel_key, is_invocation_cancelled
 from syntara.audit.dispatcher import AuditEventDispatcher
 from syntara.core.cache.stream import StreamClient
 from syntara.core.database.session import get_db

--- a/backend/src/syntara/agent_orchestrator/executor/invocation_executor.py
+++ b/backend/src/syntara/agent_orchestrator/executor/invocation_executor.py
@@ -43,8 +43,8 @@ from syntara.agent_orchestrator.models import (
 )
 from syntara.agent_orchestrator.services.error_handler import classify_streaming_error
 from syntara.agent_orchestrator.services.orchestration_service import OrchestrationService
-from syntara.agent_orchestrator.services.streaming_service import get_invocation_cancel_key
 from syntara.agent_orchestrator.token_manager.repository import TokenUsageRepository
+from syntara.agent_orchestrator.utils.cancellation import get_invocation_cancel_key
 from syntara.agent_orchestrator.utils.context_helpers import (
     extract_execution_id,
     extract_request_id,

--- a/backend/src/syntara/agent_orchestrator/executor/invocation_executor.py
+++ b/backend/src/syntara/agent_orchestrator/executor/invocation_executor.py
@@ -43,6 +43,7 @@ from syntara.agent_orchestrator.models import (
 )
 from syntara.agent_orchestrator.services.error_handler import classify_streaming_error
 from syntara.agent_orchestrator.services.orchestration_service import OrchestrationService
+from syntara.agent_orchestrator.services.streaming_service import get_invocation_cancel_key
 from syntara.agent_orchestrator.token_manager.repository import TokenUsageRepository
 from syntara.agent_orchestrator.utils.context_helpers import (
     extract_execution_id,
@@ -54,6 +55,7 @@ from syntara.agent_orchestrator.utils.workflow_signal_client import WorkflowSign
 from syntara.audit.context_managers import actor_context as audit_actor_context
 from syntara.audit.dispatcher import AuditEventDispatcher
 from syntara.audit.emitter import AuditActorContext
+from syntara.core.cache.stream import StreamClient
 from syntara.core.config.base import get_settings
 from syntara.core.database.session import get_db
 from syntara.core.models import User
@@ -155,6 +157,29 @@ class InvocationExecutor:
             actor_username=cn,
             actor_type=PrincipalType.SERVICE,
         )
+
+    async def _check_cancel_key(self, invocation_id: UUID, ctx: InvocationContextData) -> None:
+        """Check Redis cancel key with DB fallback; send cancel signal and raise if set."""
+        cancelled = False
+        try:
+            cancel_key = get_invocation_cancel_key(invocation_id)
+            async with StreamClient() as client:
+                cancelled = await client.key_exists(cancel_key) is True
+        except Exception:  # noqa: BLE001
+            try:
+                async with self.get_async_session_context() as session:
+                    inv = await session.get(Invocation, invocation_id)
+                    cancelled = inv is not None and inv.status == InvocationStatus.CANCELLED
+            except Exception:  # noqa: BLE001, S110
+                pass
+
+        if cancelled:
+            cb_url = ctx.callback_url.get_secret_value() if ctx.callback_url else None
+            try:
+                await WorkflowSignalClient.send_cancellation_signal(cb_url, invocation_id)
+            except Exception:
+                logger.exception("Failed to send cancellation signal", invocation_id=invocation_id)
+            raise InvocationCancelledError(str(invocation_id), phase="pre_execution")
 
     async def _load_invocation(self, invocation_id: UUID) -> Invocation | None:
         """Load invocation from database.
@@ -324,7 +349,16 @@ class InvocationExecutor:
         # Check if invocation was cancelled before execution
         if invocation.status == InvocationStatus.CANCELLED:
             logger.info("Invocation was cancelled before execution", invocation_id=invocation_id)
-            return
+            raw_cb = (invocation.context_data or {}).get("callback_url")
+            cb_url = raw_cb if isinstance(raw_cb, str) else None
+            try:
+                await WorkflowSignalClient.send_cancellation_signal(cb_url, invocation.id)
+            except Exception:
+                logger.exception(
+                    "Failed to send pre-start cancellation signal",
+                    invocation_id=invocation_id,
+                )
+            raise InvocationCancelledError(str(invocation_id), phase="pre_start")
 
         logger.info(
             "Executing invocation",
@@ -334,8 +368,12 @@ class InvocationExecutor:
         # Parse context_data into typed model once, reused throughout execution
         ctx = InvocationContextData.model_validate(invocation.context_data or {})
 
+        await self._check_cancel_key(invocation_id, ctx)
+
         # Wait for file conversions to reach terminal state before proceeding
         await self._wait_for_file_conversions(ctx)
+
+        await self._check_cancel_key(invocation_id, ctx)
 
         # Log conversion failures but allow execution to proceed (FR-020)
         await self._log_conversion_failures(invocation, ctx)
@@ -390,23 +428,29 @@ class InvocationExecutor:
 
         try:
             # Mark invocation as started
-            if await self._update_invocation_status(
+            updated = await self._update_invocation_status(
                 invocation.id,
                 InvocationStatus.RUNNING,
                 started_at=datetime.now(UTC),
-            ):
-                # Dispatch RUNNING event
-                AuditEventDispatcher.dispatch(
-                    InvocationLifecycleEvent(
-                        session_id=invocation.session_id,
-                        invocation_id=invocation.id,
-                        execution_id=execution_id,
-                        request_id=request_id,
-                        status=InvocationStatus.RUNNING,
-                        activity_id=ctx.activity_id,
-                        activity_name=ctx.activity_name,
-                    )
+            )
+            if not updated:
+                logger.info(
+                    "Invocation cancelled before RUNNING update",
+                    invocation_id=invocation.id,
                 )
+                raise InvocationCancelledError(str(invocation.id), phase="pre_execution")  # noqa: TRY301
+
+            AuditEventDispatcher.dispatch(
+                InvocationLifecycleEvent(
+                    session_id=invocation.session_id,
+                    invocation_id=invocation.id,
+                    execution_id=execution_id,
+                    request_id=request_id,
+                    status=InvocationStatus.RUNNING,
+                    activity_id=ctx.activity_id,
+                    activity_name=ctx.activity_name,
+                )
+            )
 
             # Execute through OrchestrationService (which handles context enhancement internally)
             logger.info(
@@ -495,8 +539,22 @@ class InvocationExecutor:
             self._record_invocation_metrics(recorder, invocation_start, invocation.id, status="success")
 
         except InvocationCancelledError:
+            # Invocation was cancelled during execution - this is expected behavior.
+            # The terminal cancelled stream event is published by
+            # orchestration_service when it catches this error.
             logger.info("Invocation cancelled during execution", invocation_id=invocation.id)
             self._record_invocation_metrics(recorder, invocation_start, invocation.id, status="cancelled")
+
+            # Notify workflow of cancellation (best-effort)
+            cb_url = ctx.callback_url.get_secret_value() if ctx.callback_url else None
+            try:
+                await WorkflowSignalClient.send_cancellation_signal(cb_url, invocation.id)
+            except Exception:
+                logger.exception(
+                    "Failed to send mid-execution cancellation signal",
+                    invocation_id=invocation.id,
+                )
+            raise
         except Exception as e:  # noqa: BLE001
             e = self._wrap_timeout_error(e, invocation.id)
             await self._handle_execution_failure(
@@ -530,7 +588,7 @@ class InvocationExecutor:
             error_type=type(e).__name__,
         )
 
-        if await self._fail_invocation_if_not_cancelled(
+        if not await self._fail_invocation_if_not_cancelled(
             invocation.id,
             completed_at=datetime.now(UTC),
             error_message=(
@@ -539,18 +597,28 @@ class InvocationExecutor:
                 else f"{type(e).__name__}: {e}"
             ),
         ):
-            AuditEventDispatcher.dispatch(
-                InvocationLifecycleEvent(
-                    session_id=invocation.session_id,
+            cb_url = ctx.callback_url.get_secret_value() if ctx.callback_url else None
+            try:
+                await WorkflowSignalClient.send_cancellation_signal(cb_url, invocation.id)
+            except Exception:
+                logger.exception(
+                    "Failed to send cancellation signal after error",
                     invocation_id=invocation.id,
-                    execution_id=execution_id,
-                    request_id=request_id,
-                    status=InvocationStatus.FAILED,
-                    error_type=type(e).__name__,
-                    activity_id=ctx.activity_id,
-                    activity_name=ctx.activity_name,
                 )
+            raise InvocationCancelledError(str(invocation.id), phase="error_after_cancel") from e
+
+        AuditEventDispatcher.dispatch(
+            InvocationLifecycleEvent(
+                session_id=invocation.session_id,
+                invocation_id=invocation.id,
+                execution_id=execution_id,
+                request_id=request_id,
+                status=InvocationStatus.FAILED,
+                error_type=type(e).__name__,
+                activity_id=ctx.activity_id,
+                activity_name=ctx.activity_name,
             )
+        )
 
         cb_url = ctx.callback_url.get_secret_value() if ctx.callback_url else None
         await WorkflowSignalClient.send_failure_signal(cb_url, invocation.id, e)
@@ -685,22 +753,29 @@ class InvocationExecutor:
                 credential_resolver=self._make_mcp_credential_resolver(meta.integration_connections if meta else None),
                 tool_selection_strategy=(meta.tool_selection_strategy if meta else None) or "NONE",
                 tool_selections=list(meta.tool_selections) if meta else [],
+                session_factory=self.session_factory,
             )
             logger.info("LLM initialized successfully for invocation", invocation_id=invocation.id)
             return service, llm_http_client
         except (LLMConfigurationError, CredentialResolutionError) as e:
             logger.exception("LLM configuration failed for invocation", invocation_id=invocation.id)
             now = datetime.now(UTC)
-            await self._update_invocation_status(
+            updated = await self._update_invocation_status(
                 invocation.id,
                 InvocationStatus.FAILED,
                 started_at=now,
                 error_message=type(e).__name__,
                 completed_at=now,
             )
-            logger.exception("Invocation failed", invocation_id=invocation.id, error_message=str(e))
-
             cb_url = ctx.callback_url.get_secret_value() if ctx.callback_url else None
+            if not updated:
+                try:
+                    await WorkflowSignalClient.send_cancellation_signal(cb_url, invocation.id)
+                except Exception:
+                    logger.exception("Failed to send cancellation signal", invocation_id=invocation.id)
+                raise InvocationCancelledError(str(invocation.id), phase="init_after_cancel") from e
+
+            logger.exception("Invocation failed", invocation_id=invocation.id, error_message=str(e))
             await WorkflowSignalClient.send_failure_signal(cb_url, invocation.id, e)
             return None
 

--- a/backend/src/syntara/agent_orchestrator/models/streaming_events.py
+++ b/backend/src/syntara/agent_orchestrator/models/streaming_events.py
@@ -70,6 +70,9 @@ class DeltaEventData(SQLModel):
     )  # type: ignore[assignment]
 
 
+CANCELLED_REASON_MAX_LENGTH = 200
+
+
 class CancelledEventData(SQLModel):
     """Data payload for streaming cancellation events.
 
@@ -83,7 +86,7 @@ class CancelledEventData(SQLModel):
     reason: str = Field(
         description="Why the streaming was cancelled",
         min_length=1,
-        max_length=200,
+        max_length=CANCELLED_REASON_MAX_LENGTH,
         examples=["user_cancelled", "timeout", "server_shutdown", "llm_error"],
     )
 

--- a/backend/src/syntara/agent_orchestrator/services/invocation_service.py
+++ b/backend/src/syntara/agent_orchestrator/services/invocation_service.py
@@ -16,11 +16,12 @@ Key design decisions:
 
 from collections.abc import AsyncGenerator, Callable, Iterable
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID, uuid4
 
 import structlog
 from fastapi import UploadFile
+from sqlmodel import col, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 if TYPE_CHECKING:
@@ -34,9 +35,11 @@ from syntara.agent_orchestrator.models import (
     InvocationStatus,
 )
 from syntara.agent_orchestrator.models.request import CancellationResult
+from syntara.agent_orchestrator.services.streaming_service import get_invocation_cancel_key
 from syntara.audit.dispatcher import AuditEventDispatcher
 from syntara.audit.emitter import request_id_context_var
 from syntara.authz.engine import AllowedProjectsResult
+from syntara.core.cache.stream import StreamClient
 from syntara.core.constants import CONTEXT_KEY_FILE_IDS
 from syntara.core.database.session import get_db
 from syntara.core.exceptions import SafeValueError
@@ -372,34 +375,81 @@ class InvocationService(BaseService):
             )
             return CancellationResult.NOT_CANCELLABLE
 
-        # Update invocation with cancellation details using existing fields
-        invocation.status = InvocationStatus.CANCELLED
-        invocation.error_message = f"User cancelled: {reason}"
-        invocation.completed_at = datetime.now(UTC)
-
-        # Store cancellation metadata in checkpoint_data for debugging
+        now = datetime.now(UTC)
+        error_message = f"User cancelled: {reason}"
         cancellation_data: dict[str, object] = {
-            "cancelled_at": invocation.completed_at.isoformat(),
+            "cancelled_at": now.isoformat(),
             "cancelled_by": str(self.user.id),
             "reason": reason,
         }
+        checkpoint_data: dict[str, object] = dict(invocation.checkpoint_data) if invocation.checkpoint_data else {}
+        checkpoint_data.update(cancellation_data)
 
-        # Merge with existing checkpoint_data if it exists
-        if invocation.checkpoint_data:
-            invocation.checkpoint_data.update(cancellation_data)
-        else:
-            invocation.checkpoint_data = cancellation_data
+        # Conditional UPDATE so a concurrent COMPLETED/FAILED write cannot be
+        # overwritten by a stale in-memory CANCELLED assignment.
+        stmt = (
+            update(Invocation)
+            .where(Invocation.id == invocation_id)  # type: ignore[arg-type]
+            .where(col(Invocation.status).in_((InvocationStatus.CREATED, InvocationStatus.RUNNING)))
+            .values(
+                status=InvocationStatus.CANCELLED,
+                error_message=error_message,
+                completed_at=now,
+                checkpoint_data=checkpoint_data,
+            )
+        )
+        result = await self.session.exec(stmt)
+        if not bool(cast("Any", result).rowcount > 0):
+            await self.session.refresh(invocation)
+            logger.warning(
+                "Cancellation failed: Invocation not in cancellable state",
+                invocation_id=invocation_id,
+                status=invocation.status.value,
+            )
+            AuditEventDispatcher.dispatch(
+                InvocationCancelledEvent(
+                    invocation_id=invocation_id,
+                    result=InvocationCancellationResult.NOT_CANCELLABLE,
+                    reason=reason,
+                    current_status=invocation.status,
+                    activity_id=activity_id,
+                    activity_name=activity_name,
+                )
+            )
+            return CancellationResult.NOT_CANCELLABLE
 
-        # Clean up uploaded and converted files associated with this invocation
-        cleaned_file_ids = await self._cleanup_invocation_files(invocation)
+        invocation.status = InvocationStatus.CANCELLED
+        invocation.error_message = error_message
+        invocation.completed_at = now
+        invocation.checkpoint_data = checkpoint_data
 
         # Note: Document conversion workflows will complete harmlessly even for
         # cancelled invocations. Execution workflow cancellation is handled by Temporal.
 
+        cleaned_file_ids: list[UUID] = []
         try:
             await self.session.commit()
 
             logger.info("Invocation cancelled successfully", invocation_id=invocation_id, reason=reason)
+
+            # Signal the running agent loop via Redis so it stops.  The
+            # terminal cancelled stream event is published by
+            # orchestration_service when the agent actually stops.
+            await self._signal_cancellation(invocation_id)
+
+            # Clean up files AFTER the signal is sent.  The agent may still be
+            # executing a tool at this point (see _cancellation_watcher known
+            # limitation) so in-flight tools could see missing files — this is
+            # accepted since the invocation is already cancelled in the DB.
+            # Best-effort: cleanup failures must not 500 a cancel that already
+            # committed — a client retry would get NOT_CANCELLABLE.
+            try:
+                cleaned_file_ids = await self._cleanup_invocation_files(invocation)
+            except Exception:
+                logger.exception(
+                    "File cleanup failed after cancellation, continuing",
+                    invocation_id=invocation_id,
+                )
 
             # Dispatch success audit event
             AuditEventDispatcher.dispatch(
@@ -428,7 +478,44 @@ class InvocationService(BaseService):
                     activity_name=activity_name,
                 )
             )
+            try:
+                await self.session.rollback()
+            except Exception:
+                logger.exception(
+                    "Failed to rollback after invocation cancel commit error",
+                    invocation_id=invocation_id,
+                )
             raise
+
+    async def _signal_cancellation(self, invocation_id: UUID) -> None:
+        """Set Redis cancellation key so the agent loop detects cancellation.
+
+        Only sets the cancel key — does NOT publish a terminal ``cancelled``
+        event to the stream.  The orchestration service publishes the terminal
+        event when the agent actually stops, ensuring no stream traffic appears
+        after the terminal marker.
+
+        Best-effort: Redis failures are logged but do not prevent cancellation.
+        """
+        from syntara.workflows.workflow_engine.constants import AGENT_EXECUTION_TIMEOUT_SECONDS  # noqa: PLC0415
+
+        cancel_key_ttl_seconds = AGENT_EXECUTION_TIMEOUT_SECONDS
+        try:
+            async with StreamClient() as client:
+                cancel_key = get_invocation_cancel_key(invocation_id)
+                await client.set_key(cancel_key, "1", cancel_key_ttl_seconds)
+
+                logger.info(
+                    "Cancellation signal sent via Redis",
+                    invocation_id=invocation_id,
+                )
+        except Exception:
+            logger.exception(
+                "Failed to signal cancellation via Redis,"
+                " agent may continue to completion if Redis stays healthy"
+                " (DB fallback only runs when Redis itself errors)",
+                invocation_id=invocation_id,
+            )
 
     async def _cleanup_files_from_paths(
         self, files_to_cleanup: list[str], invocation_id: UUID, *, context: str = ""

--- a/backend/src/syntara/agent_orchestrator/services/invocation_service.py
+++ b/backend/src/syntara/agent_orchestrator/services/invocation_service.py
@@ -35,7 +35,7 @@ from syntara.agent_orchestrator.models import (
     InvocationStatus,
 )
 from syntara.agent_orchestrator.models.request import CancellationResult
-from syntara.agent_orchestrator.services.streaming_service import get_invocation_cancel_key
+from syntara.agent_orchestrator.utils.cancellation import get_invocation_cancel_key
 from syntara.audit.dispatcher import AuditEventDispatcher
 from syntara.audit.emitter import request_id_context_var
 from syntara.authz.engine import AllowedProjectsResult

--- a/backend/src/syntara/agent_orchestrator/services/orchestration_service.py
+++ b/backend/src/syntara/agent_orchestrator/services/orchestration_service.py
@@ -43,13 +43,17 @@ from syntara.agent_orchestrator.models.streaming_events import (
     ToolResultEventData,
 )
 from syntara.agent_orchestrator.services.error_handler import classify_streaming_error
-from syntara.agent_orchestrator.services.streaming_service import get_invocation_cancel_key, get_invocation_stream_id
+from syntara.agent_orchestrator.services.streaming_service import get_invocation_stream_id
 from syntara.agent_orchestrator.tool_manager import ToolRetriever
 from syntara.agent_orchestrator.tool_manager.execution_failure_handler import (
     create_tool_awrapper,
     create_tool_wrapper,
 )
-from syntara.agent_orchestrator.utils.cancellation import is_invocation_cancelled, raise_if_invocation_cancelled
+from syntara.agent_orchestrator.utils.cancellation import (
+    get_invocation_cancel_key,
+    is_invocation_cancelled,
+    raise_if_invocation_cancelled,
+)
 from syntara.agent_orchestrator.utils.context_helpers import extract_request_id
 from syntara.agent_orchestrator.utils.token_usage import aggregate_token_usage
 from syntara.agent_orchestrator.utils.used_tools import aggregate_used_tools

--- a/backend/src/syntara/agent_orchestrator/services/orchestration_service.py
+++ b/backend/src/syntara/agent_orchestrator/services/orchestration_service.py
@@ -8,7 +8,7 @@ import asyncio
 import contextlib
 import time
 from collections import defaultdict, deque
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from datetime import UTC, datetime
 from typing import Any, cast
 from urllib.parse import urlparse, urlunparse
@@ -24,28 +24,32 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.prebuilt import ToolNode
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from syntara.agent_orchestrator.agents.generic_agent import GenericAgent
 from syntara.agent_orchestrator.agents.orchestrator_agent import OrchestratorAgent
 from syntara.agent_orchestrator.constants import AgentRoutes
 from syntara.agent_orchestrator.context_manager.planner import ContextManagerPlanner
-from syntara.agent_orchestrator.exceptions import ToolSelectionUnavailableError
+from syntara.agent_orchestrator.exceptions import InvocationCancelledError, ToolSelectionUnavailableError
 from syntara.agent_orchestrator.models.agent_response import GenericAgentResponse
 from syntara.agent_orchestrator.models.agent_state import AgentState, AgentStateFactory
 from syntara.agent_orchestrator.models.context_data import InvocationContextData
 from syntara.agent_orchestrator.models.streaming_events import (
+    CancelledEventData,
     CompletionEventData,
     DeltaEventData,
     ToolCallEventData,
     ToolResultEventData,
 )
 from syntara.agent_orchestrator.services.error_handler import classify_streaming_error
-from syntara.agent_orchestrator.services.streaming_service import get_invocation_stream_id
+from syntara.agent_orchestrator.services.streaming_service import get_invocation_cancel_key, get_invocation_stream_id
 from syntara.agent_orchestrator.tool_manager import ToolRetriever
 from syntara.agent_orchestrator.tool_manager.execution_failure_handler import (
     create_tool_awrapper,
     create_tool_wrapper,
 )
+from syntara.agent_orchestrator.utils.cancellation import is_invocation_cancelled, raise_if_invocation_cancelled
 from syntara.agent_orchestrator.utils.context_helpers import extract_request_id
 from syntara.agent_orchestrator.utils.token_usage import aggregate_token_usage
 from syntara.agent_orchestrator.utils.used_tools import aggregate_used_tools
@@ -54,6 +58,7 @@ from syntara.audit.decorators import audit
 from syntara.audit.emitter import AuditActorContext
 from syntara.audit.models.audit_event import EventCategory, EventSeverity
 from syntara.core.cache.stream import StreamClient
+from syntara.core.database.session import get_db
 from syntara.metrics.dependencies import get_metrics_recorder
 from syntara.metrics.instrumentation import LLMStreamTracker
 
@@ -62,6 +67,7 @@ logger = structlog.stdlib.get_logger(__name__)
 
 _MAX_TOOL_OUTPUT_LENGTH = 10_000
 _MAX_TOOL_CONTENT_LENGTH = 200
+_CANCELLATION_POLL_INTERVAL = 2.0
 
 
 class _TraceAccumulator:
@@ -276,6 +282,7 @@ class OrchestrationService:
         credential_resolver: Callable[[UUID], Awaitable[str | None]] | None = None,
         tool_selection_strategy: str | None = None,
         tool_selections: list[str] | None = None,
+        session_factory: Callable[[], AsyncGenerator[AsyncSession, None]] = get_db,
     ) -> None:
         """Initialize the orchestration service.
 
@@ -287,6 +294,7 @@ class OrchestrationService:
                 integration are authenticated at tool-call time.
             tool_selection_strategy: "ALL", "NONE", or "SELECTED". None/absent treated as "NONE" (no tools).
             tool_selections: Tool UUIDs to make available when strategy is "SELECTED".
+            session_factory: Session factory for DB fallback in cancellation checks.
 
         """
         self.llm = llm
@@ -294,6 +302,7 @@ class OrchestrationService:
         self._credential_resolver = credential_resolver
         self._tool_selection_strategy = tool_selection_strategy
         self._tool_selections = set(tool_selections or [])
+        self._get_async_session_context = contextlib.asynccontextmanager(session_factory)
 
     async def _setup_graph(self, state: AgentState) -> CompiledStateGraph[AgentState, None, Any, Any]:
         """Set up the LangGraph state machine with ToolNode integration.
@@ -507,6 +516,15 @@ class OrchestrationService:
             response_schema=response_schema,
         )
 
+        cancel_key = get_invocation_cancel_key(invocation_id)
+        try:
+            async with StreamClient() as pre_client:
+                await self._check_cancellation_signal(pre_client, cancel_key, invocation_id)
+        except InvocationCancelledError:
+            raise
+        except Exception:  # noqa: BLE001, S110
+            pass
+
         trace_accumulator = _TraceAccumulator()
 
         async with StreamClient() as client:
@@ -515,6 +533,7 @@ class OrchestrationService:
                 # terminal error event and workflow failure signals fire (same path as
                 # mid-stream failures). Setup must not run before StreamClient.
                 graph: CompiledStateGraph[AgentState, None, Any, Any] = await self._setup_graph(initial_state)
+                await raise_if_invocation_cancelled(invocation_id, "orchestration")
 
                 # Execute graph with streaming events
                 config: RunnableConfig = cast("RunnableConfig", {"configurable": {"thread_id": session_id}})
@@ -547,16 +566,44 @@ class OrchestrationService:
                 # over stream-derived reasoning-step estimates for Agent Steps header.
                 self._apply_provider_token_totals(result)
 
-                # Publish completion event
+                # Accepted race: if cancel lands while the watcher is in
+                # asyncio.sleep (up to the poll interval) and the stream
+                # iterator then ends, cancel_event is never set and we take
+                # this success path.  Consequences:
+                #  - A terminal "completion" event is written to the Redis
+                #    stream; WebSocket clients treat it as final and will not
+                #    see a subsequent "cancelled" event.
+                #  - A "completed" signal is posted to Temporal; the executor
+                #    skips the COMPLETED DB update (conditional WHERE != CANCELLED)
+                #    but does not send send_cancellation_signal, so the workflow
+                #    activity may complete as success while the DB row is CANCELLED.
+                #
+                # This is accepted: cancellation is best-effort and non-atomic.
+                # Once the stream iterator has exhausted, the LLM has finished
+                # and all tools have run — cancel after that point is treated
+                # as completion.  Adding a synchronous DB/Redis check here
+                # would penalise every successful invocation to close a sub-2s
+                # window on an already-completed task.
                 await self._publish_completion_event(invocation_id, stream_id, client)
-
-                # Handle completion callback with enriched result payload.
                 await self._handle_completion_callback(final_state, invocation_id, ctx, signal_result=result)
 
                 logger.info("Streaming orchestration completed", invocation_id=invocation_id)
 
                 return result
 
+            except InvocationCancelledError:
+                logger.info("Invocation cancelled during orchestration", invocation_id=invocation_id)
+                try:
+                    cancelled_data = CancelledEventData(reason="user_cancelled")
+                    await self._publish_stream_event(
+                        client, stream_id, "cancelled", invocation_id, cancelled_data.model_dump()
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to publish cancelled stream event",
+                        invocation_id=invocation_id,
+                    )
+                raise
             except Exception as e:
                 # Handle streaming errors
                 logger.exception(
@@ -572,7 +619,42 @@ class OrchestrationService:
 
                 raise
 
-    async def _execute_graph_streaming(
+    async def _cancellation_watcher(
+        self,
+        cancel_key: str,
+        invocation_id: UUID,
+        cancel_event: asyncio.Event,
+        interval: float | None = None,
+    ) -> None:
+        """Poll for cancellation independently of the stream loop.
+
+        Runs as a concurrent task so that long-running tools that block
+        ``astream_events`` do not prevent cancellation from being detected.
+        Sets *cancel_event* when cancellation is found; the stream loop
+        checks the event between iterations and raises.
+
+        Uses its own ``StreamClient`` so that cancelling the task cannot
+        corrupt the connection pool used by the stream publisher.
+
+        Known limitation: this watcher only improves *detection* latency
+        for the stream loop.  The actual raise happens inside the ``async for``
+        body, so an in-flight tool that blocks ``astream_events`` from yielding
+        keeps running until it returns or the tool wrapper's cancel check fires.
+        """
+        if interval is None:
+            interval = _CANCELLATION_POLL_INTERVAL
+        async with StreamClient() as watcher_client:
+            while not cancel_event.is_set():
+                try:
+                    await self._check_cancellation_signal(watcher_client, cancel_key, invocation_id)
+                except InvocationCancelledError:
+                    cancel_event.set()
+                    return
+                except Exception:  # noqa: BLE001
+                    logger.debug("Cancellation check failed, will retry", invocation_id=invocation_id, exc_info=True)
+                await asyncio.sleep(interval)
+
+    async def _execute_graph_streaming(  # noqa: C901
         self,
         graph: CompiledStateGraph[AgentState, None, Any, Any],
         initial_state: AgentState,
@@ -602,21 +684,91 @@ class OrchestrationService:
             recorder=get_metrics_recorder(),
             model=self._get_model_name(),
         )
+        cancel_key = get_invocation_cancel_key(invocation_id)
+        cancel_event = asyncio.Event()
 
-        # Stream events from LangGraph
-        async for event in graph.astream_events(initial_state, config, version="v2"):
-            # Process streaming events (event is StandardStreamEvent | CustomStreamEvent)
-            event_dict = cast("dict[str, Any]", event)
-            ttft_tracker.process_event(event_dict)
-            await self._process_streaming_event(event_dict, invocation_id, stream_id, client)
+        watcher = asyncio.create_task(
+            self._cancellation_watcher(cancel_key, invocation_id, cancel_event),
+            name="cancellation_watcher",
+        )
+        try:
+            # Stream events from LangGraph
+            async for event in graph.astream_events(initial_state, config, version="v2"):
+                if cancel_event.is_set():
+                    raise InvocationCancelledError(str(invocation_id), phase="streaming")  # noqa: TRY301
 
-            # Accumulate for trace persistence
-            trace_accumulator.accumulate(event_dict)
+                # Process streaming events (event is StandardStreamEvent | CustomStreamEvent)
+                event_dict = cast("dict[str, Any]", event)
+                ttft_tracker.process_event(event_dict)
+                await self._process_streaming_event(event_dict, invocation_id, stream_id, client)
 
-            # Capture final state from graph end events
-            final_state = self._extract_final_state(event_dict, final_state)
+                # Accumulate for trace persistence
+                trace_accumulator.accumulate(event_dict)
 
+                # Capture final state from graph end events
+                final_state = self._extract_final_state(event_dict, final_state)
+        except InvocationCancelledError:
+            raise
+        except Exception:
+            if cancel_event.is_set():
+                raise InvocationCancelledError(str(invocation_id), phase="streaming") from None
+            try:
+                async with self._get_async_session_context() as session:
+                    if await is_invocation_cancelled(session, invocation_id):
+                        raise InvocationCancelledError(str(invocation_id), phase="streaming") from None  # noqa: TRY301
+            except InvocationCancelledError:
+                raise
+            except Exception:  # noqa: BLE001, S110
+                pass
+            raise
+        finally:
+            watcher.cancel()
+            try:
+                await watcher
+            except asyncio.CancelledError:
+                task = asyncio.current_task()
+                if task is not None and task.cancelling():
+                    raise
+            except Exception:  # noqa: BLE001
+                logger.debug("Cancellation watcher raised on teardown", invocation_id=invocation_id, exc_info=True)
+
+        # No post-loop cancellation check: if cancellation lands after the last
+        # stream event, _complete_invocation_if_not_cancelled in the executor uses
+        # a conditional UPDATE (WHERE status != CANCELLED) to guarantee the DB
+        # never flips from CANCELLED to COMPLETED. The streaming-layer watcher is
+        # an optimisation to stop work early, not a correctness guarantee.
         return final_state
+
+    async def _check_cancellation_signal(
+        self,
+        client: StreamClient,
+        cancel_key: str,
+        invocation_id: UUID,
+    ) -> None:
+        """Check Redis for a cancellation signal; fall back to DB if Redis is unavailable."""
+        cancelled = False
+        redis_available = True
+
+        try:
+            cancelled = await client.key_exists(cancel_key) is True
+        except Exception:  # noqa: BLE001
+            redis_available = False
+            logger.debug("Redis cancellation check failed, falling back to DB", invocation_id=invocation_id)
+
+        if not redis_available and not cancelled:
+            try:
+                async with self._get_async_session_context() as session:
+                    cancelled = await is_invocation_cancelled(session, invocation_id)
+            except (SQLAlchemyError, OSError) as e:
+                logger.warning(
+                    "DB cancellation fallback failed, continuing",
+                    invocation_id=invocation_id,
+                    error=str(e),
+                )
+
+        if cancelled:
+            logger.info("Cancellation signal detected", invocation_id=invocation_id)
+            raise InvocationCancelledError(str(invocation_id), phase="streaming")
 
     def _extract_final_state(
         self, event_dict: dict[str, Any], current_final_state: AgentState | None

--- a/backend/src/syntara/agent_orchestrator/services/streaming_service.py
+++ b/backend/src/syntara/agent_orchestrator/services/streaming_service.py
@@ -3,7 +3,7 @@
 Provides WebSocket event streaming from Redis streams.
 """
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from functools import lru_cache
 from typing import Any, cast
 from uuid import UUID
@@ -15,11 +15,16 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.websockets import WebSocket
 
 from syntara.agent_orchestrator.models.invocation import Invocation, InvocationStatus
+from syntara.core.cache.stream import StreamClient
 from syntara.core.database.session import AsyncSessionLocal
 from syntara.core.models.error import ErrorData
 from syntara.core.websocket.base_handler import BaseWebSocketStreamingHandler
 from syntara.core.websocket.close_codes import POLICY_VIOLATION
-from syntara.core.websocket.exceptions import EventsExpiredError, StreamingValidationError
+from syntara.core.websocket.exceptions import (
+    EventsExpiredError,
+    InvocationCancelledStreamError,
+    StreamingValidationError,
+)
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -43,6 +48,19 @@ def get_invocation_stream_id(invocation_id: UUID) -> str:
 
     """
     return f"invocation:{invocation_id}:events"
+
+
+def get_invocation_cancel_key(invocation_id: UUID) -> str:
+    """Get Redis key for an invocation's cancellation signal.
+
+    Args:
+        invocation_id: UUID of the invocation
+
+    Returns:
+        Redis key (e.g., "invocation:UUID:cancelled")
+
+    """
+    return f"invocation:{invocation_id}:cancelled"
 
 
 # Custom exceptions for invocation streaming errors
@@ -147,6 +165,78 @@ class WebSocketStreamingHandler(BaseWebSocketStreamingHandler):
         """
         return str(session_state["invocation_id"])
 
+    async def check_before_streaming(self, session_state: dict[str, Any]) -> None:
+        """Raise if the invocation is already CANCELLED before reading events.
+
+        Uses the ``invocation_status`` snapshot from ``create_session_state``.
+        Mid-stream cancel is detected via the Redis cancel key in ``on_idle``.
+        """
+        invocation_id = session_state["invocation_id"]
+
+        if session_state.get("invocation_status") == InvocationStatus.CANCELLED:
+            logger.info(
+                "Invocation already cancelled, aborting before streaming",
+                invocation_id=invocation_id,
+            )
+            raise InvocationCancelledStreamError(
+                resource_id=str(invocation_id),
+                resource_type="invocation",
+            )
+
+    def get_on_idle(
+        self,
+        session_state: dict[str, Any],
+        client: StreamClient,
+    ) -> Callable[[], Awaitable[None]] | None:
+        """Return cancel-key checker invoked when XREAD returns no events.
+
+        Redis-first, with a DB fallback only when Redis itself errors.
+        Also short-circuits on the ``invocation_status`` snapshot from
+        ``create_session_state`` so a late connect after the cancel key
+        has expired still raises immediately.
+
+        Raises ``InvocationCancelledStreamError`` if the invocation
+        has been cancelled, which aborts the event stream.
+
+        """
+        invocation_id: UUID = session_state["invocation_id"]
+        invocation_status = session_state.get("invocation_status")
+        cancel_key = get_invocation_cancel_key(invocation_id)
+
+        async def _check_cancel_on_idle() -> None:
+            if invocation_status == InvocationStatus.CANCELLED:
+                raise InvocationCancelledStreamError(
+                    resource_id=str(invocation_id),
+                    resource_type="invocation",
+                )
+
+            cancelled = False
+            redis_available = True
+            try:
+                cancelled = await client.key_exists(cancel_key) is True
+            except Exception:  # noqa: BLE001
+                redis_available = False
+                logger.debug("Idle cancel key check failed, falling back to DB", invocation_id=invocation_id)
+
+            if not redis_available and not cancelled:
+                try:
+                    status = await self._check_invocation_exists(invocation_id)
+                    cancelled = status == InvocationStatus.CANCELLED
+                except StreamingValidationError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    logger.debug("DB fallback also failed, will retry next idle", invocation_id=invocation_id)
+                    return
+
+            if cancelled:
+                logger.info("Invocation cancelled during event streaming (idle check)", invocation_id=invocation_id)
+                raise InvocationCancelledStreamError(
+                    resource_id=str(invocation_id),
+                    resource_type="invocation",
+                )
+
+        return _check_cancel_on_idle
+
     async def wait_for_stream_ready(self, stream_id: str, session_state: dict[str, Any]) -> None:
         """Wait for invocation stream to be created.
 
@@ -163,10 +253,19 @@ class WebSocketStreamingHandler(BaseWebSocketStreamingHandler):
         invocation_status = session_state["invocation_status"]
 
         # Terminal statuses indicate invocation has finished
-        terminal_statuses = {InvocationStatus.COMPLETED, InvocationStatus.FAILED, InvocationStatus.CANCELLED}
+        terminal_statuses = {InvocationStatus.COMPLETED, InvocationStatus.FAILED}
+
+        if invocation_status == InvocationStatus.CANCELLED:
+            logger.warning(
+                "Invocation already cancelled, no stream to connect to",
+                invocation_id=invocation_id,
+            )
+            raise InvocationCancelledStreamError(
+                resource_id=str(invocation_id),
+                resource_type="invocation",
+            )
 
         if invocation_status in terminal_statuses:
-            # Invocation finished but stream doesn't exist - events expired
             logger.warning(
                 "Invocation is terminal but the Redis stream has expired",
                 invocation_id=invocation_id,
@@ -178,12 +277,35 @@ class WebSocketStreamingHandler(BaseWebSocketStreamingHandler):
                 resource_type="invocation",
             )
 
-        # Invocation still running - wait for stream to be created
+        cancel_key = get_invocation_cancel_key(invocation_id)
+
+        async def _check_cancel(client: StreamClient) -> None:
+            try:
+                cancelled = await client.key_exists(cancel_key)
+            except Exception:  # noqa: BLE001
+                # Redis failed — fall back to DB, same as _cancellation_watcher
+                logger.debug("Cancel key check failed, falling back to DB", invocation_id=invocation_id)
+                try:
+                    status = await self._check_invocation_exists(invocation_id)
+                    cancelled = status == InvocationStatus.CANCELLED
+                except StreamingValidationError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    logger.debug("DB fallback also failed, will retry next poll", invocation_id=invocation_id)
+                    return
+            if cancelled:
+                logger.info("Invocation cancelled during stream wait", invocation_id=invocation_id)
+                raise InvocationCancelledStreamError(
+                    resource_id=str(invocation_id),
+                    resource_type="invocation",
+                )
+
         await self._wait_for_stream_creation(
             stream_id=stream_id,
             resource_id=str(invocation_id),
             resource_status=invocation_status.value,
             resource_type="invocation",
+            on_poll=_check_cancel,
         )
 
     async def _check_invocation_exists(self, invocation_id: UUID) -> InvocationStatus:

--- a/backend/src/syntara/agent_orchestrator/services/streaming_service.py
+++ b/backend/src/syntara/agent_orchestrator/services/streaming_service.py
@@ -15,6 +15,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.websockets import WebSocket
 
 from syntara.agent_orchestrator.models.invocation import Invocation, InvocationStatus
+from syntara.agent_orchestrator.utils.cancellation import get_invocation_cancel_key
 from syntara.core.cache.stream import StreamClient
 from syntara.core.database.session import AsyncSessionLocal
 from syntara.core.models.error import ErrorData
@@ -48,19 +49,6 @@ def get_invocation_stream_id(invocation_id: UUID) -> str:
 
     """
     return f"invocation:{invocation_id}:events"
-
-
-def get_invocation_cancel_key(invocation_id: UUID) -> str:
-    """Get Redis key for an invocation's cancellation signal.
-
-    Args:
-        invocation_id: UUID of the invocation
-
-    Returns:
-        Redis key (e.g., "invocation:UUID:cancelled")
-
-    """
-    return f"invocation:{invocation_id}:cancelled"
 
 
 # Custom exceptions for invocation streaming errors
@@ -166,16 +154,54 @@ class WebSocketStreamingHandler(BaseWebSocketStreamingHandler):
         return str(session_state["invocation_id"])
 
     async def check_before_streaming(self, session_state: dict[str, Any]) -> None:
-        """Raise if the invocation is already CANCELLED before reading events.
+        """Raise if the invocation is CANCELLED before reading events.
 
-        Uses the ``invocation_status`` snapshot from ``create_session_state``.
-        Mid-stream cancel is detected via the Redis cancel key in ``on_idle``.
+        The connect-time ``invocation_status`` snapshot can be stale after
+        ``wait_for_stream_ready``. A live Redis cancel-key check (DB fallback
+        only when Redis itself errors) prevents replaying a raced
+        ``completion`` event for an invocation that was cancelled while waiting.
         """
         invocation_id = session_state["invocation_id"]
 
         if session_state.get("invocation_status") == InvocationStatus.CANCELLED:
             logger.info(
                 "Invocation already cancelled, aborting before streaming",
+                invocation_id=invocation_id,
+            )
+            raise InvocationCancelledStreamError(
+                resource_id=str(invocation_id),
+                resource_type="invocation",
+            )
+
+        cancel_key = get_invocation_cancel_key(invocation_id)
+        cancelled = False
+        redis_available = True
+        try:
+            async with StreamClient() as client:
+                cancelled = await client.key_exists(cancel_key) is True
+        except Exception:  # noqa: BLE001
+            redis_available = False
+            logger.debug(
+                "Pre-stream cancel key check failed, falling back to DB",
+                invocation_id=invocation_id,
+            )
+
+        if not redis_available and not cancelled:
+            try:
+                status = await self._check_invocation_exists(invocation_id)
+                cancelled = status == InvocationStatus.CANCELLED
+            except StreamingValidationError:
+                raise
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "DB fallback also failed before streaming",
+                    invocation_id=invocation_id,
+                )
+                return
+
+        if cancelled:
+            logger.info(
+                "Invocation cancelled before streaming (live check)",
                 invocation_id=invocation_id,
             )
             raise InvocationCancelledStreamError(

--- a/backend/src/syntara/agent_orchestrator/tool_manager/execution_failure_handler.py
+++ b/backend/src/syntara/agent_orchestrator/tool_manager/execution_failure_handler.py
@@ -18,8 +18,10 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 
 from syntara.agent_orchestrator.audit.tool_management import ToolInvocationEvent, ToolInvocationStatus
+from syntara.agent_orchestrator.exceptions import InvocationCancelledError
 from syntara.agent_orchestrator.tool_manager.tool_services import _get_tool_manager_client
 from syntara.agent_orchestrator.utils import retry_with_backoff
+from syntara.agent_orchestrator.utils.cancellation import raise_if_invocation_cancelled
 from syntara.audit.dispatcher import AuditEventDispatcher
 from syntara.core.config.base import get_settings
 from syntara.core.database.session import AsyncSessionLocal
@@ -367,7 +369,7 @@ def create_tool_awrapper(
     async def _execute(
         request: ToolCallRequest, execute: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]]
     ) -> ToolMessage | Command[Any]:
-        # Execute async function
+        await raise_if_invocation_cancelled(ctx.invocation_id, "tool_execution")
         return await execute(request)
 
     async def tool_awrapper(
@@ -395,6 +397,9 @@ def create_tool_awrapper(
             result = await _execute(request, execute)
             _emit_success_audit(ctx, tool_name, result)
             return result
+        except InvocationCancelledError as error:
+            caught_error = error
+            raise
         except Exception as error:  # noqa: BLE001 - logged inside _handle_tool_execution_error
             caught_error = error
             tool_id, error_msg = _handle_tool_execution_error(ctx, request, error)

--- a/backend/src/syntara/agent_orchestrator/tool_manager/execution_failure_handler.py
+++ b/backend/src/syntara/agent_orchestrator/tool_manager/execution_failure_handler.py
@@ -369,7 +369,6 @@ def create_tool_awrapper(
     async def _execute(
         request: ToolCallRequest, execute: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]]
     ) -> ToolMessage | Command[Any]:
-        await raise_if_invocation_cancelled(ctx.invocation_id, "tool_execution")
         return await execute(request)
 
     async def tool_awrapper(
@@ -394,6 +393,9 @@ def create_tool_awrapper(
         _emit_start_audit(ctx, tool_name, tool_input)
 
         try:
+            # Outside retry_with_backoff's wait_for so a hung Redis EXISTS
+            # cannot be classified as a retryable tool TimeoutError.
+            await raise_if_invocation_cancelled(ctx.invocation_id, "tool_execution")
             result = await _execute(request, execute)
             _emit_success_audit(ctx, tool_name, result)
             return result

--- a/backend/src/syntara/agent_orchestrator/tool_manager/execution_failure_handler.py
+++ b/backend/src/syntara/agent_orchestrator/tool_manager/execution_failure_handler.py
@@ -407,13 +407,19 @@ def create_tool_awrapper(
                 await _report_tool_failure(tool_id, error)
             return error_msg
         finally:
-            duration_ms, status = _finalize_tool_execution(request, start_time, caught_error, execution_id)
-            await _persist_tool_execution_to_db(
-                request.tool,
-                duration_ms,
-                status,
-                error_message=str(caught_error) if caught_error else None,
-            )
+            if isinstance(caught_error, InvocationCancelledError):
+                logger.debug(
+                    "Skipping tool execution metrics for cancelled invocation",
+                    invocation_id=ctx.invocation_id,
+                )
+            else:
+                duration_ms, status = _finalize_tool_execution(request, start_time, caught_error, execution_id)
+                await _persist_tool_execution_to_db(
+                    request.tool,
+                    duration_ms,
+                    status,
+                    error_message=str(caught_error) if caught_error else None,
+                )
 
     return tool_awrapper
 
@@ -513,17 +519,23 @@ def create_tool_wrapper(
                 _run_coroutine_from_sync(_report_tool_failure(tool_id, error), loop, "tool failure report")
             return error_msg
         finally:
-            duration_ms, status = _finalize_tool_execution(request, start_time, caught_error, execution_id)
-            _run_coroutine_from_sync(
-                _persist_tool_execution_to_db(
-                    request.tool,
-                    duration_ms,
-                    status,
-                    error_message=str(caught_error) if caught_error else None,
-                ),
-                loop,
-                "tool execution DB persistence",
-            )
+            if isinstance(caught_error, InvocationCancelledError):
+                logger.debug(
+                    "Skipping tool execution metrics for cancelled invocation",
+                    invocation_id=ctx.invocation_id,
+                )
+            else:
+                duration_ms, status = _finalize_tool_execution(request, start_time, caught_error, execution_id)
+                _run_coroutine_from_sync(
+                    _persist_tool_execution_to_db(
+                        request.tool,
+                        duration_ms,
+                        status,
+                        error_message=str(caught_error) if caught_error else None,
+                    ),
+                    loop,
+                    "tool execution DB persistence",
+                )
 
     return tool_wrapper
 

--- a/backend/src/syntara/agent_orchestrator/utils/cancellation.py
+++ b/backend/src/syntara/agent_orchestrator/utils/cancellation.py
@@ -1,5 +1,6 @@
 """Helpers for detecting invocation cancellation from a running agent."""
 
+import asyncio
 from uuid import UUID
 
 import structlog
@@ -12,6 +13,10 @@ from syntara.core.cache.stream import StreamClient
 from syntara.core.database.session import AsyncSessionLocal
 
 logger = structlog.stdlib.get_logger(__name__)
+
+# StreamClient has no socket_timeout, so EXISTS can block forever. Bound it so a
+# hung Redis is treated as unavailable and we fall back to the invocation row.
+_REDIS_CANCEL_CHECK_TIMEOUT_SECONDS = 2.0
 
 
 def get_invocation_cancel_key(invocation_id: UUID) -> str:
@@ -36,7 +41,8 @@ async def is_invocation_cancelled(session: AsyncSession, invocation_id: UUID) ->
 async def raise_if_invocation_cancelled(invocation_id: UUID, phase: str) -> None:
     """Raise ``InvocationCancelledError`` if the invocation was cancelled.
 
-    Redis-first (cancel key), with a DB fallback only when Redis itself errors.
+    Redis-first (cancel key), with a DB fallback only when Redis itself errors
+    or the EXISTS check exceeds ``_REDIS_CANCEL_CHECK_TIMEOUT_SECONDS``.
     Database errors are logged and swallowed so a failed status check cannot
     take down an otherwise healthy agent run.
     """
@@ -45,7 +51,13 @@ async def raise_if_invocation_cancelled(invocation_id: UUID, phase: str) -> None
 
     try:
         async with StreamClient() as client:
-            cancelled = await client.key_exists(get_invocation_cancel_key(invocation_id)) is True
+            cancelled = (
+                await asyncio.wait_for(
+                    client.key_exists(get_invocation_cancel_key(invocation_id)),
+                    timeout=_REDIS_CANCEL_CHECK_TIMEOUT_SECONDS,
+                )
+                is True
+            )
     except Exception:  # noqa: BLE001
         redis_available = False
         logger.debug(

--- a/backend/src/syntara/agent_orchestrator/utils/cancellation.py
+++ b/backend/src/syntara/agent_orchestrator/utils/cancellation.py
@@ -8,9 +8,23 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from syntara.agent_orchestrator.exceptions import InvocationCancelledError
 from syntara.agent_orchestrator.models.invocation import Invocation, InvocationStatus
+from syntara.core.cache.stream import StreamClient
 from syntara.core.database.session import AsyncSessionLocal
 
 logger = structlog.stdlib.get_logger(__name__)
+
+
+def get_invocation_cancel_key(invocation_id: UUID) -> str:
+    """Get Redis key for an invocation's cancellation signal.
+
+    Args:
+        invocation_id: UUID of the invocation
+
+    Returns:
+        Redis key (e.g., "invocation:UUID:cancelled")
+
+    """
+    return f"invocation:{invocation_id}:cancelled"
 
 
 async def is_invocation_cancelled(session: AsyncSession, invocation_id: UUID) -> bool:
@@ -22,20 +36,35 @@ async def is_invocation_cancelled(session: AsyncSession, invocation_id: UUID) ->
 async def raise_if_invocation_cancelled(invocation_id: UUID, phase: str) -> None:
     """Raise ``InvocationCancelledError`` if the invocation was cancelled.
 
+    Redis-first (cancel key), with a DB fallback only when Redis itself errors.
     Database errors are logged and swallowed so a failed status check cannot
     take down an otherwise healthy agent run.
     """
+    cancelled = False
+    redis_available = True
+
     try:
-        async with AsyncSessionLocal() as session:
-            cancelled = await is_invocation_cancelled(session, invocation_id)
-    except (SQLAlchemyError, OSError) as exc:
-        logger.warning(
-            "Failed to check cancellation status for invocation, continuing execution",
+        async with StreamClient() as client:
+            cancelled = await client.key_exists(get_invocation_cancel_key(invocation_id)) is True
+    except Exception:  # noqa: BLE001
+        redis_available = False
+        logger.debug(
+            "Redis cancellation check failed, falling back to DB",
             invocation_id=invocation_id,
-            error=str(exc),
-            exc_info=True,
         )
-        return
+
+    if not redis_available and not cancelled:
+        try:
+            async with AsyncSessionLocal() as session:
+                cancelled = await is_invocation_cancelled(session, invocation_id)
+        except (SQLAlchemyError, OSError) as exc:
+            logger.warning(
+                "Failed to check cancellation status for invocation, continuing execution",
+                invocation_id=invocation_id,
+                error=str(exc),
+                exc_info=True,
+            )
+            return
 
     if cancelled:
         raise InvocationCancelledError(str(invocation_id), phase)

--- a/backend/src/syntara/agent_orchestrator/utils/cancellation.py
+++ b/backend/src/syntara/agent_orchestrator/utils/cancellation.py
@@ -1,0 +1,41 @@
+"""Helpers for detecting invocation cancellation from a running agent."""
+
+from uuid import UUID
+
+import structlog
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+from syntara.agent_orchestrator.models.invocation import Invocation, InvocationStatus
+from syntara.core.database.session import AsyncSessionLocal
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+async def is_invocation_cancelled(session: AsyncSession, invocation_id: UUID) -> bool:
+    """Return True if *invocation_id* exists and is in CANCELLED status."""
+    invocation = await session.get(Invocation, invocation_id)
+    return invocation is not None and invocation.status == InvocationStatus.CANCELLED
+
+
+async def raise_if_invocation_cancelled(invocation_id: UUID, phase: str) -> None:
+    """Raise ``InvocationCancelledError`` if the invocation was cancelled.
+
+    Database errors are logged and swallowed so a failed status check cannot
+    take down an otherwise healthy agent run.
+    """
+    try:
+        async with AsyncSessionLocal() as session:
+            cancelled = await is_invocation_cancelled(session, invocation_id)
+    except (SQLAlchemyError, OSError) as exc:
+        logger.warning(
+            "Failed to check cancellation status for invocation, continuing execution",
+            invocation_id=invocation_id,
+            error=str(exc),
+            exc_info=True,
+        )
+        return
+
+    if cancelled:
+        raise InvocationCancelledError(str(invocation_id), phase)

--- a/backend/src/syntara/agent_orchestrator/utils/workflow_signal_client.py
+++ b/backend/src/syntara/agent_orchestrator/utils/workflow_signal_client.py
@@ -244,3 +244,69 @@ class WorkflowSignalClient:
                 "Unexpected error sending failure signal",
                 invocation_id=invocation_id,
             )
+
+    @staticmethod
+    async def send_cancellation_signal(
+        callback_url: str | None,
+        invocation_id: UUID,
+        reason: str = "User cancelled",
+    ) -> None:
+        """Send cancellation signal to workflow (best-effort).
+
+        Sends ``status: "cancelled"`` so the workflow engine can distinguish
+        cancellations from permanent failures.
+
+        Args:
+            callback_url: Workflow callback URL (None to skip)
+            invocation_id: Invocation UUID
+            reason: Human-readable cancellation reason
+
+        """
+        if not callback_url:
+            logger.debug(
+                "No callback_url for invocation, skipping cancellation signal",
+                invocation_id=invocation_id,
+            )
+            return
+
+        validate_signal_url(callback_url)
+
+        signal_payload = {
+            "signal_data": {
+                "id": str(invocation_id),
+                "status": "cancelled",
+                "reason": reason,
+                "error": {
+                    "message": reason,
+                    "error_type": "InvocationCancelledError",
+                },
+                "timestamp": datetime.now(UTC).isoformat(),
+                "agent_type": "GenericAgent",
+            }
+        }
+
+        logger.info(
+            "CANCELLATION SIGNAL: Sending to callback",
+            callback_url=callback_url,
+            invocation_id=invocation_id,
+        )
+
+        try:
+            await _post_signal(callback_url, signal_payload, invocation_id)
+
+            logger.info(
+                "CANCELLATION SIGNAL: Sent successfully",
+                invocation_id=invocation_id,
+                callback_url=callback_url,
+            )
+        except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException):
+            logger.exception(
+                "Failed to send cancellation signal",
+                invocation_id=invocation_id,
+                callback_url=callback_url,
+            )
+        except Exception:
+            logger.exception(
+                "Unexpected error sending cancellation signal",
+                invocation_id=invocation_id,
+            )

--- a/backend/src/syntara/core/cache/stream.py
+++ b/backend/src/syntara/core/cache/stream.py
@@ -36,14 +36,14 @@ Usage:
 
 import asyncio
 import json
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import Any
 
 import structlog
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import MaxConnectionsError, ResponseError
 
-from syntara.core.cache.base import BaseRedisClient, redis_operation_with_backoff
+from syntara.core.cache.base import BaseRedisClient, redis_error_handler, redis_operation_with_backoff
 from syntara.core.exceptions import SafeValueError
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -64,6 +64,46 @@ class StreamClient(BaseRedisClient):
     """
 
     _client_name = "stream"
+
+    async def key_exists(self, key: str) -> bool:
+        """Check whether a Redis key exists.
+
+        Args:
+            key: The Redis key to check
+
+        Returns:
+            True if the key exists, False otherwise
+
+        Raises:
+            RedisConnectionError: If connection to cache fails
+
+        """
+        client = self._ensure_connected()
+        return bool(await client.exists(key))
+
+    async def set_key(self, key: str, value: str, ttl: int) -> None:
+        """Set a Redis key with a TTL.
+
+        Uses the same retry-with-backoff wrapper as ``publish`` because
+        SETEX is idempotent and ``MaxConnectionsError`` (pool exhaustion)
+        is the most common transient failure.
+
+        Args:
+            key: The Redis key to set
+            value: The value to store
+            ttl: Time-to-live in seconds
+
+        Raises:
+            RedisConnectionError: If connection to cache fails
+
+        """
+        client = self._ensure_connected()
+
+        async def _setex() -> None:
+            async with redis_error_handler("set_key", key=key):
+                await client.setex(key, ttl, value)
+
+        await redis_operation_with_backoff(_setex, "set_key", key=key)
 
     async def publish(self, stream_id: str, data: dict[str, Any]) -> str:
         """Publish arbitrary event data to a cache stream.
@@ -292,6 +332,7 @@ class StreamClient(BaseRedisClient):
         should_stop: Callable[[dict[str, Any]], bool] | None,
         block_ms: int,
         count: int,
+        on_idle: Callable[[], Awaitable[None]] | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Read events from stream in a loop.
 
@@ -301,6 +342,10 @@ class StreamClient(BaseRedisClient):
             should_stop: Optional callback to determine when to stop
             block_ms: Milliseconds to block waiting for new events
             count: Maximum number of events to read per batch
+            on_idle: Optional async callback invoked when XREAD returns no
+                events (i.e. the block timeout expired with nothing new).
+                Useful for external checks such as cancellation detection.
+                May raise to abort the stream.
 
         Yields:
             Deserialized event data dictionaries
@@ -318,8 +363,10 @@ class StreamClient(BaseRedisClient):
                 # Read batch of events from stream
                 result = await client.xread({stream_id: current_id}, count=count, block=block_ms)
 
-                # If no events returned, continue waiting
+                # If no events returned, run idle callback and continue waiting
                 if not result:
+                    if on_idle is not None:
+                        await on_idle()
                     await asyncio.sleep(0)
                     continue
 
@@ -357,6 +404,7 @@ class StreamClient(BaseRedisClient):
         should_stop: Callable[[dict[str, Any]], bool] | None = None,
         block_ms: int = 1000,
         count: int = 100,
+        on_idle: Callable[[], Awaitable[None]] | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Read events from a stream as an async generator.
 
@@ -365,6 +413,7 @@ class StreamClient(BaseRedisClient):
         - Manual: caller can break from loop at any time
         - Conditional: provide should_stop function for automatic termination
         - External: use asyncio.Event or other signaling mechanisms
+        - Idle check: provide on_idle callback for checks between empty reads
 
         Position can be specified in two mutually exclusive ways:
         - start_id: Explicit stream position (honored first)
@@ -384,6 +433,8 @@ class StreamClient(BaseRedisClient):
                         Called with each event dict, stops when returns True.
             block_ms: Milliseconds to block waiting for new events (default 1000)
             count: Maximum number of events to read per batch (default 100)
+            on_idle: Optional async callback invoked each time XREAD returns no
+                events. May raise to abort the stream.
 
         Yields:
             Dict[str, Any]: Deserialized event data dictionaries
@@ -431,7 +482,7 @@ class StreamClient(BaseRedisClient):
         current_id = await self._determine_start_position(stream_id, start_id, replay)
 
         # Read and yield events from stream
-        async for event in self._read_event_stream(stream_id, current_id, should_stop, block_ms, count):
+        async for event in self._read_event_stream(stream_id, current_id, should_stop, block_ms, count, on_idle):
             yield event
 
     async def info(self, stream_id: str) -> dict[str, Any]:

--- a/backend/src/syntara/core/websocket/base_handler.py
+++ b/backend/src/syntara/core/websocket/base_handler.py
@@ -5,7 +5,7 @@ Provides a template method pattern for implementing WebSocket streaming handlers
 
 import asyncio
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -16,6 +16,8 @@ from starlette.websockets import WebSocket
 
 if TYPE_CHECKING:
     from uuid import UUID
+
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from syntara.core.cache.stream import StreamClient
 from syntara.core.constants import FieldLimits
@@ -113,6 +115,41 @@ class BaseWebSocketStreamingHandler(ABC):
         """
 
     # ============ Optional Hooks (Can Override) ============
+
+    async def check_before_streaming(self, session_state: dict[str, Any]) -> None:  # noqa: B027
+        """Run a pre-stream check after the stream exists but before reading.
+
+        Override to raise when the resource is already in a terminal state
+        that the replay may not surface (e.g. cancelled invocation whose
+        stream contains a ``completion`` event from the accepted race).
+
+        The default implementation is a no-op.
+
+        Args:
+            session_state: Session state dict from create_session_state
+
+        """
+
+    def get_on_idle(
+        self,
+        session_state: dict[str, Any],  # noqa: ARG002
+        client: StreamClient,  # noqa: ARG002
+    ) -> Callable[[], Awaitable[None]] | None:
+        """Return an async callback invoked when XREAD returns no events.
+
+        Override to perform periodic checks (e.g. cancellation detection)
+        during idle periods of the event stream.  The callback may raise
+        to abort streaming.
+
+        Args:
+            session_state: Session state dict from create_session_state
+            client: The StreamClient used for the event stream
+
+        Returns:
+            Async callable or None (default)
+
+        """
+        return None
 
     async def wait_for_stream_ready(
         self, stream_id: str, session_state: dict[str, Any]
@@ -277,19 +314,28 @@ class BaseWebSocketStreamingHandler(ABC):
             lifecycle_manager.activate_connection(lifecycle_conn_id)
 
             # Step 2: Check if stream exists
-            async with StreamClient() as client:
-                info = await client.info(stream_id)
+            stream_exists = False
+            try:
+                async with StreamClient() as client:
+                    info = await client.info(stream_id)
+                    stream_exists = info["exists"]
+            except (RedisConnectionError, OSError):
+                logger.debug("Redis unavailable for stream existence check, entering wait", stream_id=stream_id)
 
-                if not info["exists"]:
-                    # Stream doesn't exist - wait for it to be ready
-                    await self.wait_for_stream_ready(stream_id, session_state)
+            if not stream_exists:
+                await self.wait_for_stream_ready(stream_id, session_state)
 
             # Step 3: Determine streaming replay parameters
             start_id, replay = self.get_replay_parameters(replay_count, last_event_id, session_state)
 
-            # Step 4: Stream events to client
+            # Step 4: Pre-stream status check (e.g. already-cancelled invocation
+            # whose stream still exists but the cancel key has expired)
+            await self.check_before_streaming(session_state)
+
+            # Step 5: Stream events to client
             stop_condition = self.get_stop_condition(session_state)
             async with StreamClient() as client:
+                on_idle = self.get_on_idle(session_state, client)
                 logger.info("Starting event stream", connection_id=conn_id)
                 async for event in client.events(
                     stream_id=stream_id,
@@ -298,6 +344,7 @@ class BaseWebSocketStreamingHandler(ABC):
                     should_stop=stop_condition,
                     block_ms=1000,
                     count=10,
+                    on_idle=on_idle,
                 ):
                     # Send event to WebSocket client
                     await websocket.send_json(event)
@@ -412,6 +459,7 @@ class BaseWebSocketStreamingHandler(ABC):
         resource_status: str,
         resource_type: str = "resource",
         max_wait_seconds: int = 30,
+        on_poll: Callable[[StreamClient], Any] | None = None,
     ) -> None:
         """Wait for stream to be created in cache.
 
@@ -423,6 +471,9 @@ class BaseWebSocketStreamingHandler(ABC):
             resource_status: Current status of the resource
             resource_type: Type of resource (e.g., "invocation", "execution")
             max_wait_seconds: Maximum time to wait for stream creation
+            on_poll: Optional async callback invoked each iteration with the
+                StreamClient.  May raise to abort the wait early (e.g. when
+                a cancellation key is detected).
 
         Raises:
             WaitForStreamTimeoutError: If timeout waiting for stream creation
@@ -442,10 +493,18 @@ class BaseWebSocketStreamingHandler(ABC):
                 await asyncio.sleep(wait_interval)
                 total_waited += wait_interval
 
-                info = await client.info(stream_id)
-                if info["exists"]:
-                    logger.info("Stream created after wait", stream_id=stream_id, wait_time=total_waited)
-                    return
+                try:
+                    info = await client.info(stream_id)
+                    if info["exists"]:
+                        logger.info("Stream created after wait", stream_id=stream_id, wait_time=total_waited)
+                        return
+                except (RedisConnectionError, OSError):
+                    if on_poll is None:
+                        raise
+                    logger.debug("Stream info check failed, falling back to on_poll", stream_id=stream_id)
+
+                if on_poll is not None:
+                    await on_poll(client)
 
             # Timeout waiting for stream
             logger.error("Timeout waiting for stream to be created", stream_id=stream_id)

--- a/backend/src/syntara/core/websocket/exceptions.py
+++ b/backend/src/syntara/core/websocket/exceptions.py
@@ -59,6 +59,21 @@ class EventsExpiredError(StreamingValidationError):
         super().__init__(error_data, NORMAL_CLOSURE)
 
 
+class InvocationCancelledStreamError(StreamingValidationError):
+    """Invocation was cancelled — raised during wait or mid-stream idle check."""
+
+    def __init__(self, resource_id: str, resource_type: str = "resource") -> None:  # noqa: D107
+        error_data = ErrorData(
+            type="https://api.example.com/errors/invocation-cancelled",
+            title="Invocation Cancelled",
+            detail="The invocation was cancelled.",
+            code="INVOCATION_CANCELLED",
+            retryable=False,
+            instance=f"/{resource_type}s/{resource_id}",
+        )
+        super().__init__(error_data, NORMAL_CLOSURE)
+
+
 class WaitForStreamTimeoutError(StreamingValidationError):
     """Timeout waiting for cache stream creation."""
 

--- a/backend/src/syntara/workflows/seed_builtin.py
+++ b/backend/src/syntara/workflows/seed_builtin.py
@@ -23,6 +23,7 @@ from syntara.workflows.models import Workflow, WorkflowVersion
 from syntara.workflows.models.workflow_publish_event import PublishAction, WorkflowPublishEvent
 from syntara.workflows.services.scheduled_trigger_service import ScheduledTriggerService
 from syntara.workflows.validators import workflow_validator
+from syntara.workflows.workflow_engine.constants import AGENT_EXECUTION_TIMEOUT_SECONDS
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -77,7 +78,7 @@ _BUILTIN_DEFINITIONS: list[dict[str, Any]] = [
                     "activity": "invocation_execution",
                     "input": {"invocation_id": "${trigger.invocation_id}"},
                 },
-                "settings": {"timeout": 3600},
+                "settings": {"timeout": AGENT_EXECUTION_TIMEOUT_SECONDS},
             }
         ],
         "edges": [{"from": "trigger_api", "to": "execute"}],

--- a/backend/src/syntara/workflows/services/execution_service.py
+++ b/backend/src/syntara/workflows/services/execution_service.py
@@ -1051,10 +1051,23 @@ class ExecutionService(BaseService):
                 activity_id=activity_id,
                 error=error,
             )
+        elif status == "cancelled":
+            reason = signal_data.get("reason", "Invocation cancelled")
+            msg = f"InvocationCancelledError: {reason}"[:MAX_CALLBACK_ERROR_MSG_LENGTH]
+            error = ApplicationError(
+                msg,
+                type="InvocationCancelledError",
+                non_retryable=True,
+            )
+            await self.temporal_service.fail_async_activity(
+                temporal_workflow_id=execution.temporal_workflow_id,
+                activity_id=activity_id,
+                error=error,
+            )
         else:
-            # Fail-open: any non-"failed" status (including "approved", "rejected",
-            # "completed") completes the activity. The workflow routes based on the
-            # output data (e.g., approval decision), not the Temporal activity state.
+            # Fail-open: any non-"failed"/non-"cancelled" status (including "approved",
+            # "rejected", "completed") completes the activity. The workflow routes based
+            # on the output data (e.g., approval decision), not the Temporal activity state.
             await self.temporal_service.complete_async_activity(
                 temporal_workflow_id=execution.temporal_workflow_id,
                 activity_id=activity_id,
@@ -1125,6 +1138,21 @@ class ExecutionService(BaseService):
                 error_type=type(exc).__name__,
             )
             raise
+
+        # Best-effort: cancel any in-flight agentic invocations linked to
+        # this execution.  Agentic activities use async-completion so the
+        # Temporal cancel above does not reach the running agent process.
+        try:
+            from syntara.workflows.services.invocation_cancellation import (  # noqa: PLC0415
+                cancel_invocations_for_execution,
+            )
+
+            await cancel_invocations_for_execution(self.session, self.user, execution_id)
+        except Exception:
+            logger.exception(
+                "Best-effort invocation cancellation failed",
+                execution_id=execution_id,
+            )
 
         self._emit_lifecycle_event(
             execution_id=execution.id,

--- a/backend/src/syntara/workflows/services/invocation_cancellation.py
+++ b/backend/src/syntara/workflows/services/invocation_cancellation.py
@@ -1,0 +1,100 @@
+"""Best-effort cancellation of agentic invocations linked to a workflow execution.
+
+When a user cancels a workflow execution, Temporal cancels the workflow but
+agentic activities have already exited via ``raise_complete_async()``.  The
+running agent process is unaware of the Temporal cancel.  This module finds
+active invocations for the execution and cancels them through
+``InvocationService`` (audit events, file cleanup, conditional status update,
+Redis cancel signal). The running agent stops via the Redis watcher, with a
+DB status fallback when Redis is unavailable.
+"""
+
+from uuid import UUID
+
+import structlog
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from syntara.agent_orchestrator.models.invocation import Invocation, InvocationStatus
+from syntara.agent_orchestrator.models.request import CancellationResult
+from syntara.agent_orchestrator.services.invocation_service import InvocationService
+from syntara.core.models import User
+
+logger = structlog.stdlib.get_logger(__name__)
+
+_CANCELLABLE_STATUSES = (InvocationStatus.CREATED, InvocationStatus.RUNNING)
+
+
+async def find_active_invocations_for_execution(
+    session: AsyncSession,
+    execution_id: UUID,
+) -> list[Invocation]:
+    """Return invocations linked to *execution_id* that are still cancellable.
+
+    Uses a JSONB query on ``context_data->>'execution_id'``.  This is not
+    indexed but only runs on the cancel path so performance is acceptable.
+    """
+    result = await session.exec(
+        select(Invocation).where(
+            Invocation.context_data["execution_id"].as_string() == str(execution_id),  # type: ignore[attr-defined]
+            col(Invocation.status).in_(_CANCELLABLE_STATUSES),
+        )
+    )
+    return list(result.all())
+
+
+async def cancel_invocations_for_execution(
+    session: AsyncSession,
+    user: User,
+    execution_id: UUID,
+    reason: str = "Workflow execution cancelled",
+) -> int:
+    """Cancel all active invocations belonging to *execution_id*.
+
+    Each invocation is cancelled via ``InvocationService`` so one failure does
+    not block the others.  Returns the number of successfully cancelled
+    invocations.
+    """
+    invocations = await find_active_invocations_for_execution(session, execution_id)
+    if not invocations:
+        logger.debug(
+            "No active invocations to cancel for execution",
+            execution_id=execution_id,
+        )
+        return 0
+
+    logger.info(
+        "Cancelling invocations for execution",
+        execution_id=execution_id,
+        count=len(invocations),
+    )
+
+    service = InvocationService(session, user)
+    cancelled = 0
+    for invocation in invocations:
+        try:
+            result = await service.cancel_invocation(invocation.id, reason)
+            if result == CancellationResult.SUCCESS:
+                cancelled += 1
+        except Exception:
+            logger.exception(
+                "Failed to cancel invocation for execution",
+                invocation_id=invocation.id,
+                execution_id=execution_id,
+            )
+            try:
+                await session.rollback()
+            except Exception:
+                logger.exception(
+                    "Failed to rollback after invocation cancel error",
+                    invocation_id=invocation.id,
+                    execution_id=execution_id,
+                )
+
+    logger.info(
+        "Invocation cancellation complete",
+        execution_id=execution_id,
+        cancelled=cancelled,
+        total=len(invocations),
+    )
+    return cancelled

--- a/backend/src/syntara/workflows/workflow_engine/activities/internal_activity.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/internal_activity.py
@@ -69,8 +69,13 @@ async def _run_invocation_execution(operation_input: InvocationExecutionInput) -
             actor_type=PrincipalType(actor_type) if actor_type else None,
         )
 
+    from syntara.agent_orchestrator.exceptions import InvocationCancelledError  # noqa: PLC0415
+
     executor = InvocationExecutor()
-    await executor.execute_invocation(UUID(invocation_id), actor_context=actor_context)
+    try:
+        await executor.execute_invocation(UUID(invocation_id), actor_context=actor_context)
+    except InvocationCancelledError as exc:
+        raise ApplicationError(str(exc), type="InvocationCancelledError", non_retryable=True) from exc
     return {"output": {"status": "completed"}}
 
 

--- a/backend/src/syntara/workflows/workflow_engine/constants.py
+++ b/backend/src/syntara/workflows/workflow_engine/constants.py
@@ -28,6 +28,10 @@ MAX_ENV_VAR_LENGTH = _settings.max_env_var_length
 # executor nodes use _get_default_timeout() for type-appropriate defaults.
 DEFAULT_ACTIVITY_TIMEOUT_SECONDS = 30
 
+# Timeout for the Agent Execution builtin workflow node.  Used by
+# seed_builtin.py and as the cancel-key TTL in invocation_service.py.
+AGENT_EXECUTION_TIMEOUT_SECONDS = 3600
+
 # Key injected by the engine into each activity's input config so the activity
 # can use the already-resolved timeout without re-querying the catalog.
 # Must be popped by agentic_activity before forwarding config to the orchestrator.

--- a/backend/src/syntara/workflows/workflow_engine/dynamic_workflow.py
+++ b/backend/src/syntara/workflows/workflow_engine/dynamic_workflow.py
@@ -195,6 +195,7 @@ class OrchestratorWorkflow(WorkflowConvergeMixin, WorkflowApprovalMixin):
         self._cof_failed_nodes: set[str] = set()
         self._secret_values: set[str] = set()
         self._has_unhandled_failure: bool = False
+        self._cancelled_node: str | None = None
         self._runtime_settings = {}  # populated by run() after settings fetch
         self.pre_resolved_outputs: dict[str, dict[str, Any]] = pre_resolved_outputs or {}
         self.stop_after_nodes: set[str] = set(stop_after_nodes) if stop_after_nodes else set()
@@ -355,8 +356,7 @@ class OrchestratorWorkflow(WorkflowConvergeMixin, WorkflowApprovalMixin):
         """Record a node failure; skip downstream unless continue_on_failure is set."""
         app_error = self._extract_application_error(error)
         error_message = self._resolve_failure_message(node_id, error, app_error, graph)
-
-        self.failed_nodes[node_id] = error_message
+        is_cancellation = app_error is not None and app_error.type == "InvocationCancelledError"
 
         # Extract output from ApplicationError.details if executor attached it
         namespace_entry: dict[str, Any] = {}
@@ -372,19 +372,38 @@ class OrchestratorWorkflow(WorkflowConvergeMixin, WorkflowApprovalMixin):
             workflow.logger.debug(f"No output in ApplicationError.details for node {node_id}, using empty model")
             namespace_entry = self._build_empty_node_output(node)
 
-        namespace_entry["status"] = "failed"
+        if is_cancellation:
+            namespace_entry["status"] = "cancelled"
+            self._cancelled_node = node_id
+            # TODO(https://redhat.atlassian.net/browse/AAP-86855): cancelled nodes are not in failed_nodes
+            # or skipped_nodes, so _mark_downstream_as_skipped is a no-op (it
+            # requires predecessors in one of those sets), converge ALL-strategy
+            # treats the cancelled branch as successful, and
+            # _count_successful_predecessors includes it.  Thread cancelled node
+            # IDs through those predicates or add a _cancelled_nodes set checked
+            # alongside failed_nodes.  Additionally, continue_on_failure is not
+            # handled for cancellation: _process_pending_tasks still calls
+            # _handle_continued_failure after _handle_node_failure returns,
+            # scheduling successors while _build_result stamps the run cancelled.
+            workflow.logger.info(f"Node {node_id} cancelled: {error_message}")
+        else:
+            self.failed_nodes[node_id] = error_message
+            namespace_entry["status"] = "failed"
+            workflow.logger.error(f"Node {node_id} failed: {error_message}")
         namespace_entry["error"] = error_message
 
         self.resolver.set_namespace(node_id, namespace_entry)
-        workflow.logger.error(f"Node {node_id} failed: {error_message}")
-        if not continue_on_failure:
+        if not is_cancellation and not continue_on_failure:
             if node_id not in self._converge_branch_nodes:
                 self._has_unhandled_failure = True
             self._mark_downstream_as_skipped(node_id, graph)
-        else:
+        elif not is_cancellation and continue_on_failure:
             self._cof_failed_nodes.add(node_id)
 
-        self._check_converge_successors(node_id, graph, pending_tasks)
+        if is_cancellation:
+            self._mark_downstream_as_skipped(node_id, graph)
+        else:
+            self._check_converge_successors(node_id, graph, pending_tasks)
 
     @staticmethod
     def _extract_application_error(error: Exception) -> ApplicationError | None:
@@ -527,7 +546,9 @@ class OrchestratorWorkflow(WorkflowConvergeMixin, WorkflowApprovalMixin):
         # to the converge node: CoF absorbs it, no-CoF sets the flag directly, and
         # a successful converge reconciles any unabsorbed branch failures.  Nodes
         # outside any parallel branch set the flag eagerly on failure.
-        if self._has_unhandled_failure:
+        if self._cancelled_node is not None:
+            workflow_status = "cancelled"
+        elif self._has_unhandled_failure:
             workflow_status = "failed"
         elif self.failed_nodes:
             workflow_status = "completed_with_errors"

--- a/backend/src/syntara/workflows/workflow_engine/services/activity_sync_service.py
+++ b/backend/src/syntara/workflows/workflow_engine/services/activity_sync_service.py
@@ -1301,6 +1301,14 @@ class ActivitySyncService:
 
     def _process_activity_failed(self, event: HistoryEvent, metadata: ExecutionMonitorMetadata) -> None:
         """Process ACTIVITY_TASK_FAILED event."""
+        # TODO(https://redhat.atlassian.net/browse/AAP-86855): InvocationCancelledError raises a
+        # non-retryable ApplicationError, which Temporal records as
+        # ACTIVITY_TASK_FAILED. This unconditionally sets ActivityStatus.FAILED.
+        # Once the activity row is terminal, _sync_nodes_to_terminal_status
+        # skips it, so the Execute Invocation step shows "Failed" even though
+        # the execution-level status is CANCELLED.  Inspect
+        # attrs.failure.application_failure_info.type for
+        # "InvocationCancelledError" and set ActivityStatus.CANCELLED instead.
         attrs = event.activity_task_failed_event_attributes
         scheduled_id = attrs.scheduled_event_id
         if scheduled_id in metadata.pending_activity_updates:
@@ -1355,7 +1363,7 @@ class ActivitySyncService:
             metadata.pending_sync_event_ids.add(scheduled_id)
             metadata.terminal_activity_ids.add(update["activity_id"])
 
-    def _extract_execution_status_from_event(self, event: HistoryEvent) -> tuple[ExecutionStatus, datetime, str | None]:  # noqa: C901
+    def _extract_execution_status_from_event(self, event: HistoryEvent) -> tuple[ExecutionStatus, datetime, str | None]:  # noqa: C901, PLR0912
         """Extract execution status, completion time, and error from workflow completion event.
 
         Args:
@@ -1383,7 +1391,9 @@ class ActivitySyncService:
                     result_data = json.loads(payload.data)
                     if isinstance(result_data, dict):
                         inner_status = result_data.get("status")
-                        if inner_status == "failed":
+                        if inner_status == "cancelled":
+                            status = ExecutionStatus.CANCELLED
+                        elif inner_status == "failed":
                             status = ExecutionStatus.FAILED
                             error_details = self._extract_failed_activity_errors(result_data)
                         elif inner_status == "completed_with_errors":

--- a/backend/src/syntara/workflows/workflow_engine/signals/processor.py
+++ b/backend/src/syntara/workflows/workflow_engine/signals/processor.py
@@ -119,6 +119,19 @@ class WorkflowSignalProcessor:
         """
         signal_status = signal_data.get("status")
 
+        if signal_status == "cancelled":
+            reason = signal_data.get("reason", "Invocation cancelled")
+            with contextlib.suppress(Exception):
+                workflow.logger.warning(
+                    f"Agentic activity {activity_id} was cancelled: {reason}",
+                    extra={
+                        "activity_id": activity_id,
+                        "execution_id": execution_id,
+                    },
+                )
+            msg = f"InvocationCancelledError: {reason}"
+            raise ApplicationError(msg, type="InvocationCancelledError", non_retryable=True)
+
         if signal_status == "failed":
             # Extract error information and raise exception
             error_message, error_type, has_error_detail = resolve_signal_failure_message(signal_data.get("error"))

--- a/backend/tests/integration/agent_orchestrator/context_manager/test_planner_audit_events.py
+++ b/backend/tests/integration/agent_orchestrator/context_manager/test_planner_audit_events.py
@@ -8,7 +8,7 @@ Verifies that ContextManagerPlanner emits the expected audit events during execu
 from collections.abc import AsyncGenerator, Callable
 from contextlib import AbstractContextManager
 from unittest.mock import AsyncMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -25,10 +25,18 @@ from syntara.agent_orchestrator.context_manager import (
 )
 from syntara.agent_orchestrator.exceptions import InvocationCancelledError
 from syntara.agent_orchestrator.models import Invocation, InvocationStatus
+from syntara.agent_orchestrator.services.streaming_service import get_invocation_cancel_key
 from syntara.audit.dispatcher import AuditEventDispatcher
 from syntara.audit.models.audit_event import AuditEvent, EventCategory, EventSeverity, EventStatus
+from syntara.core.cache.stream import StreamClient
 from syntara.core.models import User
 from tests.fixtures.settings import FakeSettingsCache
+
+
+async def _signal_invocation_cancelled(invocation_id: UUID) -> None:
+    """Set the Redis cancel key the planner checks before falling back to DB."""
+    async with StreamClient() as client:
+        await client.set_key(get_invocation_cancel_key(invocation_id), "1", 60)
 
 
 class TestContextPlanningEventDispatch:
@@ -512,7 +520,7 @@ class TestCancellationEventDispatch:
 
     @pytest.mark.asyncio
     async def test_cancellation_during_retrieval_emits_event(
-        self, test_db_session: AsyncSession, test_user: User, mock_compressor, test_project_id
+        self, test_cache: None, test_db_session: AsyncSession, test_user: User, mock_compressor, test_project_id
     ) -> None:
         """Cancellation detected during retrieval emits CancellationEvent."""
         session_id = "sess-cancel-retrieval"
@@ -531,6 +539,7 @@ class TestCancellationEventDispatch:
         await test_db_session.flush()
         await test_db_session.refresh(invocation)
         invocation_id = invocation.id
+        await _signal_invocation_cancelled(invocation_id)
 
         # Mock services
         mock_retrieve_service = AsyncMock()
@@ -576,7 +585,7 @@ class TestCancellationEventDispatch:
 
     @pytest.mark.asyncio
     async def test_cancellation_during_assembly_emits_event(
-        self, test_db_session: AsyncSession, test_user: User, mock_compressor, test_project_id
+        self, test_cache: None, test_db_session: AsyncSession, test_user: User, mock_compressor, test_project_id
     ) -> None:
         """Cancellation detected during assembly emits CancellationEvent.
 
@@ -603,6 +612,7 @@ class TestCancellationEventDispatch:
         await test_db_session.flush()
         await test_db_session.refresh(invocation)
         invocation_id = invocation.id
+        await _signal_invocation_cancelled(invocation_id)
 
         # Mock services
         mock_retrieve_service = AsyncMock()

--- a/backend/tests/integration/agent_orchestrator/context_manager/test_planner_audit_events.py
+++ b/backend/tests/integration/agent_orchestrator/context_manager/test_planner_audit_events.py
@@ -25,7 +25,7 @@ from syntara.agent_orchestrator.context_manager import (
 )
 from syntara.agent_orchestrator.exceptions import InvocationCancelledError
 from syntara.agent_orchestrator.models import Invocation, InvocationStatus
-from syntara.agent_orchestrator.services.streaming_service import get_invocation_cancel_key
+from syntara.agent_orchestrator.utils.cancellation import get_invocation_cancel_key
 from syntara.audit.dispatcher import AuditEventDispatcher
 from syntara.audit.models.audit_event import AuditEvent, EventCategory, EventSeverity, EventStatus
 from syntara.core.cache.stream import StreamClient

--- a/backend/tests/integration/workflows/services/test_invocation_cancellation.py
+++ b/backend/tests/integration/workflows/services/test_invocation_cancellation.py
@@ -1,0 +1,64 @@
+"""DB-backed tests for finding invocations by execution_id JSONB."""
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from syntara.agent_orchestrator.models.invocation import Invocation, InvocationStatus
+from syntara.core.models import User
+from syntara.workflows.services.invocation_cancellation import find_active_invocations_for_execution
+
+
+def _invocation(
+    *,
+    user: User,
+    project_id: UUID,
+    status: InvocationStatus,
+    context_data: dict[str, object],
+) -> Invocation:
+    return Invocation(
+        prompt="test prompt",
+        created_by=user.id,
+        project_id=project_id,
+        session_id=f"session-{uuid4()}",
+        status=status,
+        context_data=context_data,
+    )
+
+
+@pytest.mark.asyncio
+async def test_find_active_invocations_matches_top_level_execution_id(
+    test_db_session: AsyncSession, test_user: User, test_project_id: UUID
+) -> None:
+    execution_id = uuid4()
+    matching = _invocation(
+        user=test_user,
+        project_id=test_project_id,
+        status=InvocationStatus.RUNNING,
+        context_data={"execution_id": str(execution_id)},
+    )
+    completed = _invocation(
+        user=test_user,
+        project_id=test_project_id,
+        status=InvocationStatus.COMPLETED,
+        context_data={"execution_id": str(execution_id)},
+    )
+    nested_only = _invocation(
+        user=test_user,
+        project_id=test_project_id,
+        status=InvocationStatus.RUNNING,
+        context_data={"metadata": {"execution_id": str(execution_id)}},
+    )
+    other_execution = _invocation(
+        user=test_user,
+        project_id=test_project_id,
+        status=InvocationStatus.CREATED,
+        context_data={"execution_id": str(uuid4())},
+    )
+    test_db_session.add_all([matching, completed, nested_only, other_execution])
+    await test_db_session.commit()
+
+    found = await find_active_invocations_for_execution(test_db_session, execution_id)
+
+    assert [inv.id for inv in found] == [matching.id]

--- a/backend/tests/unit/agent_orchestrator/context_manager/test_planner.py
+++ b/backend/tests/unit/agent_orchestrator/context_manager/test_planner.py
@@ -7,7 +7,7 @@ new RetrieverService framework.
 
 from collections.abc import Callable
 from contextlib import AbstractContextManager
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -17,7 +17,7 @@ from syntara.agent_orchestrator.context_manager import (
     ContextPackage,
 )
 from syntara.agent_orchestrator.context_manager.retriever_service.services import get_retriever_service
-from syntara.agent_orchestrator.models import LLMCredentialConfig
+from syntara.agent_orchestrator.models import InvocationStatus, LLMCredentialConfig
 from syntara.core.database.session import get_db
 from syntara.core.models import User
 from tests.fixtures.settings import FakeSettingsCache
@@ -471,3 +471,102 @@ class TestContextManagerPlanner:
 
         with pytest.raises(Exception, match=r"ensure this value is less than or equal to|validation error"):
             ContextPackage(grounding_score=1.1)
+
+
+class TestContextManagerPlannerCancellation:
+    """Test cancellation detection in _check_cancellation."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_runtime_settings(  # type: ignore[misc]
+        self, override_runtime_settings: Callable[..., AbstractContextManager[FakeSettingsCache]]
+    ) -> None:
+        """Auto-mock get_runtime_settings for all planner tests."""
+        with override_runtime_settings():
+            yield
+
+    @pytest.mark.asyncio
+    async def test_check_cancellation_detects_redis_key(self, mock_session_factory, mock_compressor) -> None:
+        """Test that cancellation is detected via Redis key without hitting the DB."""
+        from syntara.agent_orchestrator.audit.context_planning import ContextPlanningPhase
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+
+        planner = ContextManagerPlanner(
+            session_factory=mock_session_factory,
+            compressor_service_factory=lambda: mock_compressor,
+        )
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = True
+
+        with patch("syntara.agent_orchestrator.context_manager.planner.StreamClient") as mock_cls:
+            mock_cls.return_value.__aenter__.return_value = mock_client
+
+            with pytest.raises(InvocationCancelledError):
+                await planner._check_cancellation(
+                    session_id="test-session",
+                    invocation_id=uuid4(),
+                    phase=ContextPlanningPhase.RETRIEVAL,
+                )
+
+    @pytest.mark.asyncio
+    async def test_check_cancellation_falls_back_to_db(self, mock_session_factory, mock_compressor) -> None:
+        """Test that cancellation falls back to DB when Redis is unavailable."""
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        from syntara.agent_orchestrator.audit.context_planning import ContextPlanningPhase
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+        from syntara.agent_orchestrator.models import Invocation
+
+        planner = ContextManagerPlanner(
+            session_factory=mock_session_factory,
+            compressor_service_factory=lambda: mock_compressor,
+        )
+
+        mock_invocation = MagicMock(spec=Invocation)
+        mock_invocation.status = InvocationStatus.CANCELLED
+
+        with (
+            patch("syntara.agent_orchestrator.context_manager.planner.StreamClient") as mock_cls,
+            patch.object(planner, "get_async_session_context") as mock_session_ctx,
+        ):
+            mock_cls.return_value.__aenter__.side_effect = RedisConnectionError("down")
+
+            mock_session = AsyncMock()
+            mock_session.get.return_value = mock_invocation
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+
+            with pytest.raises(InvocationCancelledError):
+                await planner._check_cancellation(
+                    session_id="test-session",
+                    invocation_id=uuid4(),
+                    phase=ContextPlanningPhase.RETRIEVAL,
+                )
+
+    @pytest.mark.asyncio
+    async def test_check_cancellation_skips_db_when_redis_confirms(self, mock_session_factory, mock_compressor) -> None:
+        """Test that DB is not queried when Redis already confirms cancellation."""
+        from syntara.agent_orchestrator.audit.context_planning import ContextPlanningPhase
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+
+        planner = ContextManagerPlanner(
+            session_factory=mock_session_factory,
+            compressor_service_factory=lambda: mock_compressor,
+        )
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = True
+
+        with (
+            patch("syntara.agent_orchestrator.context_manager.planner.StreamClient") as mock_cls,
+            patch.object(planner, "get_async_session_context") as mock_session_ctx,
+        ):
+            mock_cls.return_value.__aenter__.return_value = mock_client
+
+            with pytest.raises(InvocationCancelledError):
+                await planner._check_cancellation(
+                    session_id="test-session",
+                    invocation_id=uuid4(),
+                    phase=ContextPlanningPhase.RETRIEVAL,
+                )
+
+            mock_session_ctx.assert_not_called()

--- a/backend/tests/unit/agent_orchestrator/executor/test_invocation_executor_audit_events.py
+++ b/backend/tests/unit/agent_orchestrator/executor/test_invocation_executor_audit_events.py
@@ -149,7 +149,10 @@ class TestInvocationExecutorLifecycleEvents:
             for p in patches[1:]:
                 stack.enter_context(p)
 
-            await executor.execute_invocation(invocation_id=invocation.id)
+            try:
+                await executor.execute_invocation(invocation_id=invocation.id)
+            except InvocationCancelledError:
+                pass
 
         # Return all emitted events for test-specific assertions
         return [call.args[0] for call in mock_do_emit.call_args_list]
@@ -528,7 +531,7 @@ class TestInvocationExecutorLifecycleEvents:
 
     @pytest.mark.asyncio
     async def test_handle_execution_error_no_failed_event_when_cancelled(self) -> None:
-        """Exception during cancelled invocation does not emit FAILED event (race condition prevented)."""
+        """Exception during cancelled invocation raises InvocationCancelledError, no FAILED event."""
         execution_id = uuid4()
         user = _make_user()
 
@@ -572,7 +575,6 @@ class TestInvocationExecutorLifecycleEvents:
 
         executor = InvocationExecutor()
 
-        # Mock WorkflowSignalClient to prevent actual signal sending
         with (
             patch("syntara.audit.emitter._do_emit_audit_event") as mock_do_emit,
             patch.object(executor, "get_async_session_context", side_effect=lambda: mock_session_context()),
@@ -580,20 +582,21 @@ class TestInvocationExecutorLifecycleEvents:
             patch(
                 "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_failure_signal",
                 new_callable=AsyncMock,
-            ),
+            ) as mock_failure_signal,
         ):
-            await executor.execute_invocation(invocation_id=invocation.id)
+            try:
+                await executor.execute_invocation(invocation_id=invocation.id)
+            except InvocationCancelledError:
+                pass
 
         events: list[AuditEvent] = [call.args[0] for call in mock_do_emit.call_args_list]
         lifecycle_events = [e for e in events if e.event_action in ["invocation_running", "invocation_failed"]]
 
-        # Should only have RUNNING event
-        # (no FAILED event because _fail_invocation_status_if_not_cancelled returned False)
+        # Should only have RUNNING event — no FAILED because the row was
+        # already CANCELLED and InvocationCancelledError was raised instead
         assert len(lifecycle_events) == 1
         assert lifecycle_events[0].event_action == "invocation_running"
-        assert lifecycle_events[0].actor_id == user.id
-        assert lifecycle_events[0].actor_username == user.username
-        assert lifecycle_events[0].actor_type == PrincipalType.USER
+        mock_failure_signal.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_invocation_lifecycle_events_includes_context_identifiers(self) -> None:

--- a/backend/tests/unit/agent_orchestrator/executor/test_invocation_executor_cancellation.py
+++ b/backend/tests/unit/agent_orchestrator/executor/test_invocation_executor_cancellation.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from syntara.agent_orchestrator.exceptions import InvocationCancelledError
 from syntara.agent_orchestrator.executor.invocation_executor import InvocationExecutor
 from syntara.agent_orchestrator.models import InvocationStatus
 
@@ -79,6 +80,53 @@ class TestInvocationExecutorCancellationRaceCondition:
             assert call_args[0][1] == InvocationStatus.RUNNING  # Second positional arg is status
 
     @pytest.mark.asyncio
+    async def test_execute_invocation_raises_when_running_update_fails(self) -> None:
+        """Cancel during file conversion / init makes RUNNING update return False.
+
+        When _update_invocation_status(RUNNING) returns False the invocation was
+        cancelled while waiting for file conversions or during init. The executor
+        must raise InvocationCancelledError and send the cancellation signal instead
+        of proceeding to execute().
+        """
+        mock_session = AsyncMock()
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        executor = InvocationExecutor(session_factory=mock_session_factory)
+        invocation_id = uuid4()
+
+        mock_invocation = MagicMock()
+        mock_invocation.id = invocation_id
+        mock_invocation.status = InvocationStatus.RUNNING
+        mock_invocation.prompt = "test prompt"
+        mock_invocation.session_id = "test-session"
+        mock_invocation.context_data = {}
+
+        mock_session.get.return_value = mock_invocation
+
+        with (
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.get_openrouter_llm",
+                return_value=(MagicMock(model_name="test-model", openai_api_base="https://test.example.com"), None),
+            ),
+            patch("syntara.agent_orchestrator.executor.invocation_executor.ContextManagerPlanner"),
+            patch("syntara.agent_orchestrator.executor.invocation_executor.OrchestrationService") as mock_orchestration,
+            patch.object(executor, "_update_invocation_status", return_value=False),
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_cancellation_signal",
+                new_callable=AsyncMock,
+            ) as mock_cancel_signal,
+        ):
+            mock_orchestration.return_value.execute = AsyncMock()
+
+            with pytest.raises(InvocationCancelledError):
+                await executor.execute_invocation(invocation_id)
+
+            mock_cancel_signal.assert_called_once()
+            mock_orchestration.return_value.execute.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_execute_invocation_completes_normally_when_not_cancelled(self) -> None:
         """Test that invocations complete normally when not cancelled."""
         # Arrange
@@ -134,7 +182,7 @@ class TestInvocationExecutorCancellationRaceCondition:
 
     @pytest.mark.asyncio
     async def test_execute_invocation_handles_pre_execution_cancellation(self) -> None:
-        """Test that invocations cancelled before execution don't execute."""
+        """Test that invocations cancelled before execution raise and notify the workflow."""
         # Arrange
         mock_session = AsyncMock()
 
@@ -148,26 +196,33 @@ class TestInvocationExecutorCancellationRaceCondition:
         mock_invocation = MagicMock()
         mock_invocation.id = invocation_id
         mock_invocation.status = InvocationStatus.CANCELLED
+        mock_invocation.context_data = {
+            "callback_url": "https://syntara:8000/api/v1/executions/abc/activities/step/signal"
+        }
 
         mock_session.get.return_value = mock_invocation
 
-        with patch("syntara.agent_orchestrator.executor.invocation_executor.get_openrouter_llm") as mock_llm:
-            # Act
-            await executor.execute_invocation(invocation_id)
+        with (
+            patch("syntara.agent_orchestrator.executor.invocation_executor.get_openrouter_llm") as mock_llm,
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_cancellation_signal",
+                new_callable=AsyncMock,
+            ) as mock_cancel_signal,
+        ):
+            with pytest.raises(InvocationCancelledError):
+                await executor.execute_invocation(invocation_id)
 
-            # Assert
-            # 1. LLM should not be created (early return)
+            # LLM should not be created
             mock_llm.assert_not_called()
 
-            # 2. Session should not be committed (early return)
-            mock_session.commit.assert_not_called()
-
-            # 3. Status should remain CANCELLED
-            assert mock_invocation.status == InvocationStatus.CANCELLED
+            # Cancellation signal should be sent to the workflow
+            mock_cancel_signal.assert_called_once()
+            call_args = mock_cancel_signal.call_args[0]
+            assert call_args[1] == invocation_id
 
     @pytest.mark.asyncio
     async def test_execute_invocation_handles_invocation_cancelled_error(self) -> None:
-        """Test that InvocationCancelledError during execution is handled correctly."""
+        """Test that InvocationCancelledError during execution re-raises after sending signal."""
         # Arrange
         mock_session = AsyncMock()
 
@@ -201,22 +256,23 @@ class TestInvocationExecutorCancellationRaceCondition:
             ),
             patch("syntara.agent_orchestrator.executor.invocation_executor.ContextManagerPlanner"),
             patch("syntara.agent_orchestrator.executor.invocation_executor.OrchestrationService") as mock_orchestration,
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_cancellation_signal",
+                new_callable=AsyncMock,
+            ) as mock_cancel_signal,
         ):
             # Simulate InvocationCancelledError being raised during execution
             mock_orchestration.return_value.execute.side_effect = InvocationCancelledError(
                 str(invocation_id), "test phase"
             )
 
-            # Act
-            await executor.execute_invocation(invocation_id)
+            # Act — should re-raise after sending the cancellation signal
+            with pytest.raises(InvocationCancelledError):
+                await executor.execute_invocation(invocation_id)
 
             # Assert
-            # 1. Only one commit should occur (marking as RUNNING), no final commit
+            mock_cancel_signal.assert_called_once()
             assert mock_session.commit.call_count == 1
-
-            # 2. No status update should occur (exception handled gracefully)
-            # The status would be set to CANCELLED by the cancellation service,
-            # not by the executor
 
     @pytest.mark.asyncio
     async def test_conditional_update_atomically_checks_cancellation(self) -> None:
@@ -428,3 +484,274 @@ class TestInvocationExecutorCancellationRaceCondition:
         assert values[started_at_col].effective_value == explicit_started_at, "Explicit started_at should be preserved"
 
         mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_sends_cancellation_signal(self) -> None:
+        """Test that InvocationCancelledError handler sends a cancellation signal."""
+        mock_session = AsyncMock()
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        executor = InvocationExecutor(session_factory=mock_session_factory)
+        invocation_id = uuid4()
+
+        mock_invocation = MagicMock()
+        mock_invocation.id = invocation_id
+        mock_invocation.status = InvocationStatus.RUNNING
+        mock_invocation.prompt = "test prompt"
+        mock_invocation.session_id = "test-session"
+        mock_invocation.context_data = {}
+
+        mock_session.get.return_value = mock_invocation
+
+        with (
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.get_openrouter_llm",
+                return_value=(MagicMock(model_name="test-model", openai_api_base="https://test.example.com"), None),
+            ),
+            patch("syntara.agent_orchestrator.executor.invocation_executor.ContextManagerPlanner"),
+            patch("syntara.agent_orchestrator.executor.invocation_executor.OrchestrationService") as mock_orchestration,
+            patch.object(executor, "_update_invocation_status", new=AsyncMock()),
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_cancellation_signal",
+                new=AsyncMock(),
+            ) as mock_signal,
+        ):
+            mock_orchestration.return_value.execute.side_effect = InvocationCancelledError(
+                str(invocation_id), "streaming"
+            )
+
+            with pytest.raises(InvocationCancelledError):
+                await executor.execute_invocation(invocation_id)
+
+            mock_signal.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_pre_start_cancel_propagates_despite_signal_failure(self) -> None:
+        """InvocationCancelledError propagates even when send_cancellation_signal raises."""
+        mock_session = AsyncMock()
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        executor = InvocationExecutor(session_factory=mock_session_factory)
+        invocation_id = uuid4()
+
+        mock_invocation = MagicMock()
+        mock_invocation.id = invocation_id
+        mock_invocation.status = InvocationStatus.CANCELLED
+        mock_invocation.context_data = {"callback_url": "not-a-url"}
+
+        mock_session.get.return_value = mock_invocation
+
+        with patch(
+            "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_cancellation_signal",
+            new_callable=AsyncMock,
+            side_effect=ValueError("invalid signal URL"),
+        ):
+            with pytest.raises(InvocationCancelledError):
+                await executor.execute_invocation(invocation_id)
+
+    @pytest.mark.asyncio
+    async def test_mid_execution_cancel_propagates_despite_signal_failure(self) -> None:
+        """InvocationCancelledError propagates even when send_cancellation_signal raises mid-execution."""
+        mock_session = AsyncMock()
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        executor = InvocationExecutor(session_factory=mock_session_factory)
+        invocation_id = uuid4()
+
+        mock_invocation = MagicMock()
+        mock_invocation.id = invocation_id
+        mock_invocation.status = InvocationStatus.RUNNING
+        mock_invocation.prompt = "test prompt"
+        mock_invocation.session_id = "test-session"
+        mock_invocation.context_data = {"callback_url": "not-a-url"}
+
+        mock_session.get.return_value = mock_invocation
+
+        with (
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.get_openrouter_llm",
+                return_value=(MagicMock(model_name="test-model", openai_api_base="https://test.example.com"), None),
+            ),
+            patch("syntara.agent_orchestrator.executor.invocation_executor.ContextManagerPlanner"),
+            patch("syntara.agent_orchestrator.executor.invocation_executor.OrchestrationService") as mock_orch,
+            patch.object(executor, "_update_invocation_status", new=AsyncMock()),
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_cancellation_signal",
+                new_callable=AsyncMock,
+                side_effect=ValueError("invalid signal URL"),
+            ),
+        ):
+            mock_orch.return_value.execute.side_effect = InvocationCancelledError(str(invocation_id), "streaming")
+
+            with pytest.raises(InvocationCancelledError):
+                await executor.execute_invocation(invocation_id)
+
+    @pytest.mark.asyncio
+    async def test_generic_error_after_cancel_raises_cancelled(self) -> None:
+        """When an error occurs after the DB row is CANCELLED, raise InvocationCancelledError."""
+        mock_session = AsyncMock()
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        executor = InvocationExecutor(session_factory=mock_session_factory)
+        invocation_id = uuid4()
+
+        mock_invocation = MagicMock()
+        mock_invocation.id = invocation_id
+        mock_invocation.status = InvocationStatus.RUNNING
+        mock_invocation.prompt = "test prompt"
+        mock_invocation.session_id = "test-session"
+        mock_invocation.context_data = {}
+
+        mock_session.get.return_value = mock_invocation
+
+        with (
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.get_openrouter_llm",
+                return_value=(MagicMock(model_name="test-model", openai_api_base="https://test.example.com"), None),
+            ),
+            patch("syntara.agent_orchestrator.executor.invocation_executor.ContextManagerPlanner"),
+            patch("syntara.agent_orchestrator.executor.invocation_executor.OrchestrationService") as mock_orch,
+            patch.object(executor, "_update_invocation_status", new=AsyncMock()),
+            patch.object(executor, "_fail_invocation_if_not_cancelled", return_value=False),
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_cancellation_signal",
+                new_callable=AsyncMock,
+            ) as mock_cancel_signal,
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_failure_signal",
+                new_callable=AsyncMock,
+            ) as mock_failure_signal,
+        ):
+            mock_orch.return_value.execute.side_effect = RuntimeError("LLM config error")
+
+            with pytest.raises(InvocationCancelledError):
+                await executor.execute_invocation(invocation_id)
+
+            mock_cancel_signal.assert_awaited_once()
+            mock_failure_signal.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_check_cancel_key_sends_signal_and_raises(self) -> None:
+        """_check_cancel_key sends cancellation signal to parent workflow before raising."""
+        from pydantic import SecretStr
+
+        from syntara.agent_orchestrator.models import InvocationContextData
+
+        mock_session = AsyncMock()
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        executor = InvocationExecutor(session_factory=mock_session_factory)
+        invocation_id = uuid4()
+        ctx = InvocationContextData(
+            callback_url=SecretStr("https://syntara:8000/api/v1/executions/abc/activities/step/signal")
+        )
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = True
+
+        with (
+            patch("syntara.agent_orchestrator.executor.invocation_executor.StreamClient") as mock_sc,
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_cancellation_signal",
+                new_callable=AsyncMock,
+            ) as mock_cancel_signal,
+        ):
+            mock_sc.return_value.__aenter__.return_value = mock_client
+            mock_sc.return_value.__aexit__.return_value = None
+
+            with pytest.raises(InvocationCancelledError):
+                await executor._check_cancel_key(invocation_id, ctx)
+
+            mock_cancel_signal.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_check_cancel_key_db_fallback_on_redis_error(self) -> None:
+        """_check_cancel_key falls back to DB when Redis errors and detects cancellation."""
+        from contextlib import asynccontextmanager
+
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        from syntara.agent_orchestrator.models import InvocationContextData
+
+        mock_session = AsyncMock()
+        mock_invocation = MagicMock()
+        mock_invocation.status = InvocationStatus.CANCELLED
+        mock_session.get.return_value = mock_invocation
+
+        @asynccontextmanager
+        async def mock_session_ctx() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        executor = InvocationExecutor(session_factory=mock_session_factory)
+        invocation_id = uuid4()
+        ctx = InvocationContextData()
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.side_effect = RedisConnectionError("Redis down")
+
+        with (
+            patch("syntara.agent_orchestrator.executor.invocation_executor.StreamClient") as mock_sc,
+            patch.object(executor, "get_async_session_context", return_value=mock_session_ctx()),
+        ):
+            mock_sc.return_value.__aenter__.return_value = mock_client
+            mock_sc.return_value.__aexit__.return_value = None
+
+            with pytest.raises(InvocationCancelledError):
+                await executor._check_cancel_key(invocation_id, ctx)
+
+    @pytest.mark.asyncio
+    async def test_init_orchestration_cancel_raises_instead_of_returning_none(self) -> None:
+        """LLM config failure after cancel raises InvocationCancelledError, not return None."""
+        from syntara.agent_orchestrator.exceptions import LLMConfigurationError
+
+        mock_session = AsyncMock()
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        executor = InvocationExecutor(session_factory=mock_session_factory)
+        invocation_id = uuid4()
+
+        mock_invocation = MagicMock()
+        mock_invocation.id = invocation_id
+        mock_invocation.status = InvocationStatus.RUNNING
+        mock_invocation.prompt = "test prompt"
+        mock_invocation.session_id = "test-session"
+        mock_invocation.context_data = {}
+        mock_invocation.project_id = None
+
+        mock_session.get.return_value = mock_invocation
+
+        with (
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.get_openrouter_llm",
+                side_effect=LLMConfigurationError("No API key"),
+            ),
+            patch.object(executor, "_update_invocation_status", return_value=False),
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_cancellation_signal",
+                new_callable=AsyncMock,
+            ) as mock_cancel_signal,
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.WorkflowSignalClient.send_failure_signal",
+                new_callable=AsyncMock,
+            ) as mock_failure_signal,
+        ):
+            with pytest.raises(InvocationCancelledError):
+                await executor.execute_invocation(invocation_id)
+
+            mock_cancel_signal.assert_awaited_once()
+            mock_failure_signal.assert_not_called()

--- a/backend/tests/unit/agent_orchestrator/services/test_invocation_service_audit_events.py
+++ b/backend/tests/unit/agent_orchestrator/services/test_invocation_service_audit_events.py
@@ -4,8 +4,10 @@ These tests verify that InvocationService methods correctly dispatch domain even
 which are then converted to AuditEvents by the registered handlers.
 """
 
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from uuid import uuid4
 
 import pytest
@@ -18,9 +20,18 @@ from syntara.audit.models.audit_event import EventCategory, EventSeverity, Event
 from syntara.audit.sanitization import REDACTED
 from syntara.core.models import User
 from syntara.files.models import FileMetadata
+from tests.fixtures.settings import FakeSettingsCache
 
 if TYPE_CHECKING:
     from syntara.audit.models.audit_event import AuditEvent
+
+
+def _attach_cancel_update(mock_session: AsyncMock, *, rowcount: int = 1) -> None:
+    mock_result = MagicMock()
+    mock_result.rowcount = rowcount
+    mock_session.exec = AsyncMock(return_value=mock_result)
+    mock_session.rollback = AsyncMock()
+    mock_session.refresh = AsyncMock()
 
 
 class TestInvocationServiceCreateAuditEvents:
@@ -220,6 +231,13 @@ class TestInvocationServiceCreateAuditEvents:
 class TestInvocationServiceCancelAuditEvents:
     """Tests for audit event emission from InvocationService.cancel_invocation()."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_runtime_settings(  # type: ignore[misc]
+        self, override_runtime_settings: Callable[..., AbstractContextManager[FakeSettingsCache]]
+    ) -> None:
+        with override_runtime_settings():
+            yield
+
     def setup_method(self) -> None:
         """Register invocations audit handlers before each test."""
         from syntara.invocations.audit.invocation_cancelled import (
@@ -250,6 +268,7 @@ class TestInvocationServiceCancelAuditEvents:
         mock_session = AsyncMock(spec=AsyncSession)
         mock_session.get = AsyncMock(return_value=invocation)
         mock_session.commit = AsyncMock()
+        _attach_cancel_update(mock_session)
         mock_file_manager = Mock()
         mock_file_manager.get_files_metadata = AsyncMock(return_value=[])
 
@@ -400,6 +419,7 @@ class TestInvocationServiceCancelAuditEvents:
         mock_session = AsyncMock(spec=AsyncSession)
         mock_session.get = AsyncMock(return_value=invocation)
         mock_session.commit = AsyncMock()
+        _attach_cancel_update(mock_session)
         mock_retriever = AsyncMock()
         mock_retriever.delete_file = AsyncMock(return_value=True)
         mock_file_manager = Mock()
@@ -444,6 +464,7 @@ class TestInvocationServiceCancelAuditEvents:
         mock_session = AsyncMock(spec=AsyncSession)
         mock_session.get = AsyncMock(return_value=invocation)
         mock_session.commit = AsyncMock(side_effect=Exception("DB Error"))
+        _attach_cancel_update(mock_session)
         mock_file_manager = Mock()
         mock_file_manager.get_files_metadata = AsyncMock(return_value=[])
 

--- a/backend/tests/unit/agent_orchestrator/services/test_orchestration_service.py
+++ b/backend/tests/unit/agent_orchestrator/services/test_orchestration_service.py
@@ -11,9 +11,23 @@ import pytest
 from langchain_core.tools import BaseTool
 
 from syntara.agent_orchestrator.context_manager.models import ContextPackage
+from syntara.agent_orchestrator.exceptions import InvocationCancelledError
 from syntara.agent_orchestrator.models import InvocationContextData
 from syntara.agent_orchestrator.services.orchestration_service import OrchestrationService
 from syntara.audit.emitter import AuditActorContext
+
+
+@pytest.fixture(autouse=True)
+def _skip_cancel_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Orchestration unit tests do not hit the database for cancel checks."""
+
+    async def _noop(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "syntara.agent_orchestrator.services.orchestration_service.raise_if_invocation_cancelled",
+        _noop,
+    )
 
 
 def create_mock_streaming_event(event_type: str, content: str | None = None) -> dict[str, Any]:
@@ -266,6 +280,54 @@ class TestOrchestrationServiceErrorHandling:
             # Verify error event was published
             error_calls = [c for c in mock_client_instance.publish.call_args_list if "error" in str(c)]
             assert len(error_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_cancelled_invocation_skips_temporal_callbacks(self) -> None:
+        """Cancellation during execute must not send success or failure signals."""
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "test-model"
+        mock_context_manager = MagicMock()
+        mock_context_manager.plan_request.return_value = ContextPackage(payload={}, grounding_score=0.0)
+
+        service = OrchestrationService(mock_llm, mock_context_manager)
+        invocation_id = uuid4()
+
+        mock_graph = AsyncMock()
+        mock_graph.astream_events = lambda *_args, **_kwargs: mock_astream_events_generator("Hello")
+
+        async def _raise_cancelled(_invocation_id: object, _phase: str) -> None:
+            raise InvocationCancelledError(str(invocation_id), "orchestration")
+
+        with (
+            patch.object(service, "_setup_graph", return_value=mock_graph),
+            patch("syntara.agent_orchestrator.services.orchestration_service.StreamClient") as mock_stream_client,
+            patch(
+                "syntara.agent_orchestrator.services.orchestration_service.raise_if_invocation_cancelled",
+                side_effect=_raise_cancelled,
+            ),
+            patch(
+                "syntara.agent_orchestrator.services.orchestration_service.WorkflowSignalClient.send_failure_signal",
+                new_callable=AsyncMock,
+            ) as mock_fail,
+            patch(
+                "syntara.agent_orchestrator.services.orchestration_service.WorkflowSignalClient.send_success_signal",
+                new_callable=AsyncMock,
+            ) as mock_success,
+        ):
+            mock_client_instance = AsyncMock()
+            mock_stream_client.return_value.__aenter__.return_value = mock_client_instance
+
+            with pytest.raises(InvocationCancelledError):
+                await service.execute(
+                    prompt="Test",
+                    session_id="test-session",
+                    invocation_id=invocation_id,
+                    actor_context=AuditActorContext(),
+                    ctx=InvocationContextData(),
+                )
+
+            mock_fail.assert_not_awaited()
+            mock_success.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_orchestration_service_publishes_error_event_on_failure(self) -> None:
@@ -916,3 +978,598 @@ class TestGetToolsStrategy:
             tool_selection_strategy="SELECTED",
             tool_selections={"uuid-a", "uuid-b"},
         )
+
+
+class TestPreGraphCancelCheck:
+    """execute() checks the cancel key before _setup_graph."""
+
+    @pytest.mark.asyncio
+    async def test_execute_raises_before_setup_graph_when_cancelled(self) -> None:
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "test-model"
+        service = OrchestrationService(mock_llm, MagicMock())
+        invocation_id = uuid4()
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = True
+
+        with (
+            patch("syntara.agent_orchestrator.services.orchestration_service.StreamClient") as mock_sc,
+            patch.object(service, "_setup_graph") as mock_setup,
+        ):
+            mock_sc.return_value.__aenter__.return_value = mock_client
+            mock_sc.return_value.__aexit__.return_value = None
+
+            with pytest.raises(InvocationCancelledError):
+                await service.execute(
+                    prompt="Test",
+                    session_id="s",
+                    invocation_id=invocation_id,
+                    actor_context=AuditActorContext(),
+                    ctx=InvocationContextData(),
+                )
+
+            mock_setup.assert_not_called()
+
+
+class TestOrchestrationServiceCancellation:
+    """Test cancellation signal detection in the streaming loop."""
+
+    @pytest.mark.asyncio
+    async def test_execute_publishes_cancelled_event_on_cancellation(self) -> None:
+        """Test that InvocationCancelledError in execute publishes a cancelled event."""
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "test-model"
+        mock_context_manager = MagicMock()
+        test_context = ContextPackage(payload={}, grounding_score=0.0)
+        mock_context_manager.plan_request.return_value = test_context
+
+        service = OrchestrationService(mock_llm, mock_context_manager)
+        invocation_id = uuid4()
+
+        with (
+            patch.object(
+                service,
+                "_execute_graph_streaming",
+                side_effect=InvocationCancelledError(str(invocation_id), "streaming"),
+            ),
+            patch.object(service, "_setup_graph", return_value=AsyncMock()),
+            patch("syntara.agent_orchestrator.services.orchestration_service.StreamClient") as mock_stream_client,
+        ):
+            mock_client_instance = AsyncMock()
+            mock_stream_client.return_value.__aenter__.return_value = mock_client_instance
+
+            with pytest.raises(InvocationCancelledError):
+                await service.execute(
+                    prompt="Test",
+                    session_id="test-session",
+                    invocation_id=invocation_id,
+                    actor_context=AuditActorContext(),
+                    ctx=InvocationContextData(),
+                )
+
+            cancelled_calls = [c for c in mock_client_instance.publish.call_args_list if "cancelled" in str(c)]
+            assert len(cancelled_calls) == 1
+            _stream_id, event = cancelled_calls[0][0]
+            assert event["event_type"] == "cancelled"
+            assert event["data"]["reason"] == "user_cancelled"
+
+    @pytest.mark.asyncio
+    async def test_execute_reraises_cancelled_even_when_publish_fails(self) -> None:
+        """A failed cancelled-event publish must not turn a cancel into a generic error."""
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "test-model"
+        mock_context_manager = MagicMock()
+        test_context = ContextPackage(payload={}, grounding_score=0.0)
+        mock_context_manager.plan_request.return_value = test_context
+
+        service = OrchestrationService(mock_llm, mock_context_manager)
+        invocation_id = uuid4()
+
+        with (
+            patch.object(
+                service,
+                "_execute_graph_streaming",
+                side_effect=InvocationCancelledError(str(invocation_id), "streaming"),
+            ),
+            patch.object(
+                service,
+                "_publish_stream_event",
+                side_effect=ConnectionError("Redis down"),
+            ),
+            patch.object(service, "_setup_graph", return_value=AsyncMock()),
+            patch("syntara.agent_orchestrator.services.orchestration_service.StreamClient") as mock_stream_client,
+        ):
+            mock_client_instance = AsyncMock()
+            mock_stream_client.return_value.__aenter__.return_value = mock_client_instance
+
+            with pytest.raises(InvocationCancelledError):
+                await service.execute(
+                    prompt="Test",
+                    session_id="test-session",
+                    invocation_id=invocation_id,
+                    actor_context=AuditActorContext(),
+                    ctx=InvocationContextData(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_check_cancellation_signal_raises_on_cancelled(self) -> None:
+        """Test _check_cancellation_signal raises InvocationCancelledError when key exists."""
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+
+        mock_llm = AsyncMock()
+        mock_context_manager = MagicMock()
+        service = OrchestrationService(mock_llm, mock_context_manager)
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = True
+        invocation_id = uuid4()
+
+        with pytest.raises(InvocationCancelledError):
+            await service._check_cancellation_signal(
+                mock_client, f"invocation:{invocation_id}:cancelled", invocation_id
+            )
+
+    @pytest.mark.asyncio
+    async def test_check_cancellation_signal_falls_back_to_db_on_redis_failure(self) -> None:
+        """Test _check_cancellation_signal falls back to DB when Redis is unavailable."""
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+        from syntara.agent_orchestrator.models import Invocation, InvocationStatus
+
+        mock_llm = AsyncMock()
+        mock_context_manager = MagicMock()
+
+        mock_invocation = MagicMock(spec=Invocation)
+        mock_invocation.status = InvocationStatus.CANCELLED
+
+        mock_session = AsyncMock()
+        mock_session.get.return_value = mock_invocation
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncMock, None]:
+            yield mock_session
+
+        service = OrchestrationService(mock_llm, mock_context_manager, session_factory=mock_session_factory)
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.side_effect = RedisConnectionError("Redis down")
+        invocation_id = uuid4()
+
+        with pytest.raises(InvocationCancelledError):
+            await service._check_cancellation_signal(
+                mock_client, f"invocation:{invocation_id}:cancelled", invocation_id
+            )
+
+        mock_session.get.assert_called_once_with(Invocation, invocation_id)
+
+    @pytest.mark.asyncio
+    async def test_check_cancellation_signal_continues_when_both_fail(self) -> None:
+        """Test _check_cancellation_signal continues when both Redis and DB fail."""
+        from redis.exceptions import ConnectionError as RedisConnectionError
+        from sqlalchemy.exc import SQLAlchemyError
+
+        mock_llm = AsyncMock()
+        mock_context_manager = MagicMock()
+
+        mock_session = AsyncMock()
+        mock_session.get.side_effect = SQLAlchemyError("DB down")
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncMock, None]:
+            yield mock_session
+
+        service = OrchestrationService(mock_llm, mock_context_manager, session_factory=mock_session_factory)
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.side_effect = RedisConnectionError("Redis down")
+        invocation_id = uuid4()
+
+        await service._check_cancellation_signal(mock_client, f"invocation:{invocation_id}:cancelled", invocation_id)
+
+    @pytest.mark.asyncio
+    async def test_check_cancellation_signal_skips_db_when_redis_says_not_cancelled(self) -> None:
+        """Test _check_cancellation_signal skips DB check when Redis is up and says not cancelled."""
+        mock_llm = AsyncMock()
+        mock_context_manager = MagicMock()
+
+        mock_session = AsyncMock()
+
+        async def mock_session_factory() -> AsyncGenerator[AsyncMock, None]:
+            yield mock_session
+
+        service = OrchestrationService(mock_llm, mock_context_manager, session_factory=mock_session_factory)
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = False
+        invocation_id = uuid4()
+
+        await service._check_cancellation_signal(mock_client, f"invocation:{invocation_id}:cancelled", invocation_id)
+
+        mock_session.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_watcher_sets_event_on_cancel(self) -> None:
+        """Test that _cancellation_watcher sets the event when cancellation is detected."""
+        import asyncio
+
+        mock_llm = AsyncMock()
+        mock_context_manager = MagicMock()
+        service = OrchestrationService(mock_llm, mock_context_manager)
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = True
+        invocation_id = uuid4()
+        cancel_event = asyncio.Event()
+
+        with patch("syntara.agent_orchestrator.services.orchestration_service.StreamClient") as mock_sc:
+            mock_sc.return_value.__aenter__.return_value = mock_client
+            mock_sc.return_value.__aexit__.return_value = None
+            await service._cancellation_watcher(
+                f"invocation:{invocation_id}:cancelled",
+                invocation_id,
+                cancel_event,
+                interval=0.0,
+            )
+
+        assert cancel_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_watcher_keeps_polling_until_cancelled(self) -> None:
+        """Test that _cancellation_watcher polls repeatedly until cancellation is found."""
+        import asyncio
+
+        mock_llm = AsyncMock()
+        mock_context_manager = MagicMock()
+        service = OrchestrationService(mock_llm, mock_context_manager)
+
+        mock_client = AsyncMock()
+        # Not cancelled on first two checks, then cancelled
+        mock_client.key_exists.side_effect = [False, False, True]
+        invocation_id = uuid4()
+        cancel_event = asyncio.Event()
+
+        with patch("syntara.agent_orchestrator.services.orchestration_service.StreamClient") as mock_sc:
+            mock_sc.return_value.__aenter__.return_value = mock_client
+            mock_sc.return_value.__aexit__.return_value = None
+            await service._cancellation_watcher(
+                f"invocation:{invocation_id}:cancelled",
+                invocation_id,
+                cancel_event,
+                interval=0.0,
+            )
+
+        assert cancel_event.is_set()
+        assert mock_client.key_exists.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_execute_graph_streaming_raises_on_mid_stream_cancellation(
+        self,
+    ) -> None:
+        """Test that _execute_graph_streaming raises InvocationCancelledError when the watcher detects cancellation."""
+        import asyncio
+
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+        from syntara.agent_orchestrator.services.orchestration_service import _TraceAccumulator
+
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "test-model"
+        mock_context_manager = MagicMock()
+        service = OrchestrationService(mock_llm, mock_context_manager)
+
+        invocation_id = uuid4()
+        mock_client = AsyncMock()
+
+        cancel_trigger = asyncio.Event()
+
+        async def fake_watcher(
+            _key: str,
+            _inv_id: object,
+            cancel_event: asyncio.Event,
+            **_kw: object,
+        ) -> None:
+            await cancel_trigger.wait()
+            cancel_event.set()
+
+        async def stream_with_yields() -> AsyncGenerator[dict[str, Any], None]:
+            yield create_mock_streaming_event("on_chat_model_stream", "Hello")
+            cancel_trigger.set()
+            await asyncio.sleep(0)
+            yield create_mock_streaming_event("on_chat_model_stream", "World")
+
+        mock_graph = AsyncMock()
+        mock_graph.astream_events = lambda *_a, **_kw: stream_with_yields()
+
+        with patch.object(service, "_cancellation_watcher", side_effect=fake_watcher):
+            with pytest.raises(InvocationCancelledError):
+                await service._execute_graph_streaming(
+                    graph=mock_graph,
+                    initial_state={},  # type: ignore[typeddict-item]
+                    config={"configurable": {"thread_id": "test"}},
+                    invocation_id=invocation_id,
+                    stream_id="stream-1",
+                    client=mock_client,
+                    trace_accumulator=_TraceAccumulator(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_execute_graph_streaming_returns_final_state_when_not_cancelled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that _execute_graph_streaming returns final_state when no cancellation occurs.
+
+        Patches StreamClient so the watcher's own connection uses a mock,
+        and yields control mid-stream so the watcher can poll at least once.
+        """
+        import asyncio
+
+        import syntara.agent_orchestrator.services.orchestration_service as orch_mod
+        from syntara.agent_orchestrator.services.orchestration_service import _TraceAccumulator
+
+        monkeypatch.setattr(orch_mod, "_CANCELLATION_POLL_INTERVAL", 0.0)
+
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "test-model"
+        mock_context_manager = MagicMock()
+        service = OrchestrationService(mock_llm, mock_context_manager)
+
+        invocation_id = uuid4()
+        mock_client = AsyncMock()
+
+        watcher_client = AsyncMock()
+        watcher_client.key_exists.return_value = False
+
+        async def stream_with_yield() -> AsyncGenerator[dict[str, Any], None]:
+            yield create_mock_streaming_event("on_chat_model_stream", "Done")
+            await asyncio.sleep(0)
+            yield {"event": "on_chain_end", "data": {}}
+
+        mock_graph = AsyncMock()
+        mock_graph.astream_events = lambda *_a, **_kw: stream_with_yield()
+
+        with patch("syntara.agent_orchestrator.services.orchestration_service.StreamClient") as mock_sc:
+            mock_sc.return_value.__aenter__.return_value = watcher_client
+            mock_sc.return_value.__aexit__.return_value = None
+
+            result = await service._execute_graph_streaming(
+                graph=mock_graph,
+                initial_state={},  # type: ignore[typeddict-item]
+                config={"configurable": {"thread_id": "test"}},
+                invocation_id=invocation_id,
+                stream_id="stream-1",
+                client=mock_client,
+                trace_accumulator=_TraceAccumulator(),
+            )
+
+        assert result is None
+        watcher_client.key_exists.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_graph_streaming_cleans_up_watcher_on_cancellation(
+        self,
+    ) -> None:
+        """Test that the watcher task is cancelled and awaited even when cancellation is raised."""
+        import asyncio
+
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+        from syntara.agent_orchestrator.services.orchestration_service import _TraceAccumulator
+
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "test-model"
+        mock_context_manager = MagicMock()
+        service = OrchestrationService(mock_llm, mock_context_manager)
+
+        invocation_id = uuid4()
+        mock_client = AsyncMock()
+
+        cancel_trigger = asyncio.Event()
+
+        async def fake_watcher(
+            _key: str,
+            _inv_id: object,
+            cancel_event: asyncio.Event,
+            **_kw: object,
+        ) -> None:
+            await cancel_trigger.wait()
+            cancel_event.set()
+
+        async def stream_with_yields() -> AsyncGenerator[dict[str, Any], None]:
+            yield create_mock_streaming_event("on_chat_model_stream", "Hello")
+            cancel_trigger.set()
+            await asyncio.sleep(0)
+            yield create_mock_streaming_event("on_chat_model_stream", "World")
+
+        mock_graph = AsyncMock()
+        mock_graph.astream_events = lambda *_a, **_kw: stream_with_yields()
+
+        with patch.object(service, "_cancellation_watcher", side_effect=fake_watcher):
+            with pytest.raises(InvocationCancelledError):
+                await service._execute_graph_streaming(
+                    graph=mock_graph,
+                    initial_state={},  # type: ignore[typeddict-item]
+                    config={"configurable": {"thread_id": "test"}},
+                    invocation_id=invocation_id,
+                    stream_id="stream-1",
+                    client=mock_client,
+                    trace_accumulator=_TraceAccumulator(),
+                )
+
+        # Give the event loop a tick to clean up
+        await asyncio.sleep(0)
+
+        # Watcher should have been cancelled and awaited in finally block
+        pending = [t for t in asyncio.all_tasks() if "cancellation_watcher" in t.get_name()]
+        assert pending == []
+
+    @pytest.mark.asyncio
+    async def test_publish_failure_with_cancelled_db_row_raises_cancelled(
+        self,
+    ) -> None:
+        """When publish raises and cancel_event is unset, DB fallback still surfaces cancellation."""
+        import asyncio
+
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+        from syntara.agent_orchestrator.models import InvocationStatus
+        from syntara.agent_orchestrator.services.orchestration_service import _TraceAccumulator
+
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "test-model"
+        mock_context_manager = MagicMock()
+        service = OrchestrationService(mock_llm, mock_context_manager)
+
+        invocation_id = uuid4()
+        mock_client = AsyncMock()
+        mock_client.publish.side_effect = RedisConnectionError("Redis down")
+        mock_client.key_exists.side_effect = RedisConnectionError("Redis down")
+
+        mock_invocation = MagicMock()
+        mock_invocation.status = InvocationStatus.CANCELLED
+
+        async def stream_one_event() -> AsyncGenerator[dict[str, Any], None]:
+            yield create_mock_streaming_event("on_chat_model_stream", "Hello")
+
+        mock_graph = AsyncMock()
+        mock_graph.astream_events = lambda *_a, **_kw: stream_one_event()
+
+        async def noop_watcher(
+            _key: str,
+            _inv_id: object,
+            _cancel_event: asyncio.Event,
+            **_kw: object,
+        ) -> None:
+            await asyncio.sleep(3600)
+
+        with (
+            patch.object(service, "_cancellation_watcher", side_effect=noop_watcher),
+            patch.object(service, "_get_async_session_context") as mock_session_ctx,
+        ):
+            mock_session = AsyncMock()
+            mock_session.get.return_value = mock_invocation
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+
+            with pytest.raises(InvocationCancelledError):
+                await service._execute_graph_streaming(
+                    graph=mock_graph,
+                    initial_state={},  # type: ignore[typeddict-item]
+                    config={"configurable": {"thread_id": "test"}},
+                    invocation_id=invocation_id,
+                    stream_id="stream-1",
+                    client=mock_client,
+                    trace_accumulator=_TraceAccumulator(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_watcher_teardown_failure_does_not_replace_real_exception(self) -> None:
+        """A failed watcher must not mask InvocationCancelledError from the stream loop."""
+        import asyncio
+
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+        from syntara.agent_orchestrator.services.orchestration_service import _TraceAccumulator
+
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "test-model"
+        mock_context_manager = MagicMock()
+        service = OrchestrationService(mock_llm, mock_context_manager)
+
+        invocation_id = uuid4()
+        mock_client = AsyncMock()
+
+        async def failing_watcher(
+            _key: str,
+            _inv_id: object,
+            cancel_event: asyncio.Event,
+            **_kw: object,
+        ) -> None:
+            cancel_event.set()
+            msg = "StreamClient connect failed"
+            raise ConnectionError(msg)
+
+        async def stream_with_yields() -> AsyncGenerator[dict[str, Any], None]:
+            await asyncio.sleep(0)
+            yield create_mock_streaming_event("on_chat_model_stream", "Hello")
+
+        mock_graph = AsyncMock()
+        mock_graph.astream_events = lambda *_a, **_kw: stream_with_yields()
+
+        with patch.object(service, "_cancellation_watcher", side_effect=failing_watcher):
+            with pytest.raises(InvocationCancelledError):
+                await service._execute_graph_streaming(
+                    graph=mock_graph,
+                    initial_state={},  # type: ignore[typeddict-item]
+                    config={"configurable": {"thread_id": "test"}},
+                    invocation_id=invocation_id,
+                    stream_id="stream-1",
+                    client=mock_client,
+                    trace_accumulator=_TraceAccumulator(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_parent_cancellation_during_watcher_teardown_propagates(self) -> None:
+        """CancelledError injected into the parent at ``await watcher`` must propagate.
+
+        The watcher blocks until cancelled (simulating the real 2s poll).
+        The stream finishes normally.  In the ``finally`` block,
+        ``watcher.cancel()`` cancels the watcher; the watcher's teardown
+        also cancels the parent, so ``task.cancelling() > 0`` when the
+        ``except CancelledError`` handler runs.  Without the guard the
+        CancelledError would be suppressed and the function would return.
+        """
+        import asyncio
+
+        from syntara.agent_orchestrator.services.orchestration_service import _TraceAccumulator
+
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "test-model"
+        mock_context_manager = MagicMock()
+        service = OrchestrationService(mock_llm, mock_context_manager)
+
+        invocation_id = uuid4()
+        mock_client = AsyncMock()
+
+        parent_task: asyncio.Task[Any] | None = None
+
+        async def watcher_that_cancels_parent_on_teardown(
+            _key: str,
+            _inv_id: object,
+            _cancel_event: asyncio.Event,
+            **_kw: object,
+        ) -> None:
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                if parent_task is not None:
+                    parent_task.cancel()
+                raise
+
+        async def stream_with_yield() -> AsyncGenerator[dict[str, Any], None]:
+            yield create_mock_streaming_event("on_chat_model_stream", "Done")
+            await asyncio.sleep(0)
+            yield {"event": "on_chain_end", "data": {}}
+
+        mock_graph = AsyncMock()
+        mock_graph.astream_events = lambda *_a, **_kw: stream_with_yield()
+
+        async def run_streaming() -> object:
+            with patch.object(service, "_cancellation_watcher", side_effect=watcher_that_cancels_parent_on_teardown):
+                return await service._execute_graph_streaming(
+                    graph=mock_graph,
+                    initial_state={},  # type: ignore[typeddict-item]
+                    config={"configurable": {"thread_id": "test"}},
+                    invocation_id=invocation_id,
+                    stream_id="stream-1",
+                    client=mock_client,
+                    trace_accumulator=_TraceAccumulator(),
+                )
+
+        parent_task = asyncio.create_task(run_streaming())
+        await asyncio.sleep(0)
+
+        with pytest.raises(asyncio.CancelledError):
+            await parent_task

--- a/backend/tests/unit/agent_orchestrator/services/test_streaming_service.py
+++ b/backend/tests/unit/agent_orchestrator/services/test_streaming_service.py
@@ -14,7 +14,6 @@ from syntara.agent_orchestrator.services.streaming_service import (
     InvocationNotFoundError,
     StreamingService,
     WebSocketStreamingHandler,
-    get_invocation_cancel_key,
     get_invocation_stream_id,
 )
 from syntara.core.websocket.close_codes import POLICY_VIOLATION
@@ -61,16 +60,6 @@ class TestGetInvocationStreamId:
         invocation_id = uuid4()
         stream_id = get_invocation_stream_id(invocation_id)
         assert stream_id == f"invocation:{invocation_id}:events"
-
-
-class TestGetInvocationCancelKey:
-    """Test get_invocation_cancel_key helper function."""
-
-    def test_generates_correct_cancel_key(self) -> None:
-        """Test that cancel key has correct format."""
-        invocation_id = uuid4()
-        cancel_key = get_invocation_cancel_key(invocation_id)
-        assert cancel_key == f"invocation:{invocation_id}:cancelled"
 
 
 class TestWebSocketStreamingHandlerCreateContext:
@@ -503,7 +492,72 @@ class TestCheckBeforeStreaming:
         invocation_id = uuid4()
         session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
 
-        await handler.check_before_streaming(session_state)  # should not raise
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = False
+
+        with patch("syntara.agent_orchestrator.services.streaming_service.StreamClient") as mock_cls:
+            mock_cls.return_value.__aenter__.return_value = mock_client
+            mock_cls.return_value.__aexit__.return_value = None
+            await handler.check_before_streaming(session_state)
+
+        mock_client.key_exists.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_live_redis_cancel_key_set(self, handler: WebSocketStreamingHandler) -> None:
+        """Stale RUNNING snapshot must still abort when the cancel key exists."""
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = True
+
+        with (
+            patch("syntara.agent_orchestrator.services.streaming_service.StreamClient") as mock_cls,
+            pytest.raises(InvocationCancelledStreamError),
+        ):
+            mock_cls.return_value.__aenter__.return_value = mock_client
+            mock_cls.return_value.__aexit__.return_value = None
+            await handler.check_before_streaming(session_state)
+
+    @pytest.mark.asyncio
+    async def test_raises_on_db_fallback_when_redis_errors(self, handler: WebSocketStreamingHandler) -> None:
+        """Redis errors fall back to the invocation row before streaming."""
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.side_effect = ConnectionError("redis down")
+
+        with (
+            patch("syntara.agent_orchestrator.services.streaming_service.StreamClient") as mock_cls,
+            patch.object(handler, "_check_invocation_exists", new_callable=AsyncMock) as mock_db,
+            pytest.raises(InvocationCancelledStreamError),
+        ):
+            mock_cls.return_value.__aenter__.return_value = mock_client
+            mock_cls.return_value.__aexit__.return_value = None
+            mock_db.return_value = InvocationStatus.CANCELLED
+            await handler.check_before_streaming(session_state)
+
+        mock_db.assert_awaited_once_with(invocation_id)
+
+    @pytest.mark.asyncio
+    async def test_skips_db_when_redis_says_not_cancelled(self, handler: WebSocketStreamingHandler) -> None:
+        """Healthy Redis miss must not consult the DB (same as other cancel checks)."""
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
+
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = False
+
+        with (
+            patch("syntara.agent_orchestrator.services.streaming_service.StreamClient") as mock_cls,
+            patch.object(handler, "_check_invocation_exists", new_callable=AsyncMock) as mock_db,
+        ):
+            mock_cls.return_value.__aenter__.return_value = mock_client
+            mock_cls.return_value.__aexit__.return_value = None
+            await handler.check_before_streaming(session_state)
+
+        mock_db.assert_not_awaited()
 
 
 class TestCheckBeforeStreamingWiring:

--- a/backend/tests/unit/agent_orchestrator/services/test_streaming_service.py
+++ b/backend/tests/unit/agent_orchestrator/services/test_streaming_service.py
@@ -14,10 +14,15 @@ from syntara.agent_orchestrator.services.streaming_service import (
     InvocationNotFoundError,
     StreamingService,
     WebSocketStreamingHandler,
+    get_invocation_cancel_key,
     get_invocation_stream_id,
 )
 from syntara.core.websocket.close_codes import POLICY_VIOLATION
-from syntara.core.websocket.exceptions import EventsExpiredError, StreamingValidationError
+from syntara.core.websocket.exceptions import (
+    EventsExpiredError,
+    InvocationCancelledStreamError,
+    StreamingValidationError,
+)
 
 
 def mock_db_session_factory(handler: WebSocketStreamingHandler, scalar_result: Any) -> None:  # noqa: ANN401
@@ -56,6 +61,16 @@ class TestGetInvocationStreamId:
         invocation_id = uuid4()
         stream_id = get_invocation_stream_id(invocation_id)
         assert stream_id == f"invocation:{invocation_id}:events"
+
+
+class TestGetInvocationCancelKey:
+    """Test get_invocation_cancel_key helper function."""
+
+    def test_generates_correct_cancel_key(self) -> None:
+        """Test that cancel key has correct format."""
+        invocation_id = uuid4()
+        cancel_key = get_invocation_cancel_key(invocation_id)
+        assert cancel_key == f"invocation:{invocation_id}:cancelled"
 
 
 class TestWebSocketStreamingHandlerCreateContext:
@@ -169,31 +184,151 @@ class TestWebSocketStreamingHandlerWaitForStreamReady:
         with pytest.raises(EventsExpiredError):
             await handler.wait_for_stream_ready(stream_id, context)
 
-    async def test_wait_for_stream_ready_raises_events_expired_for_cancelled(
+    async def test_wait_for_stream_ready_raises_cancelled_for_cancelled_invocation(
         self, handler: WebSocketStreamingHandler
     ) -> None:
-        """Test that wait_for_stream_ready raises EventsExpiredError for cancelled invocation."""
+        """Test that wait_for_stream_ready raises InvocationCancelledStreamError for cancelled invocation."""
         invocation_id = uuid4()
         stream_id = get_invocation_stream_id(invocation_id)
         context = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.CANCELLED}
 
-        with pytest.raises(EventsExpiredError):
+        with pytest.raises(InvocationCancelledStreamError) as exc_info:
             await handler.wait_for_stream_ready(stream_id, context)
 
+        assert exc_info.value.error_data.code == "INVOCATION_CANCELLED"
+
+    @pytest.mark.asyncio
     async def test_wait_for_stream_ready_waits_for_running_invocation(self, handler: WebSocketStreamingHandler) -> None:
-        """Test that wait_for_stream_ready waits for stream creation for running invocation."""
+        """Test that wait_for_stream_ready returns when stream appears."""
         invocation_id = uuid4()
         stream_id = get_invocation_stream_id(invocation_id)
         context = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
 
-        with patch.object(handler, "_wait_for_stream_creation") as mock_wait:
+        mock_client = AsyncMock()
+        mock_client.info.return_value = {"exists": True}
+        mock_client.key_exists.return_value = False
+
+        with (
+            patch("syntara.core.websocket.base_handler.StreamClient") as mock_stream_cls,
+            patch("syntara.core.websocket.base_handler.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_stream_cls.return_value.__aenter__.return_value = mock_client
             await handler.wait_for_stream_ready(stream_id, context)
-            mock_wait.assert_called_once_with(
-                stream_id=stream_id,
-                resource_id=str(invocation_id),
-                resource_status=InvocationStatus.RUNNING.value,
-                resource_type="invocation",
-            )
+
+    @pytest.mark.asyncio
+    async def test_wait_for_stream_ready_detects_cancel_key_during_wait(
+        self, handler: WebSocketStreamingHandler
+    ) -> None:
+        """Test that wait_for_stream_ready raises InvocationCancelledStreamError when cancel key appears."""
+        invocation_id = uuid4()
+        stream_id = get_invocation_stream_id(invocation_id)
+        context = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.CREATED}
+
+        mock_client = AsyncMock()
+        mock_client.info.return_value = {"exists": False}
+        # Cancel key appears on second poll
+        mock_client.key_exists.side_effect = [False, True]
+
+        with (
+            patch("syntara.core.websocket.base_handler.StreamClient") as mock_stream_cls,
+            patch("syntara.core.websocket.base_handler.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_stream_cls.return_value.__aenter__.return_value = mock_client
+
+            with pytest.raises(InvocationCancelledStreamError) as exc_info:
+                await handler.wait_for_stream_ready(stream_id, context)
+
+            assert exc_info.value.error_data.code == "INVOCATION_CANCELLED"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_stream_ready_detects_cancel_via_db_when_redis_down(
+        self, handler: WebSocketStreamingHandler
+    ) -> None:
+        """When Redis is down, DB fallback detects cancellation instead of timing out."""
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        invocation_id = uuid4()
+        stream_id = get_invocation_stream_id(invocation_id)
+        context = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.CREATED}
+
+        mock_client = AsyncMock()
+        mock_client.info.side_effect = RedisConnectionError("Redis down")
+        mock_client.key_exists.side_effect = RedisConnectionError("Redis down")
+
+        mock_invocation = MagicMock()
+        mock_invocation.status = InvocationStatus.CANCELLED
+
+        with (
+            patch("syntara.core.websocket.base_handler.StreamClient") as mock_stream_cls,
+            patch("syntara.core.websocket.base_handler.asyncio.sleep", new_callable=AsyncMock),
+            patch.object(
+                handler,
+                "_check_invocation_exists",
+                new_callable=AsyncMock,
+                return_value=InvocationStatus.CANCELLED,
+            ),
+        ):
+            mock_stream_cls.return_value.__aenter__.return_value = mock_client
+
+            with pytest.raises(InvocationCancelledStreamError) as exc_info:
+                await handler.wait_for_stream_ready(stream_id, context)
+
+            assert exc_info.value.error_data.code == "INVOCATION_CANCELLED"
+
+
+class TestStreamEventsToWebsocketRedisDown:
+    """Test stream_events_to_websocket when Redis is unavailable at connect time."""
+
+    @pytest.mark.asyncio
+    async def test_info_redis_down_triggers_wait_path_db_cancel(
+        self,
+        handler: WebSocketStreamingHandler,
+        mock_websocket: MagicMock,
+    ) -> None:
+        """When info() raises RedisConnectionError the wait path is entered and DB fallback detects cancellation."""
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        invocation_id = uuid4()
+        stream_id = get_invocation_stream_id(invocation_id)
+
+        mock_client = AsyncMock()
+        mock_client.info.side_effect = RedisConnectionError("Redis down")
+        mock_client.key_exists.side_effect = RedisConnectionError("Redis down")
+
+        with (
+            patch("syntara.core.websocket.base_handler.StreamClient") as mock_stream_cls,
+            patch("syntara.core.websocket.base_handler.get_connection_lifecycle_manager") as mock_lifecycle,
+            patch("syntara.core.websocket.base_handler.asyncio.sleep", new_callable=AsyncMock),
+            patch.object(
+                handler,
+                "create_session_state",
+                new_callable=AsyncMock,
+                return_value={
+                    "invocation_id": invocation_id,
+                    "invocation_status": InvocationStatus.RUNNING,
+                },
+            ),
+            patch.object(
+                handler,
+                "_check_invocation_exists",
+                new_callable=AsyncMock,
+                return_value=InvocationStatus.CANCELLED,
+            ),
+        ):
+            mock_stream_cls.return_value.__aenter__.return_value = mock_client
+            mock_stream_cls.return_value.__aexit__.return_value = None
+            mock_lifecycle_mgr = MagicMock()
+            mock_lifecycle_mgr.add_connection.return_value = "conn-1"
+            mock_lifecycle.return_value = mock_lifecycle_mgr
+
+            with pytest.raises(InvocationCancelledStreamError) as exc_info:
+                await handler.stream_events_to_websocket(
+                    websocket=mock_websocket,
+                    stream_id=stream_id,
+                    invocation_id=invocation_id,
+                )
+
+            assert exc_info.value.error_data.code == "INVOCATION_CANCELLED"
 
 
 class TestAAP86853InvocationStatusLookupRegression:
@@ -247,6 +382,207 @@ class TestWebSocketStreamingHandlerCheckInvocationExists:
 
         assert exc_info.value.error_data.code == "INVOCATION_NOT_FOUND"
         assert str(invocation_id) in exc_info.value.error_data.detail
+
+
+class TestGetOnIdle:
+    """Tests for get_on_idle cancel-key check during event streaming."""
+
+    def test_get_on_idle_returns_callable(self, handler: WebSocketStreamingHandler) -> None:
+        """get_on_idle must return an async callable."""
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
+        mock_client = AsyncMock()
+
+        result = handler.get_on_idle(session_state, mock_client)
+        assert callable(result)
+
+    @pytest.mark.asyncio
+    async def test_on_idle_raises_when_cancel_key_exists(self, handler: WebSocketStreamingHandler) -> None:
+        """on_idle must raise InvocationCancelledStreamError when the cancel key is set."""
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = True
+
+        on_idle = handler.get_on_idle(session_state, mock_client)
+        assert on_idle is not None
+
+        with pytest.raises(InvocationCancelledStreamError):
+            await on_idle()
+
+    @pytest.mark.asyncio
+    async def test_on_idle_does_not_raise_when_not_cancelled(self, handler: WebSocketStreamingHandler) -> None:
+        """on_idle must not raise when the cancel key is absent."""
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = False
+
+        on_idle = handler.get_on_idle(session_state, mock_client)
+        assert on_idle is not None
+
+        with patch.object(handler, "_check_invocation_exists", new_callable=AsyncMock) as mock_db:
+            await on_idle()
+            mock_db.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_idle_falls_back_to_db_when_redis_fails(self, handler: WebSocketStreamingHandler) -> None:
+        """on_idle must fall back to DB when Redis key_exists raises."""
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
+        mock_client = AsyncMock()
+        mock_client.key_exists.side_effect = ConnectionError("Redis down")
+
+        on_idle = handler.get_on_idle(session_state, mock_client)
+        assert on_idle is not None
+
+        with (
+            patch.object(
+                handler,
+                "_check_invocation_exists",
+                new_callable=AsyncMock,
+                return_value=InvocationStatus.CANCELLED,
+            ),
+            pytest.raises(InvocationCancelledStreamError),
+        ):
+            await on_idle()
+
+    @pytest.mark.asyncio
+    async def test_on_idle_continues_when_both_redis_and_db_fail(self, handler: WebSocketStreamingHandler) -> None:
+        """on_idle must not raise when both Redis and DB checks fail."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
+        mock_client = AsyncMock()
+        mock_client.key_exists.side_effect = ConnectionError("Redis down")
+
+        on_idle = handler.get_on_idle(session_state, mock_client)
+        assert on_idle is not None
+
+        with patch.object(
+            handler,
+            "_check_invocation_exists",
+            new_callable=AsyncMock,
+            side_effect=SQLAlchemyError("DB down"),
+        ):
+            await on_idle()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_on_idle_raises_when_session_status_is_cancelled(self, handler: WebSocketStreamingHandler) -> None:
+        """on_idle raises when session_state says CANCELLED, even if key_exists is False."""
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.CANCELLED}
+        mock_client = AsyncMock()
+        mock_client.key_exists.return_value = False
+
+        on_idle = handler.get_on_idle(session_state, mock_client)
+        assert on_idle is not None
+
+        with pytest.raises(InvocationCancelledStreamError):
+            await on_idle()
+
+        mock_client.key_exists.assert_not_called()
+
+
+class TestCheckBeforeStreaming:
+    """Tests for check_before_streaming pre-stream CANCELLED guard."""
+
+    @pytest.mark.asyncio
+    async def test_raises_when_snapshot_is_cancelled(self, handler: WebSocketStreamingHandler) -> None:
+        """check_before_streaming must raise when snapshot invocation_status is CANCELLED."""
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.CANCELLED}
+
+        with pytest.raises(InvocationCancelledStreamError):
+            await handler.check_before_streaming(session_state)
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_when_status_is_running(self, handler: WebSocketStreamingHandler) -> None:
+        """check_before_streaming must not raise for non-cancelled statuses."""
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
+
+        await handler.check_before_streaming(session_state)  # should not raise
+
+
+class TestCheckBeforeStreamingWiring:
+    """Test that stream_events_to_websocket calls check_before_streaming."""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_status_aborts_before_events(self, mock_session_factory: MagicMock) -> None:
+        """stream_events_to_websocket raises for CANCELLED with an existing stream.
+
+        Asserts InvocationCancelledStreamError and client.events() never called.
+        """
+        handler = WebSocketStreamingHandler(session_factory=mock_session_factory)
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.CANCELLED}
+
+        mock_client = AsyncMock()
+        mock_client.info.return_value = {"exists": True, "length": 5, "last_event_id": "1-0"}
+
+        mock_websocket = AsyncMock()
+
+        with (
+            patch.object(handler, "create_session_state", new_callable=AsyncMock, return_value=session_state),
+            patch("syntara.core.websocket.base_handler.StreamClient") as mock_sc_cls,
+        ):
+            # First StreamClient for info() check
+            mock_sc_cls.return_value.__aenter__.return_value = mock_client
+            mock_sc_cls.return_value.__aexit__.return_value = None
+
+            with pytest.raises(InvocationCancelledStreamError):
+                await handler.stream_events_to_websocket(
+                    websocket=mock_websocket,
+                    stream_id=f"invocation:{invocation_id}:events",
+                    replay_count="0",
+                    invocation_id=invocation_id,
+                )
+
+        mock_client.events.assert_not_called()
+
+
+class TestStreamEventsOnIdleWiring:
+    """Test that stream_events_to_websocket passes on_idle through to client.events()."""
+
+    @pytest.mark.asyncio
+    async def test_on_idle_passed_to_client_events(self, mock_session_factory: MagicMock) -> None:
+        """stream_events_to_websocket must pass a non-None on_idle to client.events()."""
+        handler = WebSocketStreamingHandler(session_factory=mock_session_factory)
+        invocation_id = uuid4()
+        session_state = {"invocation_id": invocation_id, "invocation_status": InvocationStatus.RUNNING}
+
+        captured_kwargs: dict[str, Any] = {}
+
+        async def fake_events(**kwargs: Any) -> Any:  # noqa: ANN401
+            captured_kwargs.update(kwargs)
+            # Yield one terminal event so the stream stops
+            yield {"event_type": "completion", "data": {}}
+
+        mock_client = AsyncMock()
+        mock_client.events = fake_events
+
+        mock_websocket = AsyncMock()
+
+        with (
+            patch.object(handler, "create_session_state", new_callable=AsyncMock, return_value=session_state),
+            patch.object(handler, "wait_for_stream_ready", new_callable=AsyncMock),
+            patch("syntara.core.websocket.base_handler.StreamClient") as mock_sc_cls,
+        ):
+            mock_sc_cls.return_value.__aenter__.return_value = mock_client
+            mock_sc_cls.return_value.__aexit__.return_value = None
+
+            await handler.stream_events_to_websocket(
+                websocket=mock_websocket,
+                stream_id=f"invocation:{invocation_id}:events",
+                replay_count="0",
+                invocation_id=invocation_id,
+            )
+
+        assert "on_idle" in captured_kwargs
+        assert captured_kwargs["on_idle"] is not None
+        assert callable(captured_kwargs["on_idle"])
 
 
 class TestStreamingService:

--- a/backend/tests/unit/agent_orchestrator/tool_manager/test_execution_failure_handler.py
+++ b/backend/tests/unit/agent_orchestrator/tool_manager/test_execution_failure_handler.py
@@ -647,6 +647,64 @@ class TestMetricsEmissionAndDbPersistence:
 
     @patch("syntara.agent_orchestrator.tool_manager.execution_failure_handler._persist_tool_execution_to_db")
     @patch("syntara.agent_orchestrator.tool_manager.execution_failure_handler._emit_tool_metrics")
+    async def test_async_wrapper_cancelled_skips_metrics_and_db(self, mock_emit: Mock, mock_persist: AsyncMock) -> None:
+        """InvocationCancelledError must not increment tool error_count or emit error metrics."""
+        tool = Mock(spec=BaseTool)
+        tool.name = "my_tool"
+        tool.metadata = {"tool_id": str(uuid4()), "namespaced_name": "provider::my_tool"}
+
+        cancelled_id = "inv"
+
+        async def _raise_cancelled(_invocation_id: object, _phase: str) -> None:
+            raise InvocationCancelledError(cancelled_id, "tool_execution")
+
+        wrapper = create_tool_awrapper(session_id="session-abc", invocation_id=uuid4(), execution_id=uuid4())
+        request = ToolCallRequest(
+            tool_call=ToolCall(name="my_tool", args={}, id="call-cancel"),
+            tool=tool,
+            state={},
+            runtime=Mock(),
+        )
+
+        async def mock_execute(_request: ToolCallRequest) -> ToolMessage:
+            return ToolMessage(content="should not run", tool_call_id="call-cancel", name="my_tool")
+
+        with (
+            patch(
+                "syntara.agent_orchestrator.tool_manager.execution_failure_handler.raise_if_invocation_cancelled",
+                side_effect=_raise_cancelled,
+            ),
+            pytest.raises(InvocationCancelledError),
+        ):
+            await wrapper(request, mock_execute)
+
+        mock_emit.assert_not_called()
+        mock_persist.assert_not_awaited()
+
+    @pytest.mark.usefixtures("fast_retry_settings")
+    @patch("syntara.agent_orchestrator.tool_manager.execution_failure_handler._run_coroutine_from_sync")
+    @patch("syntara.agent_orchestrator.tool_manager.execution_failure_handler._emit_tool_metrics")
+    def test_sync_wrapper_cancelled_skips_metrics(self, mock_emit: Mock, mock_run_coro: Mock) -> None:
+        """Sync wrapper must not emit error metrics for InvocationCancelledError."""
+        tool = Mock(spec=BaseTool)
+        tool.name = "my_tool"
+        tool.metadata = {"tool_id": str(uuid4()), "namespaced_name": "provider::my_tool"}
+
+        _execute_sync_wrapper(
+            tool_name="my_tool",
+            tool_call_id="call-cancel",
+            exception=InvocationCancelledError("inv", "tool_execution"),
+            tool=tool,
+        )
+
+        mock_emit.assert_not_called()
+        persist_calls = [
+            call for call in mock_run_coro.call_args_list if call.args and "tool execution DB persistence" in call.args
+        ]
+        assert persist_calls == []
+
+    @patch("syntara.agent_orchestrator.tool_manager.execution_failure_handler._persist_tool_execution_to_db")
+    @patch("syntara.agent_orchestrator.tool_manager.execution_failure_handler._emit_tool_metrics")
     async def test_async_wrapper_timeout_emits_timeout_status(self, mock_emit: Mock, mock_persist: AsyncMock) -> None:
         """Test that TimeoutError emits TIMEOUT status and persists with error message."""
         tool = Mock(spec=BaseTool)

--- a/backend/tests/unit/agent_orchestrator/tool_manager/test_execution_failure_handler.py
+++ b/backend/tests/unit/agent_orchestrator/tool_manager/test_execution_failure_handler.py
@@ -11,6 +11,7 @@ from langchain_core.tools import BaseTool
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 
+from syntara.agent_orchestrator.exceptions import InvocationCancelledError
 from syntara.agent_orchestrator.tool_manager.execution_failure_handler import (
     _report_tool_failure,
     _resolve_execution_status,
@@ -20,6 +21,19 @@ from syntara.agent_orchestrator.tool_manager.execution_failure_handler import (
 from syntara.core.utils.retry import is_retryable_error
 from syntara.tool_manager.models.tool import ToolStatus
 from syntara.tool_manager.models.tool_execution import ToolExecutionStatus
+
+
+@pytest.fixture(autouse=True)
+def _skip_cancel_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tool-wrapper unit tests do not hit the database for cancel checks."""
+
+    async def _noop(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "syntara.agent_orchestrator.tool_manager.execution_failure_handler.raise_if_invocation_cancelled",
+        _noop,
+    )
 
 
 async def _execute_async_wrapper(
@@ -155,6 +169,36 @@ class TestAsyncToolWrapper:
         assert result.tool_call_id == "test-id"
         assert result.name == "test_tool"
         assert result.status == "error"
+
+    async def test_async_tool_wrapper_raises_when_cancelled(self) -> None:
+        """Cancelled invocations must not execute the tool."""
+        executed = False
+
+        async def mock_execute(_request: ToolCallRequest) -> ToolMessage:
+            nonlocal executed
+            executed = True
+            return ToolMessage(content="should not run", tool_call_id="id", name="test_tool")
+
+        wrapper = create_tool_awrapper(session_id="session-abc", invocation_id=uuid4(), execution_id=uuid4())
+        request = ToolCallRequest(
+            tool_call=ToolCall(name="test_tool", args={}, id="id"),
+            tool=MockTool(),
+            state={},
+            runtime=Mock(),
+        )
+        cancelled_id = "inv"
+
+        async def _raise_cancelled(_invocation_id: object, _phase: str) -> None:
+            raise InvocationCancelledError(cancelled_id, "tool_execution")
+
+        with patch(
+            "syntara.agent_orchestrator.tool_manager.execution_failure_handler.raise_if_invocation_cancelled",
+            side_effect=_raise_cancelled,
+        ):
+            with pytest.raises(InvocationCancelledError):
+                await wrapper(request, mock_execute)
+
+        assert executed is False
 
 
 class TestSyncToolWrapper:

--- a/backend/tests/unit/agent_orchestrator/utils/test_cancellation.py
+++ b/backend/tests/unit/agent_orchestrator/utils/test_cancellation.py
@@ -1,0 +1,73 @@
+"""Unit tests for invocation cancellation helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+from syntara.agent_orchestrator.models.invocation import InvocationStatus
+from syntara.agent_orchestrator.utils.cancellation import (
+    is_invocation_cancelled,
+    raise_if_invocation_cancelled,
+)
+
+
+@pytest.mark.asyncio
+async def test_is_invocation_cancelled_true() -> None:
+    invocation = MagicMock()
+    invocation.status = InvocationStatus.CANCELLED
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=invocation)
+
+    assert await is_invocation_cancelled(session, uuid4()) is True
+
+
+@pytest.mark.asyncio
+async def test_is_invocation_cancelled_false_for_running() -> None:
+    invocation = MagicMock()
+    invocation.status = InvocationStatus.RUNNING
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=invocation)
+
+    assert await is_invocation_cancelled(session, uuid4()) is False
+
+
+@pytest.mark.asyncio
+async def test_is_invocation_cancelled_false_when_missing() -> None:
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=None)
+
+    assert await is_invocation_cancelled(session, uuid4()) is False
+
+
+@pytest.mark.asyncio
+async def test_raise_if_cancelled_raises() -> None:
+    invocation_id = uuid4()
+    invocation = MagicMock()
+    invocation.status = InvocationStatus.CANCELLED
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=invocation)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "syntara.agent_orchestrator.utils.cancellation.AsyncSessionLocal",
+        return_value=session,
+    ):
+        with pytest.raises(InvocationCancelledError):
+            await raise_if_invocation_cancelled(invocation_id, "orchestration")
+
+
+@pytest.mark.asyncio
+async def test_raise_if_cancelled_swallows_db_errors() -> None:
+    session = AsyncMock()
+    session.get = AsyncMock(side_effect=OSError("down"))
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "syntara.agent_orchestrator.utils.cancellation.AsyncSessionLocal",
+        return_value=session,
+    ):
+        await raise_if_invocation_cancelled(uuid4(), "orchestration")

--- a/backend/tests/unit/agent_orchestrator/utils/test_cancellation.py
+++ b/backend/tests/unit/agent_orchestrator/utils/test_cancellation.py
@@ -1,5 +1,6 @@
 """Unit tests for invocation cancellation helpers."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -129,6 +130,38 @@ async def test_raise_if_cancelled_db_fallback_on_redis_error() -> None:
         pytest.raises(InvocationCancelledError),
     ):
         await raise_if_invocation_cancelled(invocation_id, "orchestration")
+
+    session.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_raise_if_cancelled_db_fallback_on_redis_hang() -> None:
+    """A hung Redis EXISTS must fall back to the invocation row, not block."""
+    invocation_id = uuid4()
+    invocation = MagicMock()
+    invocation.status = InvocationStatus.CANCELLED
+    session = _db_session(invocation)
+
+    async def _hang(_key: str) -> bool:
+        await asyncio.sleep(60)
+        return False
+
+    mock_client = AsyncMock()
+    mock_client.key_exists = _hang
+    mock_cls = MagicMock()
+    mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("syntara.agent_orchestrator.utils.cancellation._REDIS_CANCEL_CHECK_TIMEOUT_SECONDS", 0.05),
+        patch("syntara.agent_orchestrator.utils.cancellation.StreamClient", mock_cls),
+        patch(
+            "syntara.agent_orchestrator.utils.cancellation.AsyncSessionLocal",
+            return_value=session,
+        ),
+        pytest.raises(InvocationCancelledError),
+    ):
+        await raise_if_invocation_cancelled(invocation_id, "tool_execution")
 
     session.get.assert_awaited_once()
 

--- a/backend/tests/unit/agent_orchestrator/utils/test_cancellation.py
+++ b/backend/tests/unit/agent_orchestrator/utils/test_cancellation.py
@@ -8,9 +8,38 @@ import pytest
 from syntara.agent_orchestrator.exceptions import InvocationCancelledError
 from syntara.agent_orchestrator.models.invocation import InvocationStatus
 from syntara.agent_orchestrator.utils.cancellation import (
+    get_invocation_cancel_key,
     is_invocation_cancelled,
     raise_if_invocation_cancelled,
 )
+
+
+def _db_session(invocation: MagicMock | None = None, *, get_side_effect: Exception | None = None) -> AsyncMock:
+    session = AsyncMock()
+    if get_side_effect is not None:
+        session.get = AsyncMock(side_effect=get_side_effect)
+    else:
+        session.get = AsyncMock(return_value=invocation)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _stream_client(*, key_exists: bool = False, error: Exception | None = None) -> MagicMock:
+    mock_client = AsyncMock()
+    if error is not None:
+        mock_client.key_exists = AsyncMock(side_effect=error)
+    else:
+        mock_client.key_exists = AsyncMock(return_value=key_exists)
+    mock_cls = MagicMock()
+    mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+    return mock_cls
+
+
+def test_get_invocation_cancel_key_format() -> None:
+    invocation_id = uuid4()
+    assert get_invocation_cancel_key(invocation_id) == f"invocation:{invocation_id}:cancelled"
 
 
 @pytest.mark.asyncio
@@ -42,32 +71,80 @@ async def test_is_invocation_cancelled_false_when_missing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_raise_if_cancelled_raises() -> None:
+async def test_raise_if_cancelled_raises_on_redis_key() -> None:
+    invocation_id = uuid4()
+    session = _db_session()
+
+    with (
+        patch(
+            "syntara.agent_orchestrator.utils.cancellation.StreamClient",
+            _stream_client(key_exists=True),
+        ),
+        patch(
+            "syntara.agent_orchestrator.utils.cancellation.AsyncSessionLocal",
+            return_value=session,
+        ),
+        pytest.raises(InvocationCancelledError),
+    ):
+        await raise_if_invocation_cancelled(invocation_id, "orchestration")
+
+    session.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raise_if_cancelled_skips_db_when_redis_says_not_cancelled() -> None:
+    session = _db_session()
+
+    with (
+        patch(
+            "syntara.agent_orchestrator.utils.cancellation.StreamClient",
+            _stream_client(key_exists=False),
+        ),
+        patch(
+            "syntara.agent_orchestrator.utils.cancellation.AsyncSessionLocal",
+            return_value=session,
+        ),
+    ):
+        await raise_if_invocation_cancelled(uuid4(), "orchestration")
+
+    session.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raise_if_cancelled_db_fallback_on_redis_error() -> None:
     invocation_id = uuid4()
     invocation = MagicMock()
     invocation.status = InvocationStatus.CANCELLED
-    session = AsyncMock()
-    session.get = AsyncMock(return_value=invocation)
-    session.__aenter__ = AsyncMock(return_value=session)
-    session.__aexit__ = AsyncMock(return_value=False)
+    session = _db_session(invocation)
 
-    with patch(
-        "syntara.agent_orchestrator.utils.cancellation.AsyncSessionLocal",
-        return_value=session,
+    with (
+        patch(
+            "syntara.agent_orchestrator.utils.cancellation.StreamClient",
+            _stream_client(error=ConnectionError("redis down")),
+        ),
+        patch(
+            "syntara.agent_orchestrator.utils.cancellation.AsyncSessionLocal",
+            return_value=session,
+        ),
+        pytest.raises(InvocationCancelledError),
     ):
-        with pytest.raises(InvocationCancelledError):
-            await raise_if_invocation_cancelled(invocation_id, "orchestration")
+        await raise_if_invocation_cancelled(invocation_id, "orchestration")
+
+    session.get.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_raise_if_cancelled_swallows_db_errors() -> None:
-    session = AsyncMock()
-    session.get = AsyncMock(side_effect=OSError("down"))
-    session.__aenter__ = AsyncMock(return_value=session)
-    session.__aexit__ = AsyncMock(return_value=False)
+    session = _db_session(get_side_effect=OSError("down"))
 
-    with patch(
-        "syntara.agent_orchestrator.utils.cancellation.AsyncSessionLocal",
-        return_value=session,
+    with (
+        patch(
+            "syntara.agent_orchestrator.utils.cancellation.StreamClient",
+            _stream_client(error=ConnectionError("redis down")),
+        ),
+        patch(
+            "syntara.agent_orchestrator.utils.cancellation.AsyncSessionLocal",
+            return_value=session,
+        ),
     ):
         await raise_if_invocation_cancelled(uuid4(), "orchestration")

--- a/backend/tests/unit/agent_orchestrator/utils/test_workflow_signal_client.py
+++ b/backend/tests/unit/agent_orchestrator/utils/test_workflow_signal_client.py
@@ -356,3 +356,80 @@ class TestWorkflowSignalClientSendFailureSignal:
 
         with pytest.raises(ValueError, match="not a valid signal endpoint"):
             await WorkflowSignalClient.send_failure_signal("https://evil.com/steal", invocation_id, error)
+
+
+class TestWorkflowSignalClientSendCancellationSignal:
+    """Tests for WorkflowSignalClient.send_cancellation_signal."""
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_callback_url(self) -> None:
+        """Test that send_cancellation_signal skips when callback_url is None."""
+        await WorkflowSignalClient.send_cancellation_signal(None, UUID(_EXEC_UUID), "test reason")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sends_reason_in_signal_data(self) -> None:
+        """Test that the cancel reason is available at signal_data['reason']."""
+        import json
+
+        invocation_id = UUID(_EXEC_UUID)
+        reason = "User requested cancellation"
+
+        route = respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(200))
+
+        await WorkflowSignalClient.send_cancellation_signal(_SIGNAL_URL, invocation_id, reason)
+
+        assert route.called
+        payload = json.loads(route.calls[0].request.content.decode("utf-8"))
+        signal_data = payload["signal_data"]
+
+        assert signal_data["status"] == "cancelled"
+        assert signal_data["reason"] == reason
+        assert signal_data["error"]["message"] == reason
+        assert signal_data["error"]["error_type"] == "InvocationCancelledError"
+        assert signal_data["agent_type"] == "GenericAgent"
+        assert "timestamp" in signal_data
+        assert signal_data["id"] == str(invocation_id)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_uses_default_reason(self) -> None:
+        """Test that the default reason is 'User cancelled'."""
+        import json
+
+        invocation_id = UUID(_EXEC_UUID)
+
+        route = respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(200))
+
+        await WorkflowSignalClient.send_cancellation_signal(_SIGNAL_URL, invocation_id)
+
+        payload = json.loads(route.calls[0].request.content.decode("utf-8"))
+        assert payload["signal_data"]["reason"] == "User cancelled"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_swallows_http_error(self) -> None:
+        """Test that send_cancellation_signal swallows HTTP errors."""
+        invocation_id = UUID(_EXEC_UUID)
+
+        respx.post(_SIGNAL_URL).mock(return_value=httpx.Response(500))
+
+        await WorkflowSignalClient.send_cancellation_signal(_SIGNAL_URL, invocation_id)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_swallows_connection_error(self) -> None:
+        """Test that send_cancellation_signal swallows connection errors."""
+        invocation_id = UUID(_EXEC_UUID)
+
+        respx.post(_SIGNAL_URL).mock(side_effect=httpx.ConnectError("Connection failed"))
+
+        await WorkflowSignalClient.send_cancellation_signal(_SIGNAL_URL, invocation_id)
+
+    @pytest.mark.asyncio
+    async def test_send_cancellation_signal_raises_on_invalid_url(self) -> None:
+        """Cancellation signal must NOT swallow SSRF validation errors."""
+        invocation_id = UUID(_EXEC_UUID)
+
+        with pytest.raises(ValueError, match="not a valid signal endpoint"):
+            await WorkflowSignalClient.send_cancellation_signal("https://evil.com/steal", invocation_id)

--- a/backend/tests/unit/core/cache/test_stream.py
+++ b/backend/tests/unit/core/cache/test_stream.py
@@ -89,6 +89,64 @@ async def test_events_handles_malformed_json() -> None:
             assert events[1]["data"]["delta"] == "also_good"
 
 
+async def test_on_idle_called_when_xread_returns_empty() -> None:
+    """Test that on_idle callback fires when XREAD returns no events."""
+    with patch("syntara.core.cache.base.redis.Redis") as mock_redis:
+        mock_client = AsyncMock()
+        call_count = 0
+
+        async def xread_side_effect(*_a: object, **_kw: object) -> list[object]:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return []
+            return [
+                [
+                    "test:stream",
+                    [["1-0", {"data": '{"event_type":"completion","data":{}}'}]],
+                ]
+            ]
+
+        mock_client.xread = AsyncMock(side_effect=xread_side_effect)
+        mock_redis.return_value = mock_client
+
+        idle_calls = 0
+
+        async def on_idle() -> None:
+            nonlocal idle_calls
+            idle_calls += 1
+
+        async with StreamClient() as client:
+            events = []
+            async for event in client.events(
+                "test:stream",
+                start_id="0-0",
+                should_stop=lambda e: e.get("event_type") == "completion",
+                on_idle=on_idle,
+            ):
+                events.append(event)
+
+            assert len(events) == 1
+            assert idle_calls == 2
+
+
+async def test_on_idle_exception_stops_stream() -> None:
+    """Test that an exception raised by on_idle aborts the event stream."""
+    with patch("syntara.core.cache.base.redis.Redis") as mock_redis:
+        mock_client = AsyncMock()
+        mock_client.xread = AsyncMock(return_value=[])
+        mock_redis.return_value = mock_client
+
+        async def on_idle_raises() -> None:
+            msg = "cancelled"
+            raise RuntimeError(msg)
+
+        async with StreamClient() as client:
+            with pytest.raises(RuntimeError, match="cancelled"):
+                async for _event in client.events("test:stream", start_id="0-0", on_idle=on_idle_raises):
+                    pass
+
+
 async def test_info_existing_stream() -> None:
     """Test getting stream info for existing stream."""
     with patch("syntara.core.cache.base.redis.Redis") as mock_redis:

--- a/backend/tests/unit/core/cache/test_stream_client.py
+++ b/backend/tests/unit/core/cache/test_stream_client.py
@@ -317,6 +317,56 @@ async def test_publish_xadd_does_not_retry_non_pool_connection_error() -> None:
     mock_sleep.assert_not_awaited()  # no backoff sleep
 
 
+async def test_set_key_retries_on_pool_exhaustion_then_succeeds() -> None:
+    """SETEX is idempotent so set_key retries on MaxConnectionsError."""
+    mock_client = AsyncMock()
+    mock_client.setex = AsyncMock(
+        side_effect=[
+            MaxConnectionsError("Too many connections"),
+            None,
+        ]
+    )
+
+    with (
+        patch("syntara.core.cache.base.redis.Redis", return_value=mock_client),
+        patch("syntara.core.cache.base.asyncio.sleep", new=AsyncMock()),
+    ):
+        async with StreamClient() as client:
+            await client.set_key("test:key", "1", 300)
+
+    assert mock_client.setex.await_count == 2
+
+
+async def test_set_key_raises_after_exhausting_retries() -> None:
+    """set_key raises RedisConnectionError after all retries fail."""
+    mock_client = AsyncMock()
+    mock_client.setex = AsyncMock(side_effect=MaxConnectionsError("Too many connections"))
+
+    with (
+        patch("syntara.core.cache.base.redis.Redis", return_value=mock_client),
+        patch("syntara.core.cache.base.asyncio.sleep", new=AsyncMock()),
+    ):
+        async with StreamClient() as client:
+            with pytest.raises(RedisConnectionError, match="Too many connections"):
+                await client.set_key("test:key", "1", 300)
+
+    assert mock_client.setex.await_count == 4
+
+
+async def test_set_key_wraps_os_error_as_redis_connection_error() -> None:
+    """OSError during SETEX is wrapped as RedisConnectionError."""
+    mock_client = AsyncMock()
+    mock_client.setex = AsyncMock(side_effect=OSError("Network unreachable"))
+
+    with (
+        patch("syntara.core.cache.base.redis.Redis", return_value=mock_client),
+        patch("syntara.core.cache.base.asyncio.sleep", new=AsyncMock()),
+    ):
+        async with StreamClient() as client:
+            with pytest.raises(RedisConnectionError, match="Network"):
+                await client.set_key("test:key", "1", 300)
+
+
 async def test_events_connection_error_propagates() -> None:
     """Test that connection errors during read are propagated."""
     mock_client = AsyncMock()

--- a/backend/tests/unit/invocations/services/test_invocation_service_cancellation.py
+++ b/backend/tests/unit/invocations/services/test_invocation_service_cancellation.py
@@ -1,6 +1,6 @@
 """Unit tests for InvocationService cancellation functionality."""
 
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from uuid import uuid4
 
 import pytest
@@ -19,29 +19,40 @@ def mock_user() -> MagicMock:
     return user
 
 
+def _session_with_invocation(invocation: MagicMock, *, rowcount: int = 1) -> AsyncMock:
+    mock_session = AsyncMock()
+    mock_session.get.return_value = invocation
+    mock_result = MagicMock()
+    mock_result.rowcount = rowcount
+    mock_session.exec = AsyncMock(return_value=mock_result)
+    mock_session.commit = AsyncMock()
+    mock_session.rollback = AsyncMock()
+    mock_session.refresh = AsyncMock()
+    return mock_session
+
+
 class TestInvocationServiceCancellation:
     """Test core cancellation business logic."""
 
     @pytest.mark.asyncio
     async def test_cancel_invocation_success(self, mock_user) -> None:
         """Test successful cancellation of running invocation."""
-        mock_session = AsyncMock()
-        service = InvocationService(mock_session, mock_user)
         invocation_id = uuid4()
 
-        # Setup: Running invocation owned by user
         mock_invocation = MagicMock()
         mock_invocation.created_by = mock_user.id
         mock_invocation.id = invocation_id
         mock_invocation.status = InvocationStatus.RUNNING
         mock_invocation.checkpoint_data = None
         mock_invocation.context_data = {"agent": "test-agent", "model": "test-model", "file_ids": []}
-        mock_session.get.return_value = mock_invocation
+        mock_session = _session_with_invocation(mock_invocation)
 
+        service = InvocationService(mock_session, mock_user)
         result = await service.cancel_invocation(invocation_id, "Test cancellation")
 
         assert result == CancellationResult.SUCCESS
         assert mock_invocation.status == InvocationStatus.CANCELLED
+        mock_session.exec.assert_awaited_once()
         mock_session.commit.assert_called_once()
 
     @pytest.mark.asyncio
@@ -57,6 +68,7 @@ class TestInvocationServiceCancellation:
 
         assert result == CancellationResult.NOT_FOUND
         mock_session.commit.assert_not_called()
+        mock_session.exec.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_cancel_invocation_not_cancellable(self, mock_user) -> None:
@@ -65,7 +77,6 @@ class TestInvocationServiceCancellation:
         service = InvocationService(mock_session, mock_user)
         invocation_id = uuid4()
 
-        # Setup: Completed invocation owned by user
         mock_invocation = MagicMock()
         mock_invocation.created_by = mock_user.id
         mock_invocation.status = InvocationStatus.COMPLETED
@@ -75,11 +86,103 @@ class TestInvocationServiceCancellation:
 
         assert result == CancellationResult.NOT_CANCELLABLE
         mock_session.commit.assert_not_called()
+        mock_session.exec.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancel_loses_race_to_completion(self, mock_user) -> None:
+        """Conditional UPDATE with rowcount 0 means completion won the race."""
+        invocation_id = uuid4()
+        mock_invocation = MagicMock()
+        mock_invocation.created_by = mock_user.id
+        mock_invocation.id = invocation_id
+        mock_invocation.status = InvocationStatus.RUNNING
+        mock_invocation.checkpoint_data = None
+        mock_invocation.context_data = {"file_ids": []}
+
+        mock_session = _session_with_invocation(mock_invocation, rowcount=0)
+
+        async def _refresh_to_completed(_invocation: object) -> None:
+            mock_invocation.status = InvocationStatus.COMPLETED
+
+        mock_session.refresh = AsyncMock(side_effect=_refresh_to_completed)
+
+        service = InvocationService(mock_session, mock_user)
+        result = await service.cancel_invocation(invocation_id, "Test cancellation")
+
+        assert result == CancellationResult.NOT_CANCELLABLE
+        assert mock_invocation.status == InvocationStatus.COMPLETED
+        mock_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancel_commit_failure_rolls_back(self, mock_user) -> None:
+        """Commit failure rolls back so the request session stays usable."""
+        invocation_id = uuid4()
+        mock_invocation = MagicMock()
+        mock_invocation.created_by = mock_user.id
+        mock_invocation.id = invocation_id
+        mock_invocation.status = InvocationStatus.RUNNING
+        mock_invocation.checkpoint_data = None
+        mock_invocation.context_data = {"file_ids": []}
+        mock_session = _session_with_invocation(mock_invocation)
+        mock_session.commit = AsyncMock(side_effect=Exception("DB Error"))
+
+        service = InvocationService(mock_session, mock_user)
+        with pytest.raises(Exception, match="DB Error"):
+            await service.cancel_invocation(invocation_id, "Test")
+
+        mock_session.rollback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancel_invocation_signals_via_redis(self, mock_user) -> None:
+        """Test that cancellation signals the agent loop via Redis after DB commit."""
+        invocation_id = uuid4()
+        mock_invocation = MagicMock()
+        mock_invocation.id = invocation_id
+        mock_invocation.status = InvocationStatus.RUNNING
+        mock_invocation.checkpoint_data = None
+        mock_invocation.context_data = {"file_ids": []}
+        mock_session = _session_with_invocation(mock_invocation)
+        service = InvocationService(mock_session, mock_user)
+
+        with patch.object(service, "_signal_cancellation", new=AsyncMock()) as mock_signal:
+            result = await service.cancel_invocation(invocation_id, "test reason")
+
+            assert result == CancellationResult.SUCCESS
+            mock_session.commit.assert_called_once()
+            mock_signal.assert_awaited_once_with(invocation_id)
+
+    @pytest.mark.asyncio
+    async def test_signal_cancellation_sets_redis_key_without_publishing(self, mock_user) -> None:
+        """Test _signal_cancellation sets the cancel key but does not publish a terminal event."""
+        mock_session = AsyncMock()
+        service = InvocationService(mock_session, mock_user)
+        invocation_id = uuid4()
+
+        mock_client = AsyncMock()
+
+        with patch("syntara.agent_orchestrator.services.invocation_service.StreamClient") as mock_stream_cls:
+            mock_stream_cls.return_value.__aenter__.return_value = mock_client
+
+            await service._signal_cancellation(invocation_id)
+
+            # TTL matches Agent Execution timeout (3600s)
+            mock_client.set_key.assert_awaited_once_with(f"invocation:{invocation_id}:cancelled", "1", 3600)
+            mock_client.publish.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_signal_cancellation_failure_does_not_prevent_cancellation(self, mock_user) -> None:
+        """Test that _signal_cancellation swallows Redis errors without raising."""
+        mock_session = AsyncMock()
+        service = InvocationService(mock_session, mock_user)
+        invocation_id = uuid4()
+
+        with patch("syntara.agent_orchestrator.services.invocation_service.StreamClient") as mock_cls:
+            mock_cls.return_value.__aenter__.side_effect = ConnectionError("Redis down")
+            await service._signal_cancellation(invocation_id)
 
     @pytest.mark.asyncio
     async def test_cancel_with_files_calls_retriever_delete(self, mock_user) -> None:
         """Cancellation deletes files via the storage retriever."""
-        mock_session = AsyncMock()
         file_id_1 = uuid4()
         file_id_2 = uuid4()
         invocation_id = uuid4()
@@ -93,7 +196,7 @@ class TestInvocationServiceCancellation:
             "model": "test-model",
             "file_ids": [str(file_id_1), str(file_id_2)],
         }
-        mock_session.get.return_value = mock_invocation
+        mock_session = _session_with_invocation(mock_invocation)
 
         mock_file_metadata = [
             FileMetadata(
@@ -132,9 +235,31 @@ class TestInvocationServiceCancellation:
         ]
 
     @pytest.mark.asyncio
+    async def test_cancel_returns_success_when_cleanup_raises(self, mock_user) -> None:
+        """A cleanup failure after DB commit must not 500 a successful cancel."""
+        invocation_id = uuid4()
+        mock_invocation = MagicMock()
+        mock_invocation.id = invocation_id
+        mock_invocation.status = InvocationStatus.RUNNING
+        mock_invocation.checkpoint_data = None
+        mock_invocation.context_data = {}
+        mock_session = _session_with_invocation(mock_invocation)
+
+        service = InvocationService(mock_session, mock_user)
+
+        with (
+            patch.object(service, "_signal_cancellation", new=AsyncMock()) as mock_signal,
+            patch.object(service, "_cleanup_invocation_files", side_effect=RuntimeError("storage unavailable")),
+        ):
+            result = await service.cancel_invocation(invocation_id, "cleanup failure test")
+
+        assert result == CancellationResult.SUCCESS
+        mock_session.commit.assert_called_once()
+        mock_signal.assert_awaited_once_with(invocation_id)
+
+    @pytest.mark.asyncio
     async def test_cancel_cleanup_continues_on_single_file_error(self, mock_user) -> None:
         """File cleanup is best-effort: one failure doesn't block the rest."""
-        mock_session = AsyncMock()
         file_id_1 = uuid4()
         file_id_2 = uuid4()
         invocation_id = uuid4()
@@ -148,7 +273,7 @@ class TestInvocationServiceCancellation:
             "model": "test-model",
             "file_ids": [str(file_id_1), str(file_id_2)],
         }
-        mock_session.get.return_value = mock_invocation
+        mock_session = _session_with_invocation(mock_invocation)
 
         mock_file_metadata = [
             FileMetadata(

--- a/backend/tests/unit/workflows/services/test_execution_service.py
+++ b/backend/tests/unit/workflows/services/test_execution_service.py
@@ -1851,6 +1851,38 @@ class TestHandleActivityCallback(TestExecutionServiceBase):
         assert "plain string error" in str(error)
 
     @pytest.mark.asyncio
+    async def test_fails_activity_on_cancelled_status(self) -> None:
+        """Test that cancelled status calls fail_async_activity instead of completing."""
+        service, mock_temporal = self._make_service()
+        service.get_execution = AsyncMock(return_value=self._mock_execution())  # type: ignore[method-assign]
+        await service.handle_activity_callback(
+            uuid4(),
+            "node-1",
+            {"status": "cancelled", "reason": "User requested cancellation"},
+        )
+
+        mock_temporal.fail_async_activity.assert_called_once()
+        mock_temporal.complete_async_activity.assert_not_called()
+        error = mock_temporal.fail_async_activity.call_args.kwargs["error"]
+        assert "InvocationCancelledError" in str(error)
+        assert error.non_retryable is True
+
+    @pytest.mark.asyncio
+    async def test_cancelled_status_uses_default_reason(self) -> None:
+        """Test that cancelled status uses default reason when none provided."""
+        service, mock_temporal = self._make_service()
+        service.get_execution = AsyncMock(return_value=self._mock_execution())  # type: ignore[method-assign]
+        await service.handle_activity_callback(
+            uuid4(),
+            "node-1",
+            {"status": "cancelled"},
+        )
+
+        mock_temporal.fail_async_activity.assert_called_once()
+        error = mock_temporal.fail_async_activity.call_args.kwargs["error"]
+        assert "Invocation cancelled" in str(error)
+
+    @pytest.mark.asyncio
     async def test_raises_temporal_unavailable_when_no_service(self) -> None:
         """Test that TemporalUnavailableError is raised when temporal_service is None."""
         from syntara.workflows.exceptions import TemporalUnavailableError

--- a/backend/tests/unit/workflows/services/test_execution_service_cancel.py
+++ b/backend/tests/unit/workflows/services/test_execution_service_cancel.py
@@ -1,6 +1,6 @@
 """Unit tests for ExecutionService.cancel_execution method."""
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
 import pytest
@@ -60,7 +60,11 @@ class TestCancelExecution:
             temporal_service=mock_temporal,
         )
 
-        await service.cancel_execution(execution.id)
+        with patch(
+            "syntara.workflows.services.invocation_cancellation.cancel_invocations_for_execution",
+            new_callable=AsyncMock,
+        ):
+            await service.cancel_execution(execution.id)
 
         mock_temporal.cancel_workflow.assert_awaited_once_with(temporal_workflow_id=execution.temporal_workflow_id)
 
@@ -150,3 +154,50 @@ class TestCancelExecution:
 
         with pytest.raises(RPCError):
             await service.cancel_execution(execution.id)
+
+    @pytest.mark.asyncio
+    async def test_cancel_execution_propagates_to_invocations(self) -> None:
+        """Test that invocation cancellation is called after Temporal cancel."""
+        execution = _make_execution(ExecutionStatus.RUNNING)
+        mock_session = _mock_session_returning(execution)
+        mock_user = Mock(spec=User)
+        mock_temporal = Mock(spec=TemporalExecutionService)
+        mock_temporal.cancel_workflow = AsyncMock()
+
+        service = ExecutionService(
+            session=mock_session,
+            user=mock_user,
+            temporal_service=mock_temporal,
+        )
+
+        with patch(
+            "syntara.workflows.services.invocation_cancellation.cancel_invocations_for_execution",
+            new_callable=AsyncMock,
+        ) as mock_cancel:
+            await service.cancel_execution(execution.id)
+
+        mock_cancel.assert_awaited_once_with(mock_session, mock_user, execution.id)
+
+    @pytest.mark.asyncio
+    async def test_cancel_execution_invocation_failure_does_not_block(self) -> None:
+        """Test that invocation cancel failure does not prevent execution cancel."""
+        execution = _make_execution(ExecutionStatus.RUNNING)
+        mock_session = _mock_session_returning(execution)
+        mock_user = Mock(spec=User)
+        mock_temporal = Mock(spec=TemporalExecutionService)
+        mock_temporal.cancel_workflow = AsyncMock()
+
+        service = ExecutionService(
+            session=mock_session,
+            user=mock_user,
+            temporal_service=mock_temporal,
+        )
+
+        with patch(
+            "syntara.workflows.services.invocation_cancellation.cancel_invocations_for_execution",
+            new_callable=AsyncMock,
+            side_effect=Exception("DB unavailable"),
+        ):
+            await service.cancel_execution(execution.id)
+
+        mock_temporal.cancel_workflow.assert_awaited_once()

--- a/backend/tests/unit/workflows/services/test_invocation_cancellation.py
+++ b/backend/tests/unit/workflows/services/test_invocation_cancellation.py
@@ -1,0 +1,198 @@
+"""Unit tests for invocation_cancellation helper module."""
+
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+
+from syntara.agent_orchestrator.models.invocation import Invocation, InvocationStatus
+from syntara.agent_orchestrator.models.request import CancellationResult
+from syntara.core.models import User
+from syntara.workflows.services.invocation_cancellation import (
+    cancel_invocations_for_execution,
+    find_active_invocations_for_execution,
+)
+
+
+def _make_invocation(
+    execution_id: str,
+    status: InvocationStatus = InvocationStatus.RUNNING,
+) -> Invocation:
+    inv = Mock(spec=Invocation)
+    inv.id = uuid4()
+    inv.status = status
+    inv.context_data = {"execution_id": execution_id}
+    inv.error_message = None
+    inv.completed_at = None
+    return inv
+
+
+def _mock_user() -> User:
+    return Mock(spec=User)
+
+
+class TestFindActiveInvocationsForExecution:
+    """Lookup of cancellable invocations by execution_id."""
+
+    @pytest.mark.asyncio
+    async def test_returns_matching_invocations(self) -> None:
+        execution_id = uuid4()
+        inv = _make_invocation(str(execution_id))
+        mock_result = Mock()
+        mock_result.all.return_value = [inv]
+        mock_session = Mock()
+        mock_session.exec = AsyncMock(return_value=mock_result)
+
+        result = await find_active_invocations_for_execution(mock_session, execution_id)
+
+        assert result == [inv]
+        mock_session.exec.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_match(self) -> None:
+        execution_id = uuid4()
+        mock_result = Mock()
+        mock_result.all.return_value = []
+        mock_session = Mock()
+        mock_session.exec = AsyncMock(return_value=mock_result)
+
+        result = await find_active_invocations_for_execution(mock_session, execution_id)
+
+        assert result == []
+
+
+class TestCancelInvocationsForExecution:
+    """Bulk cancel delegates to InvocationService."""
+
+    @pytest.mark.asyncio
+    async def test_no_active_invocations_returns_zero(self) -> None:
+        execution_id = uuid4()
+        mock_session = Mock()
+
+        with patch(
+            "syntara.workflows.services.invocation_cancellation.find_active_invocations_for_execution",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await cancel_invocations_for_execution(mock_session, _mock_user(), execution_id)
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_cancels_single_invocation_via_service(self) -> None:
+        execution_id = uuid4()
+        inv = _make_invocation(str(execution_id))
+        mock_session = Mock()
+        mock_service = Mock()
+        mock_service.cancel_invocation = AsyncMock(return_value=CancellationResult.SUCCESS)
+
+        with (
+            patch(
+                "syntara.workflows.services.invocation_cancellation.find_active_invocations_for_execution",
+                new_callable=AsyncMock,
+                return_value=[inv],
+            ),
+            patch(
+                "syntara.workflows.services.invocation_cancellation.InvocationService",
+                return_value=mock_service,
+            ),
+        ):
+            result = await cancel_invocations_for_execution(mock_session, _mock_user(), execution_id)
+
+        assert result == 1
+        mock_service.cancel_invocation.assert_awaited_once_with(inv.id, "Workflow execution cancelled")
+
+    @pytest.mark.asyncio
+    async def test_cancels_multiple_invocations(self) -> None:
+        execution_id = uuid4()
+        invocations = [_make_invocation(str(execution_id)) for _ in range(3)]
+        mock_session = Mock()
+        mock_service = Mock()
+        mock_service.cancel_invocation = AsyncMock(return_value=CancellationResult.SUCCESS)
+
+        with (
+            patch(
+                "syntara.workflows.services.invocation_cancellation.find_active_invocations_for_execution",
+                new_callable=AsyncMock,
+                return_value=invocations,
+            ),
+            patch(
+                "syntara.workflows.services.invocation_cancellation.InvocationService",
+                return_value=mock_service,
+            ),
+        ):
+            result = await cancel_invocations_for_execution(mock_session, _mock_user(), execution_id)
+
+        assert result == 3
+        assert mock_service.cancel_invocation.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_one_failure_does_not_block_others(self) -> None:
+        execution_id = uuid4()
+        invocations = [_make_invocation(str(execution_id)) for _ in range(2)]
+        mock_session = Mock()
+        mock_session.rollback = AsyncMock()
+        mock_service = Mock()
+        mock_service.cancel_invocation = AsyncMock(side_effect=[Exception("DB error"), CancellationResult.SUCCESS])
+
+        with (
+            patch(
+                "syntara.workflows.services.invocation_cancellation.find_active_invocations_for_execution",
+                new_callable=AsyncMock,
+                return_value=invocations,
+            ),
+            patch(
+                "syntara.workflows.services.invocation_cancellation.InvocationService",
+                return_value=mock_service,
+            ),
+        ):
+            result = await cancel_invocations_for_execution(mock_session, _mock_user(), execution_id)
+
+        assert result == 1
+        mock_session.rollback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_not_cancellable_is_not_counted(self) -> None:
+        execution_id = uuid4()
+        inv = _make_invocation(str(execution_id))
+        mock_session = Mock()
+        mock_service = Mock()
+        mock_service.cancel_invocation = AsyncMock(return_value=CancellationResult.NOT_CANCELLABLE)
+
+        with (
+            patch(
+                "syntara.workflows.services.invocation_cancellation.find_active_invocations_for_execution",
+                new_callable=AsyncMock,
+                return_value=[inv],
+            ),
+            patch(
+                "syntara.workflows.services.invocation_cancellation.InvocationService",
+                return_value=mock_service,
+            ),
+        ):
+            result = await cancel_invocations_for_execution(mock_session, _mock_user(), execution_id)
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_custom_reason_passed_to_service(self) -> None:
+        execution_id = uuid4()
+        inv = _make_invocation(str(execution_id))
+        mock_session = Mock()
+        mock_service = Mock()
+        mock_service.cancel_invocation = AsyncMock(return_value=CancellationResult.SUCCESS)
+
+        with (
+            patch(
+                "syntara.workflows.services.invocation_cancellation.find_active_invocations_for_execution",
+                new_callable=AsyncMock,
+                return_value=[inv],
+            ),
+            patch(
+                "syntara.workflows.services.invocation_cancellation.InvocationService",
+                return_value=mock_service,
+            ),
+        ):
+            await cancel_invocations_for_execution(mock_session, _mock_user(), execution_id, reason="User requested")
+
+        mock_service.cancel_invocation.assert_awaited_once_with(inv.id, "User requested")

--- a/backend/tests/unit/workflows/signals/test_processor.py
+++ b/backend/tests/unit/workflows/signals/test_processor.py
@@ -182,6 +182,29 @@ class TestWorkflowSignalProcessorProcessSignal:
             assert expected_fragment.lower() in error_msg.lower()
             assert f"{error_type}:" not in error_msg
 
+    def test_process_signal_cancelled_raises_application_error(self) -> None:
+        """Test that cancelled status raises non-retryable ApplicationError."""
+        signal_data = {
+            "status": "cancelled",
+            "reason": "User requested cancellation",
+        }
+
+        with pytest.raises(ApplicationError) as exc_info:
+            WorkflowSignalProcessor.process_signal(signal_data, "agent_1", "exec-456")
+
+        assert exc_info.value.non_retryable is True
+        assert exc_info.value.type == "InvocationCancelledError"
+        assert "User requested cancellation" in str(exc_info.value)
+
+    def test_process_signal_cancelled_uses_default_reason(self) -> None:
+        """Test that cancelled status uses default reason when none provided."""
+        signal_data = {"status": "cancelled"}
+
+        with pytest.raises(ApplicationError) as exc_info:
+            WorkflowSignalProcessor.process_signal(signal_data, "agent_1", "exec-456")
+
+        assert "Invocation cancelled" in str(exc_info.value)
+
     def test_process_signal_with_unknown_status(self) -> None:
         """Test processing signal with unknown status (not 'failed')."""
         # Arrange - any status other than "failed" should be treated as success

--- a/backend/tests/unit/workflows/workflow_engine/activities/test_internal_activity.py
+++ b/backend/tests/unit/workflows/workflow_engine/activities/test_internal_activity.py
@@ -92,6 +92,30 @@ class TestExecuteInternalActivity:
         assert result == {"output": {"status": "completed"}}
         mock_handler.assert_awaited_once_with({"invocation_id": str(inv_id)})
 
+    @pytest.mark.anyio
+    async def test_invocation_execution_raises_application_error_on_cancellation(self) -> None:
+        """Pre-start or mid-execution cancellation raises non-retryable ApplicationError."""
+        from syntara.agent_orchestrator.exceptions import InvocationCancelledError
+
+        inv_id = uuid4()
+        mock_executor = AsyncMock()
+        mock_executor.execute_invocation.side_effect = InvocationCancelledError(str(inv_id), phase="pre_start")
+
+        with (
+            patch(
+                "syntara.agent_orchestrator.executor.invocation_executor.InvocationExecutor",
+                return_value=mock_executor,
+            ),
+            pytest.raises(ApplicationError, match="InvocationCancelledError") as exc_info,
+        ):
+            await execute_internal_activity(
+                {"activity": "invocation_execution", "input": {"invocation_id": str(inv_id)}},
+                None,
+            )
+
+        assert exc_info.value.type == "InvocationCancelledError"
+        assert exc_info.value.non_retryable
+
 
 def _session_factory(session: AsyncMock) -> Callable[[], AbstractAsyncContextManager[AsyncMock]]:
     """Build an ``AsyncSessionLocal``-shaped factory that always yields ``session``.

--- a/backend/tests/unit/workflows/workflow_engine/services/test_activity_sync_service.py
+++ b/backend/tests/unit/workflows/workflow_engine/services/test_activity_sync_service.py
@@ -1239,6 +1239,28 @@ class TestWorkflowEventExtraction:
         assert status == ExecutionStatus.FAILED
         assert error_details is not None
 
+    def test_extract_execution_status_cancelled_from_result_payload(self) -> None:
+        """COMPLETED event with inner status 'cancelled' maps to CANCELLED."""
+        import json
+
+        from syntara.workflows.models.execution import ExecutionStatus
+
+        event = self._create_workflow_event(EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED)
+        payload = Mock()
+        payload.data = json.dumps(
+            {
+                "status": "cancelled",
+                "execution_id": "exec-1",
+                "failed_activities": {},
+            }
+        ).encode()
+        event.workflow_execution_completed_event_attributes.result.payloads = [payload]
+
+        status, _completed_at, error_details = self.service._extract_execution_status_from_event(event)
+
+        assert status == ExecutionStatus.CANCELLED
+        assert error_details is None
+
 
 class TestExecutionStatusUpdates:
     """Test execution status updates during monitoring."""

--- a/backend/tests/unit/workflows/workflow_engine/test_dynamic_workflow.py
+++ b/backend/tests/unit/workflows/workflow_engine/test_dynamic_workflow.py
@@ -63,6 +63,8 @@ def _make_workflow(
     wf._detached_nodes = set()
     wf._cof_failed_nodes = set()
     wf._converge_branch_nodes = {}
+    wf._has_unhandled_failure = False
+    wf._cancelled_node = None
     init_workflow_runtime(wf)
     wf.pre_resolved_outputs = {}
     wf.stop_after_nodes = set()
@@ -1315,6 +1317,36 @@ class TestBuildResultStatus:
         wf.resolver.set_namespace("node_c", {"status": "failed", "error": "timeout"})
         result = wf._build_result("exec-1", include_node_results=False)
         assert result["status"] == "completed_with_errors"
+
+    def test_cancelled_when_node_cancelled(self) -> None:
+        """Cancelled invocation produces workflow status 'cancelled', not 'failed'."""
+        wf = _make_workflow()
+        wf._cancelled_node = "node_a"
+        wf.resolver.set_namespace("trigger", {})
+        wf.resolver.set_namespace("node_a", {"status": "cancelled"})
+        result = wf._build_result("exec-1", include_node_results=False)
+        assert result["status"] == "cancelled"
+        assert "node_a" not in result["failed_activities"]
+
+
+class TestHandleNodeFailureCancellation:
+    """_handle_node_failure maps InvocationCancelledError to cancelled, not failed."""
+
+    def test_cancelled_node_not_in_failed_nodes(self) -> None:
+        """InvocationCancelledError sets _cancelled_node but not failed_nodes."""
+        from temporalio.exceptions import ApplicationError
+
+        graph = _build_linear_graph()
+        wf = _make_workflow()
+        wf.resolver.set_namespace("trigger", {})
+
+        error = ApplicationError("cancelled", type="InvocationCancelledError", non_retryable=True)
+        wf._handle_node_failure("node_a", error, graph)
+
+        assert "node_a" not in wf.failed_nodes
+        assert wf._cancelled_node == "node_a"
+        assert wf._has_unhandled_failure is False
+        assert wf.resolver.get_namespace("node_a")["status"] == "cancelled"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Cancelling an invocation only updated the DB status — it never signalled
the running agent loop or published a terminal event to the Redis stream.
The agent kept executing tools after cancellation and WebSocket clients
saw "completion" instead of "cancelled".

This fix adds a Redis-based cancellation signal so the agent loop
detects cancellation within ~2 s and stops:

- cancel_invocation sets a Redis key (invocation:{id}:cancelled)
  so the running agent loop can detect cancellation
- The orchestration streaming loop runs a background cancellation
  watcher that checks the cancel key every 2 s and raises
  InvocationCancelledError when found
- The orchestration service catches InvocationCancelledError and
  publishes a "cancelled" terminal event to the stream when the
  agent actually stops
- The executor's cancellation handler notifies the workflow via
  WorkflowSignalClient (best-effort, wrapped in try/except)
- The context planner's cancellation check uses the Redis key first
  (fast path) with a DB fallback
- File cleanup is deferred to after the Redis signal is sent
- InvocationCancelledError raises non-retryable ApplicationError in
  internal_activity so Temporal does not retry
- _build_result / activity_sync map the workflow result status to
  ExecutionStatus.CANCELLED
- Cancel-key TTL sized from AGENT_EXECUTION_TIMEOUT_SECONDS (3600s)
- Pre-start and mid-execution cancel paths read callback_url from
  raw dict and wrap send_cancellation_signal in try/except
- Failed RUNNING update raises InvocationCancelledError instead of
  proceeding to execute()
- Generic errors after cancel raise InvocationCancelledError when
  _fail_invocation_if_not_cancelled returns False, and send the
  cancellation signal to the parent workflow
- LLM config / credential failures after cancel raise
  InvocationCancelledError instead of returning None
- _get_tools short-circuits for NONE strategy, skipping MCP
  discovery entirely
- Pre-graph cancel check via _check_cancellation_signal before
  _setup_graph, and cancel-key checks before file conversion wait
  and before _init_orchestration
- Cancellation watcher uses its own StreamClient to avoid corrupting
  the publisher's Redis connection pool on teardown
- Watcher teardown distinguishes parent CancelledError (re-raised via
  task.cancelling()) from the watcher's own cancel (suppressed)
- WebSocket streaming: on_idle callback on StreamClient fires when
  XREAD returns empty; invocation handler checks the cancel key
  (Redis-first, DB-fallback) during idle periods
- Pre-stream check_before_streaming hook raises
  InvocationCancelledStreamError when the session status is already
  CANCELLED, preventing replay of a stale completion event
- InvocationCancelledStreamError detail is status-neutral ("The
  invocation was cancelled.") for both wait and mid-stream contexts

## Behavior change

**What changed**

When an agentic invocation is cancelled (`InvocationCancelledError`), workflow state now resolves to the existing **`cancelled`** status instead of `failed`:

- Invocation node/activity output status → `"cancelled"` (was `"failed"`).
- Execution-level status → `ExecutionStatus.CANCELLED` (was `FAILED`).

**Impact**

No new status value is introduced — `cancelled` already exists and is terminal for both executions (manual cancellation) and activities (converge-detached nodes), so consumers that already handle `cancelled` need no changes. The only semantic shift is that a cancelled agentic invocation is now classified as *cancelled* rather than *failed*. Code that specifically treated this scenario as a **failure** (failure alerting, retry-on-failed logic, tests asserting `failed`) will now observe `cancelled`.

## Known limitations (documented, not addressed in this PR)

- **In-flight tool interrupt:** the cancellation watcher improves
  detection latency, but the actual interruption only happens when the
  LangGraph streaming iterator yields. An in-flight tool that blocks
  without yielding will keep running until it returns.
- **Redis-healthy-miss skipping DB on the watcher hot path:** when
  Redis is healthy but the cancel key was never set (e.g. SETEX failed
  due to pool exhaustion then recovered), EXISTS returns false,
  redis_available stays true, and the DB fallback is skipped.
- **MCP discovery for ALL/SELECTED is uninterruptible:** when
  tool_selection_strategy is ALL or SELECTED, _get_tools →
  retrieve_tools() walks every MCP integration (default 30s HTTP
  timeout each) with no cancel check inside the discovery loop.
  Cancel during that window is only detected after discovery returns.
- **File conversion wait has no cancel poll:** _wait_for_file_conversions
  polls for up to 310s with no cancel check inside the loop. Cancel
  is detected by the cancel-key check added after the wait returns.

## Out of scope — follow-up work needed

The workflow engine does not yet fully thread cancellation through its
internal predicates. These gaps are documented with TODO comments in the
codebase and should be addressed in a dedicated follow-up:

- **Downstream skip propagation:** `_mark_downstream_as_skipped` requires
  predecessors in `failed_nodes` or `skipped_nodes`. A cancelled node is
  in neither (`_cancelled_node` is a separate slot), so the call is a
  no-op for cancelled nodes. Successors are not properly skipped.
- **Converge strategy:** `_count_successful_predecessors` and
  `_evaluate_converge_failure` (ALL-strategy) only check `failed_nodes`.
  A cancelled node feeding a converge counts as a successful branch.
- **Activity-level sync:** `_process_activity_failed` unconditionally
  sets `ActivityStatus.FAILED`. InvocationCancelledError raises a
  non-retryable `ApplicationError` which Temporal records as
  `ACTIVITY_TASK_FAILED`, so the activity row shows "Failed" even
  though the execution-level status is CANCELLED. Need to inspect
  `application_failure_info.type` for "InvocationCancelledError".
- **`_setup_graph` failure after cancel takes the error path:** when
  `_setup_graph` (including `_get_tools` / MCP discovery) raises after
  the invocation has been cancelled, the generic `except Exception`
  handler publishes a terminal `error` event and calls
  `send_failure_signal` instead of checking the cancel state and
  raising `InvocationCancelledError`. The cancel-during-discovery
  window is already documented above; this item covers converting
  the failure-path to a cancellation when the DB row is CANCELLED.

Resolves: AAP-86855

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


