### PR TITLE
doc(AAP-83333): pass arbitrary payload in EDA webhook playbook and rulebook

### DIFF
--- a/backend/samples/playbooks/eda-trigger-playbook.yml
+++ b/backend/samples/playbooks/eda-trigger-playbook.yml
@@ -3,17 +3,15 @@
 #
 # Called as a rulebook action to fire an EDA trigger endpoint.
 # Obtains an OAuth token via client credentials, then POSTs the
-# event payload to the webhook.
+# entire event payload (as-is) to the webhook.
 #
 # Usage:
 #   ansible-playbook eda-trigger-webhook.yml \
 #     -e webhook_base_url=https://syntara.example.com \
 #     -e webhook_path=my-eda-trigger \
-#     -e webhook_client_id=nx_sa_abc123 \
-#     -e webhook_client_secret=<secret> \
-#     -e alert_name=high_cpu \
-#     -e instance=web-server-01 \
-#     -e severity=critical
+#     -e client_id=nx_sa_abc123 \
+#     -e client_secret=<secret> \
+#     -e '{"event_payload": {"alert_name": "high_cpu", "instance": "web-server-01"}}'
 
 - name: Trigger EDA webhook
   hosts: localhost
@@ -21,13 +19,11 @@
   gather_facts: false
 
   vars:
-    webhook_base_url: "https://localhost:8000"
+    base_url: "https://localhost:8000"
     webhook_path: ""
-    webhook_client_id: ""
-    webhook_client_secret: ""
-    alert_name: "test_alert"
-    instance: "localhost"
-    severity: "info"
+    client_id: ""
+    client_secret: ""
+    event_payload: {}
 
   tasks:
     - name: Obtain OAuth token
@@ -51,12 +47,7 @@
         headers:
           Authorization: "Bearer {{ token_response.json.access_token }}"
           Content-Type: application/json
-        body:
-          event: "{{ alert_name }}"
-          payload:
-            instance: "{{ instance }}"
-            severity: "{{ severity }}"
-            timestamp: "{{ ansible_date_time.iso8601 | default(omit) }}"
+        body: "{{ event_payload }}"
         status_code: 202
         validate_certs: "{{ webhook_validate_certs | default(true) }}" # set to false for local dev with self-signed certs
       register: webhook_response

--- a/backend/samples/playbooks/eda-trigger-rulebook.yml
+++ b/backend/samples/playbooks/eda-trigger-rulebook.yml
@@ -1,7 +1,7 @@
 ---
 # Rulebook: Forward webhook events to the workflow trigger
 #
-# Listens for incoming webhook events and triggers an EDA
+# Listens for incoming events and triggers an EDA
 # webhook endpoint via a job template.
 #
 # The job template's credential (custom type) provides webhook_base_url,
@@ -19,7 +19,7 @@
         port: 5000
 
   rules:
-    - name: Forward all webhook events to the workflow trigger
+    - name: Forward all events to the workflow trigger
       condition: event.payload is defined
       action:
         run_job_template:
@@ -28,6 +28,4 @@
           job_args:
             extra_vars:
               webhook_path: "{{ webhook_path }}"
-              alert_name: "{{ event.payload.alert_name | default('unknown') }}"
-              instance: "{{ event.payload.instance | default('unknown') }}"
-              severity: "{{ event.payload.severity | default('info') }}"
+              event_payload: "{{ event.payload }}"


### PR DESCRIPTION
## Description

Updates the sample EDA playbook and rulebook to forward any arbitrary JSON payload instead of hardcoding specific fields (`alert_name`, `instance`, `severity`). This makes the samples usable with any event source without modification. Follows up on AAP-83333 which added service account Bearer token auth for webhook triggers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- [x] Replace hardcoded `alert_name`/`instance`/`severity` vars with a single `event_payload` dict in `eda-trigger-webhook.yml`
- [x] POST body now sends `{{ event_payload }}` directly instead of a fixed structure
- [x] Rulebook forwards `event.payload` as-is instead of cherry-picking individual fields

## Related Issues

Follows up AAP-83333

## Backend Checklist

- [x] No sensitive information (keys, passwords, etc.) is included

## General Checklist

- [x] Code follows the project's coding conventions
- [x] No secrets or credentials are included in this PR