### PR TITLE
fix(AAP-87132): replace empty-signal fallback with actionable message

### DIFF
--- a/backend/src/syntara/workflows/services/execution_service.py
+++ b/backend/src/syntara/workflows/services/execution_service.py
@@ -58,6 +58,7 @@ from syntara.workflows.models.workflow_version import WorkflowVersion
 from syntara.workflows.utils.workflow_metadata import build_workflow_metadata, resolve_user_display_name
 from syntara.workflows.workflow_engine.models.workflow_definition import NodeType, resolve_trigger_node
 from syntara.workflows.workflow_engine.services.temporal_execution_service import TemporalExecutionService
+from syntara.workflows.workflow_engine.signals.processor import resolve_signal_failure_message
 
 if TYPE_CHECKING:
     from syntara.metrics.recorder import MetricsRecorder
@@ -1036,18 +1037,13 @@ class ExecutionService(BaseService):
 
         status = signal_data.get("status")
         if status == "failed":
-            error_info = signal_data.get("error", {})
-            if isinstance(error_info, dict):
-                error_msg = str(error_info.get("message", "Activity execution failed"))[:MAX_CALLBACK_ERROR_MSG_LENGTH]
-                error_type = str(error_info.get("error_type", "UnknownError"))
-            else:
-                error_msg = (str(error_info) if error_info else "Activity execution failed")[
-                    :MAX_CALLBACK_ERROR_MSG_LENGTH
-                ]
-                error_type = "UnknownError"
+            error_msg, error_type, has_error_detail = resolve_signal_failure_message(signal_data.get("error"))
+            error_msg = error_msg[:MAX_CALLBACK_ERROR_MSG_LENGTH]
+            # Keep ErrorType prefix when a real message exists; empty fallback is already actionable.
+            application_message = f"{error_type}: {error_msg}" if has_error_detail else error_msg
 
             error = ApplicationError(
-                f"{error_type}: {error_msg}",
+                application_message,
                 type=error_type,
                 non_retryable=True,
             )

--- a/backend/src/syntara/workflows/workflow_engine/signals/processor.py
+++ b/backend/src/syntara/workflows/workflow_engine/signals/processor.py
@@ -51,6 +51,33 @@ EMPTY_SIGNAL_ERROR_MESSAGE = (
 )
 
 
+def resolve_signal_failure_message(error_info: object) -> tuple[str, str, bool]:
+    """Resolve user-facing failure text from a signal/callback error payload.
+
+    Returns:
+        Tuple of (message, error_type, has_error_detail). When ``has_error_detail``
+        is False, ``message`` is ``EMPTY_SIGNAL_ERROR_MESSAGE`` and callers should
+        not prefix ``error_type``.
+
+    """
+    if isinstance(error_info, dict):
+        raw_message = error_info.get("message")
+        error_type = error_info.get("error_type", "UnknownError")
+    elif error_info:
+        raw_message = str(error_info)
+        error_type = "UnknownError"
+    else:
+        raw_message = None
+        error_type = "UnknownError"
+
+    if not isinstance(error_type, str) or not error_type:
+        error_type = "UnknownError"
+
+    if isinstance(raw_message, str) and raw_message.strip():
+        return raw_message.strip(), error_type, True
+    return EMPTY_SIGNAL_ERROR_MESSAGE, error_type, False
+
+
 class WorkflowSignalProcessor:
     """Processor for workflow activity signals.
 
@@ -94,19 +121,7 @@ class WorkflowSignalProcessor:
 
         if signal_status == "failed":
             # Extract error information and raise exception
-            error_info = signal_data.get("error") or {}
-            if not isinstance(error_info, dict):
-                error_info = {}
-            raw_message = error_info.get("message")
-            if isinstance(raw_message, str) and raw_message.strip():
-                has_error_detail = True
-                error_message = raw_message.strip()
-            else:
-                has_error_detail = False
-                error_message = EMPTY_SIGNAL_ERROR_MESSAGE
-            error_type = error_info.get("error_type", "UnknownError")
-            if not isinstance(error_type, str) or not error_type:
-                error_type = "UnknownError"
+            error_message, error_type, has_error_detail = resolve_signal_failure_message(signal_data.get("error"))
 
             # Log only if in workflow context (workflow.logger requires workflow event loop)
             with contextlib.suppress(Exception):  # Silently skip logging if not in workflow context

--- a/backend/src/syntara/workflows/workflow_engine/signals/processor.py
+++ b/backend/src/syntara/workflows/workflow_engine/signals/processor.py
@@ -43,6 +43,14 @@ def _format_user_message(error_type: str, error_message: str) -> str:
     return f"An unexpected error occurred: {error_message}"
 
 
+# User-facing fallback when a failure signal has no error.message.
+EMPTY_SIGNAL_ERROR_MESSAGE = (
+    "The AI Agent encountered an error but did not provide details. "
+    "Try running the workflow again. If this persists, check the agent "
+    "configuration or contact your administrator."
+)
+
+
 class WorkflowSignalProcessor:
     """Processor for workflow activity signals.
 
@@ -86,9 +94,19 @@ class WorkflowSignalProcessor:
 
         if signal_status == "failed":
             # Extract error information and raise exception
-            error_info = signal_data.get("error", {})
-            error_message = error_info.get("message", "Agent execution failed")
+            error_info = signal_data.get("error") or {}
+            if not isinstance(error_info, dict):
+                error_info = {}
+            raw_message = error_info.get("message")
+            if isinstance(raw_message, str) and raw_message.strip():
+                has_error_detail = True
+                error_message = raw_message.strip()
+            else:
+                has_error_detail = False
+                error_message = EMPTY_SIGNAL_ERROR_MESSAGE
             error_type = error_info.get("error_type", "UnknownError")
+            if not isinstance(error_type, str) or not error_type:
+                error_type = "UnknownError"
 
             # Log only if in workflow context (workflow.logger requires workflow event loop)
             with contextlib.suppress(Exception):  # Silently skip logging if not in workflow context
@@ -102,10 +120,10 @@ class WorkflowSignalProcessor:
                     },
                 )
 
-            msg = _format_user_message(error_type, error_message)
+            msg = _format_user_message(error_type, error_message) if has_error_detail else error_message
 
             # Extract error code from message (works for HTTP status codes AND exit codes)
-            error_code = extract_error_code(error_message)
+            error_code = extract_error_code(error_message) if has_error_detail else None
 
             # Get retryable error codes from retry policy config (whitelist approach)
             # Default: common transient server errors that should be retried

--- a/backend/tests/unit/workflows/services/test_execution_service.py
+++ b/backend/tests/unit/workflows/services/test_execution_service.py
@@ -1787,6 +1787,40 @@ class TestHandleActivityCallback(TestExecutionServiceBase):
         assert "AgentError: LLM error" in str(error)
 
     @pytest.mark.asyncio
+    async def test_failed_callback_uses_empty_signal_fallback_when_message_missing(self) -> None:
+        """Empty/missing callback error.message uses the SIGNAL-02 fallback on the production path."""
+        from syntara.workflows.workflow_engine.signals.processor import EMPTY_SIGNAL_ERROR_MESSAGE
+
+        service, mock_temporal = self._make_service()
+        service.get_execution = AsyncMock(return_value=self._mock_execution())  # type: ignore[method-assign]
+        await service.handle_activity_callback(
+            uuid4(),
+            "node-1",
+            {"status": "failed", "error": {}},
+        )
+
+        error = mock_temporal.fail_async_activity.call_args.kwargs["error"]
+        assert error.message == EMPTY_SIGNAL_ERROR_MESSAGE
+        assert "Activity execution failed" not in error.message
+
+    @pytest.mark.asyncio
+    async def test_failed_callback_uses_empty_signal_fallback_for_whitespace_message(self) -> None:
+        """Whitespace-only callback error.message uses the SIGNAL-02 fallback."""
+        from syntara.workflows.workflow_engine.signals.processor import EMPTY_SIGNAL_ERROR_MESSAGE
+
+        service, mock_temporal = self._make_service()
+        service.get_execution = AsyncMock(return_value=self._mock_execution())  # type: ignore[method-assign]
+        await service.handle_activity_callback(
+            uuid4(),
+            "node-1",
+            {"status": "failed", "error": {"message": "   ", "error_type": "AgentError"}},
+        )
+
+        error = mock_temporal.fail_async_activity.call_args.kwargs["error"]
+        assert error.message == EMPTY_SIGNAL_ERROR_MESSAGE
+        assert "AgentError:" not in error.message
+
+    @pytest.mark.asyncio
     async def test_truncates_long_error_messages(self) -> None:
         """Test that error messages are truncated to 500 characters."""
         service, mock_temporal = self._make_service()

--- a/backend/tests/unit/workflows/signals/test_processor.py
+++ b/backend/tests/unit/workflows/signals/test_processor.py
@@ -9,7 +9,10 @@ from temporalio.exceptions import ApplicationError
 from syntara.workflows.workflow_engine.activities.common import (
     ActivityExecutionError,
 )
-from syntara.workflows.workflow_engine.signals.processor import WorkflowSignalProcessor
+from syntara.workflows.workflow_engine.signals.processor import (
+    EMPTY_SIGNAL_ERROR_MESSAGE,
+    WorkflowSignalProcessor,
+)
 
 
 class TestWorkflowSignalProcessorProcessSignal:
@@ -98,11 +101,7 @@ class TestWorkflowSignalProcessorProcessSignal:
             WorkflowSignalProcessor.process_signal(signal_data, "task_minimal", "exec-minimal")
 
         assert exc_info.value.non_retryable is True
-        assert exc_info.value.message == (
-            "The AI Agent encountered an error but did not provide details. "
-            "Try running the workflow again. If this persists, check the agent "
-            "configuration or contact your administrator."
-        )
+        assert exc_info.value.message == EMPTY_SIGNAL_ERROR_MESSAGE
         assert "Agent execution failed" not in exc_info.value.message
         assert not exc_info.value.message.startswith("UnknownError:")
 
@@ -120,11 +119,7 @@ class TestWorkflowSignalProcessorProcessSignal:
             WorkflowSignalProcessor.process_signal(signal_data, "task_no_error", "exec-no-error")
 
         assert exc_info.value.non_retryable is True
-        assert exc_info.value.message == (
-            "The AI Agent encountered an error but did not provide details. "
-            "Try running the workflow again. If this persists, check the agent "
-            "configuration or contact your administrator."
-        )
+        assert exc_info.value.message == EMPTY_SIGNAL_ERROR_MESSAGE
         assert "Agent execution failed" not in exc_info.value.message
 
     def test_process_signal_failure_with_empty_error_message(self) -> None:
@@ -141,11 +136,7 @@ class TestWorkflowSignalProcessorProcessSignal:
             WorkflowSignalProcessor.process_signal(signal_data, "task_blank", "exec-blank")
 
         assert exc_info.value.non_retryable is True
-        assert exc_info.value.message == (
-            "The AI Agent encountered an error but did not provide details. "
-            "Try running the workflow again. If this persists, check the agent "
-            "configuration or contact your administrator."
-        )
+        assert exc_info.value.message == EMPTY_SIGNAL_ERROR_MESSAGE
         assert "SomeError:" not in exc_info.value.message
 
     def test_process_signal_failure_preserves_real_error_message(self) -> None:

--- a/backend/tests/unit/workflows/signals/test_processor.py
+++ b/backend/tests/unit/workflows/signals/test_processor.py
@@ -85,7 +85,7 @@ class TestWorkflowSignalProcessorProcessSignal:
         assert "credentials" in str(exc_info.value)
 
     def test_process_signal_failure_with_minimal_error_info(self) -> None:
-        """Test that failed signal with minimal error info uses defaults."""
+        """Test that failed signal with minimal error info uses empty-signal fallback."""
         # Arrange - no error code, should be non-retryable
         signal_data = {
             "id": "invocation-minimal",
@@ -97,13 +97,17 @@ class TestWorkflowSignalProcessorProcessSignal:
         with pytest.raises(ApplicationError) as exc_info:
             WorkflowSignalProcessor.process_signal(signal_data, "task_minimal", "exec-minimal")
 
-        # Should use generic fallback with default message
         assert exc_info.value.non_retryable is True
-        assert "An unexpected error occurred" in str(exc_info.value)
-        assert "Agent execution failed" in str(exc_info.value)
+        assert exc_info.value.message == (
+            "The AI Agent encountered an error but did not provide details. "
+            "Try running the workflow again. If this persists, check the agent "
+            "configuration or contact your administrator."
+        )
+        assert "Agent execution failed" not in exc_info.value.message
+        assert not exc_info.value.message.startswith("UnknownError:")
 
     def test_process_signal_failure_without_error_dict(self) -> None:
-        """Test that failed signal without error dict uses defaults."""
+        """Test that failed signal without error dict uses empty-signal fallback."""
         # Arrange - no error code, should be non-retryable
         signal_data = {
             "id": "invocation-no-error",
@@ -116,7 +120,51 @@ class TestWorkflowSignalProcessorProcessSignal:
             WorkflowSignalProcessor.process_signal(signal_data, "task_no_error", "exec-no-error")
 
         assert exc_info.value.non_retryable is True
-        assert "An unexpected error occurred" in str(exc_info.value)
+        assert exc_info.value.message == (
+            "The AI Agent encountered an error but did not provide details. "
+            "Try running the workflow again. If this persists, check the agent "
+            "configuration or contact your administrator."
+        )
+        assert "Agent execution failed" not in exc_info.value.message
+
+    def test_process_signal_failure_with_empty_error_message(self) -> None:
+        """Empty/whitespace error.message uses the same actionable fallback."""
+        signal_data = {
+            "status": "failed",
+            "error": {
+                "message": "   ",
+                "error_type": "SomeError",
+            },
+        }
+
+        with pytest.raises(ApplicationError) as exc_info:
+            WorkflowSignalProcessor.process_signal(signal_data, "task_blank", "exec-blank")
+
+        assert exc_info.value.non_retryable is True
+        assert exc_info.value.message == (
+            "The AI Agent encountered an error but did not provide details. "
+            "Try running the workflow again. If this persists, check the agent "
+            "configuration or contact your administrator."
+        )
+        assert "SomeError:" not in exc_info.value.message
+
+    def test_process_signal_failure_preserves_real_error_message(self) -> None:
+        """When error.message is present, it is shown (not the empty-signal fallback)."""
+        signal_data = {
+            "status": "failed",
+            "error": {
+                "message": "API key is invalid",
+                "error_type": "AuthenticationError",
+            },
+        }
+
+        with pytest.raises(ApplicationError) as exc_info:
+            WorkflowSignalProcessor.process_signal(signal_data, "api_call", "exec-123")
+
+        assert "API key is invalid" in exc_info.value.message
+        assert "did not provide details" not in exc_info.value.message
+        assert "Authentication failed" in exc_info.value.message
+        assert "AuthenticationError:" not in exc_info.value.message
 
     def test_process_signal_failure_maps_known_error_types(self) -> None:
         """Test that known error types produce user-friendly messages without raw type names."""


### PR DESCRIPTION
## Description

replaces the opaque `Agent execution failed` empty-signal fallback with an actionable AI Agent error message (SIGNAL-02). real `error.message` values are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] empty/missing/whitespace `error.message` on failed signals uses the SIGNAL-02 fallback in `processor.py`
- [x] keep `{error_type}: {message}` when a real message is present
- [x] unit tests for fallback and real-message paths

## Out of Scope

other SIGNAL-* / AGENT-* runtime message swaps from the audit.

## Related Issues

Fixes AAP-87132
Related to AAP-87086

## How to Test

1. send a failed activity signal with missing, empty, or whitespace-only `error.message`
2. confirm the user-facing message is the SIGNAL-02 fallback (no `Agent execution failed`)
3. send a failed signal with a real `error.message` and confirm that message is still shown

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->