### PR TITLE
fix(AAP-86878): make audit OTEL log bodies unique per event

### DIFF
--- a/backend/src/syntara/audit/outbox/worker.py
+++ b/backend/src/syntara/audit/outbox/worker.py
@@ -123,7 +123,10 @@ def _build_otel_log_record(
         timestamp=datetime_to_unix_ns(event_date),
         severity_text="INFO",
         severity_number=SeverityNumber.INFO,
-        body="audit_event",
+        # Loki deduplicates same-stream entries with identical timestamp + body.
+        # Co-transactional outbox rows can share created_at; include event_id so
+        # each export line is unique and durable at the log store.
+        body=f"audit_event:{audit_event.event_id}",
         attributes=event_dict,
     )
     return ReadableLogRecord(

--- a/backend/tests/unit/audit/outbox/test_worker.py
+++ b/backend/tests/unit/audit/outbox/test_worker.py
@@ -1144,8 +1144,8 @@ class TestAuditEventStdoutLogging:
             mock_audit_logger.info.assert_called_once()
             call_args, call_kwargs = mock_audit_logger.info.call_args
 
-            # Body is the OTEL log record body
-            assert call_args[0] == "audit_event"
+            # Body includes event_id so Loki does not collapse co-timestamped siblings
+            assert call_args[0] == f"audit_event:{event.event_id}"
 
             # Attributes contain the serialised event fields
             assert call_kwargs["event_action"] == "credential_create"
@@ -1233,10 +1233,25 @@ class TestBuildOtelLogRecordSerialization:
         attrs = record.log_record.attributes
         assert attrs is not None
         assert attrs["audit.event_source"] == "business_event"
-        assert record.log_record.body == "audit_event"
+        assert record.log_record.body == f"audit_event:{event.event_id}"
 
         # Must not raise TypeError — no UUID objects, datetimes, etc.
         json.dumps(dict(attrs))
+
+    def test_sibling_events_get_distinct_bodies(self, override_settings) -> None:
+        """Same timestamp must not produce identical export bodies (log-store dedup)."""
+        shared_ts = datetime.now(UTC)
+        event_a = _make_event(event_action="project_create")
+        event_b = _make_event(event_action="roleassignment_create")
+
+        with override_settings(otel_service_name="nexus-test"):
+            record_a = _build_otel_log_record(event_a, shared_ts, AuditEventSource.CRUD_EVENT)
+            record_b = _build_otel_log_record(event_b, shared_ts, AuditEventSource.CRUD_EVENT)
+
+        assert record_a.log_record.timestamp == record_b.log_record.timestamp
+        assert record_a.log_record.body != record_b.log_record.body
+        assert record_a.log_record.body == f"audit_event:{event_a.event_id}"
+        assert record_b.log_record.body == f"audit_event:{event_b.event_id}"
 
     def test_uuid_subclass_in_extra_fields_coerced(self, override_settings) -> None:
         """UUID subclasses (e.g. asyncpg UUID) in extra fields become strings."""


### PR DESCRIPTION
## Description

loki silently drops co-transactional audit siblings when stream, timestamp, and body all match. outbox rows from one transaction can share `created_at`, and the OTEL body was hard-coded to `audit_event`, so only one event survived at the log store.

include `event_id` in the body so each export line is unique.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] `_build_otel_log_record` body is `audit_event:{event_id}` instead of `audit_event`
- [x] unit coverage for distinct bodies under a shared timestamp

## Out of Scope

changing `created_at` to `clock_timestamp()`, trigger/migration updates, or per-category streams.

## Related Issues

Fixes AAP-86878

## How to Test

1. export two outbox events that share the same timestamp (unit: `test_sibling_events_get_distinct_bodies`)
2. confirm OTEL bodies differ and include each `event_id`
3. optionally: `POST /api/v1/projects` and verify both project and role-assignment audit events remain queryable in the log backend

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->