### PR TITLE
fix(ci): bundle CI healthcheck, E2E stability, and scheduler fixes

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -565,28 +565,6 @@ jobs:
           print("CgroupVersion=" + str(h.get("cgroupVersion", h.get("cgroupsVersion", "?"))))
           '
 
-      - name: Pull services with podman-compose
-        timeout-minutes: 10
-        env:
-          APP_SEGMENT_WRITE_KEY: test-e2e-write-key
-          APP_SEGMENT_ENDPOINT: http://mock-segment:9999
-          APP_COLLECTION_INTERVAL_SECONDS: "10"
-          APP_WORKFLOW_HTTP_REQUEST_ALLOWED_HOSTS: '["host.containers.internal"]'
-        run: |
-          ulimit -n 65535
-          uvx podman-compose -p syntara-ci --profile telemetry-e2e pull database redis moto mcp-server mock-segment temporal
-
-      - name: Build services with podman-compose
-        timeout-minutes: 25
-        env:
-          APP_SEGMENT_WRITE_KEY: test-e2e-write-key
-          APP_SEGMENT_ENDPOINT: http://mock-segment:9999
-          APP_COLLECTION_INTERVAL_SECONDS: "10"
-          APP_WORKFLOW_HTTP_REQUEST_ALLOWED_HOSTS: '["host.containers.internal"]'
-        run: |
-          ulimit -n 65535
-          uvx podman-compose -p syntara-ci --profile telemetry-e2e build syntara mcp-server
-
       - name: Start services with podman-compose
         timeout-minutes: 20
         env:
@@ -624,31 +602,15 @@ jobs:
             return 1
           }
 
-          # Wave 1: infrastructure (no inter-service dependencies)
-          echo "::group::Wave 1: infrastructure"
-          $COMPOSE up --no-deps -d database redis moto mcp-server mock-segment
-          echo "::endgroup::"
-          wait_healthy syntara-ci_database_1 120
-          wait_healthy syntara-ci_redis_1 60
-          wait_healthy syntara-ci_moto_1 60
-          wait_healthy syntara-ci_mcp-server_1 60
-          wait_healthy syntara-ci_mock-segment_1 60
-          echo "Infrastructure is healthy"
+          # Wave 1: infrastructure (no upstream dependencies)
+          for svc in database redis moto mcp-server mock-segment; do
+            wait_healthy "syntara-ci_${svc}_1" 120
+          done
 
-          # Wave 2: temporal (needs database)
-          echo "::group::Wave 2: temporal"
-          $COMPOSE up --no-deps -d temporal
-          echo "::endgroup::"
-          wait_healthy syntara-ci_temporal_1 120
-          echo "Temporal is healthy"
-
-          # Wave 3: application services (need temporal + infra)
-          echo "::group::Wave 3: application"
-          $COMPOSE up --no-deps -d syntara temporal-worker temporal-background-worker
-          echo "::endgroup::"
-          wait_healthy syntara-ci_syntara_1 120
-          wait_healthy syntara-ci_temporal-worker_1 120
-          wait_healthy syntara-ci_temporal-background-worker_1 120
+          # Wave 2: services that depend on infrastructure
+          for svc in temporal syntara temporal-worker temporal-background-worker; do
+            wait_healthy "syntara-ci_${svc}_1" 180
+          done
           echo "All services are healthy"
 
       - name: Run E2E tests (excluding global revocation)

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -555,6 +555,28 @@ jobs:
           RH_REGISTRY_USER: ${{ secrets.RH_REGISTRY_USER }}
         run: echo "$RH_REGISTRY_TOKEN" | podman login registry.redhat.io -u "$RH_REGISTRY_USER" --password-stdin
 
+      - name: Pull services with podman-compose
+        timeout-minutes: 10
+        env:
+          APP_SEGMENT_WRITE_KEY: test-e2e-write-key
+          APP_SEGMENT_ENDPOINT: http://mock-segment:9999
+          APP_COLLECTION_INTERVAL_SECONDS: "10"
+          APP_WORKFLOW_HTTP_REQUEST_ALLOWED_HOSTS: '["host.containers.internal"]'
+        run: |
+          ulimit -n 65535
+          uvx podman-compose -p syntara-ci --profile telemetry-e2e pull database redis moto mcp-server mock-segment temporal
+
+      - name: Build services with podman-compose
+        timeout-minutes: 25
+        env:
+          APP_SEGMENT_WRITE_KEY: test-e2e-write-key
+          APP_SEGMENT_ENDPOINT: http://mock-segment:9999
+          APP_COLLECTION_INTERVAL_SECONDS: "10"
+          APP_WORKFLOW_HTTP_REQUEST_ALLOWED_HOSTS: '["host.containers.internal"]'
+        run: |
+          ulimit -n 65535
+          uvx podman-compose -p syntara-ci --profile telemetry-e2e build syntara mcp-server
+
       - name: Start services with podman-compose
         timeout-minutes: 20
         env:
@@ -588,9 +610,6 @@ jobs:
             podman inspect --format='{{json .State.Health}}' "$container" 2>/dev/null || true
             return 1
           }
-
-          # Build locally-built images (syntara image is shared by workers)
-          $COMPOSE build syntara mcp-server
 
           # Wave 1: infrastructure (no inter-service dependencies)
           echo "::group::Wave 1: infrastructure"

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -555,6 +555,16 @@ jobs:
           RH_REGISTRY_USER: ${{ secrets.RH_REGISTRY_USER }}
         run: echo "$RH_REGISTRY_TOKEN" | podman login registry.redhat.io -u "$RH_REGISTRY_USER" --password-stdin
 
+      - name: Diagnose podman environment
+        run: |
+          podman --version
+          podman info --format json | python3 -c '
+          import sys, json
+          h = json.load(sys.stdin)["host"]
+          print("EventLogger=" + str(h.get("eventLogger", "?")))
+          print("CgroupVersion=" + str(h.get("cgroupVersion", h.get("cgroupsVersion", "?"))))
+          '
+
       - name: Pull services with podman-compose
         timeout-minutes: 10
         env:
@@ -586,28 +596,31 @@ jobs:
           APP_WORKFLOW_HTTP_REQUEST_ALLOWED_HOSTS: '["host.containers.internal"]'
         run: |
           ulimit -n 65535
+          # --no-deps: start all containers immediately without health dependency ordering.
+          # On Podman 5.x (events_logger=file), healthcheck timers are never created,
+          # so compose would hang waiting for depends_on service_healthy conditions.
+          uvx podman-compose -p syntara-ci --profile telemetry-e2e up --build -d --no-deps \
+            database redis moto mcp-server mock-segment \
+            temporal syntara temporal-worker temporal-background-worker
 
-          COMPOSE="uvx podman-compose -p syntara-ci --profile telemetry-e2e"
-
-          # --no-deps: start services without waiting for compose's
-          # depends_on/service_healthy resolution. GH Actions runner image
-          # 20260810+ ships a podman version where both podman-compose and
-          # `podman wait --condition=healthy` hang indefinitely. Poll via
-          # `podman inspect` instead, which bypasses the broken event system.
+      - name: Verify services are healthy
+        timeout-minutes: 5
+        run: |
           wait_healthy() {
-            local container="$1" timeout="${2:-120}" elapsed=0 status
-            echo "Waiting for $container to become healthy (timeout: ${timeout}s)..."
-            while [ "$elapsed" -lt "$timeout" ]; do
-              status=$(podman inspect --format='{{.State.Health.Status}}' "$container" 2>/dev/null || echo "missing")
+            local ctr=$1 timeout=${2:-120} elapsed=0
+            echo "Waiting for $ctr (timeout: ${timeout}s)..."
+            while [ $elapsed -lt $timeout ]; do
+              podman healthcheck run "$ctr" >/dev/null 2>&1 || true
+              status=$(podman inspect --format '{{.State.Health.Status}}' "$ctr" 2>/dev/null || echo "unknown")
               if [ "$status" = "healthy" ]; then
-                echo "$container is healthy"
+                echo "  $ctr is healthy (${elapsed}s)"
                 return 0
               fi
-              sleep 3
-              elapsed=$((elapsed + 3))
+              sleep 5
+              elapsed=$((elapsed + 5))
             done
-            echo "ERROR: $container did not become healthy after ${timeout}s (last status: $status)" >&2
-            podman inspect --format='{{json .State.Health}}' "$container" 2>/dev/null || true
+            echo "ERROR: $ctr not healthy after ${timeout}s (status: $status)"
+            podman inspect --format '{{json .State.Health}}' "$ctr" 2>&1 || true
             return 1
           }
 

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -448,6 +448,9 @@ jobs:
             local container="$1" timeout="${2:-120}" elapsed=0 status
             echo "Waiting for $container to become healthy (timeout: ${timeout}s)..."
             while [ "$elapsed" -lt "$timeout" ]; do
+              # Manually trigger healthcheck — needed for Podman 5.x where
+              # events_logger=file prevents systemd timer scheduling.
+              podman healthcheck run "$container" >/dev/null 2>&1 || true
               status=$(podman inspect --format='{{.State.Health.Status}}' "$container" 2>/dev/null || echo "missing")
               if [ "$status" = "healthy" ]; then
                 echo "$container is healthy"

--- a/backend/src/syntara/workflows/workflow_engine/scheduled_launcher.py
+++ b/backend/src/syntara/workflows/workflow_engine/scheduled_launcher.py
@@ -14,6 +14,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from temporalio import activity, workflow
+from temporalio.exceptions import ApplicationError
 from temporalio.workflow import ParentClosePolicy
 
 with workflow.unsafe.imports_passed_through():
@@ -148,7 +149,8 @@ class ScheduledExecutionLauncher:
             Dict with execution setup data for child workflow start.
 
         Raises:
-            WorkflowNotPublishedError: If the workflow is not published.
+            ApplicationError: Non-retryable, if the workflow is missing,
+                soft-deleted, disabled, or has no published version.
 
         """
         workflow_id = UUID(workflow_id_str)
@@ -187,7 +189,7 @@ class ScheduledExecutionLauncher:
                 logger.debug("Failed to record success metric", exc_info=True)
 
             return result
-        except Exception:
+        except Exception as exc:
             try:
                 recorder.record(
                     MetricType.SCHEDULED_TRIGGER_FIRES,
@@ -196,6 +198,15 @@ class ScheduledExecutionLauncher:
                 )
             except Exception:  # noqa: BLE001
                 logger.debug("Failed to record error metric", exc_info=True)
+            if isinstance(exc, WorkflowNotPublishedError):
+                # Permanent state: workflow is missing, soft-deleted, disabled,
+                # or has no published version.  Mark non-retryable so Temporal
+                # does not retry the activity forever (AAP-86776).
+                raise ApplicationError(
+                    str(exc),
+                    type="WorkflowNotPublishedError",
+                    non_retryable=True,
+                ) from exc
             raise
 
     async def _create_execution(

--- a/backend/tests/unit/workflows/workflow_engine/test_scheduled_launcher.py
+++ b/backend/tests/unit/workflows/workflow_engine/test_scheduled_launcher.py
@@ -461,9 +461,9 @@ class TestNonRetryablePermanentFailures:
         mock_recorder = MagicMock()
 
         with (
-            patch("nexus.workflows.workflow_engine.scheduled_launcher.activity") as mock_activity,
+            patch("syntara.workflows.workflow_engine.scheduled_launcher.activity") as mock_activity,
             patch(
-                "nexus.workflows.workflow_engine.scheduled_launcher.get_metrics_recorder", return_value=mock_recorder
+                "syntara.workflows.workflow_engine.scheduled_launcher.get_metrics_recorder", return_value=mock_recorder
             ),
             patch.object(
                 launcher,
@@ -496,9 +496,9 @@ class TestNonRetryablePermanentFailures:
         mock_recorder = MagicMock()
 
         with (
-            patch("nexus.workflows.workflow_engine.scheduled_launcher.activity") as mock_activity,
+            patch("syntara.workflows.workflow_engine.scheduled_launcher.activity") as mock_activity,
             patch(
-                "nexus.workflows.workflow_engine.scheduled_launcher.get_metrics_recorder", return_value=mock_recorder
+                "syntara.workflows.workflow_engine.scheduled_launcher.get_metrics_recorder", return_value=mock_recorder
             ),
             patch.object(
                 launcher,

--- a/backend/tests/unit/workflows/workflow_engine/test_scheduled_launcher.py
+++ b/backend/tests/unit/workflows/workflow_engine/test_scheduled_launcher.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from temporalio.exceptions import ApplicationError
 
 from syntara.core.models.principal import service_principal_id
 from syntara.metrics.types import MetricType
@@ -438,3 +439,75 @@ class TestLoadPublishedWorkflow:
 
         with pytest.raises(WorkflowNotPublishedError):
             await ScheduledExecutionLauncher._load_published_workflow(session, uuid4())
+
+
+class TestNonRetryablePermanentFailures:
+    """Tests that permanent failures are raised as non-retryable ApplicationErrors (AAP-86776).
+
+    A schedule firing against a workflow that is missing, soft-deleted,
+    disabled, or unpublished must fail once — not retry forever under
+    Temporal's default unlimited retry policy.
+    """
+
+    async def test_workflow_not_published_raises_non_retryable_application_error(self) -> None:
+        """WorkflowNotPublishedError must surface as ApplicationError(non_retryable=True)."""
+        launcher = _make_launcher()
+        workflow_id = uuid4()
+        workflow_id_str = str(workflow_id)
+        scheduled_at = datetime(2024, 1, 1, 9, 0, 0, tzinfo=UTC)
+        triggered_at = scheduled_at + timedelta(seconds=3)
+
+        mock_info = _make_mock_activity_info(scheduled_at, triggered_at)
+        mock_recorder = MagicMock()
+
+        with (
+            patch("nexus.workflows.workflow_engine.scheduled_launcher.activity") as mock_activity,
+            patch(
+                "nexus.workflows.workflow_engine.scheduled_launcher.get_metrics_recorder", return_value=mock_recorder
+            ),
+            patch.object(
+                launcher,
+                "_create_execution",
+                new_callable=AsyncMock,
+                side_effect=WorkflowNotPublishedError(workflow_id),
+            ),
+        ):
+            mock_activity.info.return_value = mock_info
+
+            with pytest.raises(ApplicationError, match="has no published version") as exc_info:
+                await launcher.run(workflow_id_str, "trigger_1")
+
+            assert exc_info.value.non_retryable is True
+            assert exc_info.value.type == "WorkflowNotPublishedError"
+
+        # Error metric should still be recorded
+        calls = mock_recorder.record.call_args_list
+        assert len(calls) == 1
+        assert calls[0][1]["labels"]["status"] == "error"
+
+    async def test_transient_error_remains_retryable(self) -> None:
+        """A transient error (e.g. DB connection lost) must NOT be wrapped as non-retryable."""
+        launcher = _make_launcher()
+        workflow_id_str = str(uuid4())
+        scheduled_at = datetime(2024, 1, 1, 9, 0, 0, tzinfo=UTC)
+        triggered_at = scheduled_at + timedelta(seconds=2)
+
+        mock_info = _make_mock_activity_info(scheduled_at, triggered_at)
+        mock_recorder = MagicMock()
+
+        with (
+            patch("nexus.workflows.workflow_engine.scheduled_launcher.activity") as mock_activity,
+            patch(
+                "nexus.workflows.workflow_engine.scheduled_launcher.get_metrics_recorder", return_value=mock_recorder
+            ),
+            patch.object(
+                launcher,
+                "_create_execution",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("DB connection lost"),
+            ),
+        ):
+            mock_activity.info.return_value = mock_info
+
+            with pytest.raises(RuntimeError, match="DB connection lost"):
+                await launcher.run(workflow_id_str, "trigger_1")

--- a/frontend/packages/syntara-ui/e2e/credential-enable-disable.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-enable-disable.spec.ts
@@ -182,6 +182,7 @@ test.describe('Credential Enable/Disable State Management', () => {
       await filterCredentialByName(app, name)
 
       const updatedRow = app.getByRole('row', { name: new RegExp(name) })
+      await updatedRow.waitFor({ state: 'visible', timeout: 10_000 })
       await expect(listRowToggle(updatedRow)).not.toBeChecked()
     } finally {
       await deleteCredentialByName(app, name)

--- a/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
@@ -1,6 +1,5 @@
 /**
  * E2E Tests: Cancel Execution
- * Jira: AAP-82020
  *
  * Objective: Verify the cancel execution flow from the execution detail page.
  *
@@ -9,7 +8,7 @@
  * - Clicking cancel transitions execution to cancelled status
  * - Cancel button hidden for completed executions
  *
- * Requires a real backend with Temporal — the sleep node keeps the execution
+ * Requires a real backend with Temporal — the wait node keeps the execution
  * in "running" state long enough to interact with the cancel button.
  */
 
@@ -47,13 +46,13 @@ test.beforeAll(async ({ browser }) => {
       [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
       [
         {
-          id: 'sleep_node',
-          type: 'script',
-          name: 'Long Sleep',
-          parameters: { language: 'bash', code: 'sleep 300' },
+          id: 'long_wait',
+          type: 'wait',
+          name: 'Long Wait',
+          parameters: { duration: 300 },
         },
       ],
-      [{ from: 'trigger_manual', to: 'sleep_node' }]
+      [{ from: 'trigger_manual', to: 'long_wait' }]
     ))
 
     const runResp = await apiRequest(page, 'post', '/executions', {
@@ -72,13 +71,13 @@ test.beforeAll(async ({ browser }) => {
       [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
       [
         {
-          id: 'echo_node',
-          type: 'script',
-          name: 'Quick Echo',
-          parameters: { language: 'bash', code: 'echo done' },
+          id: 'quick_wait',
+          type: 'wait',
+          name: 'Quick Wait',
+          parameters: { duration: 1 },
         },
       ],
-      [{ from: 'trigger_manual', to: 'echo_node' }]
+      [{ from: 'trigger_manual', to: 'quick_wait' }]
     ))
 
     const echoRunResp = await apiRequest(page, 'post', '/executions', {


### PR DESCRIPTION
## Summary

Bundles independent CI and test stability fixes to land them together:

- **Podman 5.x healthcheck fix** (PR #111): Manually trigger healthchecks via `podman healthcheck run` in the polling loop — needed because Podman 5.x static bundles with `events_logger=file` never create systemd timers for healthcheck scheduling. Applied to both backend and frontend CI.
- **CI phase separation** (PR #86): Split compose startup into pull/build/up phases with per-phase timeouts for easier triage. Adds wave-based `--no-deps` startup.
- **Scheduled launcher fix** (PR #86): Wrap `WorkflowNotPublishedError` as non-retryable `ApplicationError` so Temporal doesn't retry permanent failures forever (AAP-86776).
- **Cancel-execution E2E stabilization** (PR #120): Use wait nodes instead of sleep nodes in test setup to avoid Temporal timing issues on loaded runners.
- **Credential-toggle E2E stabilization** (PR #124): Stabilize flaky credential enable/disable state persistence test.

## Included PRs
- #86 — `fix/pr59-compose-timeout-retry` (3 commits)
- #111 — `debug/ci-podman-healthcheck-diag` (1 commit)
- #120 — `fix/e2e-cancel-execution-wait-nodes` (1 commit)
- #124 — `goneri/fix-tests-stabilize-flaky-credential-toggle-and-cancel-execution-E2E-tests_9392` (1 commit)

## Test plan
- [x] Backend Compose E2E passes on Podman 5.x runner (`events_logger=file`)
- [x] Backend Compose E2E passes on Podman 4.x runner (`events_logger=journald`)
- [ ] Frontend Compose E2E passes without flaky test failures
- [ ] Scheduled launcher unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)