### PR TITLE
ci: add podman diagnostics and healthcheck fix to frontend E2E

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -428,6 +428,16 @@ jobs:
           RH_REGISTRY_USER: ${{ secrets.RH_REGISTRY_USER }}
         run: echo "$RH_REGISTRY_TOKEN" | podman login registry.redhat.io -u "$RH_REGISTRY_USER" --password-stdin
 
+      - name: Diagnose podman environment
+        run: |
+          podman --version
+          podman info --format json | python3 -c '
+          import sys, json
+          h = json.load(sys.stdin)["host"]
+          print("EventLogger=" + str(h.get("eventLogger", "?")))
+          print("CgroupVersion=" + str(h.get("cgroupVersion", h.get("cgroupsVersion", "?"))))
+          '
+
       - name: Start services with podman-compose
         timeout-minutes: 20
         env:
@@ -448,6 +458,9 @@ jobs:
             local container="$1" timeout="${2:-120}" elapsed=0 status
             echo "Waiting for $container to become healthy (timeout: ${timeout}s)..."
             while [ "$elapsed" -lt "$timeout" ]; do
+              # Manually trigger healthcheck — needed for Podman 5.x where
+              # events_logger=file prevents systemd timer scheduling.
+              podman healthcheck run "$container" >/dev/null 2>&1 || true
               status=$(podman inspect --format='{{.State.Health.Status}}' "$container" 2>/dev/null || echo "missing")
               if [ "$status" = "healthy" ]; then
                 echo "$container is healthy"


### PR DESCRIPTION
## Summary

- Adds diagnostic step to frontend Compose E2E job to surface podman version, event logger, and cgroup version
- Adds `podman healthcheck run` to the `wait_healthy()` polling loop (same fix as backend CI in PR #111)

## Context

PR #111 fixes the backend Compose E2E healthcheck hang on Podman 5.x runners. This PR applies the same fix to the frontend and adds diagnostics to investigate flaky E2E test failures on runner image `20260804.94.1`.

## Test plan
- [ ] Check "Diagnose podman environment" step output for runner details
- [ ] Monitor whether flaky test failures correlate with specific runner images

🤖 Generated with [Claude Code](https://claude.com/claude-code)