### PR TITLE
fix: move Swagger UI out of /api to fix auth issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,7 +102,7 @@ APP_OPENAPI_VALIDATION_ENABLED=true
 APP_ROUTER_DISCOVERY_ENABLED=true
 
 # API Documentation Endpoints
-# Serve /docs, /redoc, and /openapi.json. Disabled by default for production security.
+# Serve Swagger/ReDoc/OpenAPI at /api_docs/v1/ (plus /docs redirect). Disabled by default for production security.
 # Set to true here for local development only — do NOT copy this value to production.
 APP_ENABLE_API_DOCS=true
 # Enable the Swagger UI "Try it out" button. Defaults to false.

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -40,8 +40,11 @@ jobs:
 
       - name: Start services with podman-compose
         timeout-minutes: 5
+        env:
+          # RapidAST loads the live OpenAPI spec; docs must be enabled for that endpoint.
+          APP_ENABLE_API_DOCS: "true"
         run: |
-          uvx podman-compose -p syntara-ci up --build -d database redis temporal syntara
+          uvx podman-compose -f ../podman-compose.yml -p syntara-ci up --build -d database redis temporal syntara
         working-directory: backend
 
       - name: Verify services are healthy
@@ -88,11 +91,11 @@ jobs:
         if: failure()
         run: |
           echo "=== Compose logs ==="
-          uvx podman-compose -p syntara-ci logs database redis temporal syntara
+          uvx podman-compose -f ../podman-compose.yml -p syntara-ci logs database redis temporal syntara
         working-directory: backend
 
       - name: Cleanup
         if: always()
         run: |
-          uvx podman-compose -p syntara-ci down -v || true
+          uvx podman-compose -f ../podman-compose.yml -p syntara-ci down -v || true
         working-directory: backend

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -119,7 +119,7 @@ APP_OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 APP_OPENAPI_VALIDATION_ENABLED=true
 
 # API Documentation Endpoints
-# Serve /docs, /redoc, and /openapi.json. Disabled by default for production security.
+# Serve Swagger/ReDoc/OpenAPI at /api_docs/v1/ (plus /docs redirect). Disabled by default for production security.
 # Set to true here for local development only — do NOT copy this value to production.
 APP_ENABLE_API_DOCS=true
 # Enable the Swagger UI "Try it out" button. Defaults to false.

--- a/backend/README.md
+++ b/backend/README.md
@@ -740,7 +740,7 @@ curl http://localhost:8000/metrics
 
 ### `/_internal/metrics/*` — Performance-Testing JSON API
 
-A set of hidden JSON endpoints for querying raw, in-memory metric records during performance-testing or debugging sessions. These routes are **not** listed in `/docs` or `/openapi.json`.
+A set of hidden JSON endpoints for querying raw, in-memory metric records during performance-testing or debugging sessions. These routes are **not** listed in `/api_docs/v1/docs` or `/api_docs/v1/openapi.json`.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|

--- a/backend/dast/rapidast-config.yaml
+++ b/backend/dast/rapidast-config.yaml
@@ -8,11 +8,14 @@
 #   Automatically invoked by .github/workflows/dast.yml
 #
 # Usage (local, with Nexus running via podman-compose on localhost:8000):
+#   APP_ENABLE_API_DOCS=true uv run podman-compose -f ../podman-compose.yml up -d syntara
 #   podman run --rm --network=host \
 #     -v ./dast/rapidast-config.yaml:/opt/rapidast/config/config.yaml:z \
 #     -v ./dast/results:/opt/rapidast/results:z \
 #     quay.io/redhatproductsecurity/rapidast:latest \
 #     --config /opt/rapidast/config/config.yaml
+#
+# Docs must be enabled: RapidAST fetches /api_docs/v1/openapi.json (gated by APP_ENABLE_API_DOCS).
 
 config:
   configVersion: 6
@@ -35,7 +38,7 @@ scanners:
   zap:
     apiScan:
       apis:
-        apiUrl: "http://localhost:8000/openapi.json"
+        apiUrl: "http://localhost:8000/api_docs/v1/openapi.json"
 
     passiveScan:
       disabledRules: "2,10015,10024,10027,10054,10096,10109,10112"

--- a/backend/src/syntara/api/constants.py
+++ b/backend/src/syntara/api/constants.py
@@ -7,6 +7,7 @@ For configurable values, use get_settings() from syntara.core.config.base.
 # API configuration
 
 API_V1_PATH_PREFIX = "/api/v1"
+API_DOCS_V1_PATH_PREFIX = "/api_docs/v1"
 API_V1_VERSION = "1.0.0"
 
 # Full path to the OIDC callback endpoint, used by the auth router and
@@ -24,12 +25,13 @@ EXCLUDED_PATHS: frozenset[str] = frozenset(
         "/healthz/ready",
         "/api",
         "/api/v1",
-        f"{API_V1_PATH_PREFIX}/docs",
-        f"{API_V1_PATH_PREFIX}/redoc",
-        f"{API_V1_PATH_PREFIX}/openapi.json",
+        "/docs",
+        f"{API_DOCS_V1_PATH_PREFIX}/docs",
+        f"{API_DOCS_V1_PATH_PREFIX}/redoc",
+        f"{API_DOCS_V1_PATH_PREFIX}/openapi.json",
     }
 )
 
 # Prefix for paths that should be excluded via startswith matching
 # (handles parameterised routes like /_internal/metrics/kpis/{component}).
-EXCLUDED_PATH_PREFIXES: tuple[str, ...] = ("/_internal/",)
+EXCLUDED_PATH_PREFIXES: tuple[str, ...] = ("/_internal/", "/api_docs/")

--- a/backend/src/syntara/api/constants.py
+++ b/backend/src/syntara/api/constants.py
@@ -10,6 +10,12 @@ API_V1_PATH_PREFIX = "/api/v1"
 API_DOCS_V1_PATH_PREFIX = "/api_docs/v1"
 API_V1_VERSION = "1.0.0"
 
+# Full doc endpoint paths (concat avoids Sonar treating {PREFIX} in FastAPI
+# route decorators as path parameters).
+API_DOCS_V1_DOCS_PATH = API_DOCS_V1_PATH_PREFIX + "/docs"
+API_DOCS_V1_REDOC_PATH = API_DOCS_V1_PATH_PREFIX + "/redoc"
+API_DOCS_V1_OPENAPI_PATH = API_DOCS_V1_PATH_PREFIX + "/openapi.json"
+
 # Full path to the OIDC callback endpoint, used by the auth router and
 # referenced by the AAP setup service when registering redirect URIs.
 OIDC_CALLBACK_PATH = f"{API_V1_PATH_PREFIX}/auth/oidc/callback"
@@ -26,9 +32,9 @@ EXCLUDED_PATHS: frozenset[str] = frozenset(
         "/api",
         "/api/v1",
         "/docs",
-        f"{API_DOCS_V1_PATH_PREFIX}/docs",
-        f"{API_DOCS_V1_PATH_PREFIX}/redoc",
-        f"{API_DOCS_V1_PATH_PREFIX}/openapi.json",
+        API_DOCS_V1_DOCS_PATH,
+        API_DOCS_V1_REDOC_PATH,
+        API_DOCS_V1_OPENAPI_PATH,
     }
 )
 

--- a/backend/src/syntara/api/constants.py
+++ b/backend/src/syntara/api/constants.py
@@ -34,4 +34,5 @@ EXCLUDED_PATHS: frozenset[str] = frozenset(
 
 # Prefix for paths that should be excluded via startswith matching
 # (handles parameterised routes like /_internal/metrics/kpis/{component}).
+# Any path under these prefixes bypasses audit, metrics, cert, and rate-limit middleware.
 EXCLUDED_PATH_PREFIXES: tuple[str, ...] = ("/_internal/", "/api_docs/")

--- a/backend/src/syntara/api/main.py
+++ b/backend/src/syntara/api/main.py
@@ -26,7 +26,13 @@ from temporalio.service import RPCError
 
 import syntara.auth.exceptions  # Side-effect import to trigger exception handler registration
 import syntara.identity_providers.exceptions
-from syntara.api.constants import API_DOCS_V1_PATH_PREFIX, API_V1_PATH_PREFIX, API_V1_VERSION
+from syntara.api.constants import (
+    API_DOCS_V1_DOCS_PATH,
+    API_DOCS_V1_OPENAPI_PATH,
+    API_DOCS_V1_REDOC_PATH,
+    API_V1_PATH_PREFIX,
+    API_V1_VERSION,
+)
 from syntara.audit.lifecycle import start_audit_subsystems, stop_audit_subsystems
 from syntara.audit.middleware import AuditMiddleware
 from syntara.audit.registration import discover_and_register_all_handlers
@@ -695,34 +701,33 @@ async def api_v1_version(
 
     if _settings.enable_api_docs:
         response["links"] = {
-            "docs": f"{API_DOCS_V1_PATH_PREFIX}/docs",
-            "redoc": f"{API_DOCS_V1_PATH_PREFIX}/redoc",
-            "openapi": f"{API_DOCS_V1_PATH_PREFIX}/openapi.json",
+            "docs": API_DOCS_V1_DOCS_PATH,
+            "redoc": API_DOCS_V1_REDOC_PATH,
+            "openapi": API_DOCS_V1_OPENAPI_PATH,
         }
 
     return response
 
 
 if _settings.enable_api_docs:
-    api_v1_openapi_path = f"{API_DOCS_V1_PATH_PREFIX}/openapi.json"
 
-    @app.get(f"{API_DOCS_V1_PATH_PREFIX}/docs", tags=["API Docs"], include_in_schema=False)
+    @app.get(API_DOCS_V1_DOCS_PATH, tags=["API Docs"], include_in_schema=False)
     async def api_v1_docs() -> HTMLResponse:
         """Serve the Swagger UI for API v1."""
         return get_swagger_ui_html(
-            openapi_url=api_v1_openapi_path,
+            openapi_url=API_DOCS_V1_OPENAPI_PATH,
             title=f"{app.title} V1 - Docs",
             swagger_ui_parameters=swagger_ui_parameters(
                 enable_try_it_out=_settings.enable_try_it_out,
             ),
         )
 
-    @app.get(f"{API_DOCS_V1_PATH_PREFIX}/redoc", tags=["API Docs"], include_in_schema=False)
+    @app.get(API_DOCS_V1_REDOC_PATH, tags=["API Docs"], include_in_schema=False)
     async def api_v1_redoc() -> HTMLResponse:
         """Serve the ReDoc UI for API v1."""
-        return get_redoc_html(openapi_url=api_v1_openapi_path, title=f"{app.title} V1 - ReDoc")
+        return get_redoc_html(openapi_url=API_DOCS_V1_OPENAPI_PATH, title=f"{app.title} V1 - ReDoc")
 
-    @app.get(api_v1_openapi_path, tags=["API Docs"], include_in_schema=False)
+    @app.get(API_DOCS_V1_OPENAPI_PATH, tags=["API Docs"], include_in_schema=False)
     async def api_v1_openapi() -> dict[str, Any]:
         """Return the OpenAPI spec for API v1."""
         return app.openapi()
@@ -730,7 +735,7 @@ if _settings.enable_api_docs:
     @app.get("/docs", tags=["API Docs"], include_in_schema=False)
     async def docs_redirect() -> RedirectResponse:
         """Redirect /docs to /api_docs/v1/docs for convenience."""
-        return RedirectResponse(url=f"{API_DOCS_V1_PATH_PREFIX}/docs")
+        return RedirectResponse(url=API_DOCS_V1_DOCS_PATH)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/syntara/api/main.py
+++ b/backend/src/syntara/api/main.py
@@ -18,7 +18,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import text
@@ -26,7 +26,7 @@ from temporalio.service import RPCError
 
 import syntara.auth.exceptions  # Side-effect import to trigger exception handler registration
 import syntara.identity_providers.exceptions
-from syntara.api.constants import API_V1_PATH_PREFIX, API_V1_VERSION
+from syntara.api.constants import API_DOCS_V1_PATH_PREFIX, API_V1_PATH_PREFIX, API_V1_VERSION
 from syntara.audit.lifecycle import start_audit_subsystems, stop_audit_subsystems
 from syntara.audit.middleware import AuditMiddleware
 from syntara.audit.registration import discover_and_register_all_handlers
@@ -695,21 +695,19 @@ async def api_v1_version(
 
     if _settings.enable_api_docs:
         response["links"] = {
-            "docs": f"{API_V1_PATH_PREFIX}/docs",
-            "redoc": f"{API_V1_PATH_PREFIX}/redoc",
-            "openapi": f"{API_V1_PATH_PREFIX}/openapi.json",
+            "docs": f"{API_DOCS_V1_PATH_PREFIX}/docs",
+            "redoc": f"{API_DOCS_V1_PATH_PREFIX}/redoc",
+            "openapi": f"{API_DOCS_V1_PATH_PREFIX}/openapi.json",
         }
 
     return response
 
 
 if _settings.enable_api_docs:
-    api_v1_openapi_path = f"{API_V1_PATH_PREFIX}/openapi.json"
+    api_v1_openapi_path = f"{API_DOCS_V1_PATH_PREFIX}/openapi.json"
 
-    @app.get(f"{API_V1_PATH_PREFIX}/docs", tags=["API Docs"], include_in_schema=False)
-    async def api_v1_docs(
-        current_user: Annotated[User, Depends(get_current_user)],  # noqa: ARG001
-    ) -> HTMLResponse:
+    @app.get(f"{API_DOCS_V1_PATH_PREFIX}/docs", tags=["API Docs"], include_in_schema=False)
+    async def api_v1_docs() -> HTMLResponse:
         """Serve the Swagger UI for API v1."""
         return get_swagger_ui_html(
             openapi_url=api_v1_openapi_path,
@@ -719,19 +717,20 @@ if _settings.enable_api_docs:
             ),
         )
 
-    @app.get(f"{API_V1_PATH_PREFIX}/redoc", tags=["API Docs"], include_in_schema=False)
-    async def api_v1_redoc(
-        current_user: Annotated[User, Depends(get_current_user)],  # noqa: ARG001
-    ) -> HTMLResponse:
+    @app.get(f"{API_DOCS_V1_PATH_PREFIX}/redoc", tags=["API Docs"], include_in_schema=False)
+    async def api_v1_redoc() -> HTMLResponse:
         """Serve the ReDoc UI for API v1."""
         return get_redoc_html(openapi_url=api_v1_openapi_path, title=f"{app.title} V1 - ReDoc")
 
     @app.get(api_v1_openapi_path, tags=["API Docs"], include_in_schema=False)
-    async def api_v1_openapi(
-        current_user: Annotated[User, Depends(get_current_user)],  # noqa: ARG001
-    ) -> dict[str, Any]:
+    async def api_v1_openapi() -> dict[str, Any]:
         """Return the OpenAPI spec for API v1."""
         return app.openapi()
+
+    @app.get("/docs", tags=["API Docs"], include_in_schema=False)
+    async def docs_redirect() -> RedirectResponse:
+        """Redirect /docs to /api_docs/v1/docs for convenience."""
+        return RedirectResponse(url=f"{API_DOCS_V1_PATH_PREFIX}/docs")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/syntara/core/config/base.py
+++ b/backend/src/syntara/core/config/base.py
@@ -220,17 +220,18 @@ class OpenAPIValidationSettings(BaseSettings):
 class APIDocsSettings(BaseSettings):
     """API documentation endpoint configuration.
 
-    Controls whether Swagger UI (/docs), ReDoc (/redoc), and the raw
-    OpenAPI JSON (/openapi.json) endpoints are served. Disabled by
-    default so production deployments do not expose the API schema.
+    Controls whether Swagger UI, ReDoc, and the raw OpenAPI JSON
+    endpoints are served at /api_docs/v1/. A convenience redirect
+    from /docs is also registered. Disabled by default so production
+    deployments do not expose the API schema.
 
     Note: This class should not be instantiated directly. Use Settings via get_settings().
     """
 
     enable_api_docs: bool = Field(
         default=False,
-        description="Serve OpenAPI documentation endpoints (/docs, /redoc, /openapi.json). "
-        "Enable for development environments.",
+        description="Serve OpenAPI documentation endpoints at /api_docs/v1/ "
+        "(docs, redoc, openapi.json). Enable for development environments.",
     )
 
     enable_try_it_out: bool = Field(

--- a/backend/src/syntara/metrics/internal_api.py
+++ b/backend/src/syntara/metrics/internal_api.py
@@ -4,8 +4,8 @@ These endpoints expose raw in-memory metrics from the MetricsStore for use
 by external performance-test harnesses.
 
 Security model:
-    * ``include_in_schema=False`` keeps them out of ``/docs`` and
-      ``/openapi.json``.
+    * ``include_in_schema=False`` keeps them out of ``/api_docs/v1/docs`` and
+      ``/api_docs/v1/openapi.json``.
     * Each handler checks the ``metrics.perf_test_mode`` runtime setting
       and returns 404 when disabled.  Toggling the setting enables the
       endpoints (and the backing in-memory store) without a restart.

--- a/backend/tests/integration/telemetry/test_api_analytics.py
+++ b/backend/tests/integration/telemetry/test_api_analytics.py
@@ -13,7 +13,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from syntara.api.constants import API_V1_PATH_PREFIX
+from syntara.api.constants import API_DOCS_V1_PATH_PREFIX
 from syntara.audit.dispatcher import AuditEventDispatcher
 from syntara.audit.events.http_request import HTTPRequestEvent
 from syntara.audit.middleware import AuditMiddleware
@@ -63,8 +63,8 @@ def _create_test_app() -> FastAPI:
     async def api_discovery() -> dict[str, str]:
         return {"current_version": "/api/v1"}
 
-    @app.get(f"{API_V1_PATH_PREFIX}/docs", include_in_schema=False)
-    async def api_v1_docs() -> dict[str, str]:
+    @app.get(f"{API_DOCS_V1_PATH_PREFIX}/docs", include_in_schema=False)
+    async def api_docs() -> dict[str, str]:
         return {"docs": "placeholder"}
 
     app.add_middleware(AuditMiddleware, fastapi_app=app)
@@ -194,7 +194,7 @@ class TestExcludedPathsIntegration:
             patch(_REGISTRY_PATH, return_value=mock_registry),
         ):
             async with AsyncClient(transport=transport, base_url="http://test") as client:
-                await client.get(f"{API_V1_PATH_PREFIX}/docs")
+                await client.get(f"{API_DOCS_V1_PATH_PREFIX}/docs")
 
         mock_registry.send_event.assert_not_called()
 

--- a/backend/tests/unit/api/compliance/test_auth_compliance.py
+++ b/backend/tests/unit/api/compliance/test_auth_compliance.py
@@ -72,9 +72,8 @@ _INFRA_PATH_PREFIXES = (
     "/health",
     "/metrics",
     "/_internal/",
+    "/api_docs/",
     "/docs",
-    "/redoc",
-    "/openapi.json",
 )
 
 

--- a/backend/tests/unit/api/test_discovery_endpoints.py
+++ b/backend/tests/unit/api/test_discovery_endpoints.py
@@ -261,6 +261,24 @@ class TestOldDocsEndpointsRemoved:
 
         return TestClient(app, raise_server_exceptions=False)
 
+    def test_docs_redirect_404_when_disabled(self) -> None:
+        import importlib
+
+        import nexus.api.main as main_module
+        from nexus.core.config.base import get_settings
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setenv("APP_ENABLE_API_DOCS", "false")
+        get_settings.cache_clear()
+        try:
+            importlib.reload(main_module)
+            client = TestClient(main_module.app, raise_server_exceptions=False)
+            assert client.get("/docs").status_code == 404
+        finally:
+            monkeypatch.delenv("APP_ENABLE_API_DOCS", raising=False)
+            get_settings.cache_clear()
+            importlib.reload(main_module)
+
     def test_old_redoc_404(self, client: TestClient) -> None:
         assert client.get("/redoc").status_code == 404
 

--- a/backend/tests/unit/api/test_discovery_endpoints.py
+++ b/backend/tests/unit/api/test_discovery_endpoints.py
@@ -5,8 +5,9 @@ Covers the three-tier discovery hierarchy against the real production app:
 - GET /api/v1       — authenticated, lists v1 endpoints
 - GET /api/v1/version — authenticated, returns full version details
 
-Also verifies that authenticated doc endpoints reject unauthenticated
-requests and that old root-level doc paths no longer serve anything.
+Also verifies that unauthenticated doc endpoints at /api_docs/v1/ are
+accessible without auth when enabled, and that old root-level doc paths
+no longer serve anything.
 """
 
 from __future__ import annotations
@@ -19,7 +20,7 @@ from starlette.testclient import TestClient
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-from syntara.api.constants import API_V1_PATH_PREFIX, API_V1_VERSION
+from syntara.api.constants import API_DOCS_V1_PATH_PREFIX, API_V1_PATH_PREFIX, API_V1_VERSION
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -131,8 +132,15 @@ class TestApiV1Version:
         assert data["status"] == "current"
 
     def test_links_null_when_docs_disabled(self, auth_client: TestClient) -> None:
-        data = auth_client.get(f"{API_V1_PATH_PREFIX}/version").json()
-        assert data["links"] is None
+        import syntara.api.main as main_module
+
+        original = main_module._settings.enable_api_docs
+        object.__setattr__(main_module._settings, "enable_api_docs", False)
+        try:
+            data = auth_client.get(f"{API_V1_PATH_PREFIX}/version").json()
+            assert data["links"] is None
+        finally:
+            object.__setattr__(main_module._settings, "enable_api_docs", original)
 
     def test_links_present_when_docs_enabled(self, auth_client: TestClient) -> None:
         import syntara.api.main as main_module
@@ -142,9 +150,9 @@ class TestApiV1Version:
         try:
             data = auth_client.get(f"{API_V1_PATH_PREFIX}/version").json()
             assert data["links"] is not None
-            assert data["links"]["docs"] == f"{API_V1_PATH_PREFIX}/docs"
-            assert data["links"]["redoc"] == f"{API_V1_PATH_PREFIX}/redoc"
-            assert data["links"]["openapi"] == f"{API_V1_PATH_PREFIX}/openapi.json"
+            assert data["links"]["docs"] == f"{API_DOCS_V1_PATH_PREFIX}/docs"
+            assert data["links"]["redoc"] == f"{API_DOCS_V1_PATH_PREFIX}/redoc"
+            assert data["links"]["openapi"] == f"{API_DOCS_V1_PATH_PREFIX}/openapi.json"
         finally:
             object.__setattr__(main_module._settings, "enable_api_docs", original)
 
@@ -154,19 +162,18 @@ class TestApiV1Version:
 
 
 # ---------------------------------------------------------------------------
-# Docs endpoints — auth required (when docs enabled via reload)
+# Docs endpoints — unauthenticated at /api_docs/v1/ (when docs enabled)
 # ---------------------------------------------------------------------------
 
 
-class TestDocsAuth:
-    """Doc endpoints under /api/v1/ require authentication when enabled."""
+class TestDocsNoAuth:
+    """Doc endpoints at /api_docs/v1/ are accessible without authentication."""
 
     @pytest.fixture
-    def docs_enabled_unauth_client(self) -> Generator[TestClient, None, None]:
+    def docs_enabled_client(self) -> Generator[TestClient, None, None]:
         import importlib
 
         import syntara.api.main as main_module
-        from syntara.auth.dependencies import get_current_user
         from syntara.core.config.base import get_settings
 
         monkeypatch = pytest.MonkeyPatch()
@@ -174,70 +181,31 @@ class TestDocsAuth:
         get_settings.cache_clear()
         try:
             importlib.reload(main_module)
-            main_module.app.dependency_overrides.pop(get_current_user, None)
             yield TestClient(main_module.app, raise_server_exceptions=False)
         finally:
             monkeypatch.delenv("APP_ENABLE_API_DOCS", raising=False)
             get_settings.cache_clear()
             importlib.reload(main_module)
 
-    def test_docs_returns_401_without_auth(self, docs_enabled_unauth_client: TestClient) -> None:
-        assert docs_enabled_unauth_client.get(f"{API_V1_PATH_PREFIX}/docs").status_code == 401
-
-    def test_redoc_returns_401_without_auth(self, docs_enabled_unauth_client: TestClient) -> None:
-        assert docs_enabled_unauth_client.get(f"{API_V1_PATH_PREFIX}/redoc").status_code == 401
-
-    def test_openapi_json_returns_401_without_auth(self, docs_enabled_unauth_client: TestClient) -> None:
-        assert docs_enabled_unauth_client.get(f"{API_V1_PATH_PREFIX}/openapi.json").status_code == 401
-
-
-# ---------------------------------------------------------------------------
-# Docs endpoints — authenticated happy path (when docs enabled via reload)
-# ---------------------------------------------------------------------------
-
-
-class TestDocsAuthHappyPath:
-    """Doc endpoints return 200 for authenticated users when docs are enabled."""
-
-    @pytest.fixture
-    def docs_enabled_auth_client(self) -> Generator[TestClient, None, None]:
-        import importlib
-
-        import syntara.api.main as main_module
-        from syntara.auth.dependencies import get_current_user
-        from syntara.core.config.base import get_settings
-        from syntara.core.models.user import User
-
-        async def mock_user() -> User:
-            return User(username="testuser", email="test@test.com", first_name="Test")
-
-        monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setenv("APP_ENABLE_API_DOCS", "true")
-        get_settings.cache_clear()
-        try:
-            importlib.reload(main_module)
-            main_module.app.dependency_overrides[get_current_user] = mock_user
-            yield TestClient(main_module.app, raise_server_exceptions=False)
-        finally:
-            main_module.app.dependency_overrides.pop(get_current_user, None)
-            monkeypatch.delenv("APP_ENABLE_API_DOCS", raising=False)
-            get_settings.cache_clear()
-            importlib.reload(main_module)
-
-    def test_docs_returns_200(self, docs_enabled_auth_client: TestClient) -> None:
-        response = docs_enabled_auth_client.get(f"{API_V1_PATH_PREFIX}/docs")
+    def test_docs_returns_200_without_auth(self, docs_enabled_client: TestClient) -> None:
+        response = docs_enabled_client.get(f"{API_DOCS_V1_PATH_PREFIX}/docs")
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
 
-    def test_redoc_returns_200(self, docs_enabled_auth_client: TestClient) -> None:
-        response = docs_enabled_auth_client.get(f"{API_V1_PATH_PREFIX}/redoc")
+    def test_redoc_returns_200_without_auth(self, docs_enabled_client: TestClient) -> None:
+        response = docs_enabled_client.get(f"{API_DOCS_V1_PATH_PREFIX}/redoc")
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
 
-    def test_openapi_json_returns_200(self, docs_enabled_auth_client: TestClient) -> None:
-        response = docs_enabled_auth_client.get(f"{API_V1_PATH_PREFIX}/openapi.json")
+    def test_openapi_json_returns_200_without_auth(self, docs_enabled_client: TestClient) -> None:
+        response = docs_enabled_client.get(f"{API_DOCS_V1_PATH_PREFIX}/openapi.json")
         assert response.status_code == 200
         assert "openapi" in response.json()
+
+    def test_docs_redirect_from_root(self, docs_enabled_client: TestClient) -> None:
+        response = docs_enabled_client.get("/docs", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == f"{API_DOCS_V1_PATH_PREFIX}/docs"
 
 
 # ---------------------------------------------------------------------------
@@ -280,12 +248,12 @@ class TestApiV1RootWithIncludedRouters:
 
 
 # ---------------------------------------------------------------------------
-# Old root-level doc paths are gone
+# Old root-level and /api/v1 doc paths are gone (except /docs which redirects)
 # ---------------------------------------------------------------------------
 
 
 class TestOldDocsEndpointsRemoved:
-    """Old root-level /docs, /redoc, /openapi.json must return 404."""
+    """Old doc paths under / and /api/v1 must return 404."""
 
     @pytest.fixture
     def client(self) -> TestClient:
@@ -293,14 +261,20 @@ class TestOldDocsEndpointsRemoved:
 
         return TestClient(app, raise_server_exceptions=False)
 
-    def test_old_docs_404(self, client: TestClient) -> None:
-        assert client.get("/docs").status_code == 404
-
     def test_old_redoc_404(self, client: TestClient) -> None:
         assert client.get("/redoc").status_code == 404
 
     def test_old_openapi_json_404(self, client: TestClient) -> None:
         assert client.get("/openapi.json").status_code == 404
+
+    def test_old_api_v1_docs_404(self, client: TestClient) -> None:
+        assert client.get(f"{API_V1_PATH_PREFIX}/docs").status_code == 404
+
+    def test_old_api_v1_redoc_404(self, client: TestClient) -> None:
+        assert client.get(f"{API_V1_PATH_PREFIX}/redoc").status_code == 404
+
+    def test_old_api_v1_openapi_json_404(self, client: TestClient) -> None:
+        assert client.get(f"{API_V1_PATH_PREFIX}/openapi.json").status_code == 404
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/api/test_discovery_endpoints.py
+++ b/backend/tests/unit/api/test_discovery_endpoints.py
@@ -264,8 +264,8 @@ class TestOldDocsEndpointsRemoved:
     def test_docs_redirect_404_when_disabled(self) -> None:
         import importlib
 
-        import nexus.api.main as main_module
-        from nexus.core.config.base import get_settings
+        import syntara.api.main as main_module
+        from syntara.core.config.base import get_settings
 
         monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setenv("APP_ENABLE_API_DOCS", "false")

--- a/backend/tests/unit/api/test_docs_endpoints.py
+++ b/backend/tests/unit/api/test_docs_endpoints.py
@@ -11,10 +11,11 @@ The ``TestAPIDocsSettings`` class separately verifies that the
 Together the two layers confirm that the wiring in ``main.py`` will
 produce the right result when the real setting is read at startup.
 
-Note: The production app now serves custom authenticated doc endpoints
-at ``/api/v1/docs``, ``/api/v1/redoc``, and ``/api/v1/openapi.json``
-(see ``test_discovery_endpoints.py``).  The standalone ``_make_app``
-tests here verify the abstract toggling logic in isolation.
+Note: The production app now serves unauthenticated doc endpoints
+at ``/api_docs/v1/docs``, ``/api_docs/v1/redoc``, and
+``/api_docs/v1/openapi.json`` (gated by ``enable_api_docs``).
+The standalone ``_make_app`` tests here verify the abstract toggling
+logic in isolation.
 """
 
 from __future__ import annotations
@@ -26,7 +27,7 @@ import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
-from syntara.api.constants import API_V1_PATH_PREFIX, API_V1_VERSION
+from syntara.api.constants import API_DOCS_V1_PATH_PREFIX, API_V1_PATH_PREFIX, API_V1_VERSION
 from syntara.api.main import swagger_ui_parameters
 from syntara.core.config.base import get_settings
 from syntara.core.router_discovery import iter_api_routes
@@ -267,7 +268,7 @@ class TestDocsEnabledWiring:
             client = TestClient(main_module.app, raise_server_exceptions=False)
             response = client.get(f"{API_V1_PATH_PREFIX}/version")
             assert response.status_code == 200
-            assert response.json()["links"]["docs"] == f"{API_V1_PATH_PREFIX}/docs"
+            assert response.json()["links"]["docs"] == f"{API_DOCS_V1_PATH_PREFIX}/docs"
         finally:
             object.__setattr__(main_module._settings, "enable_api_docs", original)
             main_module.app.dependency_overrides.pop(get_current_user, None)
@@ -283,9 +284,10 @@ class TestDocsEnabledWiring:
         try:
             importlib.reload(main_module)
             route_paths = [r.path for r in iter_api_routes(main_module.app)]
-            assert f"{API_V1_PATH_PREFIX}/docs" in route_paths
-            assert f"{API_V1_PATH_PREFIX}/redoc" in route_paths
-            assert f"{API_V1_PATH_PREFIX}/openapi.json" in route_paths
+            assert f"{API_DOCS_V1_PATH_PREFIX}/docs" in route_paths
+            assert f"{API_DOCS_V1_PATH_PREFIX}/redoc" in route_paths
+            assert f"{API_DOCS_V1_PATH_PREFIX}/openapi.json" in route_paths
+            assert "/docs" in route_paths
         finally:
             # Force production defaults so later tests are not polluted by .env.
             monkeypatch.setenv("APP_ENABLE_API_DOCS", "false")
@@ -297,25 +299,18 @@ class TestDocsEnabledWiring:
         import importlib
 
         import syntara.api.main as main_module
-        from syntara.auth.dependencies import get_current_user
-        from syntara.core.models.user import User
-
-        async def mock_user() -> User:
-            return User(username="testuser", email="test@test.com", first_name="Test")
 
         monkeypatch.setenv("APP_ENABLE_API_DOCS", "true")
         monkeypatch.setenv("APP_ENABLE_TRY_IT_OUT", "false")
         get_settings.cache_clear()
         try:
             importlib.reload(main_module)
-            main_module.app.dependency_overrides[get_current_user] = mock_user
             client = TestClient(main_module.app, raise_server_exceptions=False)
-            response = client.get(f"{API_V1_PATH_PREFIX}/docs")
+            response = client.get(f"{API_DOCS_V1_PATH_PREFIX}/docs")
             assert response.status_code == 200
             assert '"tryItOutEnabled": false' in response.text
             assert '"supportedSubmitMethods": []' in response.text
         finally:
-            main_module.app.dependency_overrides.pop(get_current_user, None)
             monkeypatch.setenv("APP_ENABLE_API_DOCS", "false")
             monkeypatch.setenv("APP_ENABLE_TRY_IT_OUT", "false")
             get_settings.cache_clear()
@@ -325,27 +320,38 @@ class TestDocsEnabledWiring:
         import importlib
 
         import syntara.api.main as main_module
-        from syntara.auth.dependencies import get_current_user
-        from syntara.core.models.user import User
-
-        async def mock_user() -> User:
-            return User(username="testuser", email="test@test.com", first_name="Test")
 
         monkeypatch.setenv("APP_ENABLE_API_DOCS", "true")
         monkeypatch.setenv("APP_ENABLE_TRY_IT_OUT", "true")
         get_settings.cache_clear()
         try:
             importlib.reload(main_module)
-            main_module.app.dependency_overrides[get_current_user] = mock_user
             client = TestClient(main_module.app, raise_server_exceptions=False)
-            response = client.get(f"{API_V1_PATH_PREFIX}/docs")
+            response = client.get(f"{API_DOCS_V1_PATH_PREFIX}/docs")
             assert response.status_code == 200
             assert '"tryItOutEnabled": true' in response.text
             assert '"supportedSubmitMethods": []' not in response.text
         finally:
-            main_module.app.dependency_overrides.pop(get_current_user, None)
             monkeypatch.setenv("APP_ENABLE_API_DOCS", "false")
             monkeypatch.setenv("APP_ENABLE_TRY_IT_OUT", "false")
+            get_settings.cache_clear()
+            importlib.reload(main_module)
+
+    def test_docs_redirect_to_api_docs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import importlib
+
+        import syntara.api.main as main_module
+
+        monkeypatch.setenv("APP_ENABLE_API_DOCS", "true")
+        get_settings.cache_clear()
+        try:
+            importlib.reload(main_module)
+            client = TestClient(main_module.app, raise_server_exceptions=False)
+            response = client.get("/docs", follow_redirects=False)
+            assert response.status_code == 307
+            assert response.headers["location"] == f"{API_DOCS_V1_PATH_PREFIX}/docs"
+        finally:
+            monkeypatch.setenv("APP_ENABLE_API_DOCS", "false")
             get_settings.cache_clear()
             importlib.reload(main_module)
 

--- a/frontend/packages/syntara-ui/nginx.conf.template
+++ b/frontend/packages/syntara-ui/nginx.conf.template
@@ -18,8 +18,8 @@ server {
     add_header Content-Security-Policy "frame-ancestors 'self'" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
-    # Proxy backend paths (API, metrics, docs)
-    location ~ ^/(api|metrics|docs|openapi) {
+    # Proxy backend paths (API, metrics, versioned API docs, /docs redirect)
+    location ~ ^/(api|api_docs|metrics|docs) {
         proxy_pass ${APP_API_URL};
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/frontend/packages/syntara-ui/nginx.conf.template
+++ b/frontend/packages/syntara-ui/nginx.conf.template
@@ -19,7 +19,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
     # Proxy backend paths (API, metrics, versioned API docs, /docs redirect)
-    location ~ ^/(api|api_docs|metrics|docs) {
+    location ~ ^/(api_docs|api|metrics|docs) {
         proxy_pass ${APP_API_URL};
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/frontend/packages/syntara-ui/vite.config.ts
+++ b/frontend/packages/syntara-ui/vite.config.ts
@@ -13,19 +13,32 @@ export default defineConfig(({ mode }) => {
     title: env.VITE_APP_TITLE,
   })
 
+  const backendTarget = env.VITE_API_URL || 'http://localhost:3000'
+
   const proxyConfig = {
     '/api': {
-      target: env.VITE_API_URL || 'http://localhost:3000',
+      target: backendTarget,
+      changeOrigin: true,
+      secure: false,
+    },
+    // API docs live outside /api (Swagger/ReDoc/OpenAPI); keep UI proxy parity with nginx.
+    '/api_docs': {
+      target: backendTarget,
+      changeOrigin: true,
+      secure: false,
+    },
+    '/docs': {
+      target: backendTarget,
       changeOrigin: true,
       secure: false,
     },
     '/health': {
-      target: env.VITE_API_URL || 'http://localhost:3000',
+      target: backendTarget,
       changeOrigin: true,
       secure: false,
     },
     '/ws': {
-      target: env.VITE_WS_URL || env.VITE_API_URL || 'http://localhost:3000',
+      target: env.VITE_WS_URL || backendTarget,
       changeOrigin: true,
       secure: false,
       ws: true,

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -182,6 +182,8 @@ services:
       - APP_S2S_TLS_KEY_PATH=/run/secrets/s2s-cert.key
       - APP_S2S_TLS_CN_ALLOWLIST=["backend.ao.svc","worker.ao.svc","background-worker.ao.svc","temporal.ao.svc"]
       - APP_BACKGROUND_TASK_QUEUE=orchestrator-background-queue
+      # Docs off by default; enable for DAST / local container debugging.
+      - APP_ENABLE_API_DOCS=${APP_ENABLE_API_DOCS:-false}
     volumes:
       - ./backend/src:/opt/app-root/src/src:z
       - syntara_audit_exports:/data/audit-exports:z


### PR DESCRIPTION
## Description

Swagger UI / ReDoc / OpenAPI were served under `/api/v1/` with auth required, which made them unusable from a browser (you need the docs to explore the API, but you can't load the docs without already being authenticated). They also didn't belong under `/api` — docs aren't API surface.

This moves them to `/api_docs/v1/`, drops the auth requirement, and keeps them gated by `APP_ENABLE_API_DOCS` (off by default in production). Adds a convenience `/docs` → `/api_docs/v1/docs` redirect and updates proxies, DAST, env examples, and tests.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

- [x] Move Swagger UI, ReDoc, and OpenAPI JSON from `/api/v1/{docs,redoc,openapi.json}` to `/api_docs/v1/{docs,redoc,openapi.json}`
- [x] Remove `get_current_user` from docs endpoints so they load in a browser when enabled
- [x] Add `/docs` → `/api_docs/v1/docs` redirect
- [x] Update `/api/v1/version` links to the new paths
- [x] Exclude `/api_docs/` from middleware / auth-compliance infra paths
- [x] Proxy `/api_docs` (and `/docs`) via nginx and Vite
- [x] Point RapidAST at `/api_docs/v1/openapi.json` and enable docs for the DAST compose run (`APP_ENABLE_API_DOCS` passthrough in `podman-compose.yml`)
- [x] Update `.env.example` comments, README, and unit tests

## Out of Scope

- Re-auth'ing docs endpoints (e.g. cookie/session gate in front of Swagger)
- Serving docs when `APP_ENABLE_API_DOCS` is false (still disabled in prod by default)
- Changing OpenAPI schema content / contract generation

## Related Issues

Related to AAP-84803 (spec under versioned prefix) / version discovery docs placement feedback

## How to Test

1. Ensure `APP_ENABLE_API_DOCS=true` (e.g. via `.env`)
2. Start the backend (`make -C backend dev` or your usual flow)
3. Open `https://localhost:8000/docs` (or `http://…` depending on TLS) — should 307 to `/api_docs/v1/docs`
4. Confirm Swagger UI loads **without** logging in
5. Confirm `/api_docs/v1/redoc` and `/api_docs/v1/openapi.json` also work unauthenticated
6. Confirm `/api/v1/docs`, `/api/v1/redoc`, `/api/v1/openapi.json` return 404
7. With docs disabled (`APP_ENABLE_API_DOCS=false`), confirm those doc routes are absent / 404
8. Optional: hit `/api/v1/version` (authenticated) and verify `links` point at `/api_docs/v1/...` when docs are enabled

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [x] Database migrations are included if schema changed (N/A)
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality (N/A — proxy/config only)
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation) (N/A — no UI component changes)
- [x] Screenshots or screen recordings are attached for UI changes (N/A)

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [x] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab (N/A)
- [x] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline (N/A)

## General Checklist

- [x] Code follows the project's coding conventions
- [x] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

N/A — no product UI changes. Swagger still looks the same; only the URL and auth behavior change.

## Additional Notes

**Breaking change for clients/bookmarks** that still call:

- `/api/v1/docs`
- `/api/v1/redoc`
- `/api/v1/openapi.json`

Use `/api_docs/v1/...` instead (or `/docs` for Swagger). Discovery via `GET /api/v1/version` → `links` already returns the new paths when docs are enabled.

Prod remains safe: docs stay off unless `APP_ENABLE_API_DOCS=true`.