### PR TITLE
feat(tests): add dynamic xfail from URL

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -387,6 +387,7 @@ jobs:
       UV_PYTHON: ${{ matrix.python-version }}
       DOCKER_HOST: unix:///var/run/docker.sock
       TESTCONTAINERS_RYUK_DISABLED: "true"
+      XFAIL_URL: https://raw.githubusercontent.com/goneri/goneri-nexus-xfail/refs/heads/main/backend.md
 
     steps:
       - name: Checkout code
@@ -428,6 +429,7 @@ jobs:
       UV_PYTHON: ${{ matrix.python-version }}
       DOCKER_HOST: unix:///var/run/docker.sock
       TESTCONTAINERS_RYUK_DISABLED: "true"
+      XFAIL_URL: https://raw.githubusercontent.com/goneri/goneri-nexus-xfail/refs/heads/main/backend.md
 
     steps:
       - name: Checkout code
@@ -470,6 +472,7 @@ jobs:
       DOCKER_HOST: unix:///var/run/docker.sock
       TESTCONTAINERS_RYUK_DISABLED: "true"
       PYTEST_XDIST_AUTO_NUM_WORKERS: "8"
+      XFAIL_URL: https://raw.githubusercontent.com/goneri/goneri-nexus-xfail/refs/heads/main/backend.md
 
     steps:
       - name: Checkout code
@@ -515,6 +518,8 @@ jobs:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      XFAIL_URL: https://raw.githubusercontent.com/goneri/goneri-nexus-xfail/refs/heads/main/backend.md
     steps:
       - name: Free disk space
         run: |

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -19,6 +19,8 @@ REDIS_IMAGE ?= mirror.gcr.io/library/redis:6
 APP_IMAGE ?= localhost/syntara:latest
 APP_UI_IMAGE ?= quay.io/ansible/syntara-ui
 APP_UI_VERSION ?= latest
+XFAIL_URL ?=
+XFAIL_ARGS := $(if $(XFAIL_URL),--xfail-from-url $(XFAIL_URL),)
 ifeq ($(shell uname -s),Darwin)
 # macOS: try podman machine inspect first (works for any machine name),
 # then the standard symlink, then Homebrew's common location
@@ -100,7 +102,7 @@ define run-tests
 @PODMAN_SOCK="$(PODMAN_SOCK)" POSTGRES_IMAGE="$(POSTGRES_IMAGE)" REDIS_IMAGE="$(REDIS_IMAGE)" \
 	APP_JWT_PRIVATE_KEY_PATH=.secrets/jwt-primary.pem \
 	./tools/scripts/run-with-testcontainers.sh --label "🧪 Running tests" -- \
-	uv run --no-sync pytest $(1)
+	uv run --no-sync pytest $(XFAIL_ARGS) $(1)
 endef
 
 
@@ -130,7 +132,7 @@ ifndef APP_BASE_URL
 	$(call _e2e-run,tests/ -v -m "mcp")
 else
 	@echo "🧪 Running MCP tests..."
-	uv run --no-sync pytest tests/ -v -m "mcp"
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/ -v -m "mcp"
 endif
 
 .PHONY: test-performance
@@ -139,7 +141,7 @@ ifndef APP_BASE_URL
 	$(call _e2e-run,tests/performance/ -v --run-performance)
 else
 	@echo "🧪 Running performance tests..."
-	uv run --no-sync pytest tests/performance/ -v --run-performance
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/performance/ -v --run-performance
 endif
 
 
@@ -189,7 +191,7 @@ test-all: check-deps ## Run all tests (unit + integration; E2E runs separately v
 # Usage: $(call _e2e-run,<pytest-args>)
 define _e2e-run
 @COMPOSE_CMD="$(COMPOSE_FINAL_CMD)" \
-	./tools/scripts/e2e-run.sh $(1)
+	./tools/scripts/e2e-run.sh $(XFAIL_ARGS) $(1)
 endef
 
 # Default to empty so it runs all tests if not provided
@@ -203,7 +205,7 @@ ifndef APP_BASE_URL
 	$(call _e2e-run,tests/e2e/$(E2E_TARGET) -v -m "not global_revocation" $(E2E_ARGS))
 else
 	@echo "🧪 Running E2E tests $(if $(PHASE),for phase $(PHASE),$(if $(EXCLUDE),excluding phase $(EXCLUDE),))..."
-	uv run --no-sync pytest tests/e2e/$(E2E_TARGET) -v -m "not global_revocation" $(E2E_ARGS)
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/e2e/$(E2E_TARGET) -v -m "not global_revocation" $(E2E_ARGS)
 endif
 
 .PHONY: test-e2e-global-revocation
@@ -212,7 +214,7 @@ ifndef APP_BASE_URL
 	$(call _e2e-run,tests/e2e/ -v -m global_revocation)
 else
 	@echo "🧪 Running global revocation E2E tests..."
-	uv run --no-sync pytest tests/e2e/ -v -m global_revocation; \
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/e2e/ -v -m global_revocation; \
 	exitcode=$$?; \
 	if [ $$exitcode -eq 5 ]; then echo "⚠️  No global revocation tests found — all migrated downstream"; exit 0; fi; \
 	exit $$exitcode
@@ -230,11 +232,11 @@ test-e2e-exclude-pr-check: ## Run E2E tests excluding PR checks (alias for: make
 .PHONY: test-e2e-telemetry
 test-e2e-telemetry: check-deps ## Run telemetry E2E tests only
 ifndef APP_BASE_URL
-	$(call _e2e-run,tests/e2e/telemetry/ -v -n auto --dist loadscope --ignore=tests/e2e/telemetry/test_performance_and_resilience.py && APP_BASE_URL=$${APP_BASE_URL:-http://localhost:8000} uv run --no-sync pytest tests/e2e/telemetry/test_performance_and_resilience.py -v)
+	$(call _e2e-run,tests/e2e/telemetry/ -v -n auto --dist loadscope --ignore=tests/e2e/telemetry/test_performance_and_resilience.py && APP_BASE_URL=$${APP_BASE_URL:-http://localhost:8000} uv run --no-sync pytest $(XFAIL_ARGS) tests/e2e/telemetry/test_performance_and_resilience.py -v)
 else
 	@echo "🧪 Running telemetry E2E tests..."
-	uv run --no-sync pytest tests/e2e/telemetry/ -v -n auto --dist loadscope --ignore=tests/e2e/telemetry/test_performance_and_resilience.py && \
-	uv run --no-sync pytest tests/e2e/telemetry/test_performance_and_resilience.py -v
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/e2e/telemetry/ -v -n auto --dist loadscope --ignore=tests/e2e/telemetry/test_performance_and_resilience.py && \
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/e2e/telemetry/test_performance_and_resilience.py -v
 endif
 
 # Development workflow

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -305,6 +305,7 @@ markers = [
     "compliance: marks tests as compliance tests (auth coverage, API contract enforcement)",
     "destructive: marks tests that mutate live cluster state (e.g. HPA autoscaling) — excluded from routine runs",
     "k8s_required: marks tests that need KUBECONFIG + PERF_K8S_NAMESPACE to reach a Kubernetes cluster",
+    "xfail_from_url: dynamically applied by --xfail-from-url from a remote URL",
 ]
 
 # Coverage configuration

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,8 @@ nexus.* imports happen AFTER pytest-cov starts its coverage tracer.
 pytest_plugins = [
     # Logging setup, performance marker, worker_id fixture, and cleanup hooks
     "tests.fixtures.hooks",
+    # Dynamic xfail from remote URL (enabled via --xfail-from-url)
+    "tests.fixtures.xfail_from_url",
     # Shared fixtures used across unit, integration, performance, and E2E tests
     "tests.fixtures.database",
     "tests.fixtures.users",

--- a/backend/tests/fixtures/xfail_from_url.py
+++ b/backend/tests/fixtures/xfail_from_url.py
@@ -1,0 +1,108 @@
+"""Dynamically xfail tests listed at a remote URL.
+
+When ``--xfail-from-url`` is passed, fetches a Markdown file and parses
+``# `` headings as test node-id patterns.  The text below each heading is
+used as the xfail reason.  Each entry can be a directory, file, or full
+test node-id — matching tests are marked *xfail*.
+
+If the fetch fails (network, auth, …) the run continues without marking
+anything (fail-open).
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+import pytest
+import structlog
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("url_xfail", "dynamic xfail from URL")
+    group.addoption(
+        "--xfail-from-url",
+        default=None,
+        help="URL of a Markdown file listing tests to mark as xfail",
+    )
+
+
+def _fetch_xfail_file(url: str) -> str | None:
+    """Fetch the xfail Markdown file from a URL."""
+    try:
+        response = httpx.get(url, timeout=30, follow_redirects=True)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning("url_xfail: failed to fetch file", url=url, error=str(exc))
+        return None
+
+    return response.text
+
+
+_HEADING_RE = re.compile(r"^#\s+(.+)$")
+
+
+def _parse_xfail_entries(content: str) -> list[tuple[str, str]]:
+    """Parse H1 headings as test node-ids with the following text as the reason."""
+    entries: list[tuple[str, str]] = []
+    current_pattern: str | None = None
+    reason_lines: list[str] = []
+
+    def _flush() -> None:
+        if current_pattern is not None:
+            reason = " ".join(reason_lines).strip() or "listed in xfail list"
+            entries.append((current_pattern, reason))
+
+    for line in content.splitlines():
+        match = _HEADING_RE.match(line.strip())
+        if match:
+            _flush()
+            current_pattern = match.group(1).strip()
+            reason_lines = []
+        elif current_pattern is not None:
+            stripped = line.strip()
+            if stripped:
+                reason_lines.append(stripped)
+
+    _flush()
+    return entries
+
+
+def _matches(nodeid: str, pattern: str) -> bool:
+    """Check whether *nodeid* matches *pattern*.
+
+    A pattern is treated as a prefix when it looks like a directory or file
+    path (no ``::``), and as an exact match otherwise.
+    """
+    if "::" in pattern:
+        return nodeid == pattern
+    return nodeid.startswith(pattern)
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    url: str | None = config.getoption("--xfail-from-url")
+    if not url:
+        return
+    content = _fetch_xfail_file(url)
+    if content is None:
+        return
+
+    entries = _parse_xfail_entries(content)
+    if not entries:
+        logger.info("url_xfail: no patterns found in file")
+        return
+
+    patterns = [e[0] for e in entries]
+    logger.info("url_xfail: loaded patterns", count=len(entries), patterns=patterns)
+
+    matched = 0
+    for item in items:
+        for pattern, reason in entries:
+            if _matches(item.nodeid, pattern):
+                item.add_marker(pytest.mark.xfail(reason=f"url xfail: {reason}"))
+                matched += 1
+                break
+
+    logger.info("url_xfail: marked tests", matched=matched, total=len(items))


### PR DESCRIPTION
Add a pytest plugin (--xfail-from-url <URL>) that fetches a Markdown file
listing test node-ids to mark as xfail. H1 headings are parsed as test
patterns and the body text below each heading is used as the xfail reason.

The Makefile plumbs an optional XFAIL_URL variable through all pytest
invocations. The default is empty (disabled locally); CI workflows set it
to the external xfail repo.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
