### PR TITLE
fix(AAP-87226): use /v1 in OpenAI LLM provider default base URL

### DIFF
--- a/backend/src/syntara/integrations/adapters/llm_provider.py
+++ b/backend/src/syntara/integrations/adapters/llm_provider.py
@@ -50,7 +50,7 @@ logger = structlog.stdlib.get_logger(__name__)
 _MAX_PAGINATION_PAGES = 10
 
 _PROVIDER_CONSTRUCTORS: dict[LLMProviderHint, Callable[[], LLMProviderBase]] = {
-    LLMProviderHint.OPENAI: lambda: OpenAICompatibleProvider(default_url="https://api.openai.com/v1"),
+    LLMProviderHint.OPENAI: OpenAICompatibleProvider,
     LLMProviderHint.RED_HAT_AI: lambda: OpenAICompatibleProvider(default_url=None),
     LLMProviderHint.CUSTOM: lambda: OpenAICompatibleProvider(default_url=None),
     LLMProviderHint.ANTHROPIC: AnthropicProvider,

--- a/backend/src/syntara/integrations/adapters/llm_provider.py
+++ b/backend/src/syntara/integrations/adapters/llm_provider.py
@@ -50,7 +50,7 @@ logger = structlog.stdlib.get_logger(__name__)
 _MAX_PAGINATION_PAGES = 10
 
 _PROVIDER_CONSTRUCTORS: dict[LLMProviderHint, Callable[[], LLMProviderBase]] = {
-    LLMProviderHint.OPENAI: lambda: OpenAICompatibleProvider(default_url="https://api.openai.com"),
+    LLMProviderHint.OPENAI: lambda: OpenAICompatibleProvider(default_url="https://api.openai.com/v1"),
     LLMProviderHint.RED_HAT_AI: lambda: OpenAICompatibleProvider(default_url=None),
     LLMProviderHint.CUSTOM: lambda: OpenAICompatibleProvider(default_url=None),
     LLMProviderHint.ANTHROPIC: AnthropicProvider,

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/integrationUtils.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/integrationUtils.test.ts
@@ -120,7 +120,7 @@ describe('integrationUtils', () => {
           base_url: null,
         },
       })
-      expect(getBaseUrl(integration)).toBe('https://api.openai.com')
+      expect(getBaseUrl(integration)).toBe('https://api.openai.com/v1')
     })
 
     it('resolves default URL for Gemini when base_url is null', () => {

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/integrationUtils.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/integrationUtils.ts
@@ -11,7 +11,7 @@ const integrationTypeSchema = z.discriminatedUnion('integration_type', [
 ])
 
 const PROVIDER_DEFAULT_URLS: Record<string, string> = {
-  [LLMProviderHintEnum.OPENAI]: 'https://api.openai.com',
+  [LLMProviderHintEnum.OPENAI]: 'https://api.openai.com/v1',
   [LLMProviderHintEnum.ANTHROPIC]: 'https://api.anthropic.com/v1',
   [LLMProviderHintEnum.GEMINI]: 'https://generativelanguage.googleapis.com/v1',
 }


### PR DESCRIPTION
## Description

openai model discovery was hitting `https://api.openai.com/models` (404) because the OpenAI preset default base URL omitted `/v1`. align frontend and backend defaults with `https://api.openai.com/v1` (same pattern as anthropic/gemini).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] frontend `PROVIDER_DEFAULT_URLS` for OpenAI ends with `/v1`
- [x] backend `LLMProviderHint.OPENAI` constructor default_url ends with `/v1`
- [x] update `getBaseUrl` unit expectation

## Out of Scope

migrating already-saved integrations that stored a non-`/v1` base URL explicitly.

## Related Issues

Fixes AAP-87226
Related to AAP-83116

## How to Test

1. create an LLM integration with OpenAI provider (leave base URL empty / use preset)
2. test connection with a valid key → models discover (not HTTP 404)
3. invalid key → 401 (not 404)
4. confirm UI detail/list URL shows `https://api.openai.com/v1` when base_url is null

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->