### PR TITLE
docs: record AI agent hooks policy

### DIFF
--- a/.github/AI_AGENT_POLICY.md
+++ b/.github/AI_AGENT_POLICY.md
@@ -1,0 +1,71 @@
+# AI Agent Configuration Policy
+
+This document records the upstream policy for AI coding-agent configuration in
+this repository (Claude Code, Cursor, and similar tools that read project
+instruction files).
+
+## Decision: no agent hooks in upstream
+
+**Agent hooks are not allowed in the public / upstream tree.**
+
+Executable agent hooks (for example Claude Code `hooks/` scripts wired through
+`settings.json` / skill-trigger configs) were removed before publication. Those
+hooks ran shell commands on tool-use and related agent events. That execution
+model is a supply-chain risk: a compromised or poorly reviewed hook can run
+arbitrary commands in a developer or CI environment with the privileges of the
+agent session.
+
+### What replaces hooks
+
+There is **no hook-based enforcement** in upstream. The replacement is
+**advisory project guidance**:
+
+| Allowed upstream | Role |
+| --- | --- |
+| `CLAUDE.md`, `AGENTS.md`, and component `CLAUDE.md` / `AGENTS.md` | On-demand agent instructions |
+| `.claude/skills/**` | Skill documents maintainers choose to ship |
+| `.claude/commands/**` (when present) | Slash-command prompts as markdown |
+
+Skills and commands are documentation loaded by the agent. They are **not**
+executable hooks and must not invoke shell wrappers as part of agent lifecycle
+events.
+
+Local-only hook experiments (if any) stay on the contributor machine and must
+never be committed.
+
+## Private local agent settings
+
+Local agent settings must not ship publicly. Root [`.gitignore`](../.gitignore)
+ignores `.claude/*` by default and selectively un-ignores only the shared
+skills (and commands, when present). In particular the following stay private:
+
+- `.claude/settings.json` and `.claude/settings.local.json`
+- `.claude/hooks/` and any other non-skill / non-command agent runtime files
+- `CLAUDE.local.md`, `AGENTS.local.md`
+- Editor/AI local dirs such as `.cursor/`, `.gemini/`
+
+Do not force-add ignored agent settings or hooks in a pull request.
+
+## Who may change `.claude/` and related agent docs
+
+| Path | Ownership / review |
+| --- | --- |
+| This policy (`.github/AI_AGENT_POLICY.md`) | `@syntara-orchestration/syntara-leads` (see [CODEOWNERS](CODEOWNERS)) |
+| Root / component `CLAUDE.md`, `AGENTS.md` | Same reviewers as the area of the change; treat policy-affecting edits as governance |
+| `.claude/skills/**` | Owning product team per [CODEOWNERS](CODEOWNERS) (for example UX owns the PatternFly UX skill) |
+| Re-introducing hooks or shipping `settings.json` | **Not permitted** under this policy. Requires an explicit policy revision reviewed by `@syntara-orchestration/syntara-leads` |
+
+### Review bar for skill and instruction changes
+
+Pull requests that change shared agent skills or instruction files should:
+
+1. Keep content product-neutral and safe for a public repository (no internal
+   hostnames, private Slack channels, credentials, or org-only runbooks).
+2. Prefer linking to public docs over embedding internal process.
+3. Stay advisory — do not add executable hook wiring.
+4. Get review from the CODEOWNERS team for the touched paths.
+
+## Related contributor docs
+
+- Frontend AI workflow guide: [`frontend/docs/ai-assisted-development.md`](../frontend/docs/ai-assisted-development.md)
+- Root agent entrypoints: [`CLAUDE.md`](../CLAUDE.md), [`AGENTS.md`](../AGENTS.md)

--- a/.github/AI_AGENT_POLICY.md
+++ b/.github/AI_AGENT_POLICY.md
@@ -2,7 +2,9 @@
 
 This document records the upstream policy for AI coding-agent configuration in
 this repository (Claude Code, Cursor, and similar tools that read project
-instruction files).
+instruction files). For the policy on AI-assisted **contributions** (disclosure,
+accountability, quality standards), see
+[`AI_POLICY.md`](AI_POLICY.md).
 
 ## Decision: no agent hooks in upstream
 

--- a/.github/AI_POLICY.md
+++ b/.github/AI_POLICY.md
@@ -9,6 +9,10 @@ This policy applies to the following projects and resources:
 
 > **Note:** The above projects and resources **MAY have their own AI policies** which MAY expand or be more restrictive than this policy.
 
+For the policy on AI **agent runtime configuration** in this repository (hooks,
+skills, `.claude/` settings), see
+[`AI_AGENT_POLICY.md`](AI_AGENT_POLICY.md).
+
 ## Principles
 
 1. Contributors MAY use the assistance of AI tools for contributing [^1] to the above projects and resources, provided that they take full responsibility for their contributions and follow the principles described in this policy.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,7 @@
 
 # Repository governance
 /.github/CODEOWNERS @syntara-orchestration/syntara-leads
+/.github/AI_AGENT_POLICY.md @syntara-orchestration/syntara-leads
 /LICENSE @syntara-orchestration/syntara-leads
 /backend/LICENSE @syntara-orchestration/syntara-leads
 /frontend/packages/syntara-ui/LICENSE @syntara-orchestration/syntara-leads

--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,10 @@ data/uploads/
 .cursorignore
 .cursorindexingignore
 
-# AI agent local files — ignore .claude/ contents by default, then selectively un-ignore
+# AI agent local files — ignore .claude/ contents by default, then selectively un-ignore.
+# Policy: executable agent hooks and local settings must not ship publicly
+# (see .github/AI_AGENT_POLICY.md). The blanket ignore covers settings.json,
+# settings.local.json, hooks/, and other runtime agent config.
 .claude/*
 !.claude/skills/
 !.claude/skills/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Syntara is a distributed multi-agent automation system. This monorepo contains a Python/FastAPI backend (`backend/`) and a React/TypeScript frontend (`frontend/`).
 
+Upstream policy for AI agent configuration (no executable hooks; what may live
+under `.claude/`; review expectations) is in
+[`.github/AI_AGENT_POLICY.md`](.github/AI_AGENT_POLICY.md).
+
 ## Component-Specific Standards
 
 - [backend/AGENTS.md](backend/AGENTS.md) — SQLModel, Alembic migrations, uv, pytest, mypy, domain standards

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,10 @@ Read the component docs when working in that area — they contain detailed stan
 
 ### Skills
 
+Upstream AI agent policy (no executable hooks; private local settings; who may
+change `.claude/`) is documented in
+[`.github/AI_AGENT_POLICY.md`](.github/AI_AGENT_POLICY.md).
+
 Skills live in `.claude/skills/` at the repo root, prefixed by workspace:
 
 - **`frontend-*`** — Frontend-specific skills (coding standards, PR review, PatternFly UX, testing, Playwright E2E, library references)

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -6,10 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Claude, you have access to the following skills. **Do not load them all at once** -- read each skill file on-demand when its trigger condition is met. If a loaded skill (e.g., `frontend_specialist.md`) tells you to read another skill you have already loaded in this conversation, skip the re-read.
 
-<!-- NOTE: Hook enforcement (skill-gate.sh, skill-triggers.json) was removed during
-     monorepo migration. Skills are advisory — Claude should still read them on-demand
-     per the triggers below. Hook-based enforcement may be re-added at the root level
-     once the monorepo hook strategy is finalized. -->
+<!-- NOTE: Executable agent hooks (skill-gate.sh, skill-triggers.json, settings.json)
+     were removed for supply-chain safety and are not allowed upstream. Skills are
+     advisory — read them on-demand per the triggers below. See
+     ../.github/AI_AGENT_POLICY.md. -->
 
 | Trigger                                                                             | Skill file to read                                                                        |
 | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary
- Add `.github/AI_AGENT_POLICY.md` stating that executable agent hooks are not allowed upstream and describing the advisory replacement (CLAUDE.md / AGENTS.md / skills).
- Ignore local agent runtime settings under `.claude/` by default (with selective un-ignore for shared skills), and point root/component agent docs at the policy.
- Add a CODEOWNERS rule for the policy file under `@syntara-orchestration/syntara-leads`.

## Test plan
- [ ] Confirm `.gitignore` still un-ignores `.claude/skills/**` only
- [ ] Confirm CODEOWNERS covers `.github/AI_AGENT_POLICY.md`
- [ ] Skim policy for product-neutral wording

Made with [Cursor](https://cursor.com)