### PR TITLE
fix(AAP-87219): replace variable/namespace jargon in condition errors

### DIFF
--- a/backend/src/syntara/workflows/workflow_engine/unified_eval.py
+++ b/backend/src/syntara/workflows/workflow_engine/unified_eval.py
@@ -156,7 +156,10 @@ def safe_eval_with_namespace(expression: str, namespace: dict[str, Any]) -> bool
 def _eval_variable(node: ast.Name, namespace: dict[str, Any]) -> Any:  # noqa: ANN401
     """Evaluate variable reference (e.g., status, user, fetch_order)."""
     if node.id not in namespace:
-        msg = f"Variable '{node.id}' not found in namespace"
+        msg = (
+            f'The condition references "{node.id}" but no step with that name has produced '
+            "output. Check that the step name is correct and runs before this condition."
+        )
         raise KeyError(msg)
     return namespace[node.id]
 

--- a/backend/tests/unit/workflows/workflow_engine/test_unified_eval.py
+++ b/backend/tests/unit/workflows/workflow_engine/test_unified_eval.py
@@ -39,7 +39,10 @@ class TestBasicEvaluation:
 
     def test_variable_not_found_raises_key_error(self) -> None:
         namespace = {"status": "ok"}
-        with pytest.raises(KeyError, match="unknown"):
+        with pytest.raises(
+            KeyError,
+            match=r'The condition references "unknown" but no step with that name has produced output',
+        ):
             safe_eval_with_namespace("${unknown} == 'value'", namespace)
 
     def test_empty_expression_raises_error(self) -> None:
@@ -365,8 +368,15 @@ class TestErrorMessages:
             safe_eval_with_namespace("${status} ==", {"status": "ok"})
 
     def test_variable_not_found_error_message(self) -> None:
-        with pytest.raises(KeyError, match="'unknown' not found"):
+        with pytest.raises(KeyError) as exc_info:
             safe_eval_with_namespace("${unknown} == 'value'", {})
+
+        error_msg = str(exc_info.value)
+        assert 'The condition references "unknown"' in error_msg
+        assert "no step with that name has produced output" in error_msg
+        assert "runs before this condition" in error_msg
+        assert "Variable" not in error_msg
+        assert "namespace" not in error_msg.lower()
 
     def test_unsupported_operation_error_message(self) -> None:
         """Function calls are not supported."""


### PR DESCRIPTION
## Description

condition evaluation used to fail with `Variable '{name}' not found in namespace`. that jargon is opaque in the UI. this PR replaces it with a step-oriented message that tells users to check the step name and ordering.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] update `_eval_variable` missing-name `KeyError` copy in `unified_eval.py`
- [x] update unit tests to assert the new message and reject `Variable` / `namespace` jargon

## Out of Scope

other NS-* message rewrites (`namespace_resolver`, missing field / type errors). those stay on sibling tickets.

## Related Issues

Fixes AAP-87219
Related to AAP-87086

## How to Test

1. create a workflow with a Condition node that references a step name with no output yet
2. publish and run
3. confirm the failed condition shows: `The condition references "{name}" but no step with that name has produced output. Check that the step name is correct and runs before this condition.`
4. confirm the message does not contain `Variable` or `namespace`

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

## Additional Notes