### PR TITLE
fix(AAP-86300): add is_builtin guard to update_version_metadata

### DIFF
--- a/backend/src/syntara/workflows/services/workflow_service.py
+++ b/backend/src/syntara/workflows/services/workflow_service.py
@@ -903,7 +903,10 @@ class WorkflowService(BaseService):
             WorkflowVersionNotFoundError: If version not found
 
         """
-        await self.get_workflow_by_id(workflow_id)
+        workflow = await self.get_workflow_by_id(workflow_id)
+        if workflow.is_builtin:
+            raise BuiltinWorkflowModifyError(workflow.name)
+
         version_record = await self._get_version_or_none(workflow_id, version)
         if not version_record:
             raise WorkflowVersionNotFoundError(workflow_id, version)

--- a/backend/src/syntara/workflows/services/workflow_service.py
+++ b/backend/src/syntara/workflows/services/workflow_service.py
@@ -900,6 +900,7 @@ class WorkflowService(BaseService):
 
         Raises:
             WorkflowNotFoundError: If workflow not found
+            BuiltinWorkflowModifyError: If workflow is builtin
             WorkflowVersionNotFoundError: If version not found
 
         """

--- a/backend/tests/integration/workflows/services/test_workflow_service.py
+++ b/backend/tests/integration/workflows/services/test_workflow_service.py
@@ -2454,6 +2454,20 @@ class TestBuiltinWorkflowGuards(TestWorkflowServiceBase):
         assert result.published_version_id is None
 
     @pytest.mark.asyncio
+    async def test_update_version_metadata_non_builtin_workflow_succeeds(
+        self, test_db_session: AsyncSession, test_user: User, test_project_id: UUID
+    ) -> None:
+        workflow = self._create_test_workflow(name="Normal WF", created_by=test_user.id, project_id=test_project_id)
+        version = self._create_test_workflow_version(workflow_id=workflow.id, created_by=test_user.id)
+        test_db_session.add(workflow)
+        test_db_session.add(version)
+        await test_db_session.flush()
+
+        service = WorkflowService(test_db_session, test_user)
+        result = await service.update_version_metadata(workflow.id, version=1, change_description="valid edit")
+        assert result.change_description == "valid edit"
+
+    @pytest.mark.asyncio
     async def test_update_version_metadata_builtin_workflow_raises(
         self, test_db_session: AsyncSession, test_user: User, test_project_id: UUID
     ) -> None:

--- a/backend/tests/integration/workflows/services/test_workflow_service.py
+++ b/backend/tests/integration/workflows/services/test_workflow_service.py
@@ -2454,6 +2454,22 @@ class TestBuiltinWorkflowGuards(TestWorkflowServiceBase):
         assert result.published_version_id is None
 
     @pytest.mark.asyncio
+    async def test_update_version_metadata_builtin_workflow_raises(
+        self, test_db_session: AsyncSession, test_user: User, test_project_id: UUID
+    ) -> None:
+        workflow = self._create_test_workflow(
+            name="Builtin WF", created_by=test_user.id, is_builtin=True, project_id=test_project_id
+        )
+        version = self._create_test_workflow_version(workflow_id=workflow.id, created_by=test_user.id)
+        test_db_session.add(workflow)
+        test_db_session.add(version)
+        await test_db_session.flush()
+
+        service = WorkflowService(test_db_session, test_user)
+        with pytest.raises(BuiltinWorkflowModifyError, match="Builtin WF"):
+            await service.update_version_metadata(workflow.id, version=1, change_description="sneaky edit")
+
+    @pytest.mark.asyncio
     async def test_create_workflow_in_builtin_project_raises(
         self, test_db_session: AsyncSession, test_user: User
     ) -> None:

--- a/backend/tests/unit/workflows/services/test_workflow_service_uncovered.py
+++ b/backend/tests/unit/workflows/services/test_workflow_service_uncovered.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from syntara.workflows.exceptions import WorkflowVersionConflictError
+from syntara.workflows.exceptions import BuiltinWorkflowModifyError, WorkflowVersionConflictError
 from syntara.workflows.services.workflow_service import WorkflowService
 
 
@@ -136,7 +136,8 @@ class TestUpdateVersionMetadata:
         """Verify name is set when included in default fields_set."""
         workflow_id = uuid4()
         version_record = MagicMock()
-        mock_service.get_workflow_by_id = AsyncMock()  # type: ignore[method-assign]
+        mock_workflow = MagicMock(is_builtin=False)
+        mock_service.get_workflow_by_id = AsyncMock(return_value=mock_workflow)  # type: ignore[method-assign]
         mock_service._get_version_or_none = AsyncMock(return_value=version_record)  # type: ignore[method-assign]
 
         result = await mock_service.update_version_metadata(workflow_id, 1, name="New Name")
@@ -149,7 +150,8 @@ class TestUpdateVersionMetadata:
         """Verify change_description is set when included in default fields_set."""
         workflow_id = uuid4()
         version_record = MagicMock()
-        mock_service.get_workflow_by_id = AsyncMock()  # type: ignore[method-assign]
+        mock_workflow = MagicMock(is_builtin=False)
+        mock_service.get_workflow_by_id = AsyncMock(return_value=mock_workflow)  # type: ignore[method-assign]
         mock_service._get_version_or_none = AsyncMock(return_value=version_record)  # type: ignore[method-assign]
 
         await mock_service.update_version_metadata(workflow_id, 1, change_description="Updated")
@@ -162,7 +164,8 @@ class TestUpdateVersionMetadata:
         workflow_id = uuid4()
         version_record = MagicMock()
         version_record.change_description = "Original"
-        mock_service.get_workflow_by_id = AsyncMock()  # type: ignore[method-assign]
+        mock_workflow = MagicMock(is_builtin=False)
+        mock_service.get_workflow_by_id = AsyncMock(return_value=mock_workflow)  # type: ignore[method-assign]
         mock_service._get_version_or_none = AsyncMock(return_value=version_record)  # type: ignore[method-assign]
 
         await mock_service.update_version_metadata(workflow_id, 1, name="Only Name", fields_set={"name"})
@@ -175,13 +178,24 @@ class TestUpdateVersionMetadata:
         """Empty fields_set means no mutations and no commit."""
         workflow_id = uuid4()
         version_record = MagicMock()
-        mock_service.get_workflow_by_id = AsyncMock()  # type: ignore[method-assign]
+        mock_workflow = MagicMock(is_builtin=False)
+        mock_service.get_workflow_by_id = AsyncMock(return_value=mock_workflow)  # type: ignore[method-assign]
         mock_service._get_version_or_none = AsyncMock(return_value=version_record)  # type: ignore[method-assign]
 
         result = await mock_service.update_version_metadata(workflow_id, 1, fields_set=set())
 
         assert result is version_record
         mock_service.session.commit.assert_not_called()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_builtin_workflow_raises(self, mock_service: WorkflowService) -> None:
+        """Built-in workflows must not allow version metadata updates."""
+        workflow_id = uuid4()
+        mock_workflow = MagicMock(is_builtin=True, name="Builtin WF")
+        mock_service.get_workflow_by_id = AsyncMock(return_value=mock_workflow)  # type: ignore[method-assign]
+
+        with pytest.raises(BuiltinWorkflowModifyError, match="Builtin WF"):
+            await mock_service.update_version_metadata(workflow_id, 1, change_description="sneaky edit")
 
 
 class TestRestoreWorkflowVersionSourceLabel:


### PR DESCRIPTION
## Description

Adds the missing `is_builtin` guard to `WorkflowService.update_version_metadata`. This method was the only workflow mutation endpoint that did not check `workflow.is_builtin`, allowing users to modify version metadata (name, change_description) on built-in workflows that should be immutable.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- [x] Add `is_builtin` check to `WorkflowService.update_version_metadata` — raises `BuiltinWorkflowModifyError` consistent with all sibling mutation methods
- [x] Add unit test for the new guard (`TestUpdateVersionMetadata::test_builtin_workflow_raises`)
- [x] Add integration test (`TestBuiltinWorkflowGuards::test_update_version_metadata_builtin_workflow_raises`)
- [x] Update existing unit tests to set `is_builtin=False` on mock workflow objects

## Out of Scope

## Related Issues

Closes AAP-86300

## How to Test

1. Identify a built-in workflow ID
2. `PATCH /api/v1/workflows/{builtin_id}/versions/1` with `{"change_description": "sneaky edit"}`
3. Verify HTTP 403 `BUILTIN_WORKFLOW_MODIFY_FORBIDDEN` is returned

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] ~~Database migrations are included if schema changed~~ N/A
- [x] No sensitive information (keys, passwords, etc.) is included

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] ~~I have updated relevant documentation~~ N/A
- [x] No secrets or credentials are included in this PR
- [ ] ~~Breaking changes are documented with migration steps~~ N/A