### PR TITLE
feat(api-docs): enable API docs by default (APP_ENABLE_API_DOCS)

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Start services with podman-compose
         timeout-minutes: 5
         env:
-          # RapidAST loads the live OpenAPI spec; docs must be enabled for that endpoint.
+          # Docs are enabled by default; kept explicit for clarity.
           APP_ENABLE_API_DOCS: "true"
         run: |
           uvx podman-compose -f ../podman-compose.yml -p syntara-ci up --build -d database redis temporal syntara

--- a/backend/dast/rapidast-config.yaml
+++ b/backend/dast/rapidast-config.yaml
@@ -8,14 +8,14 @@
 #   Automatically invoked by .github/workflows/dast.yml
 #
 # Usage (local, with Nexus running via podman-compose on localhost:8000):
-#   APP_ENABLE_API_DOCS=true uv run podman-compose -f ../podman-compose.yml up -d syntara
+#   uv run podman-compose -f ../podman-compose.yml up -d syntara
 #   podman run --rm --network=host \
 #     -v ./dast/rapidast-config.yaml:/opt/rapidast/config/config.yaml:z \
 #     -v ./dast/results:/opt/rapidast/results:z \
 #     quay.io/redhatproductsecurity/rapidast:latest \
 #     --config /opt/rapidast/config/config.yaml
 #
-# Docs must be enabled: RapidAST fetches /api_docs/v1/openapi.json (gated by APP_ENABLE_API_DOCS).
+# RapidAST fetches /api_docs/v1/openapi.json (enabled by default via APP_ENABLE_API_DOCS).
 
 config:
   configVersion: 6

--- a/backend/src/syntara/core/config/base.py
+++ b/backend/src/syntara/core/config/base.py
@@ -222,16 +222,16 @@ class APIDocsSettings(BaseSettings):
 
     Controls whether Swagger UI, ReDoc, and the raw OpenAPI JSON
     endpoints are served at /api_docs/v1/. A convenience redirect
-    from /docs is also registered. Disabled by default so production
-    deployments do not expose the API schema.
+    from /docs is also registered. Enabled by default so customers
+    can access API docs without extra configuration.
 
     Note: This class should not be instantiated directly. Use Settings via get_settings().
     """
 
     enable_api_docs: bool = Field(
-        default=False,
+        default=True,
         description="Serve OpenAPI documentation endpoints at /api_docs/v1/ "
-        "(docs, redoc, openapi.json). Enable for development environments.",
+        "(docs, redoc, openapi.json). Set to false to disable in locked-down environments.",
     )
 
     enable_try_it_out: bool = Field(

--- a/backend/tests/unit/api/test_discovery_endpoints.py
+++ b/backend/tests/unit/api/test_discovery_endpoints.py
@@ -279,6 +279,7 @@ class TestOldDocsEndpointsRemoved:
             get_settings.cache_clear()
             importlib.reload(main_module)
 
+
     def test_old_redoc_404(self, client: TestClient) -> None:
         assert client.get("/redoc").status_code == 404
 

--- a/backend/tests/unit/api/test_discovery_endpoints.py
+++ b/backend/tests/unit/api/test_discovery_endpoints.py
@@ -279,7 +279,6 @@ class TestOldDocsEndpointsRemoved:
             get_settings.cache_clear()
             importlib.reload(main_module)
 
-
     def test_old_redoc_404(self, client: TestClient) -> None:
         assert client.get("/redoc").status_code == 404
 

--- a/backend/tests/unit/api/test_docs_endpoints.py
+++ b/backend/tests/unit/api/test_docs_endpoints.py
@@ -125,16 +125,15 @@ class TestDocsEnabled:
 
 
 class TestAPIDocsSettings:
-    """The enable_api_docs setting defaults to False and is toggleable."""
+    """The enable_api_docs setting defaults to True and is toggleable."""
 
-    def test_default_is_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_default_is_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from syntara.core.config.base import get_settings
 
-        # Override local .env so this asserts the production default.
-        monkeypatch.setenv("APP_ENABLE_API_DOCS", "false")
+        monkeypatch.setenv("APP_ENABLE_API_DOCS", "true")
         get_settings.cache_clear()
         try:
-            assert get_settings().enable_api_docs is False
+            assert get_settings().enable_api_docs is True
         finally:
             get_settings.cache_clear()
 
@@ -161,7 +160,7 @@ class TestAPIDocsSettings:
         from syntara.core.config.base import APIDocsSettings
 
         settings = APIDocsSettings()
-        assert settings.enable_api_docs is False
+        assert settings.enable_api_docs is True
 
 
 class TestTryItOutSettings:

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -182,8 +182,8 @@ services:
       - APP_S2S_TLS_KEY_PATH=/run/secrets/s2s-cert.key
       - APP_S2S_TLS_CN_ALLOWLIST=["backend.ao.svc","worker.ao.svc","background-worker.ao.svc","temporal.ao.svc"]
       - APP_BACKGROUND_TASK_QUEUE=orchestrator-background-queue
-      # Docs off by default; enable for DAST / local container debugging.
-      - APP_ENABLE_API_DOCS=${APP_ENABLE_API_DOCS:-false}
+      # Docs on by default; set to false to disable in locked-down environments.
+      - APP_ENABLE_API_DOCS=${APP_ENABLE_API_DOCS:-true}
     volumes:
       - ./backend/src:/opt/app-root/src/src:z
       - syntara_audit_exports:/data/audit-exports:z


### PR DESCRIPTION
## Description

Enable API documentation endpoints by default (`APP_ENABLE_API_DOCS=true`). Customers repeatedly report that accessing docs is difficult because the setting defaults to `false`, requiring explicit configuration. This flips the default so docs are available out of the box.

Product management has acknowledged the security trade-off: docs are served unauthenticated, so enabling by default creates a potential attack surface. A separate follow-up issue will add authentication for API docs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] Flip `enable_api_docs` field default from `False` to `True` in `APIDocsSettings` (`backend/src/nexus/core/config/base.py`)
- [x] Update `podman-compose.yml` fallback from `${APP_ENABLE_API_DOCS:-false}` to `${APP_ENABLE_API_DOCS:-true}`
- [x] Move doc endpoints from `/api/v1/` to `/api_docs/v1/` and serve unauthenticated
- [x] Add `/docs` → `/api_docs/v1/docs` convenience redirect
- [x] Add `/api_docs/` to `EXCLUDED_PATH_PREFIXES` and `EXCLUDED_PATHS` in `constants.py`
- [x] Update proxy configs (`nginx.conf.template`, `vite.config.ts`) to forward `/api_docs` and `/docs` to the backend
- [x] Update DAST config (`rapidast-config.yaml`) to use new OpenAPI URL and remove now-unnecessary `APP_ENABLE_API_DOCS=true` from usage
instructions
- [x] Update CI workflow (`.github/workflows/dast.yml`) comment to reflect new default
- [x] Update tests to assert `True` as the default and verify unauthenticated access at the new paths
- [x] Update `.env.example` comments in both root and `backend/`

## Out of Scope

- **Authentication for API docs** — a separate follow-up issue will gate docs behind auth. Enabling by default without auth is an accepted risk per product management.
- **`enable_try_it_out` default** — remains `False`; interactive execution is a separate concern.

## Related Issues

Closes AAP-86965
Related to AAP-85985

## How to Test

1. Start services with default config: `make dev`
2. Navigate to `https://localhost:8000/api_docs/v1/docs` — Swagger UI should load **without authentication**
3. Navigate to `https://localhost:8000/api_docs/v1/redoc` — ReDoc should load without authentication
4. Navigate to `https://localhost:8000/docs` — should redirect (307) to `/api_docs/v1 docs`
5. Navigate to `https://localhost:8000/api_docs/v1/openapi.json` — should return the OpenAPI spec
6. Verify old paths return 404: `/api/v1/docs`, `/api/v1/redoc`, `/api/v1/openapi.json`, `/redoc`, `/openapi.json`
7. Set `APP_ENABLE_API_DOCS=false` and restart — all doc endpoints should disappear

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [x] Database migrations are included if schema changed — N/A, no schema changes
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`) — proxy config only, no component changes
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality — N/A, config-only change
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation) — N/A
- [x] Screenshots or screen recordings are attached for UI changes — N/A, no UI changes

## Visual Regression

- [x] No UI changes — visual regression not affected

## General Checklist

- [x] Code follows the project's coding conventions
- [x] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps — not a breaking change; deployments that want docs disabled can set `APP_ENABLE_API_DOCS=false`

## Additional Notes

- Deployments that previously relied on the `false` default to keep docs hidden will now need to explicitly set `APP_ENABLE_API_DOCS=false`. This should be called out in release notes.
- The DAST workflow no longer needs to explicitly set `APP_ENABLE_API_DOCS=true` but the env var is kept for clarity/documentation.