### PR TITLE
feat(containers): make builder image configurable for community builds

### DIFF
--- a/.tekton/ansible-automation-orchestrator-backend-devel-pull-request.yaml
+++ b/.tekton/ansible-automation-orchestrator-backend-devel-pull-request.yaml
@@ -39,6 +39,7 @@ spec:
         - CONTAINER_IMAGE_VERSION={{revision}}
         - DOWNSTREAM_OVERRIDE=quay.io/redhat-user-workloads/nexus-tenant/ansible-automation-platform/automation-orchestrator-downstream-override@sha256:2c388549b6eb79f56a83468f60f821319ed48602fbd5b609f3af1508cb7e918c
         - BRANDING=true
+        - BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform/uv-builder-rhel9:latest@sha256:bdd64fcb4597cfb665c15c4b4841ded098baa26dce1f544b4dbd17a575b8984a
     - name: build-platforms
       value:
         - linux-c8xlarge/amd64

--- a/.tekton/ansible-automation-orchestrator-backend-devel-push.yaml
+++ b/.tekton/ansible-automation-orchestrator-backend-devel-push.yaml
@@ -36,6 +36,7 @@ spec:
         - CONTAINER_IMAGE_VERSION={{revision}}
         - DOWNSTREAM_OVERRIDE=quay.io/redhat-user-workloads/nexus-tenant/ansible-automation-platform/automation-orchestrator-downstream-override@sha256:2c388549b6eb79f56a83468f60f821319ed48602fbd5b609f3af1508cb7e918c
         - BRANDING=true
+        - BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform/uv-builder-rhel9:latest@sha256:bdd64fcb4597cfb665c15c4b4841ded098baa26dce1f544b4dbd17a575b8984a
     - name: build-platforms
       value:
         - linux-c8xlarge/amd64

--- a/.tekton/ansible-automation-orchestrator-backend-early-access-pull-request.yaml
+++ b/.tekton/ansible-automation-orchestrator-backend-early-access-pull-request.yaml
@@ -39,6 +39,7 @@ spec:
         - CONTAINER_IMAGE_VERSION={{revision}}
         - DOWNSTREAM_OVERRIDE=quay.io/redhat-user-workloads/nexus-tenant/ansible-automation-platform/automation-orchestrator-downstream-override@sha256:2c388549b6eb79f56a83468f60f821319ed48602fbd5b609f3af1508cb7e918c
         - BRANDING=true
+        - BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform/uv-builder-rhel9:latest@sha256:bdd64fcb4597cfb665c15c4b4841ded098baa26dce1f544b4dbd17a575b8984a
     - name: build-platforms
       value:
         - linux-c8xlarge/amd64

--- a/.tekton/ansible-automation-orchestrator-backend-early-access-push.yaml
+++ b/.tekton/ansible-automation-orchestrator-backend-early-access-push.yaml
@@ -36,6 +36,7 @@ spec:
         - CONTAINER_IMAGE_VERSION={{revision}}
         - DOWNSTREAM_OVERRIDE=quay.io/redhat-user-workloads/nexus-tenant/ansible-automation-platform/automation-orchestrator-downstream-override@sha256:2c388549b6eb79f56a83468f60f821319ed48602fbd5b609f3af1508cb7e918c
         - BRANDING=true
+        - BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform/uv-builder-rhel9:latest@sha256:bdd64fcb4597cfb665c15c4b4841ded098baa26dce1f544b4dbd17a575b8984a
     - name: build-platforms
       value:
         - linux-c8xlarge/amd64

--- a/backend/containers/nexus/Containerfile
+++ b/backend/containers/nexus/Containerfile
@@ -2,10 +2,11 @@
 # Defaults to scratch (empty, built-in) so builds without --build-arg succeed.
 ARG DOWNSTREAM_OVERRIDE=scratch
 ARG BRANDING=false
+ARG BUILDER_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
 
 FROM ${DOWNSTREAM_OVERRIDE} AS override
 
-FROM registry.redhat.io/ansible-automation-platform/uv-builder-rhel9:latest@sha256:bdd64fcb4597cfb665c15c4b4841ded098baa26dce1f544b4dbd17a575b8984a AS builder
+FROM ${BUILDER_IMAGE} AS builder
 
 ARG BRANDING
 
@@ -24,8 +25,15 @@ ENV PYTHON=python3.12 \
 
 WORKDIR /opt/app-root/src
 
-# regopy links against libatomic at build time
-RUN dnf install --setopt=install_weak_deps=0 --nodocs -y libatomic && dnf clean all
+# Build tools required by regopy (C/C++ compiler, cmake, ninja) and its
+# setup.py (git).  uv is the project's package manager.
+# When BUILDER_IMAGE is overridden to uv-builder-rhel9, these are already
+# present and the installs are no-ops.
+RUN dnf install --setopt=install_weak_deps=0 --nodocs -y \
+        gcc gcc-c++ cmake ninja-build git libatomic \
+    && dnf clean all \
+    && pip3.12 install --no-cache-dir uv \
+    && [ -f /usr/local/bin/uv ] || ln -s "$(command -v uv)" /usr/local/bin/uv
 
 # Copy dependency files first (for layer caching)
 COPY pyproject.toml uv.lock LICENSE README.md alembic.ini ./

--- a/backend/containers/nexus/Containerfile
+++ b/backend/containers/nexus/Containerfile
@@ -2,7 +2,7 @@
 # Defaults to scratch (empty, built-in) so builds without --build-arg succeed.
 ARG DOWNSTREAM_OVERRIDE=scratch
 ARG BRANDING=false
-ARG BUILDER_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
+ARG BUILDER_IMAGE=registry.access.redhat.com/ubi9/python-312@sha256:c95de2fee424548cc530c671cda0c77433801d88bdeb66d75f0101490fe3e269
 
 FROM ${DOWNSTREAM_OVERRIDE} AS override
 

--- a/backend/containers/nexus/Containerfile
+++ b/backend/containers/nexus/Containerfile
@@ -27,13 +27,13 @@ WORKDIR /opt/app-root/src
 
 # Build tools required by regopy (C/C++ compiler, cmake, ninja) and its
 # setup.py (git).  uv is the project's package manager.
-# When BUILDER_IMAGE is overridden to uv-builder-rhel9, these are already
-# present and the installs are no-ops.
+# When BUILDER_IMAGE is overridden to uv-builder-rhel9, the dnf packages
+# are already present (no-ops) and the uv guard skips the pip install.
 RUN dnf install --setopt=install_weak_deps=0 --nodocs -y \
-        gcc gcc-c++ cmake ninja-build git libatomic \
+        cmake gcc gcc-c++ git libatomic ninja-build \
     && dnf clean all \
-    && pip3.12 install --no-cache-dir uv \
-    && [ -f /usr/local/bin/uv ] || ln -s "$(command -v uv)" /usr/local/bin/uv
+    && (command -v uv >/dev/null 2>&1 || pip3.12 install --no-cache-dir uv==0.12.3) \
+    && [ -f /usr/local/bin/uv ] || { command -v uv && ln -s "$(command -v uv)" /usr/local/bin/uv; }
 
 # Copy dependency files first (for layer caching)
 COPY pyproject.toml uv.lock LICENSE README.md alembic.ini ./

--- a/backend/containers/nexus/Containerfile
+++ b/backend/containers/nexus/Containerfile
@@ -2,7 +2,7 @@
 # Defaults to scratch (empty, built-in) so builds without --build-arg succeed.
 ARG DOWNSTREAM_OVERRIDE=scratch
 ARG BRANDING=false
-ARG BUILDER_IMAGE=registry.access.redhat.com/ubi9/python-312@sha256:c95de2fee424548cc530c671cda0c77433801d88bdeb66d75f0101490fe3e269
+ARG BUILDER_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
 
 FROM ${DOWNSTREAM_OVERRIDE} AS override
 


### PR DESCRIPTION
## Summary

- Replace the hardcoded private `uv-builder-rhel9` base image in the backend
  Containerfile with a configurable `BUILDER_IMAGE` ARG that defaults to the
  public `ubi9/python-312` image.
- Install required build tools (`gcc`, `gcc-c++`, `cmake`, `ninja-build`,
  `git`, `uv`) explicitly so community contributors can build without Red Hat
  registry credentials.
- Downstream Konflux builds override `BUILDER_IMAGE` via `--build-arg` to
  continue using the internal image, where these tools are pre-installed.

## What changed

`backend/containers/nexus/Containerfile`:

1. Added `ARG BUILDER_IMAGE=registry.access.redhat.com/ubi9/python-312:latest`
   alongside the existing global ARGs.
2. Replaced the pinned `FROM registry.redhat.io/…/uv-builder-rhel9:…` with
   `FROM ${BUILDER_IMAGE}`.
3. Expanded the `dnf install` step to include `gcc`, `gcc-c++`, `cmake`,
   `ninja-build`, and `git` (previously provided by the private base image).
4. Added `pip3.12 install uv` with a symlink fallback to `/usr/local/bin/uv`
   so the runtime stage COPY continues to work.

## Test plan

- [ ] Community build (no registry credentials):
      `podman build -f containers/nexus/Containerfile -t syntara-backend .`
      from `backend/` — verify regopy compiles and all 147 packages install.
- [ ] Downstream build (simulates Konflux override):
      `podman build --build-arg BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform/uv-builder-rhel9:latest -f containers/nexus/Containerfile -t syntara-backend-downstream .`
      — verify existing behavior is unchanged.
- [ ] Smoke test the image:
      `podman run --rm syntara-backend python3.12 -c "import regopy; print('regopy OK')"`
      `podman run --rm syntara-backend uv --version`
- [ ] Verify uv is at `/usr/local/bin/uv` in the final image.

Made with [Cursor](https://cursor.com)