### PR TITLE
Revert "chore(ci): switch Tekton UI-tests pipeline resolver from bundles to git (#6)"

### DIFF
--- a/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
@@ -37,22 +37,16 @@ spec:
     - name: pipeline-github-pr-number
       value: '{{pull_request_number}}'
   pipelineRef:
-    resolver: git
     params:
-      - name: org
-        value: ansible-automation-platform
-      - name: repo
-        value: aap-konflux-pipelines
-      - name: revision
-        value: fix/deploy-ao-symlink-syntara-ui
-      - name: pathInRepo
-        value: pipelines/test/ao-ui-tests/0.1/pipeline.yaml
-      - name: token
-        value: github-aap-org-secret
-      - name: tokenKey
-        value: password
-      - name: scmType
-        value: github
+      - name: name
+        value: ao-ui-tests
+      - name: bundle
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:d8e7756e04cbd91f4df29bb38502cfbcb866bd242b7acc0d5263031fa5267e24
+      - name: kind
+        value: pipeline
+      - name: secret
+        value: quay-aap-ci-viewer
+    resolver: bundles
 
   taskRunTemplate:
     serviceAccountName: konflux-integration-runner


### PR DESCRIPTION
This reverts commit d3ca5bf8e8a6ca5749328b0bf316ee0bef647359 and bump the sha2 of the bundle.

The use of the git resolver was causing the following error:

```
Pipeline nexus-tenant/ can't be Run; it contains Tasks that don't exist: Couldn't retrieve Task "resolver type git\n": error requesting remote resource: error getting "Git" "nexus-tenant/git-d1afe8f2aa3177c729a0ccb0213c3219": couldn't fetch resource content: Not Found
```