### PR TITLE
fix(tests): stabilize flaky credential-toggle and cancel-execution E2E tests

### DIFF
--- a/frontend/packages/syntara-ui/e2e/credential-enable-disable.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-enable-disable.spec.ts
@@ -182,6 +182,7 @@ test.describe('Credential Enable/Disable State Management', () => {
       await filterCredentialByName(app, name)
 
       const updatedRow = app.getByRole('row', { name: new RegExp(name) })
+      await updatedRow.waitFor({ state: 'visible', timeout: 10_000 })
       await expect(listRowToggle(updatedRow)).not.toBeChecked()
     } finally {
       await deleteCredentialByName(app, name)

--- a/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
@@ -24,7 +24,7 @@ async function pollExecutionUntilDone(page: Page, executionId: string, token: st
     const resp = await apiRequest(page, 'get', `/executions/${executionId}`, { token })
     const exec = (await resp.json()) as { status: string }
     expect(TERMINAL_STATUSES).toContain(exec.status)
-  }).toPass({ timeout: 30_000, intervals: [1_000] })
+  }).toPass({ timeout: 60_000, intervals: [2_000] })
 }
 
 let sleepWorkflowId: string | null = null


### PR DESCRIPTION
Add missing waitFor on the credential row after navigate-back + re-filter
to avoid asserting before the filtered list renders. Increase the
pollExecutionUntilDone timeout from 30s to 60s so Temporal has enough
time to schedule the echo workflow in CI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
