### PR TITLE
fix(tests): Disable react compiler during coverage runs to fix phantom branches

### DIFF
--- a/frontend/packages/syntara-ui/vitest.config.ts
+++ b/frontend/packages/syntara-ui/vitest.config.ts
@@ -2,13 +2,18 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
 const isShardedCoverage = process.env.CI === 'true' && Boolean(process.env.VITEST_COVERAGE_DIR)
+const isCoverageRun = process.argv.includes('--coverage') || isShardedCoverage
 
 // https://vitest.dev/config/
 export default defineConfig({
   plugins: [
     react({
       babel: {
-        plugins: [['babel-plugin-react-compiler']],
+        // Disable the React Compiler during coverage runs. The compiler transforms
+        // JSX into optimized code with internal branches that V8 tracks as real
+        // conditions, producing phantom uncovered branches in lcov reports.
+        // Upstream bug: https://github.com/facebook/react/issues/32950
+        plugins: isCoverageRun ? [] : [['babel-plugin-react-compiler']],
       },
     }),
   ],

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -14,21 +14,7 @@ sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 # Exclusions
 sonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/*.stories.*,**/*.testFixtures.ts,**/src/test/**,**/*.png,**/*.jpg,**/*.jpeg,**/*.gif,**/*.svg,**/*.ico,**/*.woff,**/*.woff2,**/*.ttf,**/*.eot,**/*.mp4,**/*.webm,**/*.pdf
-# WorkflowHistoryCard / VersionHistoryPanel / RunHistoryTableHead / ExecutionActivityTable: v8 emits large
-# numbers of phantom JSX branches on the history layout and compact/sortable table headers;
-# logic is covered via historyRowModel, versionHistoryHelpers, sortExecutionActivities, and
-# RunHistoryTableHead / runHistoryTableColumns / ExecutionActivityTable unit tests instead.
-# AgentTraceView / NodeExecutionDetailsPanel: Istanbul/v8 counts JSX ternary and
-# short-circuit branches that are not meaningfully exercisable; logic is covered
-# via agentTraceTypes, executionPolling, and component behavior tests instead.
-# SimpleSchemaBuilder: v8 generates 99 branches for JSX prop objects, callbacks,
-# and template literals in a 55-line component; 100% line coverage but only 53%
-# branch coverage due to phantom branches. Covered by SimpleSchemaBuilder.test.tsx.
-# CredentialDependencySection / CredentialAffectedResourcesWarnings: new ripple
-# presentation components; 100% line coverage but v8 phantom JSX branches tank
-# new-code branch coverage. Covered by dedicated unit tests. Existing delete/
-# disable dialogs are not excluded.
-sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/*.stories.*,**/src/test/**,packages/syntara-ui/src/app/tanstackRouteTree.tsx,packages/syntara-ui/src/routes/builder/WorkflowHistoryCard.tsx,packages/syntara-ui/src/routes/builder/RunHistoryTableHead.tsx,packages/syntara-ui/src/routes/builder/ExecutionActivityTable.tsx,packages/syntara-ui/src/routes/builder/VersionHistoryPanel.tsx,packages/syntara-ui/src/routes/executions/AgentTraceView.tsx,packages/syntara-ui/src/routes/executions/NodeExecutionDetailsPanel.tsx,packages/syntara-ui/src/routes/builder/node-forms/SimpleSchemaBuilder.tsx,packages/syntara-ui/src/routes/configuration/credentials/CredentialDependencySection.tsx,packages/syntara-ui/src/routes/configuration/credentials/CredentialAffectedResourcesWarnings.tsx
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/*.stories.*,**/src/test/**,packages/syntara-ui/src/app/tanstackRouteTree.tsx
 
 # Language settings - Coverage report paths
 sonar.javascript.lcov.reportPaths=packages/syntara-ui/coverage/lcov.info


### PR DESCRIPTION
## Description

`babel-plugin-react-compiler` injects memoization if/else guards into compiled output that V8 tracks as real branch conditions in lcov reports. SonarCloud reads these phantom branches at face value, causing JSX-heavy component files to fail the 90% coverage quality gate even when all source code branches are fully tested.

This has been escalating since SonarCloud was integrated in late June 2026, with 9 component files added to `sonar.coverage.exclusions` as a workaround...  a list that would grow with every JSX-heavy PR.

This PR fixes the root cause by disabling the React Compiler during coverage runs only. Regular test runs (`npx vitest run`) and production builds (`vite.config.ts`) are unaffected, the compiler remains active for both.

### Root cause chain
1. **React Compiler** (`babel-plugin-react-compiler@1.0.0`) generates memoization branches not present in source code — known upstream bug: [facebook/react#32950](https://github.com/facebook/react/issues/32950)
2. **Vitest 4.x** (upgraded Dec 2025, commit `fe8038809`) introduced AST-aware source map remapping that accurately maps these phantom branches back to source lines — Vitest 3.x was silently ignoring them
3. **SonarCloud** (integrated Jun 2026) began enforcing coverage quality gates, surfacing the phantom branches as failures

### Local verification (before → after)
| File | Compiler ON | Compiler OFF |
|---|---|---|
| SimpleSchemaBuilder | 51.96% (53/102 branches) | **83.33%** (5/6) |
| CredentialDependencySection | 65% (13/20) | **100%** (6/6) |
| AgentTraceView | 68.65% (138/201) | **95.45%** (42/44) |
| CredentialAffectedResourcesWarnings | 70.58% (24/34) | **100%** (18/18) |
| NodeExecutionDetailsPanel | 73.77% (211/286) | **96.66%** (58/60) |
| WorkflowHistoryCard | 79.54% (105/132) | **90.9%** (30/33) |
| VersionHistoryPanel | 84.26% (257/305) | **96.96%** (64/66) |
| ExecutionActivityTable | 90.97% (131/144) | **88.37%** (38/43) |

Full test suite (13,545 tests) passes with the compiler disabled for coverage.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- [x] `frontend/packages/syntara-ui/vitest.config.ts` — conditionally disable `babel-plugin-react-compiler` when `--coverage` flag is present or CI sharded coverage is active
- [x] `frontend/sonar-project.properties` — remove 9 phantom-branch file exclusions and 14 lines of explanatory comments; retain non-phantom exclusions (test files, stories, `tanstackRouteTree.tsx`)

## Out of Scope

- Improving real (non-phantom) test coverage on the un-excluded files... some remain below 90% due to genuinely untested branches. Those are separate tickets.
- Upstream fix in `babel-plugin-react-compiler`is being tracked at [facebook/react#32950](https://github.com/facebook/react/issues/32950). Once fixed, the conditional in `vitest.config.ts` can be removed.

## Related Issues

Resolves AAP-86762

## How to Test

1. Run `cd frontend/packages/syntara-ui && npx vitest run --coverage`
2. Open `coverage/index.html` in a browser
3. Navigate to any of the previously-excluded files (e.g., `SimpleSchemaBuilder.tsx`, `AgentTraceView.tsx`)
4. Verify branch coverage numbers are realistic (not inflated by hundreds of phantom branches)
5. Confirm all tests pass

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps

## Additional Notes
Monitor [facebook/react#32950](https://github.com/facebook/react/issues/32950) for an upstream fix. Once the React Compiler properly excludes generated code from source maps, the `isCoverageRun` conditional in `vitest.config.ts` can be removed.
