### PR TITLE
fix(AAP-85215): rename AAP proxy API path and OpenAPI tag for clarity

### DIFF
--- a/backend/docs/standards/api-response-format.md
+++ b/backend/docs/standards/api-response-format.md
@@ -570,7 +570,7 @@ Not all validation errors follow the exact pattern above:
 
 #### AAP Proxy Endpoints
 
-Endpoints under `/api/v1/aap/` are pure HTTP proxies to AAP Controller API v2. They do not use cursor-based pagination or the standard query parameter conventions:
+Endpoints under `/api/v1/proxies/aap/` are pure HTTP proxies to AAP Controller API v2. They do not use cursor-based pagination or the standard query parameter conventions:
 
 | Aspect | Standard Pattern | AAP Proxy |
 |---|---|---|
@@ -581,7 +581,7 @@ Endpoints under `/api/v1/aap/` are pure HTTP proxies to AAP Controller API v2. T
 | Sorting | `-field` prefix notation with ID tiebreaker | None (upstream order) |
 | Default page size | 20 (max 100) | 50 (max 200) |
 
-**Rationale:** These endpoints proxy an external system (AAP Controller) that has its own pagination contract. Conforming to cursor-based pagination would require caching the upstream result set. AAP proxy endpoints are excluded from compliance testing by the `"aap"` tag in the OpenAPI spec, not via `list_compliance_exclusions.yaml`.
+**Rationale:** These endpoints proxy an external system (AAP Controller) that has its own pagination contract. Conforming to cursor-based pagination would require caching the upstream result set. AAP proxy endpoints are excluded from compliance testing by the `"Ansible Automation Platform Proxy"` tag in the OpenAPI spec, not via `list_compliance_exclusions.yaml`.
 
 #### Custom List Implementations
 
@@ -879,7 +879,7 @@ A catch-all `IntegrityError` handler in `core/error_handlers.py` provides a safe
 
 #### AAP Proxy Endpoints
 
-Endpoints under `/api/v1/aap/` are pure HTTP proxies to AAP Controller API v2. They do not follow Nexus CRUD conventions — status codes, error formats, and response shapes are dictated by the upstream API. AAP proxy endpoints are excluded from CRUD compliance testing by the `"aap"` tag in the OpenAPI spec, not via `crud_compliance_exclusions.yaml`. See [Known List Exceptions — AAP Proxy Endpoints](#aap-proxy-endpoints) for the full comparison.
+Endpoints under `/api/v1/proxies/aap/` are pure HTTP proxies to AAP Controller API v2. They do not follow Nexus CRUD conventions — status codes, error formats, and response shapes are dictated by the upstream API. AAP proxy endpoints are excluded from CRUD compliance testing by the `"Ansible Automation Platform Proxy"` tag in the OpenAPI spec, not via `crud_compliance_exclusions.yaml`. See [Known List Exceptions — AAP Proxy Endpoints](#aap-proxy-endpoints) for the full comparison.
 
 #### Action Endpoints
 
@@ -931,7 +931,7 @@ Endpoints are classified by operation_id prefix and HTTP method:
 - **Update**: PATCH and PUT endpoints with a path parameter
 - **Delete**: DELETE endpoints
 
-AAP proxy endpoints (tagged `"aap"` in the OpenAPI spec) are excluded from CRUD discovery, same as for list compliance. Action endpoints (disable, enable, publish, unpublish, restore, rotate, retry) are filtered out by `_ACTION_OPERATION_PREFIXES` in `endpoint_discovery.py`. Neither requires an entry in the exclusions YAML.
+AAP proxy endpoints (tagged `"Ansible Automation Platform Proxy"` in the OpenAPI spec) are excluded from CRUD discovery, same as for list compliance. Action endpoints (disable, enable, publish, unpublish, restore, rotate, retry) are filtered out by `_ACTION_OPERATION_PREFIXES` in `endpoint_discovery.py`. Neither requires an entry in the exclusions YAML.
 
 #### Exclusion mechanism
 

--- a/backend/src/api_client/syntara_api_client/api/__init__.py
+++ b/backend/src/api_client/syntara_api_client/api/__init__.py
@@ -9,7 +9,7 @@ from ..client import AuthenticatedClient
 
 if TYPE_CHECKING:
     from .admin import AdminApi
-    from .ansible_automation_platform import AnsibleAutomationPlatformApi
+    from .ansible_automation_platform_proxy import AnsibleAutomationPlatformProxyApi
     from .approvals import ApprovalsApi
     from .authentication import AuthenticationApi
     from .authorization import AuthorizationApi
@@ -44,10 +44,10 @@ class SyntaraApiRegistry:
         self._client = client
 
     @cached_property
-    def ansible_automation_platform(self) -> AnsibleAutomationPlatformApi:
-        from .ansible_automation_platform import AnsibleAutomationPlatformApi
+    def ansible_automation_platform_proxy(self) -> AnsibleAutomationPlatformProxyApi:
+        from .ansible_automation_platform_proxy import AnsibleAutomationPlatformProxyApi
 
-        return AnsibleAutomationPlatformApi(client=self._client)
+        return AnsibleAutomationPlatformProxyApi(client=self._client)
 
     @cached_property
     def admin(self) -> AdminApi:

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/__init__.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/__init__.py
@@ -1,4 +1,4 @@
-"""ansible_automation_platform API endpoints."""
+"""ansible_automation_platform_proxy API endpoints."""
 
 from __future__ import annotations
 
@@ -15,8 +15,8 @@ class _EndpointModule(Protocol):
     async def asyncio_detailed(self, *, client: AuthenticatedClient, **kwargs: Any) -> Response[Any]: ...
 
 
-class AnsibleAutomationPlatformApi:
-    """Registry for ansible_automation_platform API endpoints."""
+class AnsibleAutomationPlatformProxyApi:
+    """Registry for ansible_automation_platform_proxy API endpoints."""
 
     def __init__(self, client: AuthenticatedClient) -> None:
         self._client = client

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/get_aap_job_template.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/get_aap_job_template.py
@@ -6,18 +6,18 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.aap_list_response_aap_workflow_job_template import AAPListResponseAAPWorkflowJobTemplate
+from ...models.aap_job_template_detail import AAPJobTemplateDetail
 from ...models.error_data import ErrorData
 from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
+    job_template_id: int,
     *,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
@@ -51,18 +51,11 @@ def _get_kwargs(
         json_integration_id = integration_id
     params["integration_id"] = json_integration_id
 
-    json_organization: None | str | Unset
-    if isinstance(organization, Unset):
-        json_organization = UNSET
-    else:
-        json_organization = organization
-    params["organization"] = json_organization
-
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/aap/workflow_job_templates",
+        "url": f"/proxies/aap/job_templates/{job_template_id}",
         "params": params,
     }
 
@@ -71,9 +64,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> AAPListResponseAAPWorkflowJobTemplate | ErrorData | None:
+) -> AAPJobTemplateDetail | ErrorData | None:
     if response.status_code == 200:
-        response_200 = AAPListResponseAAPWorkflowJobTemplate.from_dict(response.json())
+        response_200 = AAPJobTemplateDetail.from_dict(response.json())
 
         return response_200
 
@@ -125,7 +118,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[AAPListResponseAAPWorkflowJobTemplate | ErrorData]:
+) -> Response[AAPJobTemplateDetail | ErrorData]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -137,40 +130,40 @@ def _build_response(
 
 
 def sync_detailed(
+    job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
-) -> Response[AAPListResponseAAPWorkflowJobTemplate | ErrorData]:
-    """List workflow job templates
+) -> Response[AAPJobTemplateDetail | ErrorData]:
+    """Get job template
 
-     List Ansible Automation Platform workflow job templates, optionally filtered by organization.
+     Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
 
     Args:
+        job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPWorkflowJobTemplate | ErrorData]
+        Response[AAPJobTemplateDetail | ErrorData]
     """
 
     kwargs = _get_kwargs(
+        job_template_id=job_template_id,
         search=search,
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
-        organization=organization,
         additional_params=additional_params,
     )
 
@@ -182,77 +175,77 @@ def sync_detailed(
 
 
 def sync(
+    job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
-) -> AAPListResponseAAPWorkflowJobTemplate | ErrorData | None:
-    """List workflow job templates
+) -> AAPJobTemplateDetail | ErrorData | None:
+    """Get job template
 
-     List Ansible Automation Platform workflow job templates, optionally filtered by organization.
+     Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
 
     Args:
+        job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPWorkflowJobTemplate | ErrorData
+        AAPJobTemplateDetail | ErrorData
     """
 
     return sync_detailed(
+        job_template_id=job_template_id,
         client=client,
         search=search,
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
-        organization=organization,
     ).parsed
 
 
 async def asyncio_detailed(
+    job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
-) -> Response[AAPListResponseAAPWorkflowJobTemplate | ErrorData]:
-    """List workflow job templates
+) -> Response[AAPJobTemplateDetail | ErrorData]:
+    """Get job template
 
-     List Ansible Automation Platform workflow job templates, optionally filtered by organization.
+     Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
 
     Args:
+        job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPWorkflowJobTemplate | ErrorData]
+        Response[AAPJobTemplateDetail | ErrorData]
     """
 
     kwargs = _get_kwargs(
+        job_template_id=job_template_id,
         search=search,
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
-        organization=organization,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -261,40 +254,40 @@ async def asyncio_detailed(
 
 
 async def asyncio(
+    job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
-) -> AAPListResponseAAPWorkflowJobTemplate | ErrorData | None:
-    """List workflow job templates
+) -> AAPJobTemplateDetail | ErrorData | None:
+    """Get job template
 
-     List Ansible Automation Platform workflow job templates, optionally filtered by organization.
+     Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
 
     Args:
+        job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPWorkflowJobTemplate | ErrorData
+        AAPJobTemplateDetail | ErrorData
     """
 
     return (
         await asyncio_detailed(
+            job_template_id=job_template_id,
             client=client,
             search=search,
             page_size=page_size,
             credential_id=credential_id,
             integration_id=integration_id,
-            organization=organization,
         )
     ).parsed

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/get_aap_workflow_job_template.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/get_aap_workflow_job_template.py
@@ -6,12 +6,13 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.aap_list_response_aap_label import AAPListResponseAAPLabel
+from ...models.aap_workflow_job_template_detail import AAPWorkflowJobTemplateDetail
 from ...models.error_data import ErrorData
 from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
+    workflow_job_template_id: int,
     *,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
@@ -54,7 +55,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/aap/labels",
+        "url": f"/proxies/aap/workflow_job_templates/{workflow_job_template_id}",
         "params": params,
     }
 
@@ -63,9 +64,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> AAPListResponseAAPLabel | ErrorData | None:
+) -> AAPWorkflowJobTemplateDetail | ErrorData | None:
     if response.status_code == 200:
-        response_200 = AAPListResponseAAPLabel.from_dict(response.json())
+        response_200 = AAPWorkflowJobTemplateDetail.from_dict(response.json())
 
         return response_200
 
@@ -117,7 +118,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[AAPListResponseAAPLabel | ErrorData]:
+) -> Response[AAPWorkflowJobTemplateDetail | ErrorData]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -129,6 +130,7 @@ def _build_response(
 
 
 def sync_detailed(
+    workflow_job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
@@ -136,12 +138,14 @@ def sync_detailed(
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
     additional_params: dict[str, Any] | None = None,
-) -> Response[AAPListResponseAAPLabel | ErrorData]:
-    """List labels
+) -> Response[AAPWorkflowJobTemplateDetail | ErrorData]:
+    """Get workflow job template
 
-     List Ansible Automation Platform labels.
+     Get Ansible Automation Platform workflow job template details including prompt-on-launch
+    capabilities.
 
     Args:
+        workflow_job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -152,10 +156,11 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPLabel | ErrorData]
+        Response[AAPWorkflowJobTemplateDetail | ErrorData]
     """
 
     kwargs = _get_kwargs(
+        workflow_job_template_id=workflow_job_template_id,
         search=search,
         page_size=page_size,
         credential_id=credential_id,
@@ -171,18 +176,21 @@ def sync_detailed(
 
 
 def sync(
+    workflow_job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPListResponseAAPLabel | ErrorData | None:
-    """List labels
+) -> AAPWorkflowJobTemplateDetail | ErrorData | None:
+    """Get workflow job template
 
-     List Ansible Automation Platform labels.
+     Get Ansible Automation Platform workflow job template details including prompt-on-launch
+    capabilities.
 
     Args:
+        workflow_job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -193,10 +201,11 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPLabel | ErrorData
+        AAPWorkflowJobTemplateDetail | ErrorData
     """
 
     return sync_detailed(
+        workflow_job_template_id=workflow_job_template_id,
         client=client,
         search=search,
         page_size=page_size,
@@ -206,18 +215,21 @@ def sync(
 
 
 async def asyncio_detailed(
+    workflow_job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> Response[AAPListResponseAAPLabel | ErrorData]:
-    """List labels
+) -> Response[AAPWorkflowJobTemplateDetail | ErrorData]:
+    """Get workflow job template
 
-     List Ansible Automation Platform labels.
+     Get Ansible Automation Platform workflow job template details including prompt-on-launch
+    capabilities.
 
     Args:
+        workflow_job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -228,10 +240,11 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPLabel | ErrorData]
+        Response[AAPWorkflowJobTemplateDetail | ErrorData]
     """
 
     kwargs = _get_kwargs(
+        workflow_job_template_id=workflow_job_template_id,
         search=search,
         page_size=page_size,
         credential_id=credential_id,
@@ -244,18 +257,21 @@ async def asyncio_detailed(
 
 
 async def asyncio(
+    workflow_job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPListResponseAAPLabel | ErrorData | None:
-    """List labels
+) -> AAPWorkflowJobTemplateDetail | ErrorData | None:
+    """Get workflow job template
 
-     List Ansible Automation Platform labels.
+     Get Ansible Automation Platform workflow job template details including prompt-on-launch
+    capabilities.
 
     Args:
+        workflow_job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -266,11 +282,12 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPLabel | ErrorData
+        AAPWorkflowJobTemplateDetail | ErrorData
     """
 
     return (
         await asyncio_detailed(
+            workflow_job_template_id=workflow_job_template_id,
             client=client,
             search=search,
             page_size=page_size,

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_credentials.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_credentials.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.aap_list_response_aap_execution_environment import AAPListResponseAAPExecutionEnvironment
+from ...models.aap_list_response_aap_credential import AAPListResponseAAPCredential
 from ...models.error_data import ErrorData
 from ...types import UNSET, Response, Unset
 
@@ -17,7 +17,6 @@ def _get_kwargs(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
@@ -51,18 +50,11 @@ def _get_kwargs(
         json_integration_id = integration_id
     params["integration_id"] = json_integration_id
 
-    json_organization: None | str | Unset
-    if isinstance(organization, Unset):
-        json_organization = UNSET
-    else:
-        json_organization = organization
-    params["organization"] = json_organization
-
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/aap/execution_environments",
+        "url": "/proxies/aap/credentials",
         "params": params,
     }
 
@@ -71,9 +63,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> AAPListResponseAAPExecutionEnvironment | ErrorData | None:
+) -> AAPListResponseAAPCredential | ErrorData | None:
     if response.status_code == 200:
-        response_200 = AAPListResponseAAPExecutionEnvironment.from_dict(response.json())
+        response_200 = AAPListResponseAAPCredential.from_dict(response.json())
 
         return response_200
 
@@ -125,7 +117,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[AAPListResponseAAPExecutionEnvironment | ErrorData]:
+) -> Response[AAPListResponseAAPCredential | ErrorData]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -143,26 +135,24 @@ def sync_detailed(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
-) -> Response[AAPListResponseAAPExecutionEnvironment | ErrorData]:
-    """List execution environments
+) -> Response[AAPListResponseAAPCredential | ErrorData]:
+    """List credentials
 
-     List Ansible Automation Platform execution environments, optionally filtered by organization.
+     List Ansible Automation Platform credentials (not organization-scoped).
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPExecutionEnvironment | ErrorData]
+        Response[AAPListResponseAAPCredential | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -170,7 +160,6 @@ def sync_detailed(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
-        organization=organization,
         additional_params=additional_params,
     )
 
@@ -188,25 +177,23 @@ def sync(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
-) -> AAPListResponseAAPExecutionEnvironment | ErrorData | None:
-    """List execution environments
+) -> AAPListResponseAAPCredential | ErrorData | None:
+    """List credentials
 
-     List Ansible Automation Platform execution environments, optionally filtered by organization.
+     List Ansible Automation Platform credentials (not organization-scoped).
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPExecutionEnvironment | ErrorData
+        AAPListResponseAAPCredential | ErrorData
     """
 
     return sync_detailed(
@@ -215,7 +202,6 @@ def sync(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
-        organization=organization,
     ).parsed
 
 
@@ -226,25 +212,23 @@ async def asyncio_detailed(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
-) -> Response[AAPListResponseAAPExecutionEnvironment | ErrorData]:
-    """List execution environments
+) -> Response[AAPListResponseAAPCredential | ErrorData]:
+    """List credentials
 
-     List Ansible Automation Platform execution environments, optionally filtered by organization.
+     List Ansible Automation Platform credentials (not organization-scoped).
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPExecutionEnvironment | ErrorData]
+        Response[AAPListResponseAAPCredential | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -252,7 +236,6 @@ async def asyncio_detailed(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
-        organization=organization,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -267,25 +250,23 @@ async def asyncio(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
-) -> AAPListResponseAAPExecutionEnvironment | ErrorData | None:
-    """List execution environments
+) -> AAPListResponseAAPCredential | ErrorData | None:
+    """List credentials
 
-     List Ansible Automation Platform execution environments, optionally filtered by organization.
+     List Ansible Automation Platform credentials (not organization-scoped).
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPExecutionEnvironment | ErrorData
+        AAPListResponseAAPCredential | ErrorData
     """
 
     return (
@@ -295,6 +276,5 @@ async def asyncio(
             page_size=page_size,
             credential_id=credential_id,
             integration_id=integration_id,
-            organization=organization,
         )
     ).parsed

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_execution_environments.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_execution_environments.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.aap_list_response_aap_inventory import AAPListResponseAAPInventory
+from ...models.aap_list_response_aap_execution_environment import AAPListResponseAAPExecutionEnvironment
 from ...models.error_data import ErrorData
 from ...types import UNSET, Response, Unset
 
@@ -62,7 +62,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/aap/inventories",
+        "url": "/proxies/aap/execution_environments",
         "params": params,
     }
 
@@ -71,9 +71,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> AAPListResponseAAPInventory | ErrorData | None:
+) -> AAPListResponseAAPExecutionEnvironment | ErrorData | None:
     if response.status_code == 200:
-        response_200 = AAPListResponseAAPInventory.from_dict(response.json())
+        response_200 = AAPListResponseAAPExecutionEnvironment.from_dict(response.json())
 
         return response_200
 
@@ -125,7 +125,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[AAPListResponseAAPInventory | ErrorData]:
+) -> Response[AAPListResponseAAPExecutionEnvironment | ErrorData]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -145,10 +145,10 @@ def sync_detailed(
     integration_id: None | Unset | UUID = UNSET,
     organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
-) -> Response[AAPListResponseAAPInventory | ErrorData]:
-    """List inventories
+) -> Response[AAPListResponseAAPExecutionEnvironment | ErrorData]:
+    """List execution environments
 
-     List Ansible Automation Platform inventories, optionally filtered by organization.
+     List Ansible Automation Platform execution environments, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
@@ -162,7 +162,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPInventory | ErrorData]
+        Response[AAPListResponseAAPExecutionEnvironment | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -189,10 +189,10 @@ def sync(
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
     organization: None | str | Unset = UNSET,
-) -> AAPListResponseAAPInventory | ErrorData | None:
-    """List inventories
+) -> AAPListResponseAAPExecutionEnvironment | ErrorData | None:
+    """List execution environments
 
-     List Ansible Automation Platform inventories, optionally filtered by organization.
+     List Ansible Automation Platform execution environments, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
@@ -206,7 +206,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPInventory | ErrorData
+        AAPListResponseAAPExecutionEnvironment | ErrorData
     """
 
     return sync_detailed(
@@ -227,10 +227,10 @@ async def asyncio_detailed(
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
     organization: None | str | Unset = UNSET,
-) -> Response[AAPListResponseAAPInventory | ErrorData]:
-    """List inventories
+) -> Response[AAPListResponseAAPExecutionEnvironment | ErrorData]:
+    """List execution environments
 
-     List Ansible Automation Platform inventories, optionally filtered by organization.
+     List Ansible Automation Platform execution environments, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
@@ -244,7 +244,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPInventory | ErrorData]
+        Response[AAPListResponseAAPExecutionEnvironment | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -268,10 +268,10 @@ async def asyncio(
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
     organization: None | str | Unset = UNSET,
-) -> AAPListResponseAAPInventory | ErrorData | None:
-    """List inventories
+) -> AAPListResponseAAPExecutionEnvironment | ErrorData | None:
+    """List execution environments
 
-     List Ansible Automation Platform inventories, optionally filtered by organization.
+     List Ansible Automation Platform execution environments, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
@@ -285,7 +285,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPInventory | ErrorData
+        AAPListResponseAAPExecutionEnvironment | ErrorData
     """
 
     return (

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_instance_groups.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_instance_groups.py
@@ -6,13 +6,12 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.aap_workflow_job_template_detail import AAPWorkflowJobTemplateDetail
+from ...models.aap_list_response_aap_instance_group import AAPListResponseAAPInstanceGroup
 from ...models.error_data import ErrorData
 from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
-    workflow_job_template_id: int,
     *,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
@@ -55,7 +54,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": f"/aap/workflow_job_templates/{workflow_job_template_id}",
+        "url": "/proxies/aap/instance_groups",
         "params": params,
     }
 
@@ -64,9 +63,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> AAPWorkflowJobTemplateDetail | ErrorData | None:
+) -> AAPListResponseAAPInstanceGroup | ErrorData | None:
     if response.status_code == 200:
-        response_200 = AAPWorkflowJobTemplateDetail.from_dict(response.json())
+        response_200 = AAPListResponseAAPInstanceGroup.from_dict(response.json())
 
         return response_200
 
@@ -118,7 +117,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[AAPWorkflowJobTemplateDetail | ErrorData]:
+) -> Response[AAPListResponseAAPInstanceGroup | ErrorData]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -130,7 +129,6 @@ def _build_response(
 
 
 def sync_detailed(
-    workflow_job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
@@ -138,14 +136,12 @@ def sync_detailed(
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
     additional_params: dict[str, Any] | None = None,
-) -> Response[AAPWorkflowJobTemplateDetail | ErrorData]:
-    """Get workflow job template
+) -> Response[AAPListResponseAAPInstanceGroup | ErrorData]:
+    """List instance groups
 
-     Get Ansible Automation Platform workflow job template details including prompt-on-launch
-    capabilities.
+     List Ansible Automation Platform instance groups (not organization-scoped).
 
     Args:
-        workflow_job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -156,11 +152,10 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPWorkflowJobTemplateDetail | ErrorData]
+        Response[AAPListResponseAAPInstanceGroup | ErrorData]
     """
 
     kwargs = _get_kwargs(
-        workflow_job_template_id=workflow_job_template_id,
         search=search,
         page_size=page_size,
         credential_id=credential_id,
@@ -176,21 +171,18 @@ def sync_detailed(
 
 
 def sync(
-    workflow_job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPWorkflowJobTemplateDetail | ErrorData | None:
-    """Get workflow job template
+) -> AAPListResponseAAPInstanceGroup | ErrorData | None:
+    """List instance groups
 
-     Get Ansible Automation Platform workflow job template details including prompt-on-launch
-    capabilities.
+     List Ansible Automation Platform instance groups (not organization-scoped).
 
     Args:
-        workflow_job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -201,11 +193,10 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPWorkflowJobTemplateDetail | ErrorData
+        AAPListResponseAAPInstanceGroup | ErrorData
     """
 
     return sync_detailed(
-        workflow_job_template_id=workflow_job_template_id,
         client=client,
         search=search,
         page_size=page_size,
@@ -215,21 +206,18 @@ def sync(
 
 
 async def asyncio_detailed(
-    workflow_job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> Response[AAPWorkflowJobTemplateDetail | ErrorData]:
-    """Get workflow job template
+) -> Response[AAPListResponseAAPInstanceGroup | ErrorData]:
+    """List instance groups
 
-     Get Ansible Automation Platform workflow job template details including prompt-on-launch
-    capabilities.
+     List Ansible Automation Platform instance groups (not organization-scoped).
 
     Args:
-        workflow_job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -240,11 +228,10 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPWorkflowJobTemplateDetail | ErrorData]
+        Response[AAPListResponseAAPInstanceGroup | ErrorData]
     """
 
     kwargs = _get_kwargs(
-        workflow_job_template_id=workflow_job_template_id,
         search=search,
         page_size=page_size,
         credential_id=credential_id,
@@ -257,21 +244,18 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    workflow_job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPWorkflowJobTemplateDetail | ErrorData | None:
-    """Get workflow job template
+) -> AAPListResponseAAPInstanceGroup | ErrorData | None:
+    """List instance groups
 
-     Get Ansible Automation Platform workflow job template details including prompt-on-launch
-    capabilities.
+     List Ansible Automation Platform instance groups (not organization-scoped).
 
     Args:
-        workflow_job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -282,12 +266,11 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPWorkflowJobTemplateDetail | ErrorData
+        AAPListResponseAAPInstanceGroup | ErrorData
     """
 
     return (
         await asyncio_detailed(
-            workflow_job_template_id=workflow_job_template_id,
             client=client,
             search=search,
             page_size=page_size,

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_inventories.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_inventories.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.aap_list_response_aap_credential import AAPListResponseAAPCredential
+from ...models.aap_list_response_aap_inventory import AAPListResponseAAPInventory
 from ...models.error_data import ErrorData
 from ...types import UNSET, Response, Unset
 
@@ -17,6 +17,7 @@ def _get_kwargs(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
+    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
@@ -50,11 +51,18 @@ def _get_kwargs(
         json_integration_id = integration_id
     params["integration_id"] = json_integration_id
 
+    json_organization: None | str | Unset
+    if isinstance(organization, Unset):
+        json_organization = UNSET
+    else:
+        json_organization = organization
+    params["organization"] = json_organization
+
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/aap/credentials",
+        "url": "/proxies/aap/inventories",
         "params": params,
     }
 
@@ -63,9 +71,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> AAPListResponseAAPCredential | ErrorData | None:
+) -> AAPListResponseAAPInventory | ErrorData | None:
     if response.status_code == 200:
-        response_200 = AAPListResponseAAPCredential.from_dict(response.json())
+        response_200 = AAPListResponseAAPInventory.from_dict(response.json())
 
         return response_200
 
@@ -117,7 +125,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[AAPListResponseAAPCredential | ErrorData]:
+) -> Response[AAPListResponseAAPInventory | ErrorData]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -135,24 +143,26 @@ def sync_detailed(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
+    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
-) -> Response[AAPListResponseAAPCredential | ErrorData]:
-    """List credentials
+) -> Response[AAPListResponseAAPInventory | ErrorData]:
+    """List inventories
 
-     List Ansible Automation Platform credentials (not organization-scoped).
+     List Ansible Automation Platform inventories, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPCredential | ErrorData]
+        Response[AAPListResponseAAPInventory | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -160,6 +170,7 @@ def sync_detailed(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
+        organization=organization,
         additional_params=additional_params,
     )
 
@@ -177,23 +188,25 @@ def sync(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPListResponseAAPCredential | ErrorData | None:
-    """List credentials
+    organization: None | str | Unset = UNSET,
+) -> AAPListResponseAAPInventory | ErrorData | None:
+    """List inventories
 
-     List Ansible Automation Platform credentials (not organization-scoped).
+     List Ansible Automation Platform inventories, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPCredential | ErrorData
+        AAPListResponseAAPInventory | ErrorData
     """
 
     return sync_detailed(
@@ -202,6 +215,7 @@ def sync(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
+        organization=organization,
     ).parsed
 
 
@@ -212,23 +226,25 @@ async def asyncio_detailed(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> Response[AAPListResponseAAPCredential | ErrorData]:
-    """List credentials
+    organization: None | str | Unset = UNSET,
+) -> Response[AAPListResponseAAPInventory | ErrorData]:
+    """List inventories
 
-     List Ansible Automation Platform credentials (not organization-scoped).
+     List Ansible Automation Platform inventories, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPCredential | ErrorData]
+        Response[AAPListResponseAAPInventory | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -236,6 +252,7 @@ async def asyncio_detailed(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
+        organization=organization,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -250,23 +267,25 @@ async def asyncio(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPListResponseAAPCredential | ErrorData | None:
-    """List credentials
+    organization: None | str | Unset = UNSET,
+) -> AAPListResponseAAPInventory | ErrorData | None:
+    """List inventories
 
-     List Ansible Automation Platform credentials (not organization-scoped).
+     List Ansible Automation Platform inventories, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPCredential | ErrorData
+        AAPListResponseAAPInventory | ErrorData
     """
 
     return (
@@ -276,5 +295,6 @@ async def asyncio(
             page_size=page_size,
             credential_id=credential_id,
             integration_id=integration_id,
+            organization=organization,
         )
     ).parsed

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_job_templates.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_job_templates.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.aap_list_response_aap_instance_group import AAPListResponseAAPInstanceGroup
+from ...models.aap_list_response_aap_job_template import AAPListResponseAAPJobTemplate
 from ...models.error_data import ErrorData
 from ...types import UNSET, Response, Unset
 
@@ -17,6 +17,7 @@ def _get_kwargs(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
+    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
@@ -50,11 +51,18 @@ def _get_kwargs(
         json_integration_id = integration_id
     params["integration_id"] = json_integration_id
 
+    json_organization: None | str | Unset
+    if isinstance(organization, Unset):
+        json_organization = UNSET
+    else:
+        json_organization = organization
+    params["organization"] = json_organization
+
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/aap/instance_groups",
+        "url": "/proxies/aap/job_templates",
         "params": params,
     }
 
@@ -63,9 +71,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> AAPListResponseAAPInstanceGroup | ErrorData | None:
+) -> AAPListResponseAAPJobTemplate | ErrorData | None:
     if response.status_code == 200:
-        response_200 = AAPListResponseAAPInstanceGroup.from_dict(response.json())
+        response_200 = AAPListResponseAAPJobTemplate.from_dict(response.json())
 
         return response_200
 
@@ -117,7 +125,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[AAPListResponseAAPInstanceGroup | ErrorData]:
+) -> Response[AAPListResponseAAPJobTemplate | ErrorData]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -135,24 +143,26 @@ def sync_detailed(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
+    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
-) -> Response[AAPListResponseAAPInstanceGroup | ErrorData]:
-    """List instance groups
+) -> Response[AAPListResponseAAPJobTemplate | ErrorData]:
+    """List job templates
 
-     List Ansible Automation Platform instance groups (not organization-scoped).
+     List Ansible Automation Platform job templates, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPInstanceGroup | ErrorData]
+        Response[AAPListResponseAAPJobTemplate | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -160,6 +170,7 @@ def sync_detailed(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
+        organization=organization,
         additional_params=additional_params,
     )
 
@@ -177,23 +188,25 @@ def sync(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPListResponseAAPInstanceGroup | ErrorData | None:
-    """List instance groups
+    organization: None | str | Unset = UNSET,
+) -> AAPListResponseAAPJobTemplate | ErrorData | None:
+    """List job templates
 
-     List Ansible Automation Platform instance groups (not organization-scoped).
+     List Ansible Automation Platform job templates, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPInstanceGroup | ErrorData
+        AAPListResponseAAPJobTemplate | ErrorData
     """
 
     return sync_detailed(
@@ -202,6 +215,7 @@ def sync(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
+        organization=organization,
     ).parsed
 
 
@@ -212,23 +226,25 @@ async def asyncio_detailed(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> Response[AAPListResponseAAPInstanceGroup | ErrorData]:
-    """List instance groups
+    organization: None | str | Unset = UNSET,
+) -> Response[AAPListResponseAAPJobTemplate | ErrorData]:
+    """List job templates
 
-     List Ansible Automation Platform instance groups (not organization-scoped).
+     List Ansible Automation Platform job templates, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPInstanceGroup | ErrorData]
+        Response[AAPListResponseAAPJobTemplate | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -236,6 +252,7 @@ async def asyncio_detailed(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
+        organization=organization,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -250,23 +267,25 @@ async def asyncio(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPListResponseAAPInstanceGroup | ErrorData | None:
-    """List instance groups
+    organization: None | str | Unset = UNSET,
+) -> AAPListResponseAAPJobTemplate | ErrorData | None:
+    """List job templates
 
-     List Ansible Automation Platform instance groups (not organization-scoped).
+     List Ansible Automation Platform job templates, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPInstanceGroup | ErrorData
+        AAPListResponseAAPJobTemplate | ErrorData
     """
 
     return (
@@ -276,5 +295,6 @@ async def asyncio(
             page_size=page_size,
             credential_id=credential_id,
             integration_id=integration_id,
+            organization=organization,
         )
     ).parsed

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_labels.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_labels.py
@@ -6,13 +6,12 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.aap_job_template_detail import AAPJobTemplateDetail
+from ...models.aap_list_response_aap_label import AAPListResponseAAPLabel
 from ...models.error_data import ErrorData
 from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
-    job_template_id: int,
     *,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
@@ -55,7 +54,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": f"/aap/job_templates/{job_template_id}",
+        "url": "/proxies/aap/labels",
         "params": params,
     }
 
@@ -64,9 +63,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> AAPJobTemplateDetail | ErrorData | None:
+) -> AAPListResponseAAPLabel | ErrorData | None:
     if response.status_code == 200:
-        response_200 = AAPJobTemplateDetail.from_dict(response.json())
+        response_200 = AAPListResponseAAPLabel.from_dict(response.json())
 
         return response_200
 
@@ -118,7 +117,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[AAPJobTemplateDetail | ErrorData]:
+) -> Response[AAPListResponseAAPLabel | ErrorData]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -130,7 +129,6 @@ def _build_response(
 
 
 def sync_detailed(
-    job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
@@ -138,13 +136,12 @@ def sync_detailed(
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
     additional_params: dict[str, Any] | None = None,
-) -> Response[AAPJobTemplateDetail | ErrorData]:
-    """Get job template
+) -> Response[AAPListResponseAAPLabel | ErrorData]:
+    """List labels
 
-     Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
+     List Ansible Automation Platform labels.
 
     Args:
-        job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -155,11 +152,10 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPJobTemplateDetail | ErrorData]
+        Response[AAPListResponseAAPLabel | ErrorData]
     """
 
     kwargs = _get_kwargs(
-        job_template_id=job_template_id,
         search=search,
         page_size=page_size,
         credential_id=credential_id,
@@ -175,20 +171,18 @@ def sync_detailed(
 
 
 def sync(
-    job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPJobTemplateDetail | ErrorData | None:
-    """Get job template
+) -> AAPListResponseAAPLabel | ErrorData | None:
+    """List labels
 
-     Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
+     List Ansible Automation Platform labels.
 
     Args:
-        job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -199,11 +193,10 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPJobTemplateDetail | ErrorData
+        AAPListResponseAAPLabel | ErrorData
     """
 
     return sync_detailed(
-        job_template_id=job_template_id,
         client=client,
         search=search,
         page_size=page_size,
@@ -213,20 +206,18 @@ def sync(
 
 
 async def asyncio_detailed(
-    job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> Response[AAPJobTemplateDetail | ErrorData]:
-    """Get job template
+) -> Response[AAPListResponseAAPLabel | ErrorData]:
+    """List labels
 
-     Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
+     List Ansible Automation Platform labels.
 
     Args:
-        job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -237,11 +228,10 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPJobTemplateDetail | ErrorData]
+        Response[AAPListResponseAAPLabel | ErrorData]
     """
 
     kwargs = _get_kwargs(
-        job_template_id=job_template_id,
         search=search,
         page_size=page_size,
         credential_id=credential_id,
@@ -254,20 +244,18 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    job_template_id: int,
     *,
     client: AuthenticatedClient,
     search: None | str | Unset = UNSET,
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPJobTemplateDetail | ErrorData | None:
-    """Get job template
+) -> AAPListResponseAAPLabel | ErrorData | None:
+    """List labels
 
-     Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
+     List Ansible Automation Platform labels.
 
     Args:
-        job_template_id (int):
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
@@ -278,12 +266,11 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPJobTemplateDetail | ErrorData
+        AAPListResponseAAPLabel | ErrorData
     """
 
     return (
         await asyncio_detailed(
-            job_template_id=job_template_id,
             client=client,
             search=search,
             page_size=page_size,

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_organizations.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_organizations.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.aap_list_response_aap_job_template import AAPListResponseAAPJobTemplate
+from ...models.aap_list_response_aap_organization import AAPListResponseAAPOrganization
 from ...models.error_data import ErrorData
 from ...types import UNSET, Response, Unset
 
@@ -17,7 +17,6 @@ def _get_kwargs(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
@@ -51,18 +50,11 @@ def _get_kwargs(
         json_integration_id = integration_id
     params["integration_id"] = json_integration_id
 
-    json_organization: None | str | Unset
-    if isinstance(organization, Unset):
-        json_organization = UNSET
-    else:
-        json_organization = organization
-    params["organization"] = json_organization
-
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/aap/job_templates",
+        "url": "/proxies/aap/organizations",
         "params": params,
     }
 
@@ -71,9 +63,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> AAPListResponseAAPJobTemplate | ErrorData | None:
+) -> AAPListResponseAAPOrganization | ErrorData | None:
     if response.status_code == 200:
-        response_200 = AAPListResponseAAPJobTemplate.from_dict(response.json())
+        response_200 = AAPListResponseAAPOrganization.from_dict(response.json())
 
         return response_200
 
@@ -125,7 +117,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[AAPListResponseAAPJobTemplate | ErrorData]:
+) -> Response[AAPListResponseAAPOrganization | ErrorData]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -143,26 +135,24 @@ def sync_detailed(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
-) -> Response[AAPListResponseAAPJobTemplate | ErrorData]:
-    """List job templates
+) -> Response[AAPListResponseAAPOrganization | ErrorData]:
+    """List organizations
 
-     List Ansible Automation Platform job templates, optionally filtered by organization.
+     List Ansible Automation Platform organizations.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPJobTemplate | ErrorData]
+        Response[AAPListResponseAAPOrganization | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -170,7 +160,6 @@ def sync_detailed(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
-        organization=organization,
         additional_params=additional_params,
     )
 
@@ -188,25 +177,23 @@ def sync(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
-) -> AAPListResponseAAPJobTemplate | ErrorData | None:
-    """List job templates
+) -> AAPListResponseAAPOrganization | ErrorData | None:
+    """List organizations
 
-     List Ansible Automation Platform job templates, optionally filtered by organization.
+     List Ansible Automation Platform organizations.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPJobTemplate | ErrorData
+        AAPListResponseAAPOrganization | ErrorData
     """
 
     return sync_detailed(
@@ -215,7 +202,6 @@ def sync(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
-        organization=organization,
     ).parsed
 
 
@@ -226,25 +212,23 @@ async def asyncio_detailed(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
-) -> Response[AAPListResponseAAPJobTemplate | ErrorData]:
-    """List job templates
+) -> Response[AAPListResponseAAPOrganization | ErrorData]:
+    """List organizations
 
-     List Ansible Automation Platform job templates, optionally filtered by organization.
+     List Ansible Automation Platform organizations.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPJobTemplate | ErrorData]
+        Response[AAPListResponseAAPOrganization | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -252,7 +236,6 @@ async def asyncio_detailed(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
-        organization=organization,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -267,25 +250,23 @@ async def asyncio(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-    organization: None | str | Unset = UNSET,
-) -> AAPListResponseAAPJobTemplate | ErrorData | None:
-    """List job templates
+) -> AAPListResponseAAPOrganization | ErrorData | None:
+    """List organizations
 
-     List Ansible Automation Platform job templates, optionally filtered by organization.
+     List Ansible Automation Platform organizations.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
-        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPJobTemplate | ErrorData
+        AAPListResponseAAPOrganization | ErrorData
     """
 
     return (
@@ -295,6 +276,5 @@ async def asyncio(
             page_size=page_size,
             credential_id=credential_id,
             integration_id=integration_id,
-            organization=organization,
         )
     ).parsed

--- a/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_workflow_job_templates.py
+++ b/backend/src/api_client/syntara_api_client/api/ansible_automation_platform_proxy/list_aap_workflow_job_templates.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.aap_list_response_aap_organization import AAPListResponseAAPOrganization
+from ...models.aap_list_response_aap_workflow_job_template import AAPListResponseAAPWorkflowJobTemplate
 from ...models.error_data import ErrorData
 from ...types import UNSET, Response, Unset
 
@@ -17,6 +17,7 @@ def _get_kwargs(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
+    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
@@ -50,11 +51,18 @@ def _get_kwargs(
         json_integration_id = integration_id
     params["integration_id"] = json_integration_id
 
+    json_organization: None | str | Unset
+    if isinstance(organization, Unset):
+        json_organization = UNSET
+    else:
+        json_organization = organization
+    params["organization"] = json_organization
+
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/aap/organizations",
+        "url": "/proxies/aap/workflow_job_templates",
         "params": params,
     }
 
@@ -63,9 +71,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> AAPListResponseAAPOrganization | ErrorData | None:
+) -> AAPListResponseAAPWorkflowJobTemplate | ErrorData | None:
     if response.status_code == 200:
-        response_200 = AAPListResponseAAPOrganization.from_dict(response.json())
+        response_200 = AAPListResponseAAPWorkflowJobTemplate.from_dict(response.json())
 
         return response_200
 
@@ -117,7 +125,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[AAPListResponseAAPOrganization | ErrorData]:
+) -> Response[AAPListResponseAAPWorkflowJobTemplate | ErrorData]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -135,24 +143,26 @@ def sync_detailed(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
+    organization: None | str | Unset = UNSET,
     additional_params: dict[str, Any] | None = None,
-) -> Response[AAPListResponseAAPOrganization | ErrorData]:
-    """List organizations
+) -> Response[AAPListResponseAAPWorkflowJobTemplate | ErrorData]:
+    """List workflow job templates
 
-     List Ansible Automation Platform organizations.
+     List Ansible Automation Platform workflow job templates, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPOrganization | ErrorData]
+        Response[AAPListResponseAAPWorkflowJobTemplate | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -160,6 +170,7 @@ def sync_detailed(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
+        organization=organization,
         additional_params=additional_params,
     )
 
@@ -177,23 +188,25 @@ def sync(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPListResponseAAPOrganization | ErrorData | None:
-    """List organizations
+    organization: None | str | Unset = UNSET,
+) -> AAPListResponseAAPWorkflowJobTemplate | ErrorData | None:
+    """List workflow job templates
 
-     List Ansible Automation Platform organizations.
+     List Ansible Automation Platform workflow job templates, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPOrganization | ErrorData
+        AAPListResponseAAPWorkflowJobTemplate | ErrorData
     """
 
     return sync_detailed(
@@ -202,6 +215,7 @@ def sync(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
+        organization=organization,
     ).parsed
 
 
@@ -212,23 +226,25 @@ async def asyncio_detailed(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> Response[AAPListResponseAAPOrganization | ErrorData]:
-    """List organizations
+    organization: None | str | Unset = UNSET,
+) -> Response[AAPListResponseAAPWorkflowJobTemplate | ErrorData]:
+    """List workflow job templates
 
-     List Ansible Automation Platform organizations.
+     List Ansible Automation Platform workflow job templates, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AAPListResponseAAPOrganization | ErrorData]
+        Response[AAPListResponseAAPWorkflowJobTemplate | ErrorData]
     """
 
     kwargs = _get_kwargs(
@@ -236,6 +252,7 @@ async def asyncio_detailed(
         page_size=page_size,
         credential_id=credential_id,
         integration_id=integration_id,
+        organization=organization,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -250,23 +267,25 @@ async def asyncio(
     page_size: int | Unset = 50,
     credential_id: None | Unset | UUID = UNSET,
     integration_id: None | Unset | UUID = UNSET,
-) -> AAPListResponseAAPOrganization | ErrorData | None:
-    """List organizations
+    organization: None | str | Unset = UNSET,
+) -> AAPListResponseAAPWorkflowJobTemplate | ErrorData | None:
+    """List workflow job templates
 
-     List Ansible Automation Platform organizations.
+     List Ansible Automation Platform workflow job templates, optionally filtered by organization.
 
     Args:
         search (None | str | Unset):
         page_size (int | Unset):  Default: 50.
         credential_id (None | Unset | UUID):
         integration_id (None | Unset | UUID):
+        organization (None | str | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AAPListResponseAAPOrganization | ErrorData
+        AAPListResponseAAPWorkflowJobTemplate | ErrorData
     """
 
     return (
@@ -276,5 +295,6 @@ async def asyncio(
             page_size=page_size,
             credential_id=credential_id,
             integration_id=integration_id,
+            organization=organization,
         )
     ).parsed

--- a/backend/src/cli/orchestrator_cli/openapi.yaml
+++ b/backend/src/cli/orchestrator_cli/openapi.yaml
@@ -17,7 +17,7 @@ servers:
   - url: /api/v1
     description: API v1
 tags:
-  - name: Ansible Automation Platform
+  - name: Ansible Automation Platform Proxy
     description: Ansible Automation Platform resource proxy
   - name: Admin
     description: Administrative revocation operations
@@ -70,7 +70,7 @@ tags:
   - name: Webhooks
     description: Inbound webhook event receivers
 paths:
-  /aap/organizations:
+  /proxies/aap/organizations:
     get:
       summary: List organizations
       description: List Ansible Automation Platform organizations.
@@ -79,7 +79,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -231,7 +231,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/job_templates:
+  /proxies/aap/job_templates:
     get:
       summary: List job templates
       description: List Ansible Automation Platform job templates, optionally filtered by organization.
@@ -240,7 +240,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -401,7 +401,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/job_templates/{job_template_id}:
+  /proxies/aap/job_templates/{job_template_id}:
     get:
       summary: Get job template
       description: Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
@@ -410,7 +410,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: path
           name: job_template_id
@@ -569,7 +569,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/workflow_job_templates:
+  /proxies/aap/workflow_job_templates:
     get:
       summary: List workflow job templates
       description: List Ansible Automation Platform workflow job templates, optionally filtered by organization.
@@ -578,7 +578,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -739,7 +739,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/workflow_job_templates/{workflow_job_template_id}:
+  /proxies/aap/workflow_job_templates/{workflow_job_template_id}:
     get:
       summary: Get workflow job template
       description: Get Ansible Automation Platform workflow job template details including prompt-on-launch capabilities.
@@ -748,7 +748,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: path
           name: workflow_job_template_id
@@ -907,7 +907,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/inventories:
+  /proxies/aap/inventories:
     get:
       summary: List inventories
       description: List Ansible Automation Platform inventories, optionally filtered by organization.
@@ -916,7 +916,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -1077,7 +1077,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/execution_environments:
+  /proxies/aap/execution_environments:
     get:
       summary: List execution environments
       description: List Ansible Automation Platform execution environments, optionally filtered by organization.
@@ -1086,7 +1086,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -1247,7 +1247,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/credentials:
+  /proxies/aap/credentials:
     get:
       summary: List credentials
       description: List Ansible Automation Platform credentials (not organization-scoped).
@@ -1256,7 +1256,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -1408,7 +1408,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/instance_groups:
+  /proxies/aap/instance_groups:
     get:
       summary: List instance groups
       description: List Ansible Automation Platform instance groups (not organization-scoped).
@@ -1417,7 +1417,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -1569,10 +1569,10 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/labels:
+  /proxies/aap/labels:
     get:
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       summary: List labels
       description: List Ansible Automation Platform labels.
       operationId: list_aap_labels

--- a/backend/src/syntara/aap/router.py
+++ b/backend/src/syntara/aap/router.py
@@ -1,4 +1,4 @@
-"""AAP proxy router — auto-discovered under /api/v1/aap.
+"""AAP proxy router — auto-discovered under /api/v1/proxies/aap.
 
 Thin layer that validates query params, resolves dependencies,
 and delegates to AAPProxyService.
@@ -53,7 +53,7 @@ from syntara.core.models import User
 
 logger = structlog.stdlib.get_logger(__name__)
 
-router = APIRouter(prefix="/aap", tags=["Ansible Automation Platform"])
+router = APIRouter(prefix="/proxies/aap", tags=["Ansible Automation Platform Proxy"])
 
 _integration_scope = ProjectScopeFilter("integration", "read")
 

--- a/backend/src/syntara/schemas/aap/openapi.yaml
+++ b/backend/src/syntara/schemas/aap/openapi.yaml
@@ -23,11 +23,11 @@ servers:
     description: API v1
 
 tags:
-  - name: Ansible Automation Platform
+  - name: Ansible Automation Platform Proxy
     description: Ansible Automation Platform resource proxy
 
 paths:
-  /aap/organizations:
+  /proxies/aap/organizations:
     get:
       summary: List organizations
       description: List Ansible Automation Platform organizations.
@@ -36,7 +36,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -84,7 +84,7 @@ paths:
       security:
         - bearerAuth: []
 
-  /aap/job_templates:
+  /proxies/aap/job_templates:
     get:
       summary: List job templates
       description: List Ansible Automation Platform job templates, optionally filtered by organization.
@@ -93,7 +93,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -150,7 +150,7 @@ paths:
       security:
         - bearerAuth: []
 
-  /aap/job_templates/{job_template_id}:
+  /proxies/aap/job_templates/{job_template_id}:
     get:
       summary: Get job template
       description: Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
@@ -159,7 +159,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: path
           name: job_template_id
@@ -214,7 +214,7 @@ paths:
       security:
         - bearerAuth: []
 
-  /aap/workflow_job_templates:
+  /proxies/aap/workflow_job_templates:
     get:
       summary: List workflow job templates
       description: List Ansible Automation Platform workflow job templates, optionally filtered by organization.
@@ -223,7 +223,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -280,7 +280,7 @@ paths:
       security:
         - bearerAuth: []
 
-  /aap/workflow_job_templates/{workflow_job_template_id}:
+  /proxies/aap/workflow_job_templates/{workflow_job_template_id}:
     get:
       summary: Get workflow job template
       description: Get Ansible Automation Platform workflow job template details including prompt-on-launch capabilities.
@@ -289,7 +289,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: path
           name: workflow_job_template_id
@@ -344,7 +344,7 @@ paths:
       security:
         - bearerAuth: []
 
-  /aap/inventories:
+  /proxies/aap/inventories:
     get:
       summary: List inventories
       description: List Ansible Automation Platform inventories, optionally filtered by organization.
@@ -353,7 +353,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -410,7 +410,7 @@ paths:
       security:
         - bearerAuth: []
 
-  /aap/execution_environments:
+  /proxies/aap/execution_environments:
     get:
       summary: List execution environments
       description: List Ansible Automation Platform execution environments, optionally filtered by organization.
@@ -419,7 +419,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -476,7 +476,7 @@ paths:
       security:
         - bearerAuth: []
 
-  /aap/credentials:
+  /proxies/aap/credentials:
     get:
       summary: List credentials
       description: List Ansible Automation Platform credentials (not organization-scoped).
@@ -485,7 +485,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -533,7 +533,7 @@ paths:
       security:
         - bearerAuth: []
 
-  /aap/instance_groups:
+  /proxies/aap/instance_groups:
     get:
       summary: List instance groups
       description: List Ansible Automation Platform instance groups (not organization-scoped).
@@ -542,7 +542,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -590,10 +590,10 @@ paths:
       security:
         - bearerAuth: []
 
-  /aap/labels:
+  /proxies/aap/labels:
     get:
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       summary: List labels
       description: List Ansible Automation Platform labels.
       operationId: list_aap_labels

--- a/backend/src/syntara/schemas/openapi.yaml
+++ b/backend/src/syntara/schemas/openapi.yaml
@@ -17,7 +17,7 @@ servers:
   - url: /api/v1
     description: API v1
 tags:
-  - name: Ansible Automation Platform
+  - name: Ansible Automation Platform Proxy
     description: Ansible Automation Platform resource proxy
   - name: Admin
     description: Administrative revocation operations
@@ -70,7 +70,7 @@ tags:
   - name: Webhooks
     description: Inbound webhook event receivers
 paths:
-  /aap/organizations:
+  /proxies/aap/organizations:
     get:
       summary: List organizations
       description: List Ansible Automation Platform organizations.
@@ -79,7 +79,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -231,7 +231,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/job_templates:
+  /proxies/aap/job_templates:
     get:
       summary: List job templates
       description: List Ansible Automation Platform job templates, optionally filtered by organization.
@@ -240,7 +240,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -401,7 +401,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/job_templates/{job_template_id}:
+  /proxies/aap/job_templates/{job_template_id}:
     get:
       summary: Get job template
       description: Get Ansible Automation Platform job template details including prompt-on-launch capabilities.
@@ -410,7 +410,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: path
           name: job_template_id
@@ -569,7 +569,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/workflow_job_templates:
+  /proxies/aap/workflow_job_templates:
     get:
       summary: List workflow job templates
       description: List Ansible Automation Platform workflow job templates, optionally filtered by organization.
@@ -578,7 +578,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -739,7 +739,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/workflow_job_templates/{workflow_job_template_id}:
+  /proxies/aap/workflow_job_templates/{workflow_job_template_id}:
     get:
       summary: Get workflow job template
       description: Get Ansible Automation Platform workflow job template details including prompt-on-launch capabilities.
@@ -748,7 +748,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: path
           name: workflow_job_template_id
@@ -907,7 +907,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/inventories:
+  /proxies/aap/inventories:
     get:
       summary: List inventories
       description: List Ansible Automation Platform inventories, optionally filtered by organization.
@@ -916,7 +916,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -1077,7 +1077,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/execution_environments:
+  /proxies/aap/execution_environments:
     get:
       summary: List execution environments
       description: List Ansible Automation Platform execution environments, optionally filtered by organization.
@@ -1086,7 +1086,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -1247,7 +1247,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/credentials:
+  /proxies/aap/credentials:
     get:
       summary: List credentials
       description: List Ansible Automation Platform credentials (not organization-scoped).
@@ -1256,7 +1256,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -1408,7 +1408,7 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/instance_groups:
+  /proxies/aap/instance_groups:
     get:
       summary: List instance groups
       description: List Ansible Automation Platform instance groups (not organization-scoped).
@@ -1417,7 +1417,7 @@ paths:
         resource: null
         action: null
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       parameters:
         - in: query
           name: search
@@ -1569,10 +1569,10 @@ paths:
                 retryable: true
       security:
         - bearerAuth: []
-  /aap/labels:
+  /proxies/aap/labels:
     get:
       tags:
-        - Ansible Automation Platform
+        - Ansible Automation Platform Proxy
       summary: List labels
       description: List Ansible Automation Platform labels.
       operationId: list_aap_labels

--- a/backend/tests/unit/aap/test_error_handlers.py
+++ b/backend/tests/unit/aap/test_error_handlers.py
@@ -20,7 +20,7 @@ from syntara.aap.exceptions import (
 )
 
 
-def _mock_request(url: str = "https://example.com/api/v1/aap/organizations") -> MagicMock:
+def _mock_request(url: str = "https://example.com/api/v1/proxies/aap/organizations") -> MagicMock:
     request = MagicMock()
     request.url = url
     return request

--- a/backend/tests/unit/aap/test_router.py
+++ b/backend/tests/unit/aap/test_router.py
@@ -64,7 +64,7 @@ def app(mock_service: AsyncMock, mock_user: User) -> FastAPI:
 
 
 class TestListOrganizations:
-    """Tests for GET /api/v1/aap/organizations."""
+    """Tests for GET /api/v1/proxies/aap/organizations."""
 
     @pytest.mark.asyncio
     async def test_returns_organizations(self, app: FastAPI, mock_service: AsyncMock) -> None:
@@ -78,7 +78,7 @@ class TestListOrganizations:
         )
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            response = await client.get("/api/v1/aap/organizations")
+            response = await client.get("/api/v1/proxies/aap/organizations")
 
         assert response.status_code == 200
         data = response.json()
@@ -89,7 +89,7 @@ class TestListOrganizations:
 
 
 class TestListJobTemplates:
-    """Tests for GET /api/v1/aap/job_templates."""
+    """Tests for GET /api/v1/proxies/aap/job_templates."""
 
     @pytest.mark.asyncio
     async def test_returns_job_templates(self, app: FastAPI, mock_service: AsyncMock) -> None:
@@ -100,7 +100,7 @@ class TestListJobTemplates:
         )
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            response = await client.get("/api/v1/aap/job_templates")
+            response = await client.get("/api/v1/proxies/aap/job_templates")
 
         assert response.status_code == 200
         data = response.json()
@@ -109,7 +109,7 @@ class TestListJobTemplates:
 
 
 class TestGetJobTemplate:
-    """Tests for GET /api/v1/aap/job_templates/{job_template_id}."""
+    """Tests for GET /api/v1/proxies/aap/job_templates/{job_template_id}."""
 
     @pytest.mark.asyncio
     async def test_returns_job_template_detail(self, app: FastAPI, mock_service: AsyncMock) -> None:
@@ -125,7 +125,7 @@ class TestGetJobTemplate:
         )
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            response = await client.get("/api/v1/aap/job_templates/1")
+            response = await client.get("/api/v1/proxies/aap/job_templates/1")
 
         assert response.status_code == 200
         data = response.json()
@@ -135,7 +135,7 @@ class TestGetJobTemplate:
 
 
 class TestListInventories:
-    """Tests for GET /api/v1/aap/inventories."""
+    """Tests for GET /api/v1/proxies/aap/inventories."""
 
     @pytest.mark.asyncio
     async def test_returns_inventories(self, app: FastAPI, mock_service: AsyncMock) -> None:
@@ -146,7 +146,7 @@ class TestListInventories:
         )
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            response = await client.get("/api/v1/aap/inventories")
+            response = await client.get("/api/v1/proxies/aap/inventories")
 
         assert response.status_code == 200
         data = response.json()
@@ -155,7 +155,7 @@ class TestListInventories:
 
 
 class TestListExecutionEnvironments:
-    """Tests for GET /api/v1/aap/execution_environments."""
+    """Tests for GET /api/v1/proxies/aap/execution_environments."""
 
     @pytest.mark.asyncio
     async def test_returns_execution_environments(self, app: FastAPI, mock_service: AsyncMock) -> None:
@@ -166,7 +166,7 @@ class TestListExecutionEnvironments:
         )
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            response = await client.get("/api/v1/aap/execution_environments")
+            response = await client.get("/api/v1/proxies/aap/execution_environments")
 
         assert response.status_code == 200
         data = response.json()
@@ -175,7 +175,7 @@ class TestListExecutionEnvironments:
 
 
 class TestListCredentials:
-    """Tests for GET /api/v1/aap/credentials."""
+    """Tests for GET /api/v1/proxies/aap/credentials."""
 
     @pytest.mark.asyncio
     async def test_returns_credentials(self, app: FastAPI, mock_service: AsyncMock) -> None:
@@ -186,7 +186,7 @@ class TestListCredentials:
         )
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            response = await client.get("/api/v1/aap/credentials")
+            response = await client.get("/api/v1/proxies/aap/credentials")
 
         assert response.status_code == 200
         data = response.json()
@@ -195,7 +195,7 @@ class TestListCredentials:
 
 
 class TestListInstanceGroups:
-    """Tests for GET /api/v1/aap/instance_groups."""
+    """Tests for GET /api/v1/proxies/aap/instance_groups."""
 
     @pytest.mark.asyncio
     async def test_returns_instance_groups(self, app: FastAPI, mock_service: AsyncMock) -> None:
@@ -206,7 +206,7 @@ class TestListInstanceGroups:
         )
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            response = await client.get("/api/v1/aap/instance_groups")
+            response = await client.get("/api/v1/proxies/aap/instance_groups")
 
         assert response.status_code == 200
         data = response.json()
@@ -215,7 +215,7 @@ class TestListInstanceGroups:
 
 
 class TestListLabels:
-    """Tests for GET /api/v1/aap/labels."""
+    """Tests for GET /api/v1/proxies/aap/labels."""
 
     @pytest.mark.asyncio
     async def test_returns_labels(self, app: FastAPI, mock_service: AsyncMock) -> None:
@@ -229,7 +229,7 @@ class TestListLabels:
         )
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            response = await client.get("/api/v1/aap/labels")
+            response = await client.get("/api/v1/proxies/aap/labels")
 
         assert response.status_code == 200
         data = response.json()

--- a/backend/tests/unit/api/compliance/auth_exclusions.yml
+++ b/backend/tests/unit/api/compliance/auth_exclusions.yml
@@ -95,43 +95,43 @@ authenticated:
 
   # -- aap: proxy to Controller which enforces its own RBAC --
   - method: GET
-    path: /api/v1/aap/credentials
+    path: /api/v1/proxies/aap/credentials
     justification: Proxy to Controller; Controller enforces RBAC
 
   - method: GET
-    path: /api/v1/aap/execution_environments
+    path: /api/v1/proxies/aap/execution_environments
     justification: Proxy to Controller; Controller enforces RBAC
 
   - method: GET
-    path: /api/v1/aap/instance_groups
+    path: /api/v1/proxies/aap/instance_groups
     justification: Proxy to Controller; Controller enforces RBAC
 
   - method: GET
-    path: /api/v1/aap/inventories
+    path: /api/v1/proxies/aap/inventories
     justification: Proxy to Controller; Controller enforces RBAC
 
   - method: GET
-    path: /api/v1/aap/job_templates
+    path: /api/v1/proxies/aap/job_templates
     justification: Proxy to Controller; Controller enforces RBAC
 
   - method: GET
-    path: /api/v1/aap/job_templates/{job_template_id}
+    path: /api/v1/proxies/aap/job_templates/{job_template_id}
     justification: Proxy to Controller; Controller enforces RBAC
 
   - method: GET
-    path: /api/v1/aap/labels
+    path: /api/v1/proxies/aap/labels
     justification: Proxy to Controller; Controller enforces RBAC
 
   - method: GET
-    path: /api/v1/aap/organizations
+    path: /api/v1/proxies/aap/organizations
     justification: Proxy to Controller; Controller enforces RBAC
 
   - method: GET
-    path: /api/v1/aap/workflow_job_templates
+    path: /api/v1/proxies/aap/workflow_job_templates
     justification: Proxy to Controller; Controller enforces RBAC
 
   - method: GET
-    path: /api/v1/aap/workflow_job_templates/{workflow_job_template_id}
+    path: /api/v1/proxies/aap/workflow_job_templates/{workflow_job_template_id}
     justification: Proxy to Controller; Controller enforces RBAC
 
   # -- tool_manager/metrics: internal observability --

--- a/backend/tests/unit/api/compliance/endpoint_discovery.py
+++ b/backend/tests/unit/api/compliance/endpoint_discovery.py
@@ -288,7 +288,7 @@ def discover_testable_list_endpoints() -> list[EndpointInfo]:
     """Discover list endpoints that should be tested for compliance.
 
     Filters out:
-    - AAP proxy endpoints (tagged "Ansible Automation Platform" in OpenAPI spec, locked to upstream format)
+    - AAP proxy endpoints (tagged "Ansible Automation Platform Proxy" in OpenAPI spec, locked to upstream format)
     - Explicitly excluded endpoints from list_compliance_exclusions.yaml
 
     Includes:

--- a/backend/tests/unit/api/compliance/endpoint_discovery.py
+++ b/backend/tests/unit/api/compliance/endpoint_discovery.py
@@ -28,7 +28,7 @@ _ACTION_OPERATION_PREFIXES = (
 )
 
 # OpenAPI tag for AAP Controller BFF proxy endpoints (locked to upstream response shape).
-_AAP_PROXY_TAG = "Ansible Automation Platform"
+_AAP_PROXY_TAG = "Ansible Automation Platform Proxy"
 
 EXCLUSIONS_FILE = Path(__file__).parent / "list_compliance_exclusions.yaml"
 CRUD_EXCLUSIONS_FILE = Path(__file__).parent / "crud_compliance_exclusions.yaml"

--- a/backend/tests/unit/api/compliance/test_crud_endpoint_discovery.py
+++ b/backend/tests/unit/api/compliance/test_crud_endpoint_discovery.py
@@ -283,7 +283,7 @@ class TestEndpointValidation:
     ) -> None:
         """AAP proxy endpoints are excluded from all CRUD discovery."""
         for ep in [*read_endpoints, *create_endpoints, *update_endpoints, *delete_endpoints]:
-            assert "Ansible Automation Platform" not in ep.tags, (
+            assert "Ansible Automation Platform Proxy" not in ep.tags, (
                 f"{ep.operation_id} is an AAP proxy endpoint and should be excluded"
             )
 

--- a/backend/tests/unit/api/compliance/test_list_endpoint_discovery.py
+++ b/backend/tests/unit/api/compliance/test_list_endpoint_discovery.py
@@ -176,7 +176,7 @@ class TestFiltering:
         testable_ids = {ep.operation_id for ep in testable_endpoints}
 
         # AAP endpoints should be in all but not testable (tagged in OpenAPI spec)
-        aap_endpoints = [ep for ep in all_endpoints if "Ansible Automation Platform" in ep.tags]
+        aap_endpoints = [ep for ep in all_endpoints if "Ansible Automation Platform Proxy" in ep.tags]
         assert len(aap_endpoints) > 0, "Should have some AAP endpoints"
 
         for ep in aap_endpoints:

--- a/frontend/packages/syntara-contracts/src/aap-api.ts
+++ b/frontend/packages/syntara-contracts/src/aap-api.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-  '/aap/organizations': {
+  '/proxies/aap/organizations': {
     parameters: {
       query?: never
       header?: never
@@ -24,7 +24,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/aap/job_templates': {
+  '/proxies/aap/job_templates': {
     parameters: {
       query?: never
       header?: never
@@ -44,7 +44,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/aap/job_templates/{job_template_id}': {
+  '/proxies/aap/job_templates/{job_template_id}': {
     parameters: {
       query?: never
       header?: never
@@ -64,7 +64,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/aap/workflow_job_templates': {
+  '/proxies/aap/workflow_job_templates': {
     parameters: {
       query?: never
       header?: never
@@ -84,7 +84,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/aap/workflow_job_templates/{workflow_job_template_id}': {
+  '/proxies/aap/workflow_job_templates/{workflow_job_template_id}': {
     parameters: {
       query?: never
       header?: never
@@ -104,7 +104,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/aap/inventories': {
+  '/proxies/aap/inventories': {
     parameters: {
       query?: never
       header?: never
@@ -124,7 +124,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/aap/execution_environments': {
+  '/proxies/aap/execution_environments': {
     parameters: {
       query?: never
       header?: never
@@ -144,7 +144,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/aap/credentials': {
+  '/proxies/aap/credentials': {
     parameters: {
       query?: never
       header?: never
@@ -164,7 +164,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/aap/instance_groups': {
+  '/proxies/aap/instance_groups': {
     parameters: {
       query?: never
       header?: never
@@ -184,7 +184,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/aap/labels': {
+  '/proxies/aap/labels': {
     parameters: {
       query?: never
       header?: never

--- a/frontend/packages/syntara-mock-api/src/handlers.ts
+++ b/frontend/packages/syntara-mock-api/src/handlers.ts
@@ -4762,7 +4762,7 @@ export const handlers = [
   }),
 
   // ── AAP proxy endpoints ──────────────────────────────────────────────
-  http.get('*/aap/organizations', ({ request }) => {
+  http.get('*/proxies/aap/organizations', ({ request }) => {
     const url = new URL(request.url)
     const validationError = validateCredentialId(url)
     if (validationError) return validationError
@@ -4773,7 +4773,7 @@ export const handlers = [
     return HttpResponse.json({ count: filtered.length, results: filtered })
   }),
 
-  http.get('*/aap/job_templates/:id', ({ params, request }) => {
+  http.get('*/proxies/aap/job_templates/:id', ({ params, request }) => {
     const url = new URL(request.url)
     const validationError = validateCredentialId(url)
     if (validationError) return validationError
@@ -4809,7 +4809,7 @@ export const handlers = [
     })
   }),
 
-  http.get('*/aap/job_templates', ({ request }) => {
+  http.get('*/proxies/aap/job_templates', ({ request }) => {
     const url = new URL(request.url)
     const org = url.searchParams.get('organization')
     const search = url.searchParams.get('search')?.toLowerCase()
@@ -4824,7 +4824,7 @@ export const handlers = [
     return HttpResponse.json({ count: filtered.length, results: filtered })
   }),
 
-  http.get('*/aap/workflow_job_templates/:id', ({ params, request }) => {
+  http.get('*/proxies/aap/workflow_job_templates/:id', ({ params, request }) => {
     const url = new URL(request.url)
     const validationError = validateCredentialId(url)
     if (validationError) return validationError
@@ -4853,7 +4853,7 @@ export const handlers = [
     })
   }),
 
-  http.get('*/aap/workflow_job_templates', ({ request }) => {
+  http.get('*/proxies/aap/workflow_job_templates', ({ request }) => {
     const url = new URL(request.url)
     const org = url.searchParams.get('organization')
     const search = url.searchParams.get('search')?.toLowerCase()
@@ -4868,7 +4868,7 @@ export const handlers = [
     return HttpResponse.json({ count: filtered.length, results: filtered })
   }),
 
-  http.get('*/aap/inventories', ({ request }) => {
+  http.get('*/proxies/aap/inventories', ({ request }) => {
     const url = new URL(request.url)
     const org = url.searchParams.get('organization')
     const search = url.searchParams.get('search')?.toLowerCase()
@@ -4883,7 +4883,7 @@ export const handlers = [
     return HttpResponse.json({ count: filtered.length, results: filtered })
   }),
 
-  http.get('*/aap/execution_environments', ({ request }) => {
+  http.get('*/proxies/aap/execution_environments', ({ request }) => {
     const url = new URL(request.url)
     const search = url.searchParams.get('search')?.toLowerCase()
 
@@ -4896,7 +4896,7 @@ export const handlers = [
     return HttpResponse.json({ count: filtered.length, results: filtered })
   }),
 
-  http.get('*/aap/credentials', ({ request }) => {
+  http.get('*/proxies/aap/credentials', ({ request }) => {
     const url = new URL(request.url)
     const search = url.searchParams.get('search')?.toLowerCase()
 
@@ -4930,7 +4930,7 @@ export const handlers = [
     })
   }),
 
-  http.get('*/aap/instance_groups', ({ request }) => {
+  http.get('*/proxies/aap/instance_groups', ({ request }) => {
     const url = new URL(request.url)
     const search = url.searchParams.get('search')?.toLowerCase()
 

--- a/frontend/packages/syntara-ui/src/hooks/useAAPBrowser.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useAAPBrowser.test.ts
@@ -344,7 +344,7 @@ describe('useAAPBrowser', () => {
 
       // Verify useQuery was called with integration_id in query params
       const calls = mockUseQuery.mock.calls
-      const orgCall = calls.find((c: unknown[]) => c[1] === '/aap/organizations')
+      const orgCall = calls.find((c: unknown[]) => c[1] === '/proxies/aap/organizations')
       expect(orgCall).toBeDefined()
       const orgCallOptions = orgCall![2] as { params: { query: { integration_id: string } } }
       expect(orgCallOptions.params.query.integration_id).toBe('int-456')

--- a/frontend/packages/syntara-ui/src/hooks/useAAPBrowser.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useAAPBrowser.ts
@@ -91,7 +91,7 @@ function useAAPQueries(
 ) {
   const orgsQuery = aapClient.useQuery(
     'get',
-    '/aap/organizations',
+    '/proxies/aap/organizations',
     { params: { query: buildSearchParams(state.orgSearch, credentialId, undefined, integrationId) } },
     { enabled: isActive }
   )
@@ -99,14 +99,14 @@ function useAAPQueries(
   // Job templates query
   const jobTemplatesQuery = aapClient.useQuery(
     'get',
-    '/aap/job_templates',
+    '/proxies/aap/job_templates',
     { params: { query: buildSearchParams(state.templateSearch, credentialId, state.selectedOrg, integrationId) } },
     { enabled: isActive && templateType === 'job' }
   )
 
   const jobTemplateDetailQuery = aapClient.useQuery(
     'get',
-    '/aap/job_templates/{job_template_id}',
+    '/proxies/aap/job_templates/{job_template_id}',
     {
       params: {
         path: { job_template_id: state.selectedTemplateId ?? 0 },
@@ -119,14 +119,14 @@ function useAAPQueries(
   // Workflow templates query
   const workflowTemplatesQuery = aapClient.useQuery(
     'get',
-    '/aap/workflow_job_templates',
+    '/proxies/aap/workflow_job_templates',
     { params: { query: buildSearchParams(state.templateSearch, credentialId, state.selectedOrg, integrationId) } },
     { enabled: isActive && templateType === 'workflow' }
   )
 
   const workflowTemplateDetailQuery = aapClient.useQuery(
     'get',
-    '/aap/workflow_job_templates/{workflow_job_template_id}',
+    '/proxies/aap/workflow_job_templates/{workflow_job_template_id}',
     {
       params: {
         path: { workflow_job_template_id: state.selectedTemplateId ?? 0 },
@@ -138,35 +138,35 @@ function useAAPQueries(
 
   const inventoriesQuery = aapClient.useQuery(
     'get',
-    '/aap/inventories',
+    '/proxies/aap/inventories',
     { params: { query: buildSearchParams(state.inventorySearch, credentialId, state.selectedOrg, integrationId) } },
     { enabled: isActive }
   )
 
   const execEnvsQuery = aapClient.useQuery(
     'get',
-    '/aap/execution_environments',
+    '/proxies/aap/execution_environments',
     { params: { query: buildSearchParams(state.execEnvSearch, credentialId, state.selectedOrg, integrationId) } },
     { enabled: isActive && templateType === 'job' } // Only needed for job templates
   )
 
   const credentialsQuery = aapClient.useQuery(
     'get',
-    '/aap/credentials',
+    '/proxies/aap/credentials',
     { params: { query: buildSearchParams(state.credentialSearch, credentialId, undefined, integrationId) } },
     { enabled: isActive && templateType === 'job' } // Only needed for job templates
   )
 
   const instanceGroupsQuery = aapClient.useQuery(
     'get',
-    '/aap/instance_groups',
+    '/proxies/aap/instance_groups',
     { params: { query: buildSearchParams(state.instanceGroupSearch, credentialId, undefined, integrationId) } },
     { enabled: isActive && templateType === 'job' } // Only needed for job templates
   )
 
   const labelsQuery = aapClient.useQuery(
     'get',
-    '/aap/labels',
+    '/proxies/aap/labels',
     { params: { query: buildSearchParams(state.labelSearch, credentialId, state.selectedOrg, integrationId) } },
     { enabled: isActive }
   )


### PR DESCRIPTION
## Description

Rename the AAP BFF proxy endpoints from `/api/v1/aap/` to `/api/v1/proxies/aap/` and the OpenAPI tag from "Ansible Automation Platform" to "Ansible Automation Platform Proxy". The current naming makes these endpoints look like they are the AAP API itself, when they are actually a proxy that forwards requests to an external AAP Controller. This is a breaking path change that must land before GA while there are no external consumers.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] Rename router prefix from `/aap` to `/proxies/aap` and tag from `"Ansible Automation Platform"` to `"Ansible Automation Platform Proxy"` in `backend/src/nexus/aap/router.py`
- [x] Update all 10 path entries and tags in OpenAPI sub-spec `backend/src/nexus/schemas/aap/openapi.yaml`
- [x] Regenerate bundled spec `backend/src/nexus/schemas/openapi.yaml`
- [x] Regenerate Python API client (`backend/src/api_client/`) — directory renamed from `ansible_automation_platform/` to `ansible_automation_platform_proxy/`
- [x] Regenerate TypeScript contracts (`frontend/packages/syntara-contracts/src/aap-api.ts`)
- [x] Update all 10 path literals in `frontend/packages/syntara-ui/src/hooks/useAAPBrowser.ts`
- [x] Update 9 MSW mock handler patterns in `frontend/packages/syntara-mock-api/src/handlers.ts`
- [x] Update all backend test files: `test_router.py`, `test_error_handlers.py`, `auth_exclusions.yml`, `endpoint_discovery.py`, `test_crud_endpoint_discovery.py`, `test_list_endpoint_discovery.py`

## Out of Scope

- The string `"Ansible Automation Platform"` used as a **credential type name** (in `credential_resolver.py`, `integration_service.py`, `preseed.py`, and test fixtures) is NOT renamed — it refers to the credential type, not the OpenAPI tag
- Node type discriminators (`aap_job_template`, `aap_workflow_job_template`) are NOT renamed — they are enum values, not URL paths
- Operator nginx proxy pass regex (`^/(api|docs|openapi)`) does not need updating since the path still starts with `/api`

## Related Issues

Closes AAP-85215

## How to Test

1. Start the backend: `make -C backend dev`
2. Start the frontend: `npm start` from `frontend/`
3. Navigate to the workflow builder and add an AAP Job Template or Workflow Template node
4. Verify the AAP resource browser (organizations, templates, inventories, etc.) loads correctly
5. Verify in browser DevTools Network tab that requests go to `/api/v1/proxies/aap/...` instead of `/api/v1/aap/...`

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps

## Additional Notes

- **25 files changed**, 121 insertions, 121 deletions — pure rename, no logic changes
- All 10,126 backend unit tests pass
- Frontend TypeScript compilation passes
- Frontend `useAAPBrowser` hook tests (21 tests) pass
- The API client directory was automatically renamed from `ansible_automation_platform/` to `ansible_automation_platform_proxy/` by the code generator following the tag rename