### PR TITLE
fix(AAP-85147): Refactor UserTimestamp to show date by user layout

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/approvals/ApprovalsTableBody.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/approvals/ApprovalsTableBody.test.tsx
@@ -223,6 +223,68 @@ describe('FlatApprovalsTableBody', () => {
     expect(screen.getAllByRole('button', { name: /details/i })).toHaveLength(1)
   })
 
+  it('renders "Actioned on" with UserTimestamp when decided_at is set', () => {
+    const Wrapper = createWrapper()
+    render(
+      <Wrapper>
+        <Table aria-label="Approvals" isExpandable>
+          <FlatApprovalsTableBody
+            {...defaultProps}
+            approvals={[
+              makeApproval({
+                status: 'approved',
+                decided_at: '2026-07-15T14:30:00Z',
+                decided_by: { id: 'user-2', name: 'reviewer' },
+              }),
+            ]}
+          />
+        </Table>
+      </Wrapper>
+    )
+
+    expect(screen.getByText('reviewer')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'reviewer' })).toBeInTheDocument()
+  })
+
+  it('renders "Actioned on" with timestamp only when decided_at is set but decided_by is null', () => {
+    const Wrapper = createWrapper()
+    const { container } = render(
+      <Wrapper>
+        <Table aria-label="Approvals" isExpandable>
+          <FlatApprovalsTableBody
+            {...defaultProps}
+            approvals={[
+              makeApproval({
+                status: 'approved',
+                decided_at: '2026-08-05T14:30:00Z',
+                decided_by: null,
+              }),
+            ]}
+          />
+        </Table>
+      </Wrapper>
+    )
+
+    expect(screen.getByText(/Aug 5/)).toBeInTheDocument()
+    expect(container.textContent).not.toContain(' by ')
+  })
+
+  it('renders dash for "Actioned on" when decided_at is null', () => {
+    const Wrapper = createWrapper()
+    render(
+      <Wrapper>
+        <Table aria-label="Approvals" isExpandable>
+          <FlatApprovalsTableBody
+            {...defaultProps}
+            approvals={[makeApproval({ decided_at: null, workflowId: 'wf-1' })]}
+          />
+        </Table>
+      </Wrapper>
+    )
+
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+
   it('has no accessibility violations', async () => {
     const Wrapper = createWrapper()
     const { container } = render(

--- a/frontend/packages/syntara-ui/src/routes/approvals/ApprovalsTableBody.tsx
+++ b/frontend/packages/syntara-ui/src/routes/approvals/ApprovalsTableBody.tsx
@@ -16,6 +16,7 @@ import groupedTableStyles from '../../components/groupedTable.module.css'
 import { DateCell } from '../../components/table/DateCell'
 import { LinkCell } from '../../components/table/LinkCell'
 import type { ProjectRead } from '../access/types'
+import { UserTimestamp } from '../configuration/credentials/UserTimestamp'
 
 import { getNotesLabel, hasExpandableNotes } from './approvalNotes'
 import type { ApprovalWithDetails } from './Approvals'
@@ -27,24 +28,11 @@ import { isApprovalSelectable } from './isApprovalSelectable'
 import { useCanDecideApproval } from './useCanDecideApproval'
 
 function DecidedCell({ approval }: Readonly<{ approval: ApprovalWithDetails }>) {
-  const decidedAt = approval.decided_at
-  const decidedBy = approval.decided_by
-
-  if (!decidedAt) {
+  if (!approval.decided_at) {
     return <DateCell dateString={null} />
   }
 
-  return (
-    <>
-      {decidedBy ? (
-        <>
-          <LinkCell href={`/users/${decidedBy.id}`}>{decidedBy.name}</LinkCell>
-          {' at '}
-        </>
-      ) : null}
-      <DateCell dateString={decidedAt} />
-    </>
-  )
+  return <UserTimestamp user={approval.decided_by} timestamp={approval.decided_at} inline />
 }
 
 function SelectCheckboxCell({

--- a/frontend/packages/syntara-ui/src/routes/builder/VersionHistoryPanel.module.css
+++ b/frontend/packages/syntara-ui/src/routes/builder/VersionHistoryPanel.module.css
@@ -2,12 +2,6 @@
   gap: var(--pf-t--global--spacer--sm);
 }
 
-.versionMetaStack {
-  --pf-v6-c-content--small--MarginBlockEnd: 0;
-  --pf-v6-c-content--MarginBlockEnd: 0;
-  gap: var(--pf-t--global--spacer--xs);
-}
-
 .versionTimestamp {
   font-weight: 600;
   margin: 0;
@@ -20,7 +14,6 @@
 
 .secondaryDatetime {
   margin: 0;
-  font-size: var(--pf-t--global--font--size--xs);
   color: var(--pf-t--global--text--color--subtle);
 }
 

--- a/frontend/packages/syntara-ui/src/routes/builder/VersionHistoryPanel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/VersionHistoryPanel.tsx
@@ -267,22 +267,21 @@ function VersionRow({
             </Tooltip>
           </FlexItem>
           {(showSecondaryDatetime && version.created_at) || version.created_by_username ? (
-            <Stack className={styles.versionMetaStack}>
-              {showSecondaryDatetime && version.created_at ? (
-                <Content component={ContentVariants.small} className={styles.secondaryDatetime}>
-                  {formatHistoryDateTime(version.created_at)}
-                </Content>
-              ) : null}
+            <Content component={ContentVariants.small} className={styles.secondaryDatetime}>
+              {showSecondaryDatetime && version.created_at ? formatHistoryDateTime(version.created_at) : null}
               {version.created_by_username ? (
-                <NxLink
-                  to={AppRoute.AccessManagement.UserDetail.replace(':userId', version.created_by)}
-                  className={styles.usernameLink}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {version.created_by_username}
-                </NxLink>
+                <>
+                  {showSecondaryDatetime && version.created_at ? ' by ' : null}
+                  <NxLink
+                    to={AppRoute.AccessManagement.UserDetail.replace(':userId', version.created_by)}
+                    className={styles.usernameLink}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {version.created_by_username}
+                  </NxLink>
+                </>
               ) : null}
-            </Stack>
+            </Content>
           ) : null}
           {badgeStatus ? (
             <div className={styles.labelsRow}>

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/UserTimestamp.module.css
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/UserTimestamp.module.css
@@ -1,30 +1,20 @@
-.user {
-  margin: 0;
+.userName {
   color: var(--pf-t--global--color--brand--default);
-}
-
-.timestamp {
-  margin: 0;
-  color: var(--pf-t--global--text--color--subtle);
-}
-
-.timestampDefault {
-  margin: 0;
 }
 
 .inlineWrapper {
-  margin: 0;
+  display: block;
 }
 
-.inlineUser {
-  color: var(--pf-t--global--color--brand--default);
-}
-
-.inlineTimestamp {
-  display: inline;
+.inlineTimestampSubtle {
   color: var(--pf-t--global--text--color--subtle);
 }
 
-.inlineTimestampDefault {
-  display: inline;
+.stackedWrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.stackedTimestampSubtle {
+  color: var(--pf-t--global--text--color--subtle);
 }

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/UserTimestamp.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/UserTimestamp.test.tsx
@@ -114,10 +114,11 @@ describe('UserTimestamp', () => {
   })
 
   describe('inline mode', () => {
-    it('renders user and timestamp on one line with separator', () => {
+    it('renders timestamp and user on one line with "by" separator', () => {
       const { container } = render(<UserTimestamp user={userRef} timestamp={timestamp} inline />)
       expect(screen.getByText('alice')).toBeInTheDocument()
-      expect(container.textContent).toContain('·')
+      expect(container.textContent).toContain('by')
+      expect(container.textContent).not.toContain('·')
     })
 
     it('renders UserReference object inline', () => {
@@ -132,7 +133,7 @@ describe('UserTimestamp', () => {
 
     it('renders only timestamp inline when user is null', () => {
       const { container } = render(<UserTimestamp user={null} timestamp={timestamp} inline />)
-      expect(container.textContent).not.toContain('·')
+      expect(container.textContent).not.toContain('by')
     })
 
     it('applies neutral timestamp color when subtleTimestamp is false', () => {
@@ -142,7 +143,7 @@ describe('UserTimestamp', () => {
 
     it('renders only timestamp inline when user is undefined', () => {
       const { container } = render(<UserTimestamp timestamp={timestamp} inline />)
-      expect(container.textContent).not.toContain('·')
+      expect(container.textContent).not.toContain('by')
     })
 
     it('renders plain string user inline with neutral timestamp', () => {
@@ -152,7 +153,7 @@ describe('UserTimestamp', () => {
 
     it('renders only timestamp inline with neutral timestamp when user is null', () => {
       const { container } = render(<UserTimestamp user={null} timestamp={timestamp} inline subtleTimestamp={false} />)
-      expect(container.textContent).not.toContain('·')
+      expect(container.textContent).not.toContain('by')
     })
 
     it('renders with explicit inline=true and subtleTimestamp=true', () => {
@@ -173,7 +174,67 @@ describe('UserTimestamp', () => {
 
     it('renders inline with undefined user and explicit subtleTimestamp=false', () => {
       const { container } = render(<UserTimestamp inline={true} subtleTimestamp={false} />)
-      expect(container.textContent).not.toContain('·')
+      expect(container.textContent).not.toContain('by')
+    })
+  })
+
+  describe('user rendering mode', () => {
+    it('renders plain string user as text (not a link) in stacked mode', () => {
+      render(<UserTimestamp user="bob" timestamp={timestamp} />)
+      expect(screen.getByText('bob')).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'bob' })).not.toBeInTheDocument()
+    })
+
+    it('renders plain string user as text (not a link) in inline mode', () => {
+      render(<UserTimestamp user="bob" timestamp={timestamp} inline />)
+      expect(screen.getByText('bob')).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'bob' })).not.toBeInTheDocument()
+    })
+
+    it('renders UserReference as a link in stacked mode', () => {
+      render(<UserTimestamp user={userRef} timestamp={timestamp} />)
+      const link = screen.getByRole('link', { name: 'alice' })
+      expect(link).toHaveAttribute('href', expectedHref)
+    })
+
+    it('renders UserReference as a link in inline mode', () => {
+      render(<UserTimestamp user={userRef} timestamp={timestamp} inline />)
+      const link = screen.getByRole('link', { name: 'alice' })
+      expect(link).toHaveAttribute('href', expectedHref)
+    })
+  })
+
+  describe('"by" separator rendering', () => {
+    it('renders "by" prefix before username in stacked mode', () => {
+      const { container } = render(<UserTimestamp user={userRef} timestamp={timestamp} />)
+      expect(container.textContent).toContain('by')
+    })
+
+    it('renders "by" prefix before username in inline mode', () => {
+      const { container } = render(<UserTimestamp user={userRef} timestamp={timestamp} inline />)
+      expect(container.textContent).toContain('by')
+    })
+
+    it('does not render "by" when user is null in stacked mode', () => {
+      const { container } = render(<UserTimestamp user={null} timestamp={timestamp} />)
+      expect(container.textContent).not.toContain('by')
+    })
+
+    it('does not render "by" when user is undefined in stacked mode', () => {
+      const { container } = render(<UserTimestamp timestamp={timestamp} />)
+      expect(container.textContent).not.toContain('by')
+    })
+
+    it('renders "by" prefix before plain string user in stacked mode', () => {
+      const { container } = render(<UserTimestamp user="bob" timestamp={timestamp} />)
+      expect(container.textContent).toContain('by')
+      expect(container.textContent).toContain('bob')
+    })
+
+    it('renders "by" prefix before plain string user in inline mode', () => {
+      const { container } = render(<UserTimestamp user="bob" timestamp={timestamp} inline />)
+      expect(container.textContent).toContain('by')
+      expect(container.textContent).toContain('bob')
     })
   })
 

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/UserTimestamp.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/UserTimestamp.tsx
@@ -1,4 +1,3 @@
-import { Content, ContentVariants } from '@patternfly/react-core'
 import type { CredentialsAPI } from '@syntara/contracts'
 
 import { NxLink } from '../../../components/NxLink'
@@ -30,11 +29,11 @@ function resolveUserId(user: UserReference | string | null | undefined): string 
 }
 
 /**
- * Displays a username with a formatted timestamp.
+ * Displays a formatted timestamp with an optional username.
  * When the user is a UserReference (has an id), the username renders as a link
  * to the user detail page. Plain strings render as brand-colored text.
- * In inline mode (tables): "username · date" on one line.
- * In stacked mode (detail views): username above date on separate lines.
+ * In inline mode (tables): "date by username" on one line.
+ * In stacked mode (detail views): date above "by username" on separate lines.
  */
 export function UserTimestamp({
   user,
@@ -46,45 +45,25 @@ export function UserTimestamp({
   const userId = resolveUserId(user)
   const formattedDate = formatDateTime(timestamp)
 
+  const userLink = userId ? (
+    <NxLink to={getUserDetailPath(userId)}>{displayName}</NxLink>
+  ) : (
+    <span className={styles.userName}>{displayName}</span>
+  )
+
   if (inline) {
     return (
-      <Content component={ContentVariants.p} className={styles.inlineWrapper}>
-        {displayName && (
-          <>
-            {userId ? (
-              <NxLink to={getUserDetailPath(userId)}>{displayName}</NxLink>
-            ) : (
-              <span className={styles.inlineUser}>{displayName}</span>
-            )}
-            {' · '}
-          </>
-        )}
-        <Content
-          component={ContentVariants.small}
-          className={subtleTimestamp ? styles.inlineTimestamp : styles.inlineTimestampDefault}
-        >
-          {formattedDate}
-        </Content>
-      </Content>
+      <span className={styles.inlineWrapper}>
+        <span className={subtleTimestamp ? styles.inlineTimestampSubtle : undefined}>{formattedDate}</span>
+        {displayName && <> by {userLink}</>}
+      </span>
     )
   }
 
   return (
-    <>
-      {displayName &&
-        (userId ? (
-          <NxLink to={getUserDetailPath(userId)}>{displayName}</NxLink>
-        ) : (
-          <Content component={ContentVariants.p} className={styles.user}>
-            {displayName}
-          </Content>
-        ))}
-      <Content
-        component={ContentVariants.small}
-        className={subtleTimestamp ? styles.timestamp : styles.timestampDefault}
-      >
-        {formattedDate}
-      </Content>
-    </>
+    <div className={styles.stackedWrapper}>
+      <div className={subtleTimestamp ? styles.stackedTimestampSubtle : undefined}>{formattedDate}</div>
+      {displayName && <div>by {userLink}</div>}
+    </div>
   )
 }


### PR DESCRIPTION
## Description

Refactors the `UserTimestamp` component to display timestamps before usernames with a "by" separator (e.g. "Jul 1, 2026 by alice") instead of the previous "user · date" pattern. Simplifies the component's JSX and CSS, removes PF `Content` wrapper overhead, and adopts the updated layout in the approvals table and version history panel.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring (no functional changes)

## Changes Made

- [x] Refactored `UserTimestamp` display order: timestamp first, then "by username" (was "username · date")
- [x] Simplified `UserTimestamp` JSX: replaced nested `Content` components with plain `span`/`div` elements, extracted shared `userLink` variable
- [x] Simplified `UserTimestamp.module.css`: removed 6 classes, replaced with 4 cleaner ones using flexbox for stacked mode
- [x] Updated `ApprovalsTableBody.tsx` `DecidedCell` to use `UserTimestamp inline` instead of manually composing `LinkCell` + `DateCell`
- [x] Updated `VersionHistoryPanel.tsx` version row metadata: replaced `Stack` with a single `Content` element, added "by" separator between timestamp and username link
- [x] Removed unused `.versionMetaStack` CSS class and `font-size` override from `VersionHistoryPanel.module.css`
- [x] Updated all `UserTimestamp` test assertions from `·` separator to `by` separator

## Out of Scope

- Migrating `UserTimestamp` to use PF `Timestamp` component (covered by a different ticket)

## Related Issues

Fixes AAP-85147

## How to Test

1. Open Configuration > Credentials and verify "Created" / "Modified" columns show "date by username" format
2. Click into a credential detail page and verify the "Created by" / "Modified by" fields show the date above "by username" in stacked layout
3. Open the Approvals list and verify the "Decided" column shows "date by alice" (not "alice · date")
4. Open a workflow in the builder, expand Version History, and verify version rows show timestamp with "by username" below
5. Verify all user links still navigate to the correct user detail page

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [x] Screenshots or screen recordings are attached for UI changes

## General Checklist

- [x] Code follows the project's coding conventions
- [x] No secrets or credentials are included in this PR

## Screenshots / Demo (if applicable)

**Approvals (short and long names):**
<img width="1828" height="824" alt="approval-long-short" src="https://github.com/user-attachments/assets/5aa9055e-6a08-4bac-9b70-ff46ac4ced4f" />

**Approvals (short and long name - wrapping):**
<img width="1058" height="822" alt="approval-long-short-wrap" src="https://github.com/user-attachments/assets/81428fa1-82fd-470d-b3b7-5cfb145253aa" />

**Credentials:**
<img width="1714" height="679" alt="cred" src="https://github.com/user-attachments/assets/5a7ebdc3-23bb-45d4-8ae9-af58ec8e931c" />

**Credential details:**
<img width="1727" height="659" alt="cred-detail" src="https://github.com/user-attachments/assets/e06de03a-25b2-4bf2-a894-6ac1f002ac7f" />

**Builder version:**
<img width="1806" height="824" alt="builder-version" src="https://github.com/user-attachments/assets/9d0242d6-85a5-47da-aa5d-b6c9746c1613" />


## Additional Notes
`UserTimestamp` was previously wrapped in PF `Content` components (`ContentVariants.p` / `ContentVariants.small`), which inject automatic `margin-block-end` spacing and `font-size` overrides. These required CSS counter-overrides (e.g. `margin: 0`, `font-size: var(--pf-t--global--font--size--xs)`) to undo PF's defaults. Switching to plain `span`/`div` elements eliminates the need for those workarounds... the component inherits its parent's font size and adds no unwanted margins. The `VersionHistoryPanel` changes follow the same rationale: the `.versionMetaStack` class existed solely to zero out `Content` margins.

The `UserTimestamp` component still uses `formatDateTime()` (plain string). Migration to PF `Timestamp` is tracked separately under AAP-77946 (#1205).
