### PR TITLE
fix(AAP-87133): replace project_id ConfigError with user-facing message

### DIFF
--- a/backend/src/syntara/workflows/workflow_engine/activities/agentic_activity.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/agentic_activity.py
@@ -153,7 +153,10 @@ async def execute_agentic_activity(  # noqa: PLR0915
             raise ApplicationError(msg, type="ConfigError", non_retryable=True)  # noqa: TRY301
 
         if not project_id:
-            msg = "Agentic activity requires non-empty 'project_id'"
+            msg = (
+                "The AI Agent node could not determine the project context. "
+                "This is usually a system error. Try re-saving the workflow or contact your administrator."
+            )
             raise ApplicationError(msg, type="ConfigError", non_retryable=True)  # noqa: TRY301
 
         file_ids = config.file_ids or []

--- a/backend/tests/unit/workflows/activities/test_agentic_runtime_settings.py
+++ b/backend/tests/unit/workflows/activities/test_agentic_runtime_settings.py
@@ -66,3 +66,9 @@ class TestExecuteAgenticActivitySettingsIntegration:
         with pytest.raises(ApplicationError) as exc_info:
             await execute_agentic_activity(config, None, project_id="")
         assert exc_info.value.type == "ConfigError"
+        assert exc_info.value.message == (
+            "The AI Agent node could not determine the project context. "
+            "This is usually a system error. Try re-saving the workflow or contact your administrator."
+        )
+        assert "project_id" not in exc_info.value.message
+        assert "requires non-empty" not in exc_info.value.message


### PR DESCRIPTION
## Description

replaces the internal `project_id` ConfigError on the AI Agent node with a user-facing project context message (AGENT-03).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] update empty `project_id` ApplicationError message in `agentic_activity.py`
- [x] assert the new message (and no `project_id` / `requires non-empty`) in unit tests

## Out of Scope

other AGENT-* runtime message swaps from the audit.

## Related Issues

Fixes AAP-87133
Related to AAP-87086

## How to Test

1. trigger an AI Agent node path with missing/empty `project_id` (unit coverage is the practical check)
2. confirm the failure message is: `The AI Agent node could not determine the project context. This is usually a system error. Try re-saving the workflow or contact your administrator.`
3. confirm the message does not mention `project_id`

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->