### PR TITLE
fix(AAP-87131): surface prompt length limit in agentic activity error

### DIFF
--- a/backend/src/syntara/workflows/workflow_engine/activities/agentic_activity.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/agentic_activity.py
@@ -66,8 +66,12 @@ async def _inject_runtime_settings(input_config: dict[str, Any]) -> None:
     prompt = input_config.get("prompt", "")
     if isinstance(prompt, str):
         max_len = await cache.get_int("workflow_engine.max_prompt_length", default=100000)
-        if len(prompt) > max_len:
-            msg = f"Prompt exceeds maximum length ({len(prompt)} > {max_len} characters)"
+        prompt_len = len(prompt)
+        if prompt_len > max_len:
+            msg = (
+                f"The AI Agent prompt is {prompt_len} characters, which exceeds the limit of "
+                f"{max_len}. Shorten the prompt or pass less data through template expressions."
+            )
             raise ValueError(msg)
 
 
@@ -112,7 +116,7 @@ def _build_agent_metadata(
 
 
 @activity.defn(name=ActivityName.AGENTIC)
-async def execute_agentic_activity(  # noqa: PLR0915
+async def execute_agentic_activity(
     input_config: dict[str, Any],
     output_config: dict[str, str] | None,  # noqa: ARG001  # must match Temporal dispatch signature; agentic completes async via callback, not via return value
     execution_id: str = "",
@@ -142,9 +146,9 @@ async def execute_agentic_activity(  # noqa: PLR0915
         try:
             await _inject_runtime_settings(input_config)
         except ValueError as e:
+            # Surface the concrete validation cause (e.g. prompt length) to the user.
             logger.warning("Agentic activity runtime settings validation failed", error=str(e))
-            msg = "Runtime settings validation failed"
-            raise ApplicationError(msg, type="ConfigError", non_retryable=True) from None
+            raise ApplicationError(str(e), type="ConfigError", non_retryable=True) from None
 
         config = AgenticExecutorParameters.model_validate(input_config)
 

--- a/backend/tests/unit/workflows/activities/test_agentic_runtime_settings.py
+++ b/backend/tests/unit/workflows/activities/test_agentic_runtime_settings.py
@@ -38,9 +38,14 @@ class TestInjectRuntimeSettings:
 
     @pytest.mark.asyncio
     async def test_rejects_prompt_exceeding_max_length(self) -> None:
-        config: dict[str, object] = {"prompt": "x" * 200000}
-        with pytest.raises(ValueError, match="exceeds maximum length"):
+        prompt_len = 200000
+        config: dict[str, object] = {"prompt": "x" * prompt_len}
+        with pytest.raises(ValueError, match="exceeds the limit") as exc_info:
             await _inject_runtime_settings(config)
+        message = str(exc_info.value)
+        assert f"The AI Agent prompt is {prompt_len} characters" in message
+        assert "Shorten the prompt or pass less data through template expressions." in message
+        assert "Runtime settings validation failed" not in message
 
     @pytest.mark.asyncio
     async def test_accepts_prompt_within_max_length(self) -> None:
@@ -54,10 +59,17 @@ class TestExecuteAgenticActivitySettingsIntegration:
     @pytest.mark.asyncio
     async def test_prompt_too_long_raises(self) -> None:
         """Activity raises ApplicationError when prompt exceeds max length."""
-        config: dict[str, object] = {"prompt": "x" * 200000, "timeout": 300}
+        prompt_len = 200000
+        config: dict[str, object] = {"prompt": "x" * prompt_len, "timeout": 300}
         with pytest.raises(ApplicationError) as exc_info:
             await execute_agentic_activity(config, None, project_id=str(uuid4()))
         assert exc_info.value.type == "ConfigError"
+        message = exc_info.value.message
+        assert f"The AI Agent prompt is {prompt_len} characters" in message
+        assert "exceeds the limit of" in message
+        assert "Shorten the prompt or pass less data through template expressions." in message
+        assert message != "Runtime settings validation failed"
+        assert "Runtime settings validation failed" not in message
 
     @pytest.mark.asyncio
     async def test_missing_project_id_raises(self) -> None:


### PR DESCRIPTION
## Description

when an AI Agent prompt exceeds `workflow_engine.max_prompt_length`, the failed step used to show the generic `Runtime settings validation failed`. the real length check was only in logs. this PR surfaces the concrete limit message on the activity error so users know to shorten the prompt or reduce template data.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] raise a user-facing prompt-length `ValueError` from `_inject_runtime_settings`
- [x] pass that message through to `ApplicationError` instead of the generic validation string
- [x] update unit tests to assert the new copy and reject the old generic message

## Out of Scope

other agentic pre-dispatch / connection error copy (covered by sibling tickets). no UI changes.

## Related Issues

Fixes AAP-87131
Related to AAP-87086

## How to Test

1. create a workflow with an AI Agent node
2. set the prompt longer than `workflow_engine.max_prompt_length` (default 100000), e.g. via a large template expression
3. publish and run
4. confirm the failed AI Agent step shows: `The AI Agent prompt is {len} characters, which exceeds the limit of {max}. Shorten the prompt or pass less data through template expressions.`
5. confirm worker still logs `Agentic activity runtime settings validation failed`

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

## Additional Notes