### PR TITLE
feat(AAP-85181): Warn before navigating away from unsaved forms

### DIFF
--- a/frontend/packages/syntara-ui/src/hooks/useDirtyFormGuard.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useDirtyFormGuard.test.ts
@@ -1,0 +1,243 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import type { DirtyCheckOptions } from '../providers/unsaved-changes/unsavedChangesContext'
+
+import { useDirtyFormGuard } from './useDirtyFormGuard'
+
+const mockUnregister = vi.fn()
+const mockRegisterDirtyCheck = vi.fn((() => mockUnregister) as (opts: DirtyCheckOptions) => () => void)
+
+vi.mock('../app/useUnsavedChanges', () => ({
+  useUnsavedChanges: () => ({ registerDirtyCheck: mockRegisterDirtyCheck }),
+}))
+
+function lastRegistration(): DirtyCheckOptions {
+  const calls = mockRegisterDirtyCheck.mock.calls
+  return calls[calls.length - 1][0]
+}
+
+describe('useDirtyFormGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('registers a dirty check on mount', () => {
+    renderHook(() =>
+      useDirtyFormGuard({
+        isDirty: false,
+        title: 'Save?',
+        body: 'Unsaved changes.',
+      })
+    )
+
+    expect(mockRegisterDirtyCheck).toHaveBeenCalledTimes(1)
+    expect(lastRegistration().title).toBe('Save?')
+    expect(lastRegistration().body).toBe('Unsaved changes.')
+  })
+
+  it('unregisters on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useDirtyFormGuard({
+        isDirty: false,
+        title: 'Save?',
+        body: 'Unsaved changes.',
+      })
+    )
+
+    unmount()
+    expect(mockUnregister).toHaveBeenCalledTimes(1)
+  })
+
+  it('check() returns false when isDirty is false', () => {
+    renderHook(() =>
+      useDirtyFormGuard({
+        isDirty: false,
+        title: 'Save?',
+        body: 'Unsaved changes.',
+      })
+    )
+
+    expect(lastRegistration().check()).toBe(false)
+  })
+
+  it('check() returns true when isDirty is true', () => {
+    renderHook(() =>
+      useDirtyFormGuard({
+        isDirty: true,
+        title: 'Save?',
+        body: 'Unsaved changes.',
+      })
+    )
+
+    expect(lastRegistration().check()).toBe(true)
+  })
+
+  it('tracks isDirty changes via ref without re-registering', () => {
+    const { rerender } = renderHook(({ isDirty }) => useDirtyFormGuard({ isDirty, title: 'Save?', body: 'Changes.' }), {
+      initialProps: { isDirty: false },
+    })
+
+    expect(lastRegistration().check()).toBe(false)
+    expect(mockRegisterDirtyCheck).toHaveBeenCalledTimes(1)
+
+    rerender({ isDirty: true })
+
+    expect(lastRegistration().check()).toBe(true)
+    expect(mockRegisterDirtyCheck).toHaveBeenCalledTimes(1)
+  })
+
+  it('check() returns false when isActive is false even if isDirty is true', () => {
+    renderHook(() =>
+      useDirtyFormGuard({
+        isDirty: true,
+        isActive: false,
+        title: 'Save?',
+        body: 'Unsaved changes.',
+      })
+    )
+
+    expect(lastRegistration().check()).toBe(false)
+  })
+
+  it('calls onSave when saveAndExit is invoked', async () => {
+    const onSave = vi.fn().mockResolvedValue(true)
+
+    renderHook(() =>
+      useDirtyFormGuard({
+        isDirty: true,
+        onSave,
+        title: 'Save?',
+        body: 'Unsaved changes.',
+      })
+    )
+
+    const result = await lastRegistration().saveAndExit!()
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(result).toBe(true)
+  })
+
+  it('does not register saveAndExit when onSave is omitted', () => {
+    renderHook(() =>
+      useDirtyFormGuard({
+        isDirty: true,
+        title: 'Save?',
+        body: 'Unsaved changes.',
+      })
+    )
+
+    expect(lastRegistration().saveAndExit).toBeUndefined()
+  })
+
+  it('calls onDiscard and clears isDirty ref when exitWithoutSaving is invoked', () => {
+    const onDiscard = vi.fn()
+
+    renderHook(() =>
+      useDirtyFormGuard({
+        isDirty: true,
+        onDiscard,
+        title: 'Save?',
+        body: 'Unsaved changes.',
+      })
+    )
+
+    expect(lastRegistration().check()).toBe(true)
+
+    act(() => {
+      lastRegistration().exitWithoutSaving!()
+    })
+
+    expect(onDiscard).toHaveBeenCalledTimes(1)
+    expect(lastRegistration().check()).toBe(false)
+  })
+
+  it('does not register exitWithoutSaving when onDiscard is omitted', () => {
+    renderHook(() =>
+      useDirtyFormGuard({
+        isDirty: true,
+        title: 'Save?',
+        body: 'Unsaved changes.',
+      })
+    )
+
+    expect(lastRegistration().exitWithoutSaving).toBeUndefined()
+  })
+
+  it('passes saveLabel through to registerDirtyCheck', () => {
+    renderHook(() =>
+      useDirtyFormGuard({
+        isDirty: false,
+        title: 'Save settings?',
+        body: 'Unsaved settings.',
+        saveLabel: 'Save settings',
+      })
+    )
+
+    expect(lastRegistration().saveLabel).toBe('Save settings')
+  })
+
+  it('re-registers when title changes', () => {
+    const { rerender } = renderHook(({ title }) => useDirtyFormGuard({ isDirty: false, title, body: 'Changes.' }), {
+      initialProps: { title: 'Save?' },
+    })
+
+    expect(mockRegisterDirtyCheck).toHaveBeenCalledTimes(1)
+
+    rerender({ title: 'Save settings?' })
+
+    expect(mockRegisterDirtyCheck).toHaveBeenCalledTimes(2)
+    expect(mockUnregister).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-registers when isActive changes', () => {
+    const { rerender } = renderHook(
+      ({ isActive }) => useDirtyFormGuard({ isDirty: true, isActive, title: 'Save?', body: 'Changes.' }),
+      { initialProps: { isActive: true } }
+    )
+
+    expect(mockRegisterDirtyCheck).toHaveBeenCalledTimes(1)
+
+    rerender({ isActive: false })
+
+    expect(mockRegisterDirtyCheck).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses latest onSave without re-registering', async () => {
+    const onSave1 = vi.fn().mockResolvedValue(true)
+    const onSave2 = vi.fn().mockResolvedValue(true)
+
+    const { rerender } = renderHook(
+      ({ onSave }) => useDirtyFormGuard({ isDirty: true, onSave, title: 'Save?', body: 'Changes.' }),
+      { initialProps: { onSave: onSave1 } }
+    )
+
+    rerender({ onSave: onSave2 })
+
+    expect(mockRegisterDirtyCheck).toHaveBeenCalledTimes(1)
+
+    await lastRegistration().saveAndExit!()
+    expect(onSave1).not.toHaveBeenCalled()
+    expect(onSave2).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses latest onDiscard without re-registering', () => {
+    const onDiscard1 = vi.fn()
+    const onDiscard2 = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ onDiscard }) => useDirtyFormGuard({ isDirty: true, onDiscard, title: 'Save?', body: 'Changes.' }),
+      { initialProps: { onDiscard: onDiscard1 } }
+    )
+
+    rerender({ onDiscard: onDiscard2 })
+
+    expect(mockRegisterDirtyCheck).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      lastRegistration().exitWithoutSaving!()
+    })
+
+    expect(onDiscard1).not.toHaveBeenCalled()
+    expect(onDiscard2).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/packages/syntara-ui/src/hooks/useDirtyFormGuard.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useDirtyFormGuard.test.ts
@@ -151,7 +151,7 @@ describe('useDirtyFormGuard', () => {
     expect(lastRegistration().check()).toBe(false)
   })
 
-  it('does not register exitWithoutSaving when onDiscard is omitted', () => {
+  it('registers exitWithoutSaving even when onDiscard is omitted', () => {
     renderHook(() =>
       useDirtyFormGuard({
         isDirty: true,
@@ -160,7 +160,9 @@ describe('useDirtyFormGuard', () => {
       })
     )
 
-    expect(lastRegistration().exitWithoutSaving).toBeUndefined()
+    expect(lastRegistration().exitWithoutSaving).toBeDefined()
+    lastRegistration().exitWithoutSaving!()
+    expect(lastRegistration().check()).toBe(false)
   })
 
   it('passes saveLabel through to registerDirtyCheck', () => {

--- a/frontend/packages/syntara-ui/src/hooks/useDirtyFormGuard.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useDirtyFormGuard.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { useUnsavedChanges } from '../app/useUnsavedChanges'
 
@@ -38,8 +38,10 @@ export function useDirtyFormGuard({
   body,
   saveLabel,
   isActive = true,
-}: DirtyFormGuardOptions): void {
+}: DirtyFormGuardOptions): { dismiss: () => void } {
   const { registerDirtyCheck } = useUnsavedChanges()
+
+  const unregisterRef = useRef<(() => void) | null>(null)
 
   const isDirtyRef = useRef(isDirty)
   useEffect(() => {
@@ -57,18 +59,30 @@ export function useDirtyFormGuard({
   })
 
   useEffect(() => {
-    return registerDirtyCheck({
+    const unregister = registerDirtyCheck({
       check: () => isActive && isDirtyRef.current,
       saveAndExit: onSaveRef.current ? () => onSaveRef.current!() : undefined,
-      exitWithoutSaving: onDiscardRef.current
-        ? () => {
-            isDirtyRef.current = false
-            onDiscardRef.current?.()
-          }
-        : undefined,
+      exitWithoutSaving: () => {
+        isDirtyRef.current = false
+        unregisterRef.current?.()
+        unregisterRef.current = null
+        onDiscardRef.current?.()
+      },
       title,
       body,
       saveLabel,
     })
+    unregisterRef.current = unregister
+    return () => {
+      unregisterRef.current = null
+      unregister()
+    }
   }, [registerDirtyCheck, isActive, title, body, saveLabel])
+
+  const dismiss = useCallback(() => {
+    unregisterRef.current?.()
+    unregisterRef.current = null
+  }, [])
+
+  return { dismiss }
 }

--- a/frontend/packages/syntara-ui/src/hooks/useDirtyFormGuard.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useDirtyFormGuard.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef } from 'react'
+
+import { useUnsavedChanges } from '../app/useUnsavedChanges'
+
+type DirtyFormGuardOptions = {
+  /** Whether the form currently has unsaved changes. */
+  isDirty: boolean
+  /** Save the form and return true on success, false on failure. Omit to hide the "Save" button in the modal. */
+  onSave?: () => Promise<boolean>
+  /** Reset the form to its clean state when the user discards changes. */
+  onDiscard?: () => void
+  /** Modal title, e.g. "Save settings?" */
+  title: string
+  /** Modal body text, e.g. "You have unsaved changes." */
+  body: string
+  /** Label for the save button in the modal. Defaults to "Save". */
+  saveLabel?: string
+  /**
+   * Whether this guard is active. Defaults to true. Set to false when the guarded
+   * surface is mounted but not visible (e.g. an inactive tab in a tabbed detail view).
+   */
+  isActive?: boolean
+}
+
+/**
+ * Registers an unsaved-changes guard with the {@link UnsavedChangesProvider}.
+ * When the user navigates away while `isDirty` is true, a confirmation modal
+ * prompts them to save, discard, or cancel.
+ *
+ * Handles ref tracking and effect cleanup internally — callers just pass
+ * reactive values and stable callbacks.
+ */
+export function useDirtyFormGuard({
+  isDirty,
+  onSave,
+  onDiscard,
+  title,
+  body,
+  saveLabel,
+  isActive = true,
+}: DirtyFormGuardOptions): void {
+  const { registerDirtyCheck } = useUnsavedChanges()
+
+  const isDirtyRef = useRef(isDirty)
+  useEffect(() => {
+    isDirtyRef.current = isDirty
+  })
+
+  const onSaveRef = useRef(onSave)
+  useEffect(() => {
+    onSaveRef.current = onSave
+  })
+
+  const onDiscardRef = useRef(onDiscard)
+  useEffect(() => {
+    onDiscardRef.current = onDiscard
+  })
+
+  useEffect(() => {
+    return registerDirtyCheck({
+      check: () => isActive && isDirtyRef.current,
+      saveAndExit: onSaveRef.current ? () => onSaveRef.current!() : undefined,
+      exitWithoutSaving: onDiscardRef.current
+        ? () => {
+            isDirtyRef.current = false
+            onDiscardRef.current?.()
+          }
+        : undefined,
+      title,
+      body,
+      saveLabel,
+    })
+  }, [registerDirtyCheck, isActive, title, body, saveLabel])
+}

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.tsx
@@ -332,7 +332,7 @@ export function IdentityProviderForm({ mode }: Readonly<IdentityProviderFormProp
   })
   const handleError = useFormMutationErrorHandler<IdentityProviderFormData>(setError)
 
-  useDirtyFormGuard({
+  const { dismiss } = useDirtyFormGuard({
     isDirty,
     onDiscard: () => reset(),
     title: 'Discard unsaved changes?',
@@ -363,6 +363,7 @@ export function IdentityProviderForm({ mode }: Readonly<IdentityProviderFormProp
       const successTitle = isEdit ? 'Identity provider updated' : 'Identity provider created'
       const onSuccess = () => {
         showSuccess({ title: successTitle })
+        dismiss()
         navigateBack()
       }
 
@@ -375,7 +376,7 @@ export function IdentityProviderForm({ mode }: Readonly<IdentityProviderFormProp
         createProvider({ body: toCreatePayload(formData) }, { onSuccess, onError: onConflict })
       }
     },
-    [isEdit, providerId, setError, handleError, showSuccess, navigateBack, patchProvider, createProvider]
+    [isEdit, providerId, setError, handleError, showSuccess, dismiss, navigateBack, patchProvider, createProvider]
   )
 
   const normalizeAndSubmit = useCallback(

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.tsx
@@ -26,6 +26,7 @@ import { NxPageHeader } from '../../../../components/layout/NxPageHeader'
 import { NxPanel } from '../../../../components/layout/NxPanel'
 import { NxPageTitle } from '../../../../components/NxPageTitle'
 import { useQueryState } from '../../../../components/states/useQueryState'
+import { useDirtyFormGuard } from '../../../../hooks/useDirtyFormGuard'
 import { useFormMutationErrorHandler } from '../../../../hooks/useFormMutationErrorHandler'
 import { useAlerts } from '../../../../providers/alerts'
 import { getErrorMessage, getErrorStatus, isConflictError } from '../../../../utils/apiErrors'
@@ -314,13 +315,29 @@ export function IdentityProviderForm({ mode }: Readonly<IdentityProviderFormProp
   const formValues = providerData ? toFormValues(providerData) : undefined
 
   const schema = isEdit ? identityProviderEditSchema : identityProviderAddSchema
-  const { control, handleSubmit, setError, getValues, setValue, trigger } = useForm<IdentityProviderFormData>({
+  const {
+    control,
+    handleSubmit,
+    setError,
+    getValues,
+    setValue,
+    trigger,
+    formState: { isDirty },
+    reset,
+  } = useForm<IdentityProviderFormData>({
     resolver: zodResolver(schema, undefined, { mode: 'sync' }),
     mode: 'onBlur',
     defaultValues: formValues ?? identityProviderDefaults,
     values: isEdit && formValues ? formValues : undefined,
   })
   const handleError = useFormMutationErrorHandler<IdentityProviderFormData>(setError)
+
+  useDirtyFormGuard({
+    isDirty,
+    onDiscard: () => reset(),
+    title: 'Discard unsaved changes?',
+    body: 'You have unsaved changes to this identity provider. Your changes will be lost if you leave.',
+  })
 
   const navigateBack = useCallback(
     () => detachPromise(navigate({ to: AppRoute.SystemAdministration.Authentication.Root })),

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useGroupMappingForm.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useGroupMappingForm.ts
@@ -9,6 +9,7 @@ import { breadcrumbsIdentityProviderGroupMappingForm } from '../../../../app/bre
 import type { AppBreadcrumbItem } from '../../../../app/breadcrumbs/appBreadcrumbItem'
 import { identityProvidersClient } from '../../../../client'
 import { useQueryState } from '../../../../components/states/useQueryState'
+import { useDirtyFormGuard } from '../../../../hooks/useDirtyFormGuard'
 import { useMutationErrorHandler } from '../../../../hooks/useMutationErrorHandler'
 import { useAlerts } from '../../../../providers/alerts'
 import { getErrorStatus } from '../../../../utils/apiErrors'
@@ -259,6 +260,13 @@ export function useGroupMappingEditForm({
       setCreateGroupForIndex(null)
     }
   }, [refetchGroups, createGroupForIndex, form])
+
+  useDirtyFormGuard({
+    isDirty: form.formState.isDirty,
+    onDiscard: () => form.reset(),
+    title: 'Discard unsaved changes?',
+    body: 'You have unsaved changes to group mapping. Your changes will be lost if you leave.',
+  })
 
   const panel: GroupMappingEditPanelState = {
     signInAlert,

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useGroupMappingForm.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useGroupMappingForm.ts
@@ -239,6 +239,7 @@ export function useGroupMappingEditForm({
       {
         onSuccess: () => {
           showSuccess({ title: 'Group mapping saved' })
+          dismiss()
           navigateToTab()
         },
         onError: handleMutationError({ title: 'Failed to save group mapping' }),
@@ -261,7 +262,7 @@ export function useGroupMappingEditForm({
     }
   }, [refetchGroups, createGroupForIndex, form])
 
-  useDirtyFormGuard({
+  const { dismiss } = useDirtyFormGuard({
     isDirty: form.formState.isDirty,
     onDiscard: () => form.reset(),
     title: 'Discard unsaved changes?',

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.tsx
@@ -202,7 +202,7 @@ export function UserForm({ mode }: Readonly<UserFormProps>) {
 
   const navigateBack = () => detachPromise(navigate({ to: AppRoute.AccessManagement.Users }))
 
-  useDirtyFormGuard({
+  const { dismiss } = useDirtyFormGuard({
     isDirty,
     onDiscard: () => reset(),
     title: 'Discard unsaved changes?',
@@ -217,7 +217,10 @@ export function UserForm({ mode }: Readonly<UserFormProps>) {
     isFederatedUser,
     isSelf,
     setError,
-    navigateBack,
+    navigateBack: () => {
+      dismiss()
+      navigateBack()
+    },
   })
 
   const passwordValue = useWatch({ control, name: 'password' })

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.tsx
@@ -14,6 +14,7 @@ import { NxPageHeader } from '../../../components/layout/NxPageHeader'
 import { NxPanel } from '../../../components/layout/NxPanel'
 import { NxPageTitle } from '../../../components/NxPageTitle'
 import { useQueryState } from '../../../components/states/useQueryState'
+import { useDirtyFormGuard } from '../../../hooks/useDirtyFormGuard'
 import { detachPromise } from '../../../utils/detachPromise'
 import { useDocLink } from '../../../utils/docs/useDocLink'
 import { userFormSchema, userCreateSchema, type UserFormData } from '../userFormSchema'
@@ -187,13 +188,26 @@ export function UserForm({ mode }: Readonly<UserFormProps>) {
   } = useUserFormData(isEdit)
 
   const schema = isEdit ? userFormSchema : userCreateSchema
-  const { control, handleSubmit, setError } = useForm<UserFormData>({
+  const {
+    control,
+    handleSubmit,
+    setError,
+    formState: { isDirty },
+    reset,
+  } = useForm<UserFormData>({
     resolver: zodResolver(schema, undefined, { mode: 'sync' }),
     defaultValues: formValues ?? DEFAULT_VALUES,
     values: isEdit && formValues ? formValues : undefined,
   })
 
   const navigateBack = () => detachPromise(navigate({ to: AppRoute.AccessManagement.Users }))
+
+  useDirtyFormGuard({
+    isDirty,
+    onDiscard: () => reset(),
+    title: 'Discard unsaved changes?',
+    body: 'You have unsaved changes to this user. Your changes will be lost if you leave.',
+  })
 
   const { onSubmit, isSaving } = useUserFormSubmit({
     isEdit,

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/EditIntegrationForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/EditIntegrationForm.tsx
@@ -354,7 +354,7 @@ export function EditIntegrationForm() {
   const scope = useWatch({ control, name: 'scope' })
   const credentialId = useWatch({ control, name: 'management_credential_id' })
 
-  useDirtyFormGuard({
+  const { dismiss } = useDirtyFormGuard({
     isDirty,
     onDiscard: () => reset(),
     title: 'Discard unsaved changes?',
@@ -413,6 +413,7 @@ export function EditIntegrationForm() {
             variant,
             autoDismiss: true,
           })
+          dismiss()
           detachPromise(navigate({ to: detailPath }))
         } catch (error: unknown) {
           handleError({ title: 'Failed to update integration', context: `Integration "${values.name}"` })(error)

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/EditIntegrationForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/EditIntegrationForm.tsx
@@ -33,6 +33,7 @@ import { NxPanel } from '../../../components/layout/NxPanel'
 import { NxPageTitle } from '../../../components/NxPageTitle'
 import { NxErrorState } from '../../../components/states/NxErrorState'
 import { useQueryState } from '../../../components/states/useQueryState'
+import { useDirtyFormGuard } from '../../../hooks/useDirtyFormGuard'
 import { useFormMutationErrorHandler } from '../../../hooks/useFormMutationErrorHandler'
 import { useAlerts } from '../../../providers/alerts'
 import { detachPromise } from '../../../utils/detachPromise'
@@ -330,7 +331,8 @@ export function EditIntegrationForm() {
     setError,
     setValue,
     getValues,
-    formState: { errors },
+    reset,
+    formState: { errors, isDirty },
   } = useForm<EditIntegrationFormValues>({
     resolver: zodResolver(schema, undefined, { mode: 'sync' }) as Resolver<EditIntegrationFormValues>,
     defaultValues: {
@@ -351,6 +353,13 @@ export function EditIntegrationForm() {
 
   const scope = useWatch({ control, name: 'scope' })
   const credentialId = useWatch({ control, name: 'management_credential_id' })
+
+  useDirtyFormGuard({
+    isDirty,
+    onDiscard: () => reset(),
+    title: 'Discard unsaved changes?',
+    body: 'You have unsaved changes to this integration. Your changes will be lost if you leave.',
+  })
 
   const handleError = useFormMutationErrorHandler<EditIntegrationFormValues>(setError)
 

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationForm.tsx
@@ -279,13 +279,13 @@ export function IntegrationForm() {
   })
   const handleError = useFormMutationErrorHandler<IntegrationFormData>(setError)
 
-  useDirtyFormGuard({
+  const { dismiss } = useDirtyFormGuard({
     isDirty,
     onDiscard: () => reset(),
     title: 'Discard unsaved changes?',
     body: 'You have unsaved changes to this integration. Your changes will be lost if you leave.',
   })
-  const createIntegration = useCreateIntegration({ handleError })
+  const createIntegration = useCreateIntegration({ handleError, onBeforeNavigate: dismiss })
   const credentialId = useWatch({ control, name: 'management_credential_id' })
   const integrationTypeValue = useWatch({ control, name: 'integration_type' })
   const scopeValue = useWatch({ control, name: 'scope' })

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationForm.tsx
@@ -22,6 +22,7 @@ import { NxPage, NxPageBody } from '../../../../components/layout/NxPage'
 import { NxPageHeader } from '../../../../components/layout/NxPageHeader'
 import { NxPanel } from '../../../../components/layout/NxPanel'
 import { NxPageTitle } from '../../../../components/NxPageTitle'
+import { useDirtyFormGuard } from '../../../../hooks/useDirtyFormGuard'
 import { useFormMutationErrorHandler } from '../../../../hooks/useFormMutationErrorHandler'
 import { useAlerts } from '../../../../providers/alerts'
 import { getErrorMessage } from '../../../../utils/apiErrors'
@@ -249,7 +250,16 @@ export function IntegrationForm() {
   // zodResolver with discriminated unions produces a resolver type that react-hook-form
   // cannot reconcile — the TFieldValues generic diverges. This is a known @hookform/resolvers
   // limitation. The cast is safe because the schema defines the actual validation.
-  const { control, handleSubmit, setError, trigger, setValue, getValues } = useForm<IntegrationFormData>({
+  const {
+    control,
+    handleSubmit,
+    setError,
+    trigger,
+    setValue,
+    getValues,
+    formState: { isDirty },
+    reset,
+  } = useForm<IntegrationFormData>({
     resolver: zodResolver(integrationFormSchema, undefined, { mode: 'sync' }) as Resolver<IntegrationFormData>,
     defaultValues: {
       name: '',
@@ -268,6 +278,13 @@ export function IntegrationForm() {
     },
   })
   const handleError = useFormMutationErrorHandler<IntegrationFormData>(setError)
+
+  useDirtyFormGuard({
+    isDirty,
+    onDiscard: () => reset(),
+    title: 'Discard unsaved changes?',
+    body: 'You have unsaved changes to this integration. Your changes will be lost if you leave.',
+  })
   const createIntegration = useCreateIntegration({ handleError })
   const credentialId = useWatch({ control, name: 'management_credential_id' })
   const integrationTypeValue = useWatch({ control, name: 'integration_type' })

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/useCreateIntegration.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/useCreateIntegration.ts
@@ -14,6 +14,7 @@ import type { IntegrationFormData } from './integrationFormSchema'
 
 type UseCreateIntegrationOptions = {
   handleError: ReturnType<typeof useFormMutationErrorHandler>
+  onBeforeNavigate?: () => void
 }
 
 type InitialToolSelection = {
@@ -25,7 +26,7 @@ type InitialToolSelection = {
 
 type InitialModelSelection = IntegrationsAPI.components['schemas']['InitialModelSelection']
 
-export function useCreateIntegration({ handleError }: UseCreateIntegrationOptions) {
+export function useCreateIntegration({ handleError, onBeforeNavigate }: UseCreateIntegrationOptions) {
   const { mutateAsync: createIntegration } = integrationsClient.useMutation('post', '/integrations')
   const { syncAssignments } = useProjectAssignmentSync()
   const queryClient = useQueryClient()
@@ -70,6 +71,7 @@ export function useCreateIntegration({ handleError }: UseCreateIntegrationOption
                   variant: 'warning',
                   autoDismiss: true,
                 })
+                onBeforeNavigate?.()
                 navigateToList()
                 return
               }
@@ -81,6 +83,7 @@ export function useCreateIntegration({ handleError }: UseCreateIntegrationOption
               variant: 'success',
               autoDismiss: true,
             })
+            onBeforeNavigate?.()
             navigateToList()
           } catch (error: unknown) {
             handleError({ title: 'Failed to add integration', context })(error)
@@ -88,6 +91,6 @@ export function useCreateIntegration({ handleError }: UseCreateIntegrationOption
         })()
       )
     },
-    [createIntegration, syncAssignments, queryClient, handleError, showAlert]
+    [createIntegration, syncAssignments, queryClient, handleError, showAlert, onBeforeNavigate]
   )
 }

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/useIntegrationModelsState.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/useIntegrationModelsState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 
-import { useUnsavedChanges } from '../../../app/useUnsavedChanges'
+import { useDirtyFormGuard } from '../../../hooks/useDirtyFormGuard'
 import { detachPromise } from '../../../utils/detachPromise'
 
 import { useAllIntegrationModels } from './useAllIntegrationModels'
@@ -9,8 +9,6 @@ import { useModelDefaultTracking } from './useModelDefaultTracking'
 import { useModelSave } from './useModelSave'
 
 export function useIntegrationModelsState(integrationId: string, isActive: boolean) {
-  const { registerDirtyCheck } = useUnsavedChanges()
-
   const { models, isLoading, error, refetch: refetchModels } = useAllIntegrationModels(integrationId)
 
   const {
@@ -47,26 +45,18 @@ export function useIntegrationModelsState(integrationId: string, isActive: boole
     detachPromise(saveRef.current?.() ?? Promise.resolve(false))
   }, [])
 
-  const isDirtyRef = useRef(false)
-
-  useEffect(() => {
-    isDirtyRef.current = isDirty
+  useDirtyFormGuard({
+    isDirty,
+    onSave: () => saveRef.current?.() ?? Promise.resolve(false),
+    onDiscard: () => {
+      resetSelectionToServer()
+      resetDefault()
+    },
+    title: 'Save model changes?',
+    body: 'You have unsaved changes to enabled models. Would you like to save before leaving?',
+    saveLabel: 'Save model changes',
+    isActive,
   })
-
-  useEffect(() => {
-    return registerDirtyCheck({
-      check: () => isActive && isDirtyRef.current,
-      saveAndExit: () => saveRef.current?.() ?? Promise.resolve(false),
-      exitWithoutSaving: () => {
-        isDirtyRef.current = false
-        resetSelectionToServer()
-        resetDefault()
-      },
-      title: 'Save model changes?',
-      body: 'You have unsaved changes to enabled models. Would you like to save before leaving?',
-      saveLabel: 'Save model changes',
-    })
-  }, [registerDirtyCheck, resetSelectionToServer, resetDefault, isActive])
 
   return {
     models,

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/useResourcesSave.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/useResourcesSave.ts
@@ -1,9 +1,9 @@
 import type { Tool } from '@syntara/contracts'
 import { useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
-import { useUnsavedChanges } from '../../../app/useUnsavedChanges'
 import { integrationsClient } from '../../../client'
+import { useDirtyFormGuard } from '../../../hooks/useDirtyFormGuard'
 import { useAlerts } from '../../../providers/alerts'
 import { getErrorMessage } from '../../../utils/apiErrors'
 import { detachPromise } from '../../../utils/detachPromise'
@@ -19,7 +19,6 @@ export function useResourcesSave(opts: {
   const { integrationId, tools, enabledToolIds, isDirty, resetToServer, isActive } = opts
   const { showAlert } = useAlerts()
   const queryClient = useQueryClient()
-  const { registerDirtyCheck } = useUnsavedChanges()
   const { mutateAsync: updateTools } = integrationsClient.useMutation(
     'patch',
     '/integrations/{integration_id}/tools/bulk_update'
@@ -69,25 +68,15 @@ export function useResourcesSave(opts: {
     detachPromise(handleSaveRef.current?.() ?? Promise.resolve(false))
   }, [])
 
-  const isDirtyRef = useRef(false)
-  isDirtyRef.current = isDirty
-
-  const resetToServerRef = useRef(resetToServer)
-  resetToServerRef.current = resetToServer
-
-  useEffect(() => {
-    return registerDirtyCheck({
-      check: () => isActive && isDirtyRef.current,
-      saveAndExit: () => handleSaveRef.current?.() ?? Promise.resolve(false),
-      exitWithoutSaving: () => {
-        isDirtyRef.current = false
-        resetToServerRef.current()
-      },
-      title: 'Save resource changes?',
-      body: 'You have unsaved changes to enabled resources. Would you like to save before leaving?',
-      saveLabel: 'Save changes',
-    })
-  }, [registerDirtyCheck, isActive])
+  useDirtyFormGuard({
+    isDirty,
+    onSave: () => handleSaveRef.current?.() ?? Promise.resolve(false),
+    onDiscard: resetToServer,
+    title: 'Save resource changes?',
+    body: 'You have unsaved changes to enabled resources. Would you like to save before leaving?',
+    saveLabel: 'Save changes',
+    isActive,
+  })
 
   return { isSaving, handleSave }
 }

--- a/frontend/packages/syntara-ui/src/routes/configuration/settings/Settings.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/settings/Settings.tsx
@@ -12,6 +12,7 @@ import { NxPanel } from '../../../components/layout/NxPanel'
 import { NxPageTitle } from '../../../components/NxPageTitle'
 import { useQueryState } from '../../../components/states/useQueryState'
 import { NxUrlTabs } from '../../../components/tabs/NxUrlTabs'
+import { useDirtyFormGuard } from '../../../hooks/useDirtyFormGuard'
 import {
   FILE_STORAGE_UNAVAILABLE_MESSAGE,
   FILE_STORAGE_UNCONFIGURED_MESSAGE,
@@ -29,6 +30,20 @@ import { useAllSettings } from './useAllSettings'
 import { useSettingsPermissions } from './useSettingsPermissions'
 
 const basePath = AppRoute.SystemAdministration.Settings
+
+function buildBulkUpdates(
+  edits: Map<string, unknown>,
+  allSettings: { key: string; version: number }[]
+): Array<{ key: string; value: unknown; expected_version: number }> {
+  return Array.from(edits.entries()).reduce<Array<{ key: string; value: unknown; expected_version: number }>>(
+    (acc, [key, value]) => {
+      const setting = allSettings.find((s) => s.key === key)
+      if (setting) acc.push({ key, value, expected_version: setting.version })
+      return acc
+    },
+    []
+  )
+}
 
 function FileStorageAlert() {
   const { isConfigured, status } = useFileStorageStatus()
@@ -139,16 +154,8 @@ export default function Settings() {
   )
 
   const handleSave = useCallback(() => {
-    const updates = Array.from(edits.entries()).reduce<
-      Array<{ key: string; value: unknown; expected_version: number }>
-    >((acc, [key, value]) => {
-      const setting = allSettings.find((s) => s.key === key)
-      if (setting) acc.push({ key, value, expected_version: setting.version })
-      return acc
-    }, [])
-
     bulkUpdate(
-      { body: { updates } },
+      { body: { updates: buildBulkUpdates(edits, allSettings) } },
       {
         onSuccess: () => {
           setEdits(new Map())
@@ -172,6 +179,13 @@ export default function Settings() {
 
   const hasChanges = edits.size > 0
   const hasValidationErrors = validationErrors.size > 0
+
+  useDirtyFormGuard({
+    isDirty: hasChanges,
+    onDiscard: () => setEdits(new Map()),
+    title: 'Discard unsaved changes?',
+    body: 'You have unsaved setting changes. Your changes will be lost if you leave.',
+  })
 
   if (!canRead || isForbidden) {
     return (


### PR DESCRIPTION
## Description

Adds a new `useDirtyFormGuard` hook that encapsulates the boilerplate for registering unsaved-changes guards with `UnsavedChangesProvider`, then wires it into 8 surfaces... 2 refactors of existing guards and 6 new guards for previously unprotected forms.

The hook handles ref tracking and effect cleanup internally so callers just pass reactive values and stable callbacks.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring (no functional changes)

## Changes Made

**New hook:**
- `useDirtyFormGuard.ts` — shared hook that wraps `registerDirtyCheck` with ref tracking, `isActive` support, and automatic cleanup
- `useDirtyFormGuard.test.ts` — 244-line test suite covering registration, unregistration, dirty state tracking, `isActive`, save/discard delegation, and prop passing
**Refactored (existing `registerDirtyCheck` → `useDirtyFormGuard`):**
- `useResourcesSave.ts` — integration detail Resources tab (MCP tools)
- `useIntegrationModelsState.ts` — integration detail Resources tab (LLM models)
**New guards (previously unprotected):**
- `Settings.tsx` — settings page (AAP-85181)
- `UserForm.tsx` — create/edit user (AAP-85182)
- `IdentityProviderForm.tsx` — add/edit OIDC identity provider (AAP-85182)
- `useGroupMappingForm.ts` — edit group mapping (AAP-85182)
- `EditIntegrationForm.tsx` — edit integration (AAP-85183)
- `IntegrationForm.tsx` — configure (create) integration wizard (AAP-85183)

## Out of Scope

- Adding `onSave` to new guards... these forms use submit-on-click, so a "Save" button in the discard modal doesn't apply. The two refactored integration detail hooks retain their existing `onSave` behavior.
- E2E tests for the new guards... the hook itself has thorough unit coverage; integration-level guards are wiring-only.

## Related Issues

Resolves AAP-85181, AAP-85182, AAP-85183

## How to Test

For each surface below, make a change → click a sidebar nav link → verify the "Discard unsaved changes?" modal appears. Test both **Discard** (navigates away, resets form) and **Cancel** (stays on page, edits intact). Also verify no modal appears when the form is clean.

1. **Settings**: change any settings value > navigate away
2. **Create/Edit User**: Access Management > Users > Create (or edit) > type in a field > navigate away
3. **Add/Edit Identity Provider**: Access Management > Authentication > Add OIDC provider (or edit) > fill a field > navigate away
4. **Edit Group Mapping**:  Authentication > click an IdP > Group mapping > Edit > change expression > navigate away
5. **Edit Integration**: Configuration > Integrations > click one > Edit > change name > navigate away
6. **Configure Integration wizard**: Configuration > Integrations > Configure integration > fill name > navigate away
7. **Integration Resources tab (MCP)**: Click an MCP integration > Resources > toggle a tool > navigate away (should show "Save resource changes?" with Save option — unchanged behavior)
8. **Integration Resources tab (LLM)**: Click an LLM integration > Resources > toggle a model > navigate away (should show "Save model changes?" with Save option — unchanged behavior)

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [x] Screenshots or screen recordings are attached for UI changes

## General Checklist

- [x] Code follows the project's coding conventions
- [x] No secrets or credentials are included in this PR

## Screenshots / Demo (if applicable)

**Before:**
<img width="1564" height="820" alt="int-resources-unsaved-before" src="https://github.com/user-attachments/assets/34104352-bc80-4971-9eac-dcaef71bc974" />

<img width="1566" height="826" alt="int-models-unsaved-before" src="https://github.com/user-attachments/assets/f563f8ac-2deb-44be-92ba-0084b8c6d6eb" />

**After:**
<img width="1565" height="824" alt="int-resources-after" src="https://github.com/user-attachments/assets/2e934158-0939-474c-8f1b-e8ea552c4515" />

<img width="1565" height="822" alt="int-models-after" src="https://github.com/user-attachments/assets/4c8ecd9d-af34-4652-a7c1-251e192a3795" />

**New:**
<img width="1566" height="827" alt="settings-unsaved" src="https://github.com/user-attachments/assets/edc3a12f-2a85-4513-a753-ae682a0d6a94" />

<img width="1566" height="820" alt="idp-unsaved" src="https://github.com/user-attachments/assets/8c3afa6f-79ea-4236-9fac-e5a65b80f3fc" />
