### PR TITLE
fix(e2e): use wait nodes in cancel-execution setup

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
@@ -1,6 +1,5 @@
 /**
  * E2E Tests: Cancel Execution
- * Jira: AAP-82020
  *
  * Objective: Verify the cancel execution flow from the execution detail page.
  *
@@ -9,7 +8,7 @@
  * - Clicking cancel transitions execution to cancelled status
  * - Cancel button hidden for completed executions
  *
- * Requires a real backend with Temporal — the sleep node keeps the execution
+ * Requires a real backend with Temporal — the wait node keeps the execution
  * in "running" state long enough to interact with the cancel button.
  */
 
@@ -47,13 +46,13 @@ test.beforeAll(async ({ browser }) => {
       [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
       [
         {
-          id: 'sleep_node',
-          type: 'script',
-          name: 'Long Sleep',
-          parameters: { language: 'bash', code: 'sleep 300' },
+          id: 'long_wait',
+          type: 'wait',
+          name: 'Long Wait',
+          parameters: { duration: 300 },
         },
       ],
-      [{ from: 'trigger_manual', to: 'sleep_node' }]
+      [{ from: 'trigger_manual', to: 'long_wait' }]
     ))
 
     const runResp = await apiRequest(page, 'post', '/executions', {
@@ -72,13 +71,13 @@ test.beforeAll(async ({ browser }) => {
       [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
       [
         {
-          id: 'echo_node',
-          type: 'script',
-          name: 'Quick Echo',
-          parameters: { language: 'bash', code: 'echo done' },
+          id: 'quick_wait',
+          type: 'wait',
+          name: 'Quick Wait',
+          parameters: { duration: 1 },
         },
       ],
-      [{ from: 'trigger_manual', to: 'echo_node' }]
+      [{ from: 'trigger_manual', to: 'quick_wait' }]
     ))
 
     const echoRunResp = await apiRequest(page, 'post', '/executions', {


### PR DESCRIPTION
## Description

cancel-execution e2e setup was hanging in compose CI because bash script fixtures (`echo done` / `sleep 300`) stayed `running` past the 30s `beforeAll` poll. switch those fixtures to wait nodes so setup only needs Temporal timers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

- [x] replace long-running and completed script nodes with wait nodes (`duration: 300` / `duration: 1`) in `cancel-execution.spec.ts`
- [x] drop ticket key from the file header comment

## Out of Scope

- enabling or debugging script-node execution in CI
- changes to cancel UI behavior

## Related Issues

n/a — compose e2e flake on `workflows/cancel-execution.spec.ts`

## How to Test

1. run compose e2e (or CI Frontend Podman Compose E2E)
2. confirm `Cancel Execution` suite passes, including `beforeAll` setup for running + completed fixtures
3. optional: `npx playwright test e2e/workflows/cancel-execution.spec.ts` against a real backend with Temporal

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->