### PR TITLE
fix(AAP-87134): user-friendly AI Agent service unreachable message

### DIFF
--- a/backend/src/syntara/workflows/workflow_engine/activities/agentic_activity.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/agentic_activity.py
@@ -227,7 +227,10 @@ async def execute_agentic_activity(  # noqa: PLR0915
         raise ApplicationError(msg, type="ConfigError", non_retryable=True) from None
     except AgentOrchestratorClientConnectionError:
         logger.exception("Failed to connect to Agent Orchestrator")
-        msg = "Failed to connect to Agent Orchestrator"
+        msg = (
+            "The AI Agent service is temporarily unavailable. This is a system issue. "
+            "Please try again in a few minutes. If this persists, contact your administrator."
+        )
         raise ApplicationError(msg, type="ConnectionError", non_retryable=True) from None
     except Exception as e:
         logger.exception("Unexpected error during agentic activity")

--- a/backend/tests/integration/workflows/test_agentic_activity_api.py
+++ b/backend/tests/integration/workflows/test_agentic_activity_api.py
@@ -146,7 +146,11 @@ class TestAgenticActivityErrorHandling:
 
         with pytest.raises(ApplicationError) as exc_info:
             await execute_agentic_activity(input_config, None, project_id=str(uuid4()))
-        assert "agent orchestrator" in str(exc_info.value).lower()
+        error_message = str(exc_info.value)
+        assert "temporarily unavailable" in error_message.lower()
+        assert "try again" in error_message.lower()
+        assert "agent orchestrator" not in error_message.lower()
+        assert "Failed to connect to Agent Orchestrator" not in error_message
 
     @pytest.mark.asyncio
     async def test_handles_agent_orchestrator_timeout(self, mock_agent_client) -> None:

--- a/backend/tests/unit/workflows/activities/test_agentic_activity_connection_error.py
+++ b/backend/tests/unit/workflows/activities/test_agentic_activity_connection_error.py
@@ -1,0 +1,65 @@
+"""Unit tests for agentic activity connection-failure messaging (AGENT-05)."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from nexus.workflows.clients.agent_orchestrator_client import AgentOrchestratorClientConnectionError
+from nexus.workflows.workflow_engine.activities.agentic_activity import execute_agentic_activity
+
+AGENT_SERVICE_UNAVAILABLE_MESSAGE = (
+    "The AI Agent service is temporarily unavailable. This is a system issue. "
+    "Please try again in a few minutes. If this persists, contact your administrator."
+)
+
+
+async def _fake_inject_runtime_settings(input_config: dict[str, object]) -> None:
+    """Inject default timeout like the real helper does."""
+    if "timeout" not in input_config:
+        input_config["timeout"] = 300
+
+
+@pytest.fixture
+def mock_agent_client() -> Generator[AsyncMock, None, None]:
+    """Mock Agent Orchestrator client and activity heartbeat."""
+    with (
+        patch("temporalio.activity.heartbeat"),
+        patch("nexus.workflows.workflow_engine.activities.agentic_activity.AgentOrchestratorClient") as mock_cls,
+        patch(
+            "nexus.workflows.workflow_engine.activities.agentic_activity._inject_runtime_settings",
+            side_effect=_fake_inject_runtime_settings,
+        ),
+    ):
+        mock_instance = AsyncMock()
+        mock_instance.invoke_agent_async = AsyncMock(return_value="inv_123456")
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_cls.return_value = mock_instance
+        yield mock_instance
+
+
+class TestAgenticActivityConnectionError:
+    """Pre-dispatch connection failures must use user-friendly copy."""
+
+    @pytest.mark.asyncio
+    async def test_connection_error_uses_user_friendly_message(self, mock_agent_client: AsyncMock) -> None:
+        """AgentOrchestratorClientConnectionError surfaces AGENT-05 guidance, not internal service name."""
+        mock_agent_client.invoke_agent_async.side_effect = AgentOrchestratorClientConnectionError(
+            "Agent Orchestrator unavailable"
+        )
+
+        input_config = {
+            "prompt": "Test prompt",
+            "llm_model_id": "550e8400-e29b-41d4-a716-446655440000",
+        }
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await execute_agentic_activity(input_config, None, project_id=str(uuid4()))
+
+        assert exc_info.value.message == AGENT_SERVICE_UNAVAILABLE_MESSAGE
+        assert exc_info.value.type == "ConnectionError"
+        assert "agent orchestrator" not in exc_info.value.message.lower()
+        assert "Failed to connect to Agent Orchestrator" not in exc_info.value.message

--- a/backend/tests/unit/workflows/activities/test_agentic_activity_connection_error.py
+++ b/backend/tests/unit/workflows/activities/test_agentic_activity_connection_error.py
@@ -5,9 +5,10 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+from temporalio.exceptions import ApplicationError
+
 from syntara.workflows.clients.agent_orchestrator_client import AgentOrchestratorClientConnectionError
 from syntara.workflows.workflow_engine.activities.agentic_activity import execute_agentic_activity
-from temporalio.exceptions import ApplicationError
 
 AGENT_SERVICE_UNAVAILABLE_MESSAGE = (
     "The AI Agent service is temporarily unavailable. This is a system issue. "

--- a/backend/tests/unit/workflows/activities/test_agentic_activity_connection_error.py
+++ b/backend/tests/unit/workflows/activities/test_agentic_activity_connection_error.py
@@ -5,10 +5,9 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+from syntara.workflows.clients.agent_orchestrator_client import AgentOrchestratorClientConnectionError
+from syntara.workflows.workflow_engine.activities.agentic_activity import execute_agentic_activity
 from temporalio.exceptions import ApplicationError
-
-from nexus.workflows.clients.agent_orchestrator_client import AgentOrchestratorClientConnectionError
-from nexus.workflows.workflow_engine.activities.agentic_activity import execute_agentic_activity
 
 AGENT_SERVICE_UNAVAILABLE_MESSAGE = (
     "The AI Agent service is temporarily unavailable. This is a system issue. "
@@ -27,9 +26,9 @@ def mock_agent_client() -> Generator[AsyncMock, None, None]:
     """Mock Agent Orchestrator client and activity heartbeat."""
     with (
         patch("temporalio.activity.heartbeat"),
-        patch("nexus.workflows.workflow_engine.activities.agentic_activity.AgentOrchestratorClient") as mock_cls,
+        patch("syntara.workflows.workflow_engine.activities.agentic_activity.AgentOrchestratorClient") as mock_cls,
         patch(
-            "nexus.workflows.workflow_engine.activities.agentic_activity._inject_runtime_settings",
+            "syntara.workflows.workflow_engine.activities.agentic_activity._inject_runtime_settings",
             side_effect=_fake_inject_runtime_settings,
         ),
     ):


### PR DESCRIPTION
## Description

pre-dispatch connection failures were exposing the internal name `Agent Orchestrator` via `Failed to connect to Agent Orchestrator`. this swaps that for the AGENT-05 guidance (temporary unavailability, retry, contact admin) while leaving operator logs unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] replace user-facing `ApplicationError` message on `AgentOrchestratorClientConnectionError` in `agentic_activity.py`
- [x] update integration assertion so it rejects `Agent Orchestrator` in the surfaced copy
- [x] add unit coverage for the AGENT-05 message and `ConnectionError` type

## Out of Scope

post-dispatch LLM/provider failures (AAP-87136 / AGENT-08). client-internal exception text for retries remains for diagnostics.

## Related Issues

Fixes AAP-87134

## How to Test

1. stop the agent orchestrator or point `AGENT_ORCHESTRATOR_BASE_URL` at a dead endpoint
2. run a workflow with an AI Agent step
3. confirm the failure shows the AGENT-05 copy, with no `Agent Orchestrator` wording
4. optional: from `backend/`, `uv run pytest tests/unit/workflows/activities/test_agentic_activity_connection_error.py -q`

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->