### PR TITLE
chore(AAP-87598): Reduce CI time wasted by conditional E2E test skips

### DIFF
--- a/frontend/packages/syntara-ui/e2e/access-management.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/access-management.spec.ts
@@ -14,7 +14,7 @@
  * - Filters and sort survive a full page reload
  * - User detail sub-tabs sync to URL
  */
-import { test, expect, toAppUrl } from './fixtures'
+import { test, expect, toAppUrl, createUnavailableGuard } from './fixtures'
 import { APP_TITLE } from './helpers/appTitle'
 import { buildUniqueName } from './helpers/workflows'
 import {
@@ -112,12 +112,7 @@ test.describe('Access Management — Tab Navigation', () => {
 })
 
 test.describe('Access Management — Roles Tab Filtering', () => {
-  let rolesFilterUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(rolesFilterUnavailable, 'No roles data available; seed data required')
-  })
+  const guard = createUnavailableGuard('No roles data available; seed data required')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl(`${ACCESS_URL}/roles`))
@@ -128,7 +123,7 @@ test.describe('Access Management — Roles Tab Filtering', () => {
       .waitFor({ state: 'visible', timeout: 5000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasTable) rolesFilterUnavailable = true
+    if (!hasTable) guard.markUnavailable()
     test.skip(!hasTable, 'No roles data available; seed data required')
   })
 
@@ -180,12 +175,7 @@ test.describe('Access Management — Roles Tab Filtering', () => {
 })
 
 test.describe('Access Management — Roles Tab Sorting', () => {
-  let rolesSortUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(rolesSortUnavailable, 'No roles data available; seed data required')
-  })
+  const guard = createUnavailableGuard('No roles data available; seed data required')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl(`${ACCESS_URL}/roles`))
@@ -196,7 +186,7 @@ test.describe('Access Management — Roles Tab Sorting', () => {
       .waitFor({ state: 'visible', timeout: 5000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasTable) rolesSortUnavailable = true
+    if (!hasTable) guard.markUnavailable()
     test.skip(!hasTable, 'No roles data available; seed data required')
   })
 
@@ -340,12 +330,7 @@ test.describe('Access Management — User Detail Tabs', () => {
 })
 
 test.describe('Access Management — Policies Tab Columns', () => {
-  let policiesUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(policiesUnavailable, 'No policies data available; seed data required')
-  })
+  const guard = createUnavailableGuard('No policies data available; seed data required')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl(`${ACCESS_URL}/policies`))
@@ -356,7 +341,7 @@ test.describe('Access Management — Policies Tab Columns', () => {
       .waitFor({ state: 'visible', timeout: 5000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasTable) policiesUnavailable = true
+    if (!hasTable) guard.markUnavailable()
     test.skip(!hasTable, 'No policies data available; seed data required')
   })
 

--- a/frontend/packages/syntara-ui/e2e/access-management.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/access-management.spec.ts
@@ -112,16 +112,23 @@ test.describe('Access Management — Tab Navigation', () => {
 })
 
 test.describe('Access Management — Roles Tab Filtering', () => {
+  let rolesFilterUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(rolesFilterUnavailable, 'No roles data available; seed data required')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl(`${ACCESS_URL}/roles`))
     await expect(app.getByRole('tab', { name: /Roles/i })).toHaveAttribute('aria-selected', 'true')
 
-    // Skip if no roles data available
     const table = app.locator('table')
     const hasTable = await table
       .waitFor({ state: 'visible', timeout: 5000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasTable) rolesFilterUnavailable = true
     test.skip(!hasTable, 'No roles data available; seed data required')
   })
 
@@ -173,6 +180,13 @@ test.describe('Access Management — Roles Tab Filtering', () => {
 })
 
 test.describe('Access Management — Roles Tab Sorting', () => {
+  let rolesSortUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(rolesSortUnavailable, 'No roles data available; seed data required')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl(`${ACCESS_URL}/roles`))
     await expect(app.getByRole('tab', { name: /Roles/i })).toHaveAttribute('aria-selected', 'true')
@@ -182,6 +196,7 @@ test.describe('Access Management — Roles Tab Sorting', () => {
       .waitFor({ state: 'visible', timeout: 5000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasTable) rolesSortUnavailable = true
     test.skip(!hasTable, 'No roles data available; seed data required')
   })
 
@@ -325,6 +340,13 @@ test.describe('Access Management — User Detail Tabs', () => {
 })
 
 test.describe('Access Management — Policies Tab Columns', () => {
+  let policiesUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(policiesUnavailable, 'No policies data available; seed data required')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl(`${ACCESS_URL}/policies`))
     await expect(app.getByRole('tab', { name: /Policies/i })).toHaveAttribute('aria-selected', 'true')
@@ -334,6 +356,7 @@ test.describe('Access Management — Policies Tab Columns', () => {
       .waitFor({ state: 'visible', timeout: 5000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasTable) policiesUnavailable = true
     test.skip(!hasTable, 'No policies data available; seed data required')
   })
 

--- a/frontend/packages/syntara-ui/e2e/access-pagination.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/access-pagination.spec.ts
@@ -106,56 +106,58 @@ test.describe('Access Management — Dropdown Pagination', () => {
     await expect(dialog).not.toBeVisible()
   })
 
-  test('Add Member modal shows users in the typeahead dropdown', async ({ app }) => {
+  test.describe('Member typeahead (mock backend only)', () => {
     test.skip(!!process.env.SYNTARA_E2E_SKIP_WEB_SERVER, 'Group typeahead unreliable against real backend')
 
-    await app.goto(toAppUrl('/system-administration/access-management/groups'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Access Management' })).toBeVisible()
+    test('Add Member modal shows users in the typeahead dropdown', async ({ app }) => {
+      await app.goto(toAppUrl('/system-administration/access-management/groups'))
+      await expect(app.getByRole('heading', { level: 1, name: 'Access Management' })).toBeVisible()
 
-    const groupsTable = app.getByRole('grid', { name: 'Groups table' })
-    const firstGroupRow = groupsTable.getByRole('row').nth(1)
-    const firstGroupButton = firstGroupRow.getByRole('button')
-    const hasGroup = await firstGroupButton
-      .waitFor({ state: 'visible', timeout: 5000 })
-      .then(() => true)
-      .catch(() => false)
-    test.skip(!hasGroup, 'No groups available; seed data required')
+      const groupsTable = app.getByRole('grid', { name: 'Groups table' })
+      const firstGroupRow = groupsTable.getByRole('row').nth(1)
+      const firstGroupButton = firstGroupRow.getByRole('button')
+      const hasGroup = await firstGroupButton
+        .waitFor({ state: 'visible', timeout: 5000 })
+        .then(() => true)
+        .catch(() => false)
+      test.skip(!hasGroup, 'No groups available; seed data required')
 
-    await firstGroupButton.click()
+      await firstGroupButton.click()
 
-    await expect(app).toHaveURL(/system-administration\/access-management\/groups\//)
+      await expect(app).toHaveURL(/system-administration\/access-management\/groups\//)
 
-    const membersTab = app.getByRole('tab', { name: /members/i })
-    const hasMembersTab = await membersTab
-      .waitFor({ state: 'visible', timeout: 5000 })
-      .then(() => true)
-      .catch(() => false)
-    test.skip(!hasMembersTab, 'First group has no Members tab (may be the "authenticated" group)')
+      const membersTab = app.getByRole('tab', { name: /members/i })
+      const hasMembersTab = await membersTab
+        .waitFor({ state: 'visible', timeout: 5000 })
+        .then(() => true)
+        .catch(() => false)
+      test.skip(!hasMembersTab, 'First group has no Members tab (may be the "authenticated" group)')
 
-    await membersTab.click()
+      await membersTab.click()
 
-    const addMemberButton = app.getByRole('button', { name: /add member/i })
-    await expect(addMemberButton).toBeVisible({ timeout: 10_000 })
-    await addMemberButton.click()
+      const addMemberButton = app.getByRole('button', { name: /add member/i })
+      await expect(addMemberButton).toBeVisible({ timeout: 10_000 })
+      await addMemberButton.click()
 
-    const dialog = app.getByRole('dialog')
-    await expect(dialog).toBeVisible()
-    await expect(dialog.getByText('Add member')).toBeVisible()
+      const dialog = app.getByRole('dialog')
+      await expect(dialog).toBeVisible()
+      await expect(dialog.getByText('Add member')).toBeVisible()
 
-    const searchInput = dialog.getByPlaceholder('Search for a user...')
-    await searchInput.click()
+      const searchInput = dialog.getByPlaceholder('Search for a user...')
+      await searchInput.click()
 
-    const noResults = dialog.getByText(/No results match/i)
-    const userOptions = dialog.getByRole('option').filter({ hasNotText: /No results match/i })
-    const hasOptions = await userOptions
-      .or(noResults)
-      .waitFor({ state: 'visible', timeout: 15_000 })
-      .then(() => true)
-      .catch(() => false)
-    test.skip(!hasOptions, 'Typeahead dropdown did not populate')
-    expect(await userOptions.count()).toBeGreaterThan(0)
+      const noResults = dialog.getByText(/No results match/i)
+      const userOptions = dialog.getByRole('option').filter({ hasNotText: /No results match/i })
+      const hasOptions = await userOptions
+        .or(noResults)
+        .waitFor({ state: 'visible', timeout: 15_000 })
+        .then(() => true)
+        .catch(() => false)
+      test.skip(!hasOptions, 'Typeahead dropdown did not populate')
+      expect(await userOptions.count()).toBeGreaterThan(0)
 
-    await dialog.getByRole('button', { name: 'Cancel' }).click()
-    await expect(dialog).not.toBeVisible()
+      await dialog.getByRole('button', { name: 'Cancel' }).click()
+      await expect(dialog).not.toBeVisible()
+    })
   })
 })

--- a/frontend/packages/syntara-ui/e2e/credentials-list.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credentials-list.spec.ts
@@ -12,7 +12,7 @@
  * - Kebab menu edit action
  * - Kebab menu delete action
  */
-import { test, expect } from './fixtures'
+import { createUnavailableGuard, test, expect } from './fixtures'
 import { APP_TITLE } from './helpers/appTitle'
 import {
   createTestCredential,
@@ -143,12 +143,7 @@ test.describe('Table Display and Sorting', () => {
 // Test 4: Cursor-Based Pagination
 // ---------------------------------------------------------------------------
 test.describe('Cursor-Based Pagination', () => {
-  let credentialsUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(credentialsUnavailable, 'No credential data available; seed data required')
-  })
+  const guard = createUnavailableGuard('No credential data available; seed data required')
 
   test.beforeEach(async ({ app }) => {
     await goToCredentialsList(app)
@@ -157,7 +152,7 @@ test.describe('Cursor-Based Pagination', () => {
       .waitFor({ state: 'visible', timeout: 5000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasTable) credentialsUnavailable = true
+    if (!hasTable) guard.markUnavailable()
     test.skip(!hasTable, 'No credential data available; seed data required')
   })
 

--- a/frontend/packages/syntara-ui/e2e/credentials-list.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credentials-list.spec.ts
@@ -143,30 +143,30 @@ test.describe('Table Display and Sorting', () => {
 // Test 4: Cursor-Based Pagination
 // ---------------------------------------------------------------------------
 test.describe('Cursor-Based Pagination', () => {
-  test('pagination footer displays credential count', async ({ app }) => {
-    await goToCredentialsList(app)
+  let credentialsUnavailable = false
 
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(credentialsUnavailable, 'No credential data available; seed data required')
+  })
+
+  test.beforeEach(async ({ app }) => {
+    await goToCredentialsList(app)
     const table = app.getByRole('grid', { name: 'Credentials table' })
     const hasTable = await table
       .waitFor({ state: 'visible', timeout: 5000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasTable) credentialsUnavailable = true
     test.skip(!hasTable, 'No credential data available; seed data required')
+  })
 
+  test('pagination footer displays credential count', async ({ app }) => {
     const credentialCountText = app.locator('.pf-v6-c-pagination').getByText(/of \d+/)
     await expect(credentialCountText).toBeVisible()
   })
 
   test('next/previous controls navigate between pages when available', async ({ app }) => {
-    await goToCredentialsList(app)
-
-    const table = app.getByRole('grid', { name: 'Credentials table' })
-    const hasTable = await table
-      .waitFor({ state: 'visible', timeout: 5000 })
-      .then(() => true)
-      .catch(() => false)
-    test.skip(!hasTable, 'No credential data available; seed data required')
-
     const pagination = app.locator('.pf-v6-c-pagination')
     const nextButton = pagination.getByRole('button', { name: /next/i })
     const hasNext = await nextButton
@@ -181,6 +181,7 @@ test.describe('Cursor-Based Pagination', () => {
       await expect(prevButton).toBeEnabled()
 
       await prevButton.click()
+      const table = app.getByRole('grid', { name: 'Credentials table' })
       await expect(table).toBeVisible()
     }
   })

--- a/frontend/packages/syntara-ui/e2e/execution-filtering.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/execution-filtering.spec.ts
@@ -46,6 +46,13 @@ async function switchFieldSelector(app: Page, currentFieldLabel: string, targetF
 }
 
 test.describe('Execution Filtering @pr-check', () => {
+  let executionsUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(executionsUnavailable, 'No execution data available; seed data required')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/executions'))
     await expect(app.getByRole('heading', { level: 1, name: 'Workflow Runs' })).toBeVisible()
@@ -55,6 +62,7 @@ test.describe('Execution Filtering @pr-check', () => {
       .waitFor({ state: 'visible', timeout: 10_000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasTable) executionsUnavailable = true
     test.skip(!hasTable, 'No execution data available; seed data required')
   })
 

--- a/frontend/packages/syntara-ui/e2e/execution-filtering.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/execution-filtering.spec.ts
@@ -16,7 +16,7 @@
  * - Filter persistence across navigation
  */
 
-import { test, expect, toAppUrl, type Page } from './fixtures'
+import { createUnavailableGuard, test, expect, toAppUrl, type Page } from './fixtures'
 import { apiRequest } from './utils/api'
 
 /** Select a workflow from the async typeahead, waiting for real options to load. */
@@ -46,12 +46,7 @@ async function switchFieldSelector(app: Page, currentFieldLabel: string, targetF
 }
 
 test.describe('Execution Filtering @pr-check', () => {
-  let executionsUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(executionsUnavailable, 'No execution data available; seed data required')
-  })
+  const guard = createUnavailableGuard('No execution data available; seed data required')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/executions'))
@@ -62,7 +57,7 @@ test.describe('Execution Filtering @pr-check', () => {
       .waitFor({ state: 'visible', timeout: 10_000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasTable) executionsUnavailable = true
+    if (!hasTable) guard.markUnavailable()
     test.skip(!hasTable, 'No execution data available; seed data required')
   })
 

--- a/frontend/packages/syntara-ui/e2e/execution-url.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/execution-url.spec.ts
@@ -3,6 +3,8 @@ import { addScriptNode } from './helpers/v2-nodes'
 import { buildUniqueName, createBasicWorkflowViaApi, deleteWorkflow, openWorkflowInBuilder } from './helpers/workflows'
 
 test.describe('Execution URL unification', () => {
+  test.skip(!process.env['SYNTARA_E2E_HAS_EXECUTION_ENGINE'], 'Execution engine unavailable (globalSetup probe)')
+
   test('running a workflow shows inline run panel in builder', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-exec-url-run')
     const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Run action')

--- a/frontend/packages/syntara-ui/e2e/executions.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/executions.spec.ts
@@ -1,25 +1,28 @@
 import { test, expect, toAppUrl } from './fixtures'
 import { APP_TITLE } from './helpers/appTitle'
 
-test('user views executions and opens a running execution', async ({ app }) => {
+test.describe(() => {
   test.skip(!!process.env.CI, 'CI deploys a fresh backend with no running executions to assert on')
-  await app.goto(toAppUrl('/executions'))
-  await expect(app.getByRole('heading', { name: 'Workflow Runs' })).toBeVisible()
-  await expect(app).toHaveTitle(`Workflow Runs | ${APP_TITLE}`)
 
-  const executionsTable = app.getByRole('grid').filter({ has: app.getByRole('columnheader', { name: 'Status' }) })
-  const runningRow = executionsTable
-    .getByRole('row')
-    .filter({ has: app.getByText(/Running/i) })
-    .nth(0)
-  const hasRunning = await runningRow
-    .waitFor({ state: 'visible', timeout: 5000 })
-    .then(() => true)
-    .catch(() => false)
-  test.skip(!hasRunning, 'Mock API has no running execution; seed data required')
+  test('user views executions and opens a running execution', async ({ app }) => {
+    await app.goto(toAppUrl('/executions'))
+    await expect(app.getByRole('heading', { name: 'Workflow Runs' })).toBeVisible()
+    await expect(app).toHaveTitle(`Workflow Runs | ${APP_TITLE}`)
 
-  const runDetailButton = runningRow.getByRole('link').filter({ has: app.locator('code') })
-  await runDetailButton.click()
-  await expect(app).toHaveURL((url) => /^\/executions\/[^/]+$/.test(new URL(url).pathname))
-  await expect(app.getByRole('heading', { name: 'Current run details' })).toBeVisible()
+    const executionsTable = app.getByRole('grid').filter({ has: app.getByRole('columnheader', { name: 'Status' }) })
+    const runningRow = executionsTable
+      .getByRole('row')
+      .filter({ has: app.getByText(/Running/i) })
+      .nth(0)
+    const hasRunning = await runningRow
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .then(() => true)
+      .catch(() => false)
+    test.skip(!hasRunning, 'Mock API has no running execution; seed data required')
+
+    const runDetailButton = runningRow.getByRole('link').filter({ has: app.locator('code') })
+    await runDetailButton.click()
+    await expect(app).toHaveURL((url) => /^\/executions\/[^/]+$/.test(new URL(url).pathname))
+    await expect(app.getByRole('heading', { name: 'Current run details' })).toBeVisible()
+  })
 })

--- a/frontend/packages/syntara-ui/e2e/executions.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/executions.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, toAppUrl } from './fixtures'
 import { APP_TITLE } from './helpers/appTitle'
 
-test.describe(() => {
+test.describe('Execution list (requires running executions)', () => {
   test.skip(!!process.env.CI, 'CI deploys a fresh backend with no running executions to assert on')
 
   test('user views executions and opens a running execution', async ({ app }) => {

--- a/frontend/packages/syntara-ui/e2e/fixtures.ts
+++ b/frontend/packages/syntara-ui/e2e/fixtures.ts
@@ -173,4 +173,33 @@ export const test = xfailBase.extend<
   },
 })
 
+/**
+ * Creates a describe-scoped guard that skips all remaining tests without
+ * setting up fixtures once a data-availability check fails.
+ *
+ * Configures the enclosing describe as `mode: 'serial'` so the unavailable
+ * flag reliably propagates across tests (with `fullyParallel: true`, parallel
+ * tests land on separate workers that each have their own flag).
+ *
+ * Usage inside a test.describe:
+ *   const guard = createUnavailableGuard('No data available')
+ *   test.beforeEach(async ({ app }) => {
+ *     const hasData = await checkData(app)
+ *     if (!hasData) guard.markUnavailable()
+ *     test.skip(!hasData, 'No data available')
+ *   })
+ */
+export function createUnavailableGuard(reason: string) {
+  let unavailable = false
+  test.describe.configure({ mode: 'serial' })
+  test.beforeEach(() => {
+    test.skip(unavailable, reason)
+  })
+  return {
+    markUnavailable: () => {
+      unavailable = true
+    },
+  }
+}
+
 export { expect, type Page, type Request }

--- a/frontend/packages/syntara-ui/e2e/global-setup.ts
+++ b/frontend/packages/syntara-ui/e2e/global-setup.ts
@@ -1,0 +1,163 @@
+/**
+ * Playwright globalSetup — probes backend service health once before all tests.
+ *
+ * On a real backend (NEXUS_E2E_SKIP_WEB_SERVER=1), this creates a throwaway
+ * workflow, runs it, and checks whether the execution engine and Temporal worker
+ * are operational. Results are exported as environment variables so test files
+ * can skip entire describe blocks at collection time (0ms cost).
+ *
+ * On the mock backend this is a no-op — all services are synthetic.
+ */
+import { isSkipWebServerForPlaywrightTests } from './playwrightWebServerEnv'
+
+const appBaseUrl: string = process.env['NEXUS_E2E_BASE_URL'] ?? 'http://localhost:4173'
+
+function apiUrl(path: string): string {
+  return new URL(`/api/v1${path}`, appBaseUrl).toString()
+}
+
+async function authenticate(): Promise<string | null> {
+  const password = process.env['NEXUS_E2E_PASSWORD']
+  if (!password) return null
+
+  try {
+    const resp = await fetch(apiUrl('/auth/login'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'admin', password }),
+    })
+    if (!resp.ok) return null
+    const body = (await resp.json()) as { access_token?: string }
+    return body.access_token ?? null
+  } catch {
+    return null
+  }
+}
+
+async function api(
+  token: string,
+  method: string,
+  path: string,
+  data?: unknown
+): Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }> {
+  const resp = await fetch(apiUrl(path), {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: data ? JSON.stringify(data) : undefined,
+  })
+  return { ok: resp.ok, status: resp.status, json: () => resp.json() }
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Probe the execution engine and Temporal worker by creating, running, and
+ * polling a minimal workflow. Returns which capabilities are available.
+ */
+async function probeExecutionEngine(token: string): Promise<{
+  executionEngine: boolean
+  temporalWorker: boolean
+}> {
+  const result = { executionEngine: false, temporalWorker: false }
+
+  try {
+    // Find or create a project
+    const projectsResp = await api(token, 'GET', '/projects')
+    if (!projectsResp.ok) return result
+    const projects = (await projectsResp.json()) as { resources: Array<{ id: string }> }
+    let projectId = projects.resources?.[0]?.id
+
+    if (!projectId) {
+      const createProject = await api(token, 'POST', '/projects', {
+        name: 'e2e-probe',
+        description: 'Health probe project',
+      })
+      if (!createProject.ok) return result
+      projectId = ((await createProject.json()) as { id: string }).id
+    }
+
+    // Create a minimal workflow
+    const createResp = await api(token, 'POST', '/workflows', {
+      name: `__e2e_probe_${Date.now()}`,
+      project_id: projectId,
+      workflow_definition: {
+        schema_version: '2.0.0',
+        name: '__e2e_probe',
+        triggers: [{ id: 't1', type: 'manual_trigger', name: 'Probe trigger', parameters: {} }],
+        nodes: [
+          {
+            id: 'n1',
+            type: 'script',
+            name: 'Probe script',
+            parameters: { language: 'python', code: 'print("probe")' },
+          },
+        ],
+        edges: [{ from: 't1', to: 'n1' }],
+      },
+    })
+    if (!createResp.ok) return result
+    const workflow = (await createResp.json()) as { id: string; current_version: number }
+    const workflowId = workflow.id
+
+    try {
+      // Publish
+      await api(token, 'POST', `/workflows/${workflowId}/versions/${workflow.current_version}/publish`, {})
+
+      // Run
+      const runResp = await api(token, 'POST', `/workflows/${workflowId}/run`, {})
+      if (!runResp.ok) return result
+      const execution = (await runResp.json()) as { id?: string; execution_id?: string }
+      const executionId = execution.id ?? execution.execution_id
+      if (!executionId) return result
+
+      result.executionEngine = true
+
+      // Poll execution status — check if Temporal picks it up
+      for (let i = 0; i < 15; i++) {
+        await sleep(2000)
+        const statusResp = await api(token, 'GET', `/executions/${executionId}`)
+        if (!statusResp.ok) break
+        const exec = (await statusResp.json()) as { status: string }
+        if (exec.status !== 'pending') {
+          result.temporalWorker = true
+          break
+        }
+      }
+    } finally {
+      // Clean up
+      await api(token, 'DELETE', `/workflows/${workflowId}`).catch(() => {})
+    }
+  } catch {
+    // Probe failed — leave defaults (false)
+  }
+
+  return result
+}
+
+// eslint-disable-next-line no-restricted-exports -- Playwright requires globalSetup to be a default export
+export default async function globalSetup(): Promise<void> {
+  if (!isSkipWebServerForPlaywrightTests()) return
+
+  // eslint-disable-next-line no-console -- globalSetup runs in Node before tests; console is the only logging mechanism
+  console.log('[global-setup] Probing backend service health...')
+
+  const token = await authenticate()
+  if (!token) {
+    // eslint-disable-next-line no-console
+    console.log('[global-setup] Could not authenticate — skipping probes')
+    return
+  }
+
+  const { executionEngine, temporalWorker } = await probeExecutionEngine(token)
+
+  if (executionEngine) process.env['SYNTARA_E2E_HAS_EXECUTION_ENGINE'] = '1'
+  if (temporalWorker) process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'] = '1'
+
+  // eslint-disable-next-line no-console
+  console.log(`[global-setup] Probe results: execution_engine=${executionEngine}, temporal_worker=${temporalWorker}`)
+}

--- a/frontend/packages/syntara-ui/e2e/global-setup.ts
+++ b/frontend/packages/syntara-ui/e2e/global-setup.ts
@@ -6,7 +6,13 @@
  * are operational. Results are exported as environment variables so test files
  * can skip entire describe blocks at collection time (0ms cost).
  *
- * On the mock backend this is a no-op — all services are synthetic.
+ * The probe is **fail-open**: env vars default to '1' (healthy). Only a positive
+ * confirmation that a service is down (API responded but execution never left
+ * "pending") clears the flag. Timeouts, auth failures, and network errors all
+ * leave the flags set so tests run and discover issues themselves.
+ *
+ * On the mock backend the flags are set to '1' unconditionally — all services
+ * are synthetic and always available.
  */
 import { isSkipWebServerForPlaywrightTests } from './playwrightWebServerEnv'
 
@@ -57,16 +63,19 @@ async function sleep(ms: number): Promise<void> {
 
 /**
  * Probe the execution engine and Temporal worker by creating, running, and
- * polling a minimal workflow. Returns which capabilities are available.
+ * polling a minimal workflow.
+ *
+ * Returns which services are **positively confirmed as down**. A timeout or
+ * error is treated as inconclusive (fail-open).
  */
 async function probeExecutionEngine(token: string): Promise<{
-  executionEngine: boolean
-  temporalWorker: boolean
+  executionEngineDown: boolean
+  temporalWorkerDown: boolean
 }> {
-  const result = { executionEngine: false, temporalWorker: false }
+  const result = { executionEngineDown: false, temporalWorkerDown: false }
+  let createdProjectId: string | null = null
 
   try {
-    // Find or create a project
     const projectsResp = await api(token, 'GET', '/projects')
     if (!projectsResp.ok) return result
     const projects = (await projectsResp.json()) as { resources: Array<{ id: string }> }
@@ -79,9 +88,9 @@ async function probeExecutionEngine(token: string): Promise<{
       })
       if (!createProject.ok) return result
       projectId = ((await createProject.json()) as { id: string }).id
+      createdProjectId = projectId
     }
 
-    // Create a minimal workflow
     const createResp = await api(token, 'POST', '/workflows', {
       name: `__e2e_probe_${Date.now()}`,
       project_id: projectId,
@@ -105,59 +114,74 @@ async function probeExecutionEngine(token: string): Promise<{
     const workflowId = workflow.id
 
     try {
-      // Publish
       await api(token, 'POST', `/workflows/${workflowId}/versions/${workflow.current_version}/publish`, {})
 
-      // Run
       const runResp = await api(token, 'POST', `/workflows/${workflowId}/run`, {})
-      if (!runResp.ok) return result
+      if (!runResp.ok) {
+        // API explicitly rejected the run request — engine is positively down
+        result.executionEngineDown = true
+        return result
+      }
+
       const execution = (await runResp.json()) as { id?: string; execution_id?: string }
       const executionId = execution.id ?? execution.execution_id
       if (!executionId) return result
 
-      result.executionEngine = true
-
       // Poll execution status — check if Temporal picks it up
-      for (let i = 0; i < 15; i++) {
+      // Use a longer window (60s) to tolerate Temporal warm-up in Compose
+      let finalStatus = 'pending'
+      for (let i = 0; i < 30; i++) {
         await sleep(2000)
         const statusResp = await api(token, 'GET', `/executions/${executionId}`)
-        if (!statusResp.ok) break
+        if (!statusResp.ok) return result
         const exec = (await statusResp.json()) as { status: string }
-        if (exec.status !== 'pending') {
-          result.temporalWorker = true
-          break
-        }
+        finalStatus = exec.status
+        if (finalStatus !== 'pending') break
+      }
+
+      if (finalStatus === 'pending') {
+        // Execution stayed pending for the full 60s — Temporal is positively not processing
+        result.temporalWorkerDown = true
       }
     } finally {
-      // Clean up
       await api(token, 'DELETE', `/workflows/${workflowId}`).catch(() => {})
     }
   } catch {
-    // Probe failed — leave defaults (false)
+    // Network/unexpected error — inconclusive, leave fail-open defaults
+  } finally {
+    if (createdProjectId) {
+      await api(token, 'DELETE', `/projects/${createdProjectId}`).catch(() => {})
+    }
   }
 
   return result
 }
 
-// eslint-disable-next-line no-restricted-exports -- Playwright requires globalSetup to be a default export
 export default async function globalSetup(): Promise<void> {
+  // Default to healthy — tests run unless probe positively confirms otherwise
+  process.env['SYNTARA_E2E_HAS_EXECUTION_ENGINE'] = '1'
+  process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'] = '1'
+
   if (!isSkipWebServerForPlaywrightTests()) return
 
-  // eslint-disable-next-line no-console -- globalSetup runs in Node before tests; console is the only logging mechanism
   console.log('[global-setup] Probing backend service health...')
 
   const token = await authenticate()
   if (!token) {
-    // eslint-disable-next-line no-console
-    console.log('[global-setup] Could not authenticate — skipping probes')
+    console.log('[global-setup] Could not authenticate — assuming services are healthy (fail-open)')
     return
   }
 
-  const { executionEngine, temporalWorker } = await probeExecutionEngine(token)
+  const { executionEngineDown, temporalWorkerDown } = await probeExecutionEngine(token)
 
-  if (executionEngine) process.env['SYNTARA_E2E_HAS_EXECUTION_ENGINE'] = '1'
-  if (temporalWorker) process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'] = '1'
+  if (executionEngineDown) {
+    delete process.env['SYNTARA_E2E_HAS_EXECUTION_ENGINE']
+    delete process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER']
+  } else if (temporalWorkerDown) {
+    delete process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER']
+  }
 
-  // eslint-disable-next-line no-console
-  console.log(`[global-setup] Probe results: execution_engine=${executionEngine}, temporal_worker=${temporalWorker}`)
+  console.log(
+    `[global-setup] Probe results: execution_engine=${!executionEngineDown}, temporal_worker=${!temporalWorkerDown}`
+  )
 }

--- a/frontend/packages/syntara-ui/e2e/group-membership.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/group-membership.spec.ts
@@ -9,7 +9,7 @@
  * - Navigate back to groups list
  * - Manage group membership from user detail page
  */
-import { test, expect, toAppUrl } from './fixtures'
+import { createUnavailableGuard, test, expect, toAppUrl } from './fixtures'
 import { buildUniqueName } from './helpers/workflows'
 import { createUserViaApi, deleteUserViaApi, ensureGroupExists, type SeededUser } from './seeds/iam'
 import { getAuthToken } from './utils/api'
@@ -37,12 +37,7 @@ test.afterAll(async ({ browser }) => {
 })
 
 test.describe('Group Detail — Navigation & Tabs', () => {
-  let adminsUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(adminsUnavailable, 'No "admins" group found; seed data required')
-  })
+  const guard = createUnavailableGuard('No "admins" group found; seed data required')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/system-administration/access-management/groups'))
@@ -53,7 +48,7 @@ test.describe('Group Detail — Navigation & Tabs', () => {
       .waitFor({ state: 'visible', timeout: 3000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasAdmins) adminsUnavailable = true
+    if (!hasAdmins) guard.markUnavailable()
     test.skip(!hasAdmins, 'No "admins" group found; seed data required')
   })
 
@@ -108,7 +103,7 @@ test.describe('Group Detail — Navigation & Tabs', () => {
     await expect(table.getByRole('button', { name: 'admins', exact: true })).toBeVisible()
   })
 
-  test.describe(() => {
+  test.describe('Member add/remove (typeahead)', () => {
     test.skip(!!process.env.CI, "Typeahead dropdown timing is unreliable in CI — options don't render within timeout")
 
     test('add and remove a member from the group detail', async ({ app }) => {

--- a/frontend/packages/syntara-ui/e2e/group-membership.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/group-membership.spec.ts
@@ -37,16 +37,23 @@ test.afterAll(async ({ browser }) => {
 })
 
 test.describe('Group Detail — Navigation & Tabs', () => {
+  let adminsUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(adminsUnavailable, 'No "admins" group found; seed data required')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/system-administration/access-management/groups'))
     await expect(app.getByRole('heading', { level: 1, name: /access management/i })).toBeVisible()
-    // Skip if "admins" group doesn't exist (real backend may not have seeded groups)
     const table = app.getByRole('grid', { name: 'Groups table' })
     const hasAdmins = await table
       .getByRole('button', { name: 'admins', exact: true })
       .waitFor({ state: 'visible', timeout: 3000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasAdmins) adminsUnavailable = true
     test.skip(!hasAdmins, 'No "admins" group found; seed data required')
   })
 
@@ -101,72 +108,55 @@ test.describe('Group Detail — Navigation & Tabs', () => {
     await expect(table.getByRole('button', { name: 'admins', exact: true })).toBeVisible()
   })
 
-  test('add and remove a member from the group detail', async ({ app }) => {
+  test.describe(() => {
     test.skip(!!process.env.CI, "Typeahead dropdown timing is unreliable in CI — options don't render within timeout")
-    // Navigate to admins group detail
-    const table = app.getByRole('grid', { name: 'Groups table' })
-    await table.getByRole('button', { name: 'admins', exact: true }).click()
-    await expect(app.getByRole('heading', { level: 1, name: 'admins', exact: true })).toBeVisible()
 
-    // Switch to members tab
-    await app.getByRole('tab', { name: /members/i }).click()
+    test('add and remove a member from the group detail', async ({ app }) => {
+      const table = app.getByRole('grid', { name: 'Groups table' })
+      await table.getByRole('button', { name: 'admins', exact: true }).click()
+      await expect(app.getByRole('heading', { level: 1, name: 'admins', exact: true })).toBeVisible()
 
-    // Click add member button
-    await app.getByRole('button', { name: 'Add member' }).click()
+      await app.getByRole('tab', { name: /members/i }).click()
+      await app.getByRole('button', { name: 'Add member' }).click()
 
-    // Modal should appear
-    const dialog = app.getByRole('dialog')
-    await expect(dialog).toBeVisible()
+      const dialog = app.getByRole('dialog')
+      await expect(dialog).toBeVisible()
 
-    // Open the typeahead to pick an available user
-    const selectInput = dialog.getByPlaceholder('Search for a user...')
-    await selectInput.click()
+      const selectInput = dialog.getByPlaceholder('Search for a user...')
+      await selectInput.click()
 
-    // Wait for either options or "No results match" to appear.
-    // PF6 Select renders the listbox in a portal outside the dialog DOM,
-    // so we must query at page level, not scoped to the dialog.
-    const noResults = app.getByRole('option', { name: /No results match/ })
-    const availableOptions = app.getByRole('option').filter({ hasNotText: /No results match/ })
-    const selectedOption = availableOptions.nth(0)
-    await expect(noResults.or(selectedOption)).toBeVisible({ timeout: 15_000 })
+      const noResults = app.getByRole('option', { name: /No results match/ })
+      const availableOptions = app.getByRole('option').filter({ hasNotText: /No results match/ })
+      const selectedOption = availableOptions.nth(0)
+      await expect(noResults.or(selectedOption)).toBeVisible({ timeout: 15_000 })
 
-    if (await noResults.isVisible()) {
-      // Only one user exists and is already a member — skip add/remove
-      test.skip(true, 'No available users to add (all users are already members)')
-      return
-    }
+      if (await noResults.isVisible()) {
+        test.skip(true, 'No available users to add (all users are already members)')
+        return
+      }
 
-    // The option contains two child spans: username + display name.
-    // Extract just the username (first child text) for later verification.
-    const userName = await selectedOption.locator('> *').nth(0).textContent()
-    await selectedOption.click()
+      const userName = await selectedOption.locator('> *').nth(0).textContent()
+      await selectedOption.click()
 
-    // Submit
-    await dialog.getByRole('button', { name: 'Add', exact: true }).click()
+      await dialog.getByRole('button', { name: 'Add', exact: true }).click()
 
-    // Verify success — wait for the dialog to close and alert to appear
-    await expect(dialog).not.toBeVisible()
-    await expect(app.getByText(/member added/i)).toBeVisible()
+      await expect(dialog).not.toBeVisible()
+      await expect(app.getByText(/member added/i)).toBeVisible()
 
-    // The new member should appear in the Username column.
-    // The table refetches after a successful add, so allow extra time.
-    // PF6 uses role="grid" / role="gridcell", so match with 'gridcell'.
-    if (userName) {
-      const memberName = userName.trim()
-      await expect(app.getByRole('gridcell', { name: memberName, exact: true })).toBeVisible({ timeout: 10_000 })
+      if (userName) {
+        const memberName = userName.trim()
+        await expect(app.getByRole('gridcell', { name: memberName, exact: true })).toBeVisible({ timeout: 10_000 })
 
-      // Now remove the member via kebab menu
-      const memberRow = app.getByRole('row').filter({ hasText: memberName })
-      await memberRow.getByRole('button', { name: /kebab toggle/i }).click()
-      await app.getByRole('menuitem', { name: 'Remove' }).click()
+        const memberRow = app.getByRole('row').filter({ hasText: memberName })
+        await memberRow.getByRole('button', { name: /kebab toggle/i }).click()
+        await app.getByRole('menuitem', { name: 'Remove' }).click()
 
-      // Confirm removal dialog
-      await expect(app.getByRole('dialog')).toBeVisible()
-      await app.getByRole('button', { name: 'Remove', exact: true }).click()
+        await expect(app.getByRole('dialog')).toBeVisible()
+        await app.getByRole('button', { name: 'Remove', exact: true }).click()
 
-      // Verify success
-      await expect(app.getByText(/member removed/i)).toBeVisible()
-    }
+        await expect(app.getByText(/member removed/i)).toBeVisible()
+      }
+    })
   })
 
   test('navigating to a different group shows its details', async ({ app }) => {

--- a/frontend/packages/syntara-ui/e2e/integration-connection-test.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/integration-connection-test.spec.ts
@@ -37,68 +37,71 @@ async function createLlmCredential(app: Page, name: string): Promise<string> {
 }
 
 test.describe('Integration Wizard @pr-check', () => {
-  test('connection test succeeds and discovers resources within 10s', async ({ app }) => {
+  test.describe(() => {
     test.skip(
       isRealBackend && !mcpServerUrl,
       'SYNTARA_E2E_MCP_SERVER_URL not set; cannot test MCP Server on real backend'
     )
-    const mcpUrl = isRealBackend ? mcpServerUrl! : 'https://mcp-test.example.com/mcp'
-    const name = buildUniqueName('e2e-wizard-t7')
-    let integrationId: string | undefined
 
-    try {
-      // Step 1 — Integration details
-      await app.goto(toAppUrl('/configuration/integrations/configure'))
-      await expect(app.getByRole('heading', { name: 'Integration details', level: 2 })).toBeVisible()
+    test('connection test succeeds and discovers resources within 10s', async ({ app }) => {
+      const mcpUrl = isRealBackend ? mcpServerUrl! : 'https://mcp-test.example.com/mcp'
+      const name = buildUniqueName('e2e-wizard-t7')
+      let integrationId: string | undefined
 
-      await app.getByRole('textbox', { name: 'Server name / ID' }).fill(name)
-      await app.getByRole('textbox', { name: 'API URL' }).fill(mcpUrl)
+      try {
+        // Step 1 — Integration details
+        await app.goto(toAppUrl('/configuration/integrations/configure'))
+        await expect(app.getByRole('heading', { name: 'Integration details', level: 2 })).toBeVisible()
 
-      if (mcpUrl.startsWith('http://')) {
-        await app.getByRole('button', { name: 'Security' }).click()
-        await app.getByRole('checkbox', { name: 'Allow HTTP connections' }).check()
+        await app.getByRole('textbox', { name: 'Server name / ID' }).fill(name)
+        await app.getByRole('textbox', { name: 'API URL' }).fill(mcpUrl)
+
+        if (mcpUrl.startsWith('http://')) {
+          await app.getByRole('button', { name: 'Security' }).click()
+          await app.getByRole('checkbox', { name: 'Allow HTTP connections' }).check()
+        }
+
+        await app.getByRole('button', { name: 'Next' }).click()
+
+        // Step 2 — Connection credential
+        await expect(app.getByRole('heading', { name: 'Connection credential', level: 2 })).toBeVisible()
+
+        const startTime = Date.now()
+        await app.getByRole('button', { name: 'Test connection' }).click()
+
+        // Wait for success alert within 10s
+        await expect(app.getByRole('heading', { name: 'Connection tested' })).toBeVisible({ timeout: 15_000 })
+        const elapsed = Date.now() - startTime
+        expect(elapsed).toBeLessThan(10_000)
+
+        // Verify success description mentions discovered tools
+        await expect(app.getByText(/Successfully connected\. Discovered \d+ tool/)).toBeVisible()
+
+        await app.getByRole('button', { name: 'Next' }).click()
+
+        // Step 3 — Enable tools
+        await expect(app.getByRole('heading', { name: 'Enable tools' })).toBeVisible()
+
+        // Verify at least one tool row appears in the table
+        await expect(app.locator('table tbody tr')).not.toHaveCount(0, { timeout: 10_000 })
+
+        // Save the integration — capture the API response to get the ID
+        const responsePromise = app.waitForResponse('**/api/v1/integrations')
+        await app.getByRole('button', { name: 'Save' }).click()
+        const response = await responsePromise
+        expect(response.status()).toBe(201)
+
+        const body = (await response.json()) as { id?: string }
+        integrationId = body.id
+
+        // Verify redirect to integrations list
+        await expect(app.getByRole('heading', { level: 1, name: 'Integrations' })).toBeVisible({ timeout: 10_000 })
+      } finally {
+        if (integrationId) {
+          await deleteIntegrationViaApi(app, integrationId)
+        }
       }
-
-      await app.getByRole('button', { name: 'Next' }).click()
-
-      // Step 2 — Connection credential
-      await expect(app.getByRole('heading', { name: 'Connection credential', level: 2 })).toBeVisible()
-
-      const startTime = Date.now()
-      await app.getByRole('button', { name: 'Test connection' }).click()
-
-      // Wait for success alert within 10s
-      await expect(app.getByRole('heading', { name: 'Connection tested' })).toBeVisible({ timeout: 15_000 })
-      const elapsed = Date.now() - startTime
-      expect(elapsed).toBeLessThan(10_000)
-
-      // Verify success description mentions discovered tools
-      await expect(app.getByText(/Successfully connected\. Discovered \d+ tool/)).toBeVisible()
-
-      await app.getByRole('button', { name: 'Next' }).click()
-
-      // Step 3 — Enable tools
-      await expect(app.getByRole('heading', { name: 'Enable tools' })).toBeVisible()
-
-      // Verify at least one tool row appears in the table
-      await expect(app.locator('table tbody tr')).not.toHaveCount(0, { timeout: 10_000 })
-
-      // Save the integration — capture the API response to get the ID
-      const responsePromise = app.waitForResponse('**/api/v1/integrations')
-      await app.getByRole('button', { name: 'Save' }).click()
-      const response = await responsePromise
-      expect(response.status()).toBe(201)
-
-      const body = (await response.json()) as { id?: string }
-      integrationId = body.id
-
-      // Verify redirect to integrations list
-      await expect(app.getByRole('heading', { level: 1, name: 'Integrations' })).toBeVisible({ timeout: 10_000 })
-    } finally {
-      if (integrationId) {
-        await deleteIntegrationViaApi(app, integrationId)
-      }
-    }
+    })
   })
 
   test('connection test with invalid credential returns auth failure', async ({ app }) => {
@@ -342,189 +345,191 @@ test.describe('Integration Wizard @pr-check', () => {
     }
   })
 
-  test('health check status transitions between available and error', async ({ app }) => {
-    test.skip(!isRealBackend, 'Requires real backend — mock API validate always returns success')
-    test.skip(!mcpServerUrl, 'SYNTARA_E2E_MCP_SERVER_URL not set; requires running MCP server')
-    test.slow() // validate against unreachable port takes up to ~10s
+  test.describe(() => {
+    test.skip(!isRealBackend || !mcpServerUrl, 'Requires real backend with SYNTARA_E2E_MCP_SERVER_URL set')
 
-    const name = buildUniqueName('e2e-wizard-t11')
-    let integrationId: string | undefined
+    test('health check status transitions between available and error', async ({ app }) => {
+      test.slow()
 
-    try {
-      // Create MCP Server integration pointing at the local MCP test server
-      const createResp = await apiRequest(app, 'post', '/integrations', {
-        data: {
-          name,
-          integration_type: 'mcp_server',
-          configuration: { integration_type: 'mcp_server', base_url: mcpServerUrl! },
-          scope: 'global',
-        },
-      })
-      if (!createResp.ok()) throw new Error(`Could not create integration: ${createResp.status()}`)
-      integrationId = ((await createResp.json()) as { id: string }).id
+      const name = buildUniqueName('e2e-wizard-t11')
+      let integrationId: string | undefined
 
-      // ── Phase 1: Establish "available" status via manual validate ──────────
-      const v1Resp = await apiRequest(app, 'post', `/integrations/${integrationId}/validate`)
-      expect(((await v1Resp.json()) as { success: boolean }).success).toBe(true)
+      try {
+        // Create MCP Server integration pointing at the local MCP test server
+        const createResp = await apiRequest(app, 'post', '/integrations', {
+          data: {
+            name,
+            integration_type: 'mcp_server',
+            configuration: { integration_type: 'mcp_server', base_url: mcpServerUrl! },
+            scope: 'global',
+          },
+        })
+        if (!createResp.ok()) throw new Error(`Could not create integration: ${createResp.status()}`)
+        integrationId = ((await createResp.json()) as { id: string }).id
 
-      // Verify on list page
-      await app.goto(toAppUrl('/configuration/integrations'))
-      await app.getByPlaceholder('Filter by name').fill(name)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-      await expect(app.getByRole('row', { name: new RegExp(name) }).getByText('Available')).toBeVisible({
-        timeout: 10_000,
-      })
+        // ── Phase 1: Establish "available" status via manual validate ──────────
+        const v1Resp = await apiRequest(app, 'post', `/integrations/${integrationId}/validate`)
+        expect(((await v1Resp.json()) as { success: boolean }).success).toBe(true)
 
-      // Verify on detail page
-      await app.goto(toAppUrl(`/configuration/integrations/${integrationId}`))
-      await expect(app.getByText('Available', { exact: true })).toBeVisible({ timeout: 10_000 })
-
-      // Capture last_validated_at baseline
-      const g1 = (await (await apiRequest(app, 'get', `/integrations/${integrationId}`)).json()) as {
-        validation_status: string
-        last_validated_at: string | null
-      }
-      expect(g1.validation_status).toBe('available')
-      const ts1 = g1.last_validated_at
-      expect(ts1).not.toBeNull()
-
-      // ── Phase 2: Transition to "error" ────────────────────────────────────
-      // Swap base_url to an unreachable port
-      const patch1Resp = await apiRequest(app, 'patch', `/integrations/${integrationId}`, {
-        data: { configuration: { integration_type: 'mcp_server', base_url: 'http://127.0.0.1:9999' } },
-      })
-      if (!patch1Resp.ok()) throw new Error(`PATCH to unreachable URL failed: ${patch1Resp.status()}`)
-
-      // Manual validate → backend hits the unreachable port and marks as error
-      const v2Resp = await apiRequest(app, 'post', `/integrations/${integrationId}/validate`)
-      expect(((await v2Resp.json()) as { success: boolean }).success).toBe(false)
-
-      // Verify on list page
-      await app.goto(toAppUrl('/configuration/integrations'))
-      await app.getByPlaceholder('Filter by name').fill(name)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-      await expect(app.getByRole('row', { name: new RegExp(name) }).getByText('Error')).toBeVisible({ timeout: 10_000 })
-
-      // Verify on detail page
-      await app.goto(toAppUrl(`/configuration/integrations/${integrationId}`))
-      await expect(app.getByText('Error', { exact: true })).toBeVisible({ timeout: 10_000 })
-
-      // last_validated_at must have advanced
-      const g2 = (await (await apiRequest(app, 'get', `/integrations/${integrationId}`)).json()) as {
-        validation_status: string
-        last_validated_at: string | null
-      }
-      expect(g2.validation_status).toBe('error')
-      expect(g2.last_validated_at).not.toBeNull()
-      expect(g2.last_validated_at).not.toBe(ts1)
-
-      // ── Phase 3: Restore to "available" ───────────────────────────────────
-      const patch2Resp = await apiRequest(app, 'patch', `/integrations/${integrationId}`, {
-        data: { configuration: { integration_type: 'mcp_server', base_url: mcpServerUrl! } },
-      })
-      if (!patch2Resp.ok()) throw new Error(`PATCH restore failed: ${patch2Resp.status()}`)
-
-      const v3Resp = await apiRequest(app, 'post', `/integrations/${integrationId}/validate`)
-      expect(((await v3Resp.json()) as { success: boolean }).success).toBe(true)
-
-      // Verify on list page
-      await app.goto(toAppUrl('/configuration/integrations'))
-      await app.getByPlaceholder('Filter by name').fill(name)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-      await expect(app.getByRole('row', { name: new RegExp(name) }).getByText('Available')).toBeVisible({
-        timeout: 10_000,
-      })
-
-      // Verify on detail page
-      await app.goto(toAppUrl(`/configuration/integrations/${integrationId}`))
-      await expect(app.getByText('Available', { exact: true })).toBeVisible({ timeout: 10_000 })
-
-      // last_validated_at must have advanced again
-      const g3 = (await (await apiRequest(app, 'get', `/integrations/${integrationId}`)).json()) as {
-        validation_status: string
-        last_validated_at: string | null
-      }
-      expect(g3.validation_status).toBe('available')
-      expect(g3.last_validated_at).not.toBe(g2.last_validated_at)
-    } finally {
-      if (integrationId) await deleteIntegrationViaApi(app, integrationId)
-    }
-  })
-
-  test('health check error classifications appear correctly on integration detail page', async ({ app }) => {
-    test.skip(!isRealBackend, 'Requires real backend — mock API validate always returns success')
-    test.skip(!mcpServerUrl, 'SYNTARA_E2E_MCP_SERVER_URL not set; requires running MCP server')
-    test.slow() // validate against unreachable port takes up to ~10s
-
-    const name = buildUniqueName('e2e-wizard-t13')
-    let integrationId: string | undefined
-
-    try {
-      // Create MCP Server integration initially pointing at the working MCP test server
-      const createResp = await apiRequest(app, 'post', '/integrations', {
-        data: {
-          name,
-          integration_type: 'mcp_server',
-          configuration: { integration_type: 'mcp_server', base_url: mcpServerUrl! },
-          scope: 'global',
-        },
-      })
-      if (!createResp.ok()) throw new Error(`Could not create integration: ${createResp.status()}`)
-      integrationId = ((await createResp.json()) as { id: string }).id
-
-      // Capture the base integration object for building mocked GET responses
-      const baseData = (await (await apiRequest(app, 'get', `/integrations/${integrationId}`)).json()) as Record<
-        string,
-        unknown
-      >
-
-      // ── connection_error: real end-to-end validate ──────────────────────
-      await apiRequest(app, 'patch', `/integrations/${integrationId}`, {
-        data: { configuration: { integration_type: 'mcp_server', base_url: 'http://127.0.0.1:9999' } },
-      })
-      await apiRequest(app, 'post', `/integrations/${integrationId}/validate`)
-
-      await app.goto(toAppUrl(`/configuration/integrations/${integrationId}`))
-      await expect(app.getByText('Error', { exact: true })).toBeVisible({ timeout: 10_000 })
-
-      // ── auth_failure, ssl_error, timeout: inject error state via GET mock ─
-      // These error types require specific network conditions not reliably available
-      // in the dev environment. We mock GET /integrations/{id} to inject the expected
-      // integration state and verify the detail page renders each classification correctly.
-      const routePattern = `**/api/v1/integrations/${integrationId}`
-      for (const { errorMsg } of [
-        { errorMsg: 'Authentication failed: the provided credential was rejected.' },
-        { errorMsg: "TLS certificate verification failed: unable to verify the server's certificate." },
-        { errorMsg: 'Connection timed out: the server did not respond within the configured time limit.' },
-      ]) {
-        await app.route(routePattern, async (route, request) => {
-          if (request.method() === 'GET') {
-            await route.fulfill({
-              status: 200,
-              contentType: 'application/json',
-              body: JSON.stringify({
-                ...baseData,
-                validation_status: 'error',
-                validation_error: errorMsg,
-                last_validated_at: new Date().toISOString(),
-              }),
-            })
-          } else {
-            await route.continue()
-          }
+        // Verify on list page
+        await app.goto(toAppUrl('/configuration/integrations'))
+        await app.getByPlaceholder('Filter by name').fill(name)
+        await app.getByRole('button', { name: 'Apply filter' }).click()
+        await expect(app.getByRole('row', { name: new RegExp(name) }).getByText('Available')).toBeVisible({
+          timeout: 10_000,
         })
 
+        // Verify on detail page
         await app.goto(toAppUrl(`/configuration/integrations/${integrationId}`))
-        const errorBadge = app.getByText('Error', { exact: true })
-        await expect(errorBadge).toBeVisible({ timeout: 10_000 })
-        // Hover to reveal the tooltip and verify each classification shows a distinct message
-        await errorBadge.hover()
-        await expect(app.getByText(errorMsg)).toBeVisible()
+        await expect(app.getByText('Available', { exact: true })).toBeVisible({ timeout: 10_000 })
 
-        await app.unroute(routePattern)
+        // Capture last_validated_at baseline
+        const g1 = (await (await apiRequest(app, 'get', `/integrations/${integrationId}`)).json()) as {
+          validation_status: string
+          last_validated_at: string | null
+        }
+        expect(g1.validation_status).toBe('available')
+        const ts1 = g1.last_validated_at
+        expect(ts1).not.toBeNull()
+
+        // ── Phase 2: Transition to "error" ────────────────────────────────────
+        // Swap base_url to an unreachable port
+        const patch1Resp = await apiRequest(app, 'patch', `/integrations/${integrationId}`, {
+          data: { configuration: { integration_type: 'mcp_server', base_url: 'http://127.0.0.1:9999' } },
+        })
+        if (!patch1Resp.ok()) throw new Error(`PATCH to unreachable URL failed: ${patch1Resp.status()}`)
+
+        // Manual validate → backend hits the unreachable port and marks as error
+        const v2Resp = await apiRequest(app, 'post', `/integrations/${integrationId}/validate`)
+        expect(((await v2Resp.json()) as { success: boolean }).success).toBe(false)
+
+        // Verify on list page
+        await app.goto(toAppUrl('/configuration/integrations'))
+        await app.getByPlaceholder('Filter by name').fill(name)
+        await app.getByRole('button', { name: 'Apply filter' }).click()
+        await expect(app.getByRole('row', { name: new RegExp(name) }).getByText('Error')).toBeVisible({
+          timeout: 10_000,
+        })
+
+        // Verify on detail page
+        await app.goto(toAppUrl(`/configuration/integrations/${integrationId}`))
+        await expect(app.getByText('Error', { exact: true })).toBeVisible({ timeout: 10_000 })
+
+        // last_validated_at must have advanced
+        const g2 = (await (await apiRequest(app, 'get', `/integrations/${integrationId}`)).json()) as {
+          validation_status: string
+          last_validated_at: string | null
+        }
+        expect(g2.validation_status).toBe('error')
+        expect(g2.last_validated_at).not.toBeNull()
+        expect(g2.last_validated_at).not.toBe(ts1)
+
+        // ── Phase 3: Restore to "available" ───────────────────────────────────
+        const patch2Resp = await apiRequest(app, 'patch', `/integrations/${integrationId}`, {
+          data: { configuration: { integration_type: 'mcp_server', base_url: mcpServerUrl! } },
+        })
+        if (!patch2Resp.ok()) throw new Error(`PATCH restore failed: ${patch2Resp.status()}`)
+
+        const v3Resp = await apiRequest(app, 'post', `/integrations/${integrationId}/validate`)
+        expect(((await v3Resp.json()) as { success: boolean }).success).toBe(true)
+
+        // Verify on list page
+        await app.goto(toAppUrl('/configuration/integrations'))
+        await app.getByPlaceholder('Filter by name').fill(name)
+        await app.getByRole('button', { name: 'Apply filter' }).click()
+        await expect(app.getByRole('row', { name: new RegExp(name) }).getByText('Available')).toBeVisible({
+          timeout: 10_000,
+        })
+
+        // Verify on detail page
+        await app.goto(toAppUrl(`/configuration/integrations/${integrationId}`))
+        await expect(app.getByText('Available', { exact: true })).toBeVisible({ timeout: 10_000 })
+
+        // last_validated_at must have advanced again
+        const g3 = (await (await apiRequest(app, 'get', `/integrations/${integrationId}`)).json()) as {
+          validation_status: string
+          last_validated_at: string | null
+        }
+        expect(g3.validation_status).toBe('available')
+        expect(g3.last_validated_at).not.toBe(g2.last_validated_at)
+      } finally {
+        if (integrationId) await deleteIntegrationViaApi(app, integrationId)
       }
-    } finally {
-      if (integrationId) await deleteIntegrationViaApi(app, integrationId)
-    }
+    })
+
+    test('health check error classifications appear correctly on integration detail page', async ({ app }) => {
+      test.slow()
+
+      const name = buildUniqueName('e2e-wizard-t13')
+      let integrationId: string | undefined
+
+      try {
+        // Create MCP Server integration initially pointing at the working MCP test server
+        const createResp = await apiRequest(app, 'post', '/integrations', {
+          data: {
+            name,
+            integration_type: 'mcp_server',
+            configuration: { integration_type: 'mcp_server', base_url: mcpServerUrl! },
+            scope: 'global',
+          },
+        })
+        if (!createResp.ok()) throw new Error(`Could not create integration: ${createResp.status()}`)
+        integrationId = ((await createResp.json()) as { id: string }).id
+
+        // Capture the base integration object for building mocked GET responses
+        const baseData = (await (await apiRequest(app, 'get', `/integrations/${integrationId}`)).json()) as Record<
+          string,
+          unknown
+        >
+
+        // ── connection_error: real end-to-end validate ──────────────────────
+        await apiRequest(app, 'patch', `/integrations/${integrationId}`, {
+          data: { configuration: { integration_type: 'mcp_server', base_url: 'http://127.0.0.1:9999' } },
+        })
+        await apiRequest(app, 'post', `/integrations/${integrationId}/validate`)
+
+        await app.goto(toAppUrl(`/configuration/integrations/${integrationId}`))
+        await expect(app.getByText('Error', { exact: true })).toBeVisible({ timeout: 10_000 })
+
+        // ── auth_failure, ssl_error, timeout: inject error state via GET mock ─
+        // These error types require specific network conditions not reliably available
+        // in the dev environment. We mock GET /integrations/{id} to inject the expected
+        // integration state and verify the detail page renders each classification correctly.
+        const routePattern = `**/api/v1/integrations/${integrationId}`
+        for (const { errorMsg } of [
+          { errorMsg: 'Authentication failed: the provided credential was rejected.' },
+          { errorMsg: "TLS certificate verification failed: unable to verify the server's certificate." },
+          { errorMsg: 'Connection timed out: the server did not respond within the configured time limit.' },
+        ]) {
+          await app.route(routePattern, async (route, request) => {
+            if (request.method() === 'GET') {
+              await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                  ...baseData,
+                  validation_status: 'error',
+                  validation_error: errorMsg,
+                  last_validated_at: new Date().toISOString(),
+                }),
+              })
+            } else {
+              await route.continue()
+            }
+          })
+
+          await app.goto(toAppUrl(`/configuration/integrations/${integrationId}`))
+          const errorBadge = app.getByText('Error', { exact: true })
+          await expect(errorBadge).toBeVisible({ timeout: 10_000 })
+          // Hover to reveal the tooltip and verify each classification shows a distinct message
+          await errorBadge.hover()
+          await expect(app.getByText(errorMsg)).toBeVisible()
+
+          await app.unroute(routePattern)
+        }
+      } finally {
+        if (integrationId) await deleteIntegrationViaApi(app, integrationId)
+      }
+    })
   })
 })

--- a/frontend/packages/syntara-ui/e2e/integration-connection-test.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/integration-connection-test.spec.ts
@@ -37,7 +37,7 @@ async function createLlmCredential(app: Page, name: string): Promise<string> {
 }
 
 test.describe('Integration Wizard @pr-check', () => {
-  test.describe(() => {
+  test.describe('Connection test — MCP Server', () => {
     test.skip(
       isRealBackend && !mcpServerUrl,
       'SYNTARA_E2E_MCP_SERVER_URL not set; cannot test MCP Server on real backend'
@@ -345,7 +345,7 @@ test.describe('Integration Wizard @pr-check', () => {
     }
   })
 
-  test.describe(() => {
+  test.describe('Health check transitions (real backend)', () => {
     test.skip(!isRealBackend || !mcpServerUrl, 'Requires real backend with SYNTARA_E2E_MCP_SERVER_URL set')
 
     test('health check status transitions between available and error', async ({ app }) => {

--- a/frontend/packages/syntara-ui/e2e/integration-filtering.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/integration-filtering.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, toAppUrl } from './fixtures'
+import { createUnavailableGuard, test, expect, toAppUrl } from './fixtures'
 import { buildUniqueName } from './helpers/workflows'
 import { createIntegrationViaApi, deleteIntegrationViaApi, type SeededIntegration } from './seeds/resources'
 import { getAuthToken } from './utils/api'
@@ -28,12 +28,7 @@ test.afterAll(async ({ browser }) => {
 })
 
 test.describe('Integration Filtering', () => {
-  let filteringUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(filteringUnavailable, 'No integration data available; seed data required')
-  })
+  const guard = createUnavailableGuard('No integration data available; seed data required')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/configuration/integrations'))
@@ -43,7 +38,7 @@ test.describe('Integration Filtering', () => {
       .waitFor({ state: 'visible', timeout: 5000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasGrid) filteringUnavailable = true
+    if (!hasGrid) guard.markUnavailable()
     test.skip(!hasGrid, 'No integration data available; seed data required')
   })
 

--- a/frontend/packages/syntara-ui/e2e/integration-filtering.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/integration-filtering.spec.ts
@@ -28,6 +28,13 @@ test.afterAll(async ({ browser }) => {
 })
 
 test.describe('Integration Filtering', () => {
+  let filteringUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(filteringUnavailable, 'No integration data available; seed data required')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/configuration/integrations'))
     await expect(app.getByRole('heading', { level: 1, name: 'Integrations' })).toBeVisible()
@@ -36,6 +43,7 @@ test.describe('Integration Filtering', () => {
       .waitFor({ state: 'visible', timeout: 5000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasGrid) filteringUnavailable = true
     test.skip(!hasGrid, 'No integration data available; seed data required')
   })
 

--- a/frontend/packages/syntara-ui/e2e/integration-wizard.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/integration-wizard.spec.ts
@@ -17,167 +17,173 @@ const WIZARD_URL = '/configuration/integrations/configure'
 const INTEGRATIONS_LIST_URL = '/configuration/integrations'
 
 test.describe('Create Integration Wizard', () => {
-  test('user creates an MCP Server integration through the wizard', async ({ app }) => {
+  test.describe(() => {
     test.skip(
       isRealBackend && !mcpServerUrl,
       'SYNTARA_E2E_MCP_SERVER_URL not set; cannot test MCP Server on real backend'
     )
 
-    const integrationName = buildUniqueName('e2e-wizard-mcp')
-    const credName = buildUniqueName('e2e-wizard-mcp-cred')
-    let credential: SeededCredential | null = null
-    let integrationId: string | null = null
+    test('user creates an MCP Server integration through the wizard', async ({ app }) => {
+      const integrationName = buildUniqueName('e2e-wizard-mcp')
+      const credName = buildUniqueName('e2e-wizard-mcp-cred')
+      let credential: SeededCredential | null = null
+      let integrationId: string | null = null
 
-    const mcpUrl = isRealBackend ? mcpServerUrl! : 'https://mcp-test.example.com/mcp'
+      const mcpUrl = isRealBackend ? mcpServerUrl! : 'https://mcp-test.example.com/mcp'
 
-    try {
-      credential = await createCredentialForIntegrationType(app, {
-        name: credName,
-        integrationType: 'mcp_server',
-      })
-      expect(credential).not.toBeNull()
+      try {
+        credential = await createCredentialForIntegrationType(app, {
+          name: credName,
+          integrationType: 'mcp_server',
+        })
+        expect(credential).not.toBeNull()
 
-      await app.goto(toAppUrl(WIZARD_URL))
-      await expect(app.getByRole('heading', { level: 1, name: 'Configure integration' })).toBeVisible()
-      await expect(app.getByRole('heading', { level: 2, name: 'Integration details' })).toBeVisible()
-      await app.getByRole('textbox', { name: 'Server name / ID' }).fill(integrationName)
-      await app.getByRole('textbox', { name: 'API URL' }).fill(mcpUrl)
+        await app.goto(toAppUrl(WIZARD_URL))
+        await expect(app.getByRole('heading', { level: 1, name: 'Configure integration' })).toBeVisible()
+        await expect(app.getByRole('heading', { level: 2, name: 'Integration details' })).toBeVisible()
+        await app.getByRole('textbox', { name: 'Server name / ID' }).fill(integrationName)
+        await app.getByRole('textbox', { name: 'API URL' }).fill(mcpUrl)
 
-      if (mcpUrl.startsWith('http://')) {
-        await app.getByRole('button', { name: 'Security' }).click()
-        await app.getByRole('checkbox', { name: 'Allow HTTP connections' }).check()
+        if (mcpUrl.startsWith('http://')) {
+          await app.getByRole('button', { name: 'Security' }).click()
+          await app.getByRole('checkbox', { name: 'Allow HTTP connections' }).check()
+        }
+
+        await app.getByRole('button', { name: 'Next' }).click()
+        await expect(app.getByRole('heading', { level: 2, name: 'Connection credential' })).toBeVisible()
+
+        await app.getByRole('button', { name: 'Health check credential', exact: true }).click()
+        await app.getByRole('option', { name: credName }).click()
+
+        await app.getByRole('button', { name: 'Test connection' }).click()
+        await expect(app.getByRole('button', { name: 'Next' })).toBeEnabled({ timeout: 30_000 })
+        await app.getByRole('button', { name: 'Next' }).click()
+
+        await expect(app.getByRole('button', { name: 'Save' })).toBeVisible()
+        const responsePromise = app.waitForResponse('**/api/v1/integrations')
+        await app.getByRole('button', { name: 'Save' }).click()
+        const response = await responsePromise
+        integrationId = ((await response.json()) as { id?: string }).id ?? null
+
+        await expect(app).toHaveURL(new RegExp(INTEGRATIONS_LIST_URL))
+        await app.getByPlaceholder('Filter by name').fill(integrationName)
+        await app.getByRole('button', { name: 'Apply filter' }).click()
+        await expect(app.getByRole('row', { name: new RegExp(integrationName) })).toBeVisible()
+      } finally {
+        if (integrationId) await deleteIntegrationViaApi(app, integrationId)
+        if (credential) await deleteCredentialViaApi(app, credential.id)
       }
-
-      await app.getByRole('button', { name: 'Next' }).click()
-      await expect(app.getByRole('heading', { level: 2, name: 'Connection credential' })).toBeVisible()
-
-      await app.getByRole('button', { name: 'Health check credential', exact: true }).click()
-      await app.getByRole('option', { name: credName }).click()
-
-      await app.getByRole('button', { name: 'Test connection' }).click()
-      await expect(app.getByRole('button', { name: 'Next' })).toBeEnabled({ timeout: 30_000 })
-      await app.getByRole('button', { name: 'Next' }).click()
-
-      await expect(app.getByRole('button', { name: 'Save' })).toBeVisible()
-      const responsePromise = app.waitForResponse('**/api/v1/integrations')
-      await app.getByRole('button', { name: 'Save' }).click()
-      const response = await responsePromise
-      integrationId = ((await response.json()) as { id?: string }).id ?? null
-
-      await expect(app).toHaveURL(new RegExp(INTEGRATIONS_LIST_URL))
-      await app.getByPlaceholder('Filter by name').fill(integrationName)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-      await expect(app.getByRole('row', { name: new RegExp(integrationName) })).toBeVisible()
-    } finally {
-      if (integrationId) await deleteIntegrationViaApi(app, integrationId)
-      if (credential) await deleteCredentialViaApi(app, credential.id)
-    }
+    })
   })
 
-  test('user creates an LLM Provider integration through the wizard', async ({ app }) => {
+  test.describe(() => {
     test.skip(
       isRealBackend && !openrouterApiKey,
       'APP_OPENROUTER_API_KEY not set; cannot test LLM Provider on real backend'
     )
 
-    const integrationName = buildUniqueName('e2e-wizard-llm')
-    const credName = buildUniqueName('e2e-wizard-llm-cred')
-    let credential: SeededCredential | null = null
-    let integrationId: string | null = null
+    test('user creates an LLM Provider integration through the wizard', async ({ app }) => {
+      const integrationName = buildUniqueName('e2e-wizard-llm')
+      const credName = buildUniqueName('e2e-wizard-llm-cred')
+      let credential: SeededCredential | null = null
+      let integrationId: string | null = null
 
-    const apiUrl = isRealBackend ? openrouterBaseUrl : 'https://llm-test.example.com/v1'
+      const apiUrl = isRealBackend ? openrouterBaseUrl : 'https://llm-test.example.com/v1'
 
-    try {
-      credential = await createCredentialForIntegrationType(app, {
-        name: credName,
-        integrationType: 'llm_provider',
-        apiKey: isRealBackend ? openrouterApiKey : undefined,
-      })
-      expect(credential).not.toBeNull()
+      try {
+        credential = await createCredentialForIntegrationType(app, {
+          name: credName,
+          integrationType: 'llm_provider',
+          apiKey: isRealBackend ? openrouterApiKey : undefined,
+        })
+        expect(credential).not.toBeNull()
 
-      await app.goto(toAppUrl(WIZARD_URL))
-      await expect(app.getByRole('heading', { level: 1, name: 'Configure integration' })).toBeVisible()
+        await app.goto(toAppUrl(WIZARD_URL))
+        await expect(app.getByRole('heading', { level: 1, name: 'Configure integration' })).toBeVisible()
 
-      await app.getByRole('button', { name: 'MCP Server' }).click()
-      await app.getByRole('option', { name: 'LLM Provider' }).click()
+        await app.getByRole('button', { name: 'MCP Server' }).click()
+        await app.getByRole('option', { name: 'LLM Provider' }).click()
 
-      await app.getByRole('button', { name: 'Red Hat AI' }).click()
-      await app.getByRole('option', { name: 'Custom' }).click()
+        await app.getByRole('button', { name: 'Red Hat AI' }).click()
+        await app.getByRole('option', { name: 'Custom' }).click()
 
-      await app.getByRole('textbox', { name: 'Name' }).fill(integrationName)
-      await app.getByRole('textbox', { name: 'API URL' }).fill(apiUrl)
-      await app.getByRole('button', { name: 'Next' }).click()
+        await app.getByRole('textbox', { name: 'Name' }).fill(integrationName)
+        await app.getByRole('textbox', { name: 'API URL' }).fill(apiUrl)
+        await app.getByRole('button', { name: 'Next' }).click()
 
-      await expect(app.getByRole('heading', { level: 2, name: 'Connection credential' })).toBeVisible()
-      await app.getByRole('button', { name: 'Health check credential', exact: true }).click()
-      await app.getByRole('option', { name: credName }).click()
+        await expect(app.getByRole('heading', { level: 2, name: 'Connection credential' })).toBeVisible()
+        await app.getByRole('button', { name: 'Health check credential', exact: true }).click()
+        await app.getByRole('option', { name: credName }).click()
 
-      await app.getByRole('button', { name: 'Test connection' }).click()
-      await expect(app.getByRole('button', { name: 'Next' })).toBeEnabled({ timeout: 30_000 })
-      await app.getByRole('button', { name: 'Next' }).click()
+        await app.getByRole('button', { name: 'Test connection' }).click()
+        await expect(app.getByRole('button', { name: 'Next' })).toBeEnabled({ timeout: 30_000 })
+        await app.getByRole('button', { name: 'Next' }).click()
 
-      await expect(app.getByRole('button', { name: 'Save' })).toBeVisible()
-      const responsePromise = app.waitForResponse('**/api/v1/integrations')
-      await app.getByRole('button', { name: 'Save' }).click()
-      const response = await responsePromise
-      integrationId = ((await response.json()) as { id?: string }).id ?? null
+        await expect(app.getByRole('button', { name: 'Save' })).toBeVisible()
+        const responsePromise = app.waitForResponse('**/api/v1/integrations')
+        await app.getByRole('button', { name: 'Save' }).click()
+        const response = await responsePromise
+        integrationId = ((await response.json()) as { id?: string }).id ?? null
 
-      await expect(app).toHaveURL(new RegExp(INTEGRATIONS_LIST_URL))
-      await app.getByPlaceholder('Filter by name').fill(integrationName)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-      await expect(app.getByRole('row', { name: new RegExp(integrationName) })).toBeVisible()
-    } finally {
-      if (integrationId) await deleteIntegrationViaApi(app, integrationId)
-      if (credential) await deleteCredentialViaApi(app, credential.id)
-    }
+        await expect(app).toHaveURL(new RegExp(INTEGRATIONS_LIST_URL))
+        await app.getByPlaceholder('Filter by name').fill(integrationName)
+        await app.getByRole('button', { name: 'Apply filter' }).click()
+        await expect(app.getByRole('row', { name: new RegExp(integrationName) })).toBeVisible()
+      } finally {
+        if (integrationId) await deleteIntegrationViaApi(app, integrationId)
+        if (credential) await deleteCredentialViaApi(app, credential.id)
+      }
+    })
   })
 
-  test('user creates an AAP Gateway integration through the wizard', async ({ app }) => {
+  test.describe(() => {
     test.skip(isRealBackend, 'AAP Gateway not available in upstream test environment')
 
-    const integrationName = buildUniqueName('e2e-wizard-aap')
-    const credName = buildUniqueName('e2e-wizard-aap-cred')
-    let credential: SeededCredential | null = null
-    let integrationId: string | null = null
+    test('user creates an AAP Gateway integration through the wizard', async ({ app }) => {
+      const integrationName = buildUniqueName('e2e-wizard-aap')
+      const credName = buildUniqueName('e2e-wizard-aap-cred')
+      let credential: SeededCredential | null = null
+      let integrationId: string | null = null
 
-    try {
-      credential = await createCredentialForIntegrationType(app, {
-        name: credName,
-        integrationType: 'aap_gateway',
-      })
-      expect(credential).not.toBeNull()
+      try {
+        credential = await createCredentialForIntegrationType(app, {
+          name: credName,
+          integrationType: 'aap_gateway',
+        })
+        expect(credential).not.toBeNull()
 
-      await app.goto(toAppUrl(WIZARD_URL))
-      await expect(app.getByRole('heading', { level: 1, name: 'Configure integration' })).toBeVisible()
+        await app.goto(toAppUrl(WIZARD_URL))
+        await expect(app.getByRole('heading', { level: 1, name: 'Configure integration' })).toBeVisible()
 
-      await app.getByRole('button', { name: 'MCP Server' }).click()
-      await app.getByRole('option', { name: 'Ansible Automation Platform' }).click()
+        await app.getByRole('button', { name: 'MCP Server' }).click()
+        await app.getByRole('option', { name: 'Ansible Automation Platform' }).click()
 
-      await app.getByRole('textbox', { name: 'Server name / ID' }).fill(integrationName)
-      await app.getByRole('textbox', { name: 'API URL' }).fill('https://aap.example.com')
-      await app.getByRole('button', { name: 'Next' }).click()
+        await app.getByRole('textbox', { name: 'Server name / ID' }).fill(integrationName)
+        await app.getByRole('textbox', { name: 'API URL' }).fill('https://aap.example.com')
+        await app.getByRole('button', { name: 'Next' }).click()
 
-      await expect(app.getByRole('heading', { level: 2, name: 'Connection credential' })).toBeVisible()
-      await app.getByRole('button', { name: 'Health check credential', exact: true }).click()
-      await app.getByRole('option', { name: credName }).click()
+        await expect(app.getByRole('heading', { level: 2, name: 'Connection credential' })).toBeVisible()
+        await app.getByRole('button', { name: 'Health check credential', exact: true }).click()
+        await app.getByRole('option', { name: credName }).click()
 
-      await app.getByRole('button', { name: 'Test connection' }).click()
+        await app.getByRole('button', { name: 'Test connection' }).click()
 
-      const saveButton = app.getByRole('button', { name: 'Save' })
-      await expect(saveButton).toBeEnabled({ timeout: 30_000 })
-      const responsePromise = app.waitForResponse('**/api/v1/integrations')
-      await saveButton.click()
-      const response = await responsePromise
-      integrationId = ((await response.json()) as { id?: string }).id ?? null
+        const saveButton = app.getByRole('button', { name: 'Save' })
+        await expect(saveButton).toBeEnabled({ timeout: 30_000 })
+        const responsePromise = app.waitForResponse('**/api/v1/integrations')
+        await saveButton.click()
+        const response = await responsePromise
+        integrationId = ((await response.json()) as { id?: string }).id ?? null
 
-      await expect(app).toHaveURL(new RegExp(INTEGRATIONS_LIST_URL))
-      await app.getByPlaceholder('Filter by name').fill(integrationName)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-      await expect(app.getByRole('row', { name: new RegExp(integrationName) })).toBeVisible()
-    } finally {
-      if (integrationId) await deleteIntegrationViaApi(app, integrationId)
-      if (credential) await deleteCredentialViaApi(app, credential.id)
-    }
+        await expect(app).toHaveURL(new RegExp(INTEGRATIONS_LIST_URL))
+        await app.getByPlaceholder('Filter by name').fill(integrationName)
+        await app.getByRole('button', { name: 'Apply filter' }).click()
+        await expect(app.getByRole('row', { name: new RegExp(integrationName) })).toBeVisible()
+      } finally {
+        if (integrationId) await deleteIntegrationViaApi(app, integrationId)
+        if (credential) await deleteCredentialViaApi(app, credential.id)
+      }
+    })
   })
 })
 

--- a/frontend/packages/syntara-ui/e2e/integration-wizard.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/integration-wizard.spec.ts
@@ -17,7 +17,7 @@ const WIZARD_URL = '/configuration/integrations/configure'
 const INTEGRATIONS_LIST_URL = '/configuration/integrations'
 
 test.describe('Create Integration Wizard', () => {
-  test.describe(() => {
+  test.describe('MCP Server integration', () => {
     test.skip(
       isRealBackend && !mcpServerUrl,
       'SYNTARA_E2E_MCP_SERVER_URL not set; cannot test MCP Server on real backend'
@@ -76,7 +76,7 @@ test.describe('Create Integration Wizard', () => {
     })
   })
 
-  test.describe(() => {
+  test.describe('LLM Provider integration', () => {
     test.skip(
       isRealBackend && !openrouterApiKey,
       'APP_OPENROUTER_API_KEY not set; cannot test LLM Provider on real backend'
@@ -136,7 +136,7 @@ test.describe('Create Integration Wizard', () => {
     })
   })
 
-  test.describe(() => {
+  test.describe('AAP Gateway integration', () => {
     test.skip(isRealBackend, 'AAP Gateway not available in upstream test environment')
 
     test('user creates an AAP Gateway integration through the wizard', async ({ app }) => {

--- a/frontend/packages/syntara-ui/e2e/pagination.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/pagination.spec.ts
@@ -8,7 +8,7 @@
  */
 import type { Page } from '@playwright/test'
 
-import { test, expect, toAppUrl } from './fixtures'
+import { createUnavailableGuard, test, expect, toAppUrl } from './fixtures'
 import { buildUniqueName } from './helpers/workflows'
 import {
   createUserViaApi,
@@ -134,12 +134,7 @@ function isGlobalWorkflowsListUrl(url: string): boolean {
 }
 
 test.describe('Pagination Footer — Users Tab', () => {
-  let usersUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(usersUnavailable, 'No users data available')
-  })
+  const guard = createUnavailableGuard('No users data available')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/system-administration/access-management/users'))
@@ -149,7 +144,7 @@ test.describe('Pagination Footer — Users Tab', () => {
       .waitFor({ state: 'visible', timeout: 30_000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasTable) usersUnavailable = true
+    if (!hasTable) guard.markUnavailable()
     test.skip(!hasTable, 'No users data available')
   })
 
@@ -188,12 +183,7 @@ test.describe('Pagination Footer — Groups Tab', () => {
 })
 
 test.describe('Project Selector — Workflows', () => {
-  let selectorUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(selectorUnavailable, 'No workflows or project selector not available')
-  })
+  const guard = createUnavailableGuard('No workflows or project selector not available')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/workflows'))
@@ -205,7 +195,7 @@ test.describe('Project Selector — Workflows', () => {
       .then(() => true)
       .catch(() => false)
     if (!hasTable) {
-      selectorUnavailable = true
+      guard.markUnavailable()
       test.skip(true, 'No workflows available — create workflows first')
       return
     }
@@ -216,7 +206,7 @@ test.describe('Project Selector — Workflows', () => {
       .then(() => true)
       .catch(() => false)
     if (!selectorVisible) {
-      selectorUnavailable = true
+      guard.markUnavailable()
       test.skip(true, 'Project selector not available in this environment')
       return
     }
@@ -228,7 +218,7 @@ test.describe('Project Selector — Workflows', () => {
       .then(() => true)
       .catch(() => false)
     await app.keyboard.press('Escape')
-    if (!optionsInteractive) selectorUnavailable = true
+    if (!optionsInteractive) guard.markUnavailable()
     test.skip(!optionsInteractive, 'Project selector is not interactive in this environment')
   })
 
@@ -325,12 +315,7 @@ test.describe('Project Selector — Workflows', () => {
 })
 
 test.describe('Pagination Navigation — Workflows', () => {
-  let paginationUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(paginationUnavailable, 'Not enough data to paginate')
-  })
+  const guard = createUnavailableGuard('Not enough data to paginate')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/workflows'))
@@ -340,7 +325,7 @@ test.describe('Pagination Navigation — Workflows', () => {
       .then(() => true)
       .catch(() => false)
     if (!hasTable) {
-      paginationUnavailable = true
+      guard.markUnavailable()
       test.skip(true, 'No workflows available')
       return
     }
@@ -357,7 +342,7 @@ test.describe('Pagination Navigation — Workflows', () => {
       .then(() => true)
       .catch(() => false)
     const hasNextPage = buttonVisible && (await nextButton.isEnabled().catch(() => false))
-    if (!hasNextPage) paginationUnavailable = true
+    if (!hasNextPage) guard.markUnavailable()
     test.skip(!hasNextPage, 'Not enough data to paginate — need more than 10 workflows')
   })
 
@@ -391,12 +376,7 @@ test.describe('Pagination Navigation — Workflows', () => {
 })
 
 test.describe('Pagination Footer — Credentials', () => {
-  let credentialsUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(credentialsUnavailable, 'No credentials data available')
-  })
+  const guard = createUnavailableGuard('No credentials data available')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/configuration/credentials'))
@@ -405,7 +385,7 @@ test.describe('Pagination Footer — Credentials', () => {
       .waitFor({ state: 'visible', timeout: 30_000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasTable) credentialsUnavailable = true
+    if (!hasTable) guard.markUnavailable()
     test.skip(!hasTable, 'No credentials data available')
   })
 
@@ -416,12 +396,7 @@ test.describe('Pagination Footer — Credentials', () => {
 })
 
 test.describe('Pagination Footer — Integrations', () => {
-  let integrationsUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(integrationsUnavailable, 'No integrations data available')
-  })
+  const guard = createUnavailableGuard('No integrations data available')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/configuration/integrations'))
@@ -431,7 +406,7 @@ test.describe('Pagination Footer — Integrations', () => {
       .waitFor({ state: 'visible', timeout: 30_000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasTable) integrationsUnavailable = true
+    if (!hasTable) guard.markUnavailable()
     test.skip(!hasTable, 'No integrations data available')
   })
 

--- a/frontend/packages/syntara-ui/e2e/pagination.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/pagination.spec.ts
@@ -134,6 +134,13 @@ function isGlobalWorkflowsListUrl(url: string): boolean {
 }
 
 test.describe('Pagination Footer — Users Tab', () => {
+  let usersUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(usersUnavailable, 'No users data available')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/system-administration/access-management/users'))
     await expect(app.getByRole('tab', { name: /Users/i })).toHaveAttribute('aria-selected', 'true')
@@ -142,6 +149,7 @@ test.describe('Pagination Footer — Users Tab', () => {
       .waitFor({ state: 'visible', timeout: 30_000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasTable) usersUnavailable = true
     test.skip(!hasTable, 'No users data available')
   })
 
@@ -180,6 +188,13 @@ test.describe('Pagination Footer — Groups Tab', () => {
 })
 
 test.describe('Project Selector — Workflows', () => {
+  let selectorUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(selectorUnavailable, 'No workflows or project selector not available')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/workflows'))
     await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
@@ -189,7 +204,11 @@ test.describe('Project Selector — Workflows', () => {
       .waitFor({ state: 'visible', timeout: 30_000 })
       .then(() => true)
       .catch(() => false)
-    test.skip(!hasTable, 'No workflows available — create workflows first')
+    if (!hasTable) {
+      selectorUnavailable = true
+      test.skip(true, 'No workflows available — create workflows first')
+      return
+    }
 
     const projectInput = app.getByPlaceholder('All projects')
     const selectorVisible = await projectInput
@@ -197,11 +216,11 @@ test.describe('Project Selector — Workflows', () => {
       .then(() => true)
       .catch(() => false)
     if (!selectorVisible) {
+      selectorUnavailable = true
       test.skip(true, 'Project selector not available in this environment')
       return
     }
 
-    // Also verify the dropdown is interactive (opens options on click)
     await projectInput.click()
     const optionsInteractive = await app
       .getByRole('option', { name: 'All projects' })
@@ -209,6 +228,7 @@ test.describe('Project Selector — Workflows', () => {
       .then(() => true)
       .catch(() => false)
     await app.keyboard.press('Escape')
+    if (!optionsInteractive) selectorUnavailable = true
     test.skip(!optionsInteractive, 'Project selector is not interactive in this environment')
   })
 
@@ -305,6 +325,13 @@ test.describe('Project Selector — Workflows', () => {
 })
 
 test.describe('Pagination Navigation — Workflows', () => {
+  let paginationUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(paginationUnavailable, 'Not enough data to paginate')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/workflows'))
     const table = app.getByRole('grid', { name: 'Workflows table' })
@@ -312,9 +339,12 @@ test.describe('Pagination Navigation — Workflows', () => {
       .waitFor({ state: 'visible', timeout: 30_000 })
       .then(() => true)
       .catch(() => false)
-    test.skip(!hasTable, 'No workflows available')
+    if (!hasTable) {
+      paginationUnavailable = true
+      test.skip(true, 'No workflows available')
+      return
+    }
 
-    // Set per-page to 10 so pagination activates even with fewer items
     const perPageToggle = app.locator('.pf-v6-c-pagination').getByRole('button', { name: /\d+ - \d+/ })
     await perPageToggle.waitFor({ state: 'visible', timeout: 10_000 })
     await perPageToggle.click()
@@ -327,6 +357,7 @@ test.describe('Pagination Navigation — Workflows', () => {
       .then(() => true)
       .catch(() => false)
     const hasNextPage = buttonVisible && (await nextButton.isEnabled().catch(() => false))
+    if (!hasNextPage) paginationUnavailable = true
     test.skip(!hasNextPage, 'Not enough data to paginate — need more than 10 workflows')
   })
 
@@ -360,6 +391,13 @@ test.describe('Pagination Navigation — Workflows', () => {
 })
 
 test.describe('Pagination Footer — Credentials', () => {
+  let credentialsUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(credentialsUnavailable, 'No credentials data available')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/configuration/credentials'))
     const table = app.getByRole('grid', { name: 'Credentials table' })
@@ -367,6 +405,7 @@ test.describe('Pagination Footer — Credentials', () => {
       .waitFor({ state: 'visible', timeout: 30_000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasTable) credentialsUnavailable = true
     test.skip(!hasTable, 'No credentials data available')
   })
 
@@ -377,6 +416,13 @@ test.describe('Pagination Footer — Credentials', () => {
 })
 
 test.describe('Pagination Footer — Integrations', () => {
+  let integrationsUnavailable = false
+
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(integrationsUnavailable, 'No integrations data available')
+  })
+
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/configuration/integrations'))
     await expect(app.getByRole('heading', { level: 1, name: 'Integrations' })).toBeVisible()
@@ -385,6 +431,7 @@ test.describe('Pagination Footer — Integrations', () => {
       .waitFor({ state: 'visible', timeout: 30_000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasTable) integrationsUnavailable = true
     test.skip(!hasTable, 'No integrations data available')
   })
 

--- a/frontend/packages/syntara-ui/e2e/settings.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/settings.spec.ts
@@ -79,9 +79,8 @@ async function resetAllToDefaults(app: import('@playwright/test').Page) {
 }
 
 test.describe('Settings', () => {
-  // Settings tests share backend state — run serially to avoid conflicts
-  test.describe.configure({ mode: 'serial' })
-
+  // Settings tests share backend state — run serially to avoid conflicts.
+  // mode: 'serial' is set by createUnavailableGuard below.
   const guard = createUnavailableGuard('Settings page has no tabs; backend may not have settings configured')
 
   test.beforeEach(async ({ app }) => {

--- a/frontend/packages/syntara-ui/e2e/settings.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/settings.spec.ts
@@ -82,13 +82,15 @@ test.describe('Settings', () => {
   // Settings tests share backend state — run serially to avoid conflicts
   test.describe.configure({ mode: 'serial' })
 
-  // Cache tab unavailability after the first probe to avoid repeating the 10s
-  // timeout wait in every subsequent test when Settings has no tabs.
   let settingsTabsUnavailable = false
 
-  test.beforeEach(async ({ app }) => {
+  // Guard hook: no fixtures requested, so skipping here avoids the app fixture
+  // (login + page creation) entirely for all subsequent tests once tabs are known unavailable.
+  test.beforeEach(() => {
     test.skip(settingsTabsUnavailable, 'Settings page has no tabs; backend may not have settings configured')
+  })
 
+  test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/system-administration/settings'))
     const heading = app.getByRole('heading', { level: 1, name: 'Settings' })
     const hasPage = await heading
@@ -96,7 +98,6 @@ test.describe('Settings', () => {
       .then(() => true)
       .catch(() => false)
     test.skip(!hasPage, 'Settings page not available; backend may not be running')
-    // Wait for content to fully load (tabs + save button)
     const hasTabs = await app
       .getByRole('tab', { name: /Context Manager|System|Authentication/i })
       .waitFor({ state: 'visible', timeout: 10_000 })

--- a/frontend/packages/syntara-ui/e2e/settings.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/settings.spec.ts
@@ -28,7 +28,7 @@
  * - Version conflict auto-refetches latest values
  */
 
-import { expect, test, toAppUrl } from './fixtures'
+import { createUnavailableGuard, expect, test, toAppUrl } from './fixtures'
 import { APP_TITLE } from './helpers/appTitle'
 import { apiRequest } from './utils/api'
 
@@ -82,13 +82,7 @@ test.describe('Settings', () => {
   // Settings tests share backend state — run serially to avoid conflicts
   test.describe.configure({ mode: 'serial' })
 
-  let settingsTabsUnavailable = false
-
-  // Guard hook: no fixtures requested, so skipping here avoids the app fixture
-  // (login + page creation) entirely for all subsequent tests once tabs are known unavailable.
-  test.beforeEach(() => {
-    test.skip(settingsTabsUnavailable, 'Settings page has no tabs; backend may not have settings configured')
-  })
+  const guard = createUnavailableGuard('Settings page has no tabs; backend may not have settings configured')
 
   test.beforeEach(async ({ app }) => {
     await app.goto(toAppUrl('/system-administration/settings'))
@@ -97,13 +91,14 @@ test.describe('Settings', () => {
       .waitFor({ state: 'visible', timeout: 10_000 })
       .then(() => true)
       .catch(() => false)
+    if (!hasPage) guard.markUnavailable()
     test.skip(!hasPage, 'Settings page not available; backend may not be running')
     const hasTabs = await app
       .getByRole('tab', { name: /Context Manager|System|Authentication/i })
       .waitFor({ state: 'visible', timeout: 10_000 })
       .then(() => true)
       .catch(() => false)
-    if (!hasTabs) settingsTabsUnavailable = true
+    if (!hasTabs) guard.markUnavailable()
     test.skip(!hasTabs, 'Settings page has no tabs; backend may not have settings configured')
   })
 

--- a/frontend/packages/syntara-ui/e2e/undo-redo.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/undo-redo.spec.ts
@@ -107,42 +107,46 @@ test('undo history resets when navigating away from the builder', async ({ app }
   }
 })
 
-test('selecting execution from history navigates to execution page', async ({ app }) => {
-  const workflowName = buildUniqueName('e2e-undo-exec-view')
-  const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Initial action')
+test.describe('Execution History Navigation', () => {
+  test.skip(!process.env['SYNTARA_E2E_HAS_EXECUTION_ENGINE'], 'Execution engine unavailable (globalSetup probe)')
 
-  try {
-    await openWorkflowInBuilder(app, workflowName, id)
+  test('selecting execution from history navigates to execution page', async ({ app }) => {
+    const workflowName = buildUniqueName('e2e-undo-exec-view')
+    const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Initial action')
 
-    // Create an execution by running the workflow through the UI
-    await app.getByRole('button', { name: 'Run', exact: true }).click()
-    await app.getByRole('button', { name: 'Run now' }).click()
+    try {
+      await openWorkflowInBuilder(app, workflowName, id)
 
-    // Execution may fail if the workflow engine (Temporal) is unavailable
-    const didNavigate = await expect(app)
-      .toHaveURL(/\/executions\//)
-      .then(() => true)
-      .catch(() => false)
-    test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
+      // Create an execution by running the workflow through the UI
+      await app.getByRole('button', { name: 'Run', exact: true }).click()
+      await app.getByRole('button', { name: 'Run now' }).click()
 
-    // Navigate back to the builder
-    await openWorkflowInBuilder(app, workflowName, id)
+      // Execution may fail if the workflow engine (Temporal) is unavailable
+      const didNavigate = await expect(app)
+        .toHaveURL(/\/executions\//)
+        .then(() => true)
+        .catch(() => false)
+      test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
 
-    // Open run history via kebab menu — the execution we just created should appear
-    await app.getByLabel('Workflow actions').click()
-    await app.getByRole('menuitem', { name: 'Run history' }).click()
-    await expect(app.getByRole('heading', { name: 'Run history' })).toBeVisible()
+      // Navigate back to the builder
+      await openWorkflowInBuilder(app, workflowName, id)
 
-    // Click the execution to navigate to the execution page
-    const runHistoryPanel = app.getByRole('heading', { name: 'Run history' }).locator('..')
-    const executionItems = runHistoryPanel.locator('button[class*="simpleList"]')
-    const itemCount = await executionItems.count()
-    if (itemCount > 0) {
-      await executionItems.nth(0).click()
-      await expect(app).toHaveURL(/\/executions\//)
-      await expect(app.getByRole('button', { name: 'Back to editor' })).toBeVisible()
+      // Open run history via kebab menu — the execution we just created should appear
+      await app.getByLabel('Workflow actions').click()
+      await app.getByRole('menuitem', { name: 'Run history' }).click()
+      await expect(app.getByRole('heading', { name: 'Run history' })).toBeVisible()
+
+      // Click the execution to navigate to the execution page
+      const runHistoryPanel = app.getByRole('heading', { name: 'Run history' }).locator('..')
+      const executionItems = runHistoryPanel.locator('button[class*="simpleList"]')
+      const itemCount = await executionItems.count()
+      if (itemCount > 0) {
+        await executionItems.nth(0).click()
+        await expect(app).toHaveURL(/\/executions\//)
+        await expect(app.getByRole('button', { name: 'Back to editor' })).toBeVisible()
+      }
+    } finally {
+      await deleteWorkflow(app, workflowName)
     }
-  } finally {
-    await deleteWorkflow(app, workflowName)
-  }
+  })
 })

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-pending-badge.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-pending-badge.spec.ts
@@ -80,6 +80,8 @@ async function applyPendingApprovalStatusFilter(app: Page): Promise<void> {
 }
 
 test.describe('Approval Pending Badge', () => {
+  test.skip(!process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'], 'Temporal worker unavailable (globalSetup probe)')
+
   test('shows "Pending approval" badge in all three locations when execution has pending approval', async ({ app }) => {
     let workflowName: string | undefined
 

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -66,10 +66,20 @@ test.describe('Approval Side Panel — list navigation', () => {
 })
 
 test.describe('Approval Side Panel — deep-link', () => {
-  test('side panel displays approval details and action buttons', async ({ app }) => {
-    const hasPanel = await navigateToApprovalPanel(app)
-    test.skip(!hasPanel, 'Approval side panel not available')
+  let panelUnavailable = false
 
+  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
+  test.beforeEach(() => {
+    test.skip(panelUnavailable, 'Approval side panel not available')
+  })
+
+  test.beforeEach(async ({ app }) => {
+    const hasPanel = await navigateToApprovalPanel(app)
+    if (!hasPanel) panelUnavailable = true
+    test.skip(!hasPanel, 'Approval side panel not available')
+  })
+
+  test('side panel displays approval details and action buttons', async ({ app }) => {
     // Decision buttons
     await expect(app.getByRole('button', { name: 'Approve' })).toBeVisible()
     await expect(app.getByRole('button', { name: 'Reject' })).toBeVisible()
@@ -83,9 +93,6 @@ test.describe('Approval Side Panel — deep-link', () => {
   })
 
   test('clicking approve shows notes input and submit button', async ({ app }) => {
-    const hasPanel = await navigateToApprovalPanel(app)
-    test.skip(!hasPanel, 'Approval side panel not available')
-
     const approveBtn = app.getByRole('button', { name: 'Approve' })
     await expect(approveBtn).not.toHaveAttribute('aria-disabled', 'true')
 
@@ -101,9 +108,6 @@ test.describe('Approval Side Panel — deep-link', () => {
   })
 
   test('clicking reject shows notes input and submit button', async ({ app }) => {
-    const hasPanel = await navigateToApprovalPanel(app)
-    test.skip(!hasPanel, 'Approval side panel not available')
-
     const rejectBtn = app.getByRole('button', { name: 'Reject' })
     await expect(rejectBtn).not.toHaveAttribute('aria-disabled', 'true')
 
@@ -117,9 +121,6 @@ test.describe('Approval Side Panel — deep-link', () => {
   })
 
   test('run history and approval panel are mutually exclusive', async ({ app }) => {
-    const hasPanel = await navigateToApprovalPanel(app)
-    test.skip(!hasPanel, 'Approval side panel not available')
-
     // History should be closed (deep-link sets history=closed)
     const historyHeading = app.getByRole('heading', { name: 'Run history' })
     await expect(historyHeading).not.toBeVisible()
@@ -135,7 +136,9 @@ test.describe('Approval Side Panel — deep-link', () => {
     await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible()
     await expect(historyHeading).not.toBeVisible()
   })
+})
 
+test.describe('Approval Side Panel — deep-link (viewer)', () => {
   test('viewer: approve and reject buttons are disabled', async ({ viewerApp }) => {
     await viewerApp.goto(toAppUrl(DEEP_LINK))
     await expect(viewerApp.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -14,7 +14,7 @@
  * Seed data:
  * - Approval "Production Deployment Approval" (550e8400-...-446655440050) linked to exec-approval
  */
-import { test, expect, toAppUrl } from '../fixtures'
+import { createUnavailableGuard, test, expect, toAppUrl } from '../fixtures'
 import { addApprovalNodeWithBranch } from '../helpers/v2-nodes'
 import { buildUniqueName, createBasicWorkflowViaApi, openWorkflowInBuilder } from '../helpers/workflows'
 import { apiRequest, pollExecutionStatus } from '../utils/api'
@@ -66,16 +66,11 @@ test.describe('Approval Side Panel — list navigation', () => {
 })
 
 test.describe('Approval Side Panel — deep-link', () => {
-  let panelUnavailable = false
-
-  // Guard hook: skips without setting up the app fixture (login) once data is known unavailable.
-  test.beforeEach(() => {
-    test.skip(panelUnavailable, 'Approval side panel not available')
-  })
+  const guard = createUnavailableGuard('Approval side panel not available')
 
   test.beforeEach(async ({ app }) => {
     const hasPanel = await navigateToApprovalPanel(app)
-    if (!hasPanel) panelUnavailable = true
+    if (!hasPanel) guard.markUnavailable()
     test.skip(!hasPanel, 'Approval side panel not available')
   })
 

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-workflow-e2e.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-workflow-e2e.spec.ts
@@ -60,6 +60,8 @@ async function createPendingApproval(app: Page): Promise<{ workflowId: string; a
  * - View pending approval with previous step output displayed in panel
  */
 test.describe('Approval Workflow E2E', () => {
+  test.skip(!process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'], 'Temporal worker unavailable (globalSetup probe)')
+
   test('view pending approval with previous step output', async ({ app }) => {
     // Create a pending approval (workflow has a script node before the approval node)
     const approval = await createPendingApproval(app)

--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -126,410 +126,414 @@ test('user filters approvals by name and status', async ({ app }) => {
   await expect(table).toBeVisible()
 })
 
-test('user performs batch approval operations', async ({ app }) => {
-  // Create 2 pending approvals with a shared prefix for filtering
-  const batchId = `batch-${Date.now()}`
-  const approval1 = await createPendingApproval(app, batchId)
-  const approval2 = await createPendingApproval(app, batchId)
+test.describe('Approval Workflow Operations', () => {
+  test.skip(!process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'], 'Temporal worker unavailable (globalSetup probe)')
 
-  try {
-    // Navigate to approvals page
-    await app.goto(toAppUrl('/approvals'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+  test('user performs batch approval operations', async ({ app }) => {
+    // Create 2 pending approvals with a shared prefix for filtering
+    const batchId = `batch-${Date.now()}`
+    const approval1 = await createPendingApproval(app, batchId)
+    const approval2 = await createPendingApproval(app, batchId)
 
-    const table = app.getByRole('grid', { name: 'Approvals table' })
-    await table.waitFor({ state: 'visible', timeout: 15_000 })
+    try {
+      // Navigate to approvals page
+      await app.goto(toAppUrl('/approvals'))
+      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
 
-    // Filter to show only our test approvals using shared batch ID
-    await app.getByPlaceholder('Filter by name').fill(batchId)
-    await app.getByRole('button', { name: 'Apply filter' }).click()
+      const table = app.getByRole('grid', { name: 'Approvals table' })
+      await table.waitFor({ state: 'visible', timeout: 15_000 })
 
-    // Step 1: Select both approvals using row-scoped checkboxes
-    const rows = table.getByRole('row')
-    await rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox').check()
-    await rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox').check()
+      // Filter to show only our test approvals using shared batch ID
+      await app.getByPlaceholder('Filter by name').fill(batchId)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
 
-    // Step 2: Verify batch toolbar appears with count
-    const batchToolbar = app.getByRole('toolbar', { name: /selected/i })
-    await expect(batchToolbar).toBeVisible()
-    await expect(app.getByText('2 selected')).toBeVisible()
+      // Step 1: Select both approvals using row-scoped checkboxes
+      const rows = table.getByRole('row')
+      await rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox').check()
+      await rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox').check()
 
-    // Step 3: Verify batch action buttons are visible
-    const approveButton = app.getByRole('button', { name: 'Approve' })
-    const rejectButton = app.getByRole('button', { name: 'Reject' })
-    await expect(approveButton).toBeVisible()
-    await expect(rejectButton).toBeVisible()
+      // Step 2: Verify batch toolbar appears with count
+      const batchToolbar = app.getByRole('toolbar', { name: /selected/i })
+      await expect(batchToolbar).toBeVisible()
+      await expect(app.getByText('2 selected')).toBeVisible()
 
-    // Step 4: Click "Approve Selected" and verify confirmation dialog
-    await approveButton.click()
-
-    const dialog = app.getByRole('dialog')
-    await expect(dialog).toBeVisible()
-    await expect(dialog.getByRole('heading', { name: /approve.*approval/i })).toBeVisible()
-
-    // Step 5: Fill in approval notes
-    const notesInput = dialog.getByPlaceholder(/optional.*note|explain.*reason/i)
-    await expect(notesInput).toBeVisible()
-    await notesInput.fill('Batch approval - E2E test')
-
-    // Step 6: Submit batch approval
-    const submitButton = dialog.getByRole('button', { name: 'Approve' })
-    await expect(submitButton).toBeVisible()
-    await submitButton.click()
-
-    // Step 7: Verify success notification
-    await expect(app.getByText('Approval submitted')).toBeVisible({ timeout: 10_000 })
-
-    // Step 8: Verify selection cleared (batch toolbar should disappear)
-    await expect(batchToolbar).not.toBeVisible()
-    await expect(app.getByText('2 selected')).not.toBeVisible()
-
-    // Step 9: Verify checkboxes are unchecked
-    await expect(rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox')).not.toBeChecked()
-    await expect(rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox')).not.toBeChecked()
-  } finally {
-    // Cleanup: delete created workflows
-    await apiRequest(app, 'delete', `/workflows/${approval1.workflowId}`).catch(() => {})
-    await apiRequest(app, 'delete', `/workflows/${approval2.workflowId}`).catch(() => {})
-  }
-})
-
-test('user performs batch rejection operations', async ({ app }) => {
-  // Create 2 pending approvals with a shared prefix for filtering
-  const batchId = `batch-${Date.now()}`
-  const approval1 = await createPendingApproval(app, batchId)
-  const approval2 = await createPendingApproval(app, batchId)
-
-  try {
-    // Navigate to approvals page
-    await app.goto(toAppUrl('/approvals'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
-
-    const table = app.getByRole('grid', { name: 'Approvals table' })
-    await table.waitFor({ state: 'visible', timeout: 15_000 })
-
-    // Filter to show only our test approvals using shared batch ID
-    await app.getByPlaceholder('Filter by name').fill(batchId)
-    await app.getByRole('button', { name: 'Apply filter' }).click()
-
-    // Step 1: Select both approvals using row-scoped checkboxes
-    const rows = table.getByRole('row')
-    await rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox').check()
-    await rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox').check()
-
-    // Step 2: Verify batch toolbar and count
-    await expect(app.getByText('2 selected')).toBeVisible()
-
-    // Step 3: Click "Reject Selected"
-    const rejectButton = app.getByRole('button', { name: 'Reject' })
-    await expect(rejectButton).toBeVisible()
-    await rejectButton.click()
-
-    // Step 4: Verify rejection dialog
-    const dialog = app.getByRole('dialog')
-    await expect(dialog).toBeVisible()
-    await expect(dialog.getByRole('heading', { name: /reject.*approval/i })).toBeVisible()
-
-    // Step 5: Fill in rejection notes
-    const notesInput = dialog.getByPlaceholder(/optional.*note|explain.*reason/i)
-    await expect(notesInput).toBeVisible()
-    await notesInput.fill('Batch rejection - E2E test')
-
-    // Step 6: Submit batch rejection
-    const submitButton = dialog.getByRole('button', { name: 'Reject' })
-    await expect(submitButton).toBeVisible()
-    await submitButton.click()
-
-    // Step 7: Verify success notification
-    await expect(app.getByText('Rejection submitted')).toBeVisible({ timeout: 10_000 })
-
-    // Step 8: Verify selection cleared
-    await expect(app.getByText('2 selected')).not.toBeVisible()
-
-    // Step 9: Verify checkboxes are unchecked
-    await expect(rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox')).not.toBeChecked()
-    await expect(rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox')).not.toBeChecked()
-  } finally {
-    // Cleanup: delete created workflows
-    await apiRequest(app, 'delete', `/workflows/${approval1.workflowId}`).catch(() => {})
-    await apiRequest(app, 'delete', `/workflows/${approval2.workflowId}`).catch(() => {})
-  }
-})
-
-test('user cancels batch approval without API call', async ({ app }) => {
-  // Create a pending approval to test cancel behavior
-  const approval = await createPendingApproval(app)
-
-  try {
-    // Navigate to approvals page
-    await app.goto(toAppUrl('/approvals'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
-
-    const table = app.getByRole('grid', { name: 'Approvals table' })
-    await table.waitFor({ state: 'visible', timeout: 15_000 })
-
-    // Filter to show only our test approval
-    await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
-    await app.getByRole('button', { name: 'Apply filter' }).click()
-
-    // Step 1: Select the approval using row-scoped checkbox
-    const row = table.getByRole('row').filter({ hasText: approval.approvalName })
-    await row.getByRole('checkbox').check()
-    await expect(app.getByText('1 selected')).toBeVisible()
-
-    // Step 2: Click "Approve Selected"
-    const approveButton = app.getByRole('button', { name: 'Approve' })
-    await approveButton.click()
-
-    // Step 3: Verify dialog appears
-    const dialog = app.getByRole('dialog')
-    await expect(dialog).toBeVisible()
-
-    // Step 4: Click "Cancel" button
-    const cancelButton = dialog.getByRole('button', { name: 'Cancel' })
-    await expect(cancelButton).toBeVisible()
-    await cancelButton.click()
-
-    // Step 5: Verify dialog closed
-    await expect(dialog).not.toBeVisible()
-
-    // Step 6: Verify selection is still active (no API call was made)
-    await expect(app.getByText('1 selected')).toBeVisible()
-
-    // Step 7: Deselect to clean up
-    await row.getByRole('checkbox').uncheck()
-    await expect(app.getByText('1 selected')).not.toBeVisible()
-  } finally {
-    // Cleanup: delete created workflow
-    await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
-  }
-})
-
-test('user changes decision from approve to reject (undo)', async ({ app }) => {
-  // Create a pending approval to test undo behavior
-  const approval = await createPendingApproval(app)
-
-  try {
-    // Navigate to approvals page
-    await app.goto(toAppUrl('/approvals'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
-
-    const table = app.getByRole('grid', { name: 'Approvals table' })
-    await table.waitFor({ state: 'visible', timeout: 15_000 })
-
-    // Filter to show only our test approval
-    await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
-    await app.getByRole('button', { name: 'Apply filter' }).click()
-
-    // Step 1: Click on the pending approval to open side panel
-    const approvalBtn = table.getByRole('button', { name: approval.approvalName })
-    await approvalBtn.waitFor({ state: 'visible', timeout: 10_000 })
-    await approvalBtn.click()
-
-    // Step 2: Verify navigation to execution detail with side panel
-    await expect(app).toHaveURL(/\/executions\/[^?]+\?approval=/)
-    await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
-
-    // Step 3: Click "Approve" button
-    const approveButton = app.getByRole('button', { name: 'Approve', exact: true })
-    await expect(approveButton).toBeVisible()
-    await approveButton.click()
-
-    // Step 4: Verify approval notes field appears
-    const approvalNotesInput = app.getByPlaceholder(/explain.*reason.*approving|optional.*note/i)
-    await expect(approvalNotesInput).toBeVisible()
-
-    // Step 5: Click "Reject" to undo the approve decision
-    const rejectButton = app.getByRole('button', { name: 'Reject', exact: true })
-    await expect(rejectButton).toBeVisible()
-    await rejectButton.click()
-
-    // Step 6: Verify rejection notes field appears (approval notes replaced)
-    const rejectionNotesInput = app.getByPlaceholder(/explain.*reason.*rejecting|optional.*note/i)
-    await expect(rejectionNotesInput).toBeVisible()
-
-    // Step 7: Verify approval notes field is no longer visible
-    await expect(approvalNotesInput).not.toBeVisible()
-
-    // Step 8: Verify "Submit decision" button is available for rejection
-    const submitButton = app.getByRole('button', { name: 'Submit decision' })
-    await expect(submitButton).toBeVisible()
-
-    // NOTE: This test verifies undo behavior (switching between approve/reject)
-    // without actually submitting to avoid mutating approval state
-  } finally {
-    // Cleanup: delete created workflow
-    await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
-  }
-})
-
-test('user clears decision with explicit undo button', async ({ app }) => {
-  // Create a pending approval to test undo/clear behavior
-  const approval = await createPendingApproval(app)
-
-  try {
-    // Navigate to approvals page
-    await app.goto(toAppUrl('/approvals'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
-
-    const table = app.getByRole('grid', { name: 'Approvals table' })
-    await table.waitFor({ state: 'visible', timeout: 15_000 })
-
-    // Filter to show only our test approval
-    await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
-    await app.getByRole('button', { name: 'Apply filter' }).click()
-
-    // Click on the pending approval
-    const approvalBtn = table.getByRole('button', { name: approval.approvalName })
-    await approvalBtn.waitFor({ state: 'visible', timeout: 10_000 })
-    await approvalBtn.click()
-    await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
-
-    // Step 1: Click "Approve"
-    const approveButton = app.getByRole('button', { name: 'Approve', exact: true })
-    await approveButton.click()
-    await expect(app.getByPlaceholder(/explain.*reason.*approving/i)).toBeVisible()
-
-    // Step 2: Look for "Undo decision" or "Clear" button
-    const undoButton = app.getByRole('button', { name: /undo.*decision|clear.*selection/i })
-    const hasUndoButton = await undoButton.isVisible().catch(() => false)
-
-    if (hasUndoButton) {
-      await undoButton.click()
-
-      // Step 3: Verify both approve and reject buttons are visible again
-      await expect(app.getByRole('button', { name: 'Approve', exact: true })).toBeVisible()
-      await expect(app.getByRole('button', { name: 'Reject', exact: true })).toBeVisible()
-
-      // Step 4: Verify notes field is cleared
-      const notesField = app.getByPlaceholder(/explain.*reason/i)
-      await expect(notesField).not.toBeVisible()
-    } else {
-      // If no explicit undo button exists, verify switching between approve/reject acts as undo
-      const rejectButton = app.getByRole('button', { name: 'Reject', exact: true })
+      // Step 3: Verify batch action buttons are visible
+      const approveButton = app.getByRole('button', { name: 'Approve' })
+      const rejectButton = app.getByRole('button', { name: 'Reject' })
+      await expect(approveButton).toBeVisible()
       await expect(rejectButton).toBeVisible()
 
-      // Clicking reject after approve is the undo mechanism
+      // Step 4: Click "Approve Selected" and verify confirmation dialog
+      await approveButton.click()
+
+      const dialog = app.getByRole('dialog')
+      await expect(dialog).toBeVisible()
+      await expect(dialog.getByRole('heading', { name: /approve.*approval/i })).toBeVisible()
+
+      // Step 5: Fill in approval notes
+      const notesInput = dialog.getByPlaceholder(/optional.*note|explain.*reason/i)
+      await expect(notesInput).toBeVisible()
+      await notesInput.fill('Batch approval - E2E test')
+
+      // Step 6: Submit batch approval
+      const submitButton = dialog.getByRole('button', { name: 'Approve' })
+      await expect(submitButton).toBeVisible()
+      await submitButton.click()
+
+      // Step 7: Verify success notification
+      await expect(app.getByText('Approval submitted')).toBeVisible({ timeout: 10_000 })
+
+      // Step 8: Verify selection cleared (batch toolbar should disappear)
+      await expect(batchToolbar).not.toBeVisible()
+      await expect(app.getByText('2 selected')).not.toBeVisible()
+
+      // Step 9: Verify checkboxes are unchecked
+      await expect(rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox')).not.toBeChecked()
+      await expect(rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox')).not.toBeChecked()
+    } finally {
+      // Cleanup: delete created workflows
+      await apiRequest(app, 'delete', `/workflows/${approval1.workflowId}`).catch(() => {})
+      await apiRequest(app, 'delete', `/workflows/${approval2.workflowId}`).catch(() => {})
+    }
+  })
+
+  test('user performs batch rejection operations', async ({ app }) => {
+    // Create 2 pending approvals with a shared prefix for filtering
+    const batchId = `batch-${Date.now()}`
+    const approval1 = await createPendingApproval(app, batchId)
+    const approval2 = await createPendingApproval(app, batchId)
+
+    try {
+      // Navigate to approvals page
+      await app.goto(toAppUrl('/approvals'))
+      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+
+      const table = app.getByRole('grid', { name: 'Approvals table' })
+      await table.waitFor({ state: 'visible', timeout: 15_000 })
+
+      // Filter to show only our test approvals using shared batch ID
+      await app.getByPlaceholder('Filter by name').fill(batchId)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
+
+      // Step 1: Select both approvals using row-scoped checkboxes
+      const rows = table.getByRole('row')
+      await rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox').check()
+      await rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox').check()
+
+      // Step 2: Verify batch toolbar and count
+      await expect(app.getByText('2 selected')).toBeVisible()
+
+      // Step 3: Click "Reject Selected"
+      const rejectButton = app.getByRole('button', { name: 'Reject' })
+      await expect(rejectButton).toBeVisible()
       await rejectButton.click()
-      await expect(app.getByPlaceholder(/explain.*reason.*rejecting/i)).toBeVisible()
+
+      // Step 4: Verify rejection dialog
+      const dialog = app.getByRole('dialog')
+      await expect(dialog).toBeVisible()
+      await expect(dialog.getByRole('heading', { name: /reject.*approval/i })).toBeVisible()
+
+      // Step 5: Fill in rejection notes
+      const notesInput = dialog.getByPlaceholder(/optional.*note|explain.*reason/i)
+      await expect(notesInput).toBeVisible()
+      await notesInput.fill('Batch rejection - E2E test')
+
+      // Step 6: Submit batch rejection
+      const submitButton = dialog.getByRole('button', { name: 'Reject' })
+      await expect(submitButton).toBeVisible()
+      await submitButton.click()
+
+      // Step 7: Verify success notification
+      await expect(app.getByText('Rejection submitted')).toBeVisible({ timeout: 10_000 })
+
+      // Step 8: Verify selection cleared
+      await expect(app.getByText('2 selected')).not.toBeVisible()
+
+      // Step 9: Verify checkboxes are unchecked
+      await expect(rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox')).not.toBeChecked()
+      await expect(rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox')).not.toBeChecked()
+    } finally {
+      // Cleanup: delete created workflows
+      await apiRequest(app, 'delete', `/workflows/${approval1.workflowId}`).catch(() => {})
+      await apiRequest(app, 'delete', `/workflows/${approval2.workflowId}`).catch(() => {})
     }
-  } finally {
-    // Cleanup: delete created workflow
-    await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
-  }
-})
+  })
 
-test('user selects all approvals using header checkbox', async ({ app }) => {
-  // Create 2 pending approvals with a shared prefix for filtering
-  const batchId = `batch-${Date.now()}`
-  const approval1 = await createPendingApproval(app, batchId)
-  const approval2 = await createPendingApproval(app, batchId)
+  test('user cancels batch approval without API call', async ({ app }) => {
+    // Create a pending approval to test cancel behavior
+    const approval = await createPendingApproval(app)
 
-  try {
-    // Navigate to approvals page
-    await app.goto(toAppUrl('/approvals'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+    try {
+      // Navigate to approvals page
+      await app.goto(toAppUrl('/approvals'))
+      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
 
-    const table = app.getByRole('grid', { name: 'Approvals table' })
-    await table.waitFor({ state: 'visible', timeout: 15_000 })
+      const table = app.getByRole('grid', { name: 'Approvals table' })
+      await table.waitFor({ state: 'visible', timeout: 15_000 })
 
-    // Filter to show only our test approvals using shared batch ID
-    await app.getByPlaceholder('Filter by name').fill(batchId)
-    await app.getByRole('button', { name: 'Apply filter' }).click()
+      // Filter to show only our test approval
+      await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
 
-    // Step 1: Click header row checkbox to select all
-    const headerRow = table.getByRole('row').nth(0)
-    const selectAllCheckbox = headerRow.getByRole('checkbox')
-    await selectAllCheckbox.check()
+      // Step 1: Select the approval using row-scoped checkbox
+      const row = table.getByRole('row').filter({ hasText: approval.approvalName })
+      await row.getByRole('checkbox').check()
+      await expect(app.getByText('1 selected')).toBeVisible()
 
-    // Step 2: Verify all approvals are selected (2 in this case)
-    const selectedText = app.getByText('2 selected')
-    await expect(selectedText).toBeVisible()
+      // Step 2: Click "Approve Selected"
+      const approveButton = app.getByRole('button', { name: 'Approve' })
+      await approveButton.click()
 
-    // Step 3: Verify batch toolbar is visible
-    const batchToolbar = app.getByRole('toolbar', { name: /selected/i })
-    await expect(batchToolbar).toBeVisible()
+      // Step 3: Verify dialog appears
+      const dialog = app.getByRole('dialog')
+      await expect(dialog).toBeVisible()
 
-    // Step 4: Uncheck header checkbox to deselect all
-    await selectAllCheckbox.uncheck()
+      // Step 4: Click "Cancel" button
+      const cancelButton = dialog.getByRole('button', { name: 'Cancel' })
+      await expect(cancelButton).toBeVisible()
+      await cancelButton.click()
 
-    // Step 5: Verify selection cleared
-    await expect(selectedText).not.toBeVisible()
-    await expect(batchToolbar).not.toBeVisible()
+      // Step 5: Verify dialog closed
+      await expect(dialog).not.toBeVisible()
 
-    // Step 6: Verify all checkboxes are unchecked
-    const rows = table.getByRole('row')
-    await expect(rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox')).not.toBeChecked()
-    await expect(rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox')).not.toBeChecked()
-  } finally {
-    // Cleanup: delete created workflows
-    await apiRequest(app, 'delete', `/workflows/${approval1.workflowId}`).catch(() => {})
-    await apiRequest(app, 'delete', `/workflows/${approval2.workflowId}`).catch(() => {})
-  }
-})
+      // Step 6: Verify selection is still active (no API call was made)
+      await expect(app.getByText('1 selected')).toBeVisible()
 
-test('UI-29: self-contained approve flow via approvals queue', async ({ app }) => {
-  // Create a workflow with an approval node so we control the approval name
-  const workflowName = buildUniqueName('e2e-approve')
-  const approvalNodeName = buildUniqueName('gate')
-  const { id: workflowId } = await createBasicWorkflowViaApi(app, workflowName, 'Pre-approval step')
-  await openWorkflowInBuilder(app, workflowName, workflowId)
-
-  try {
-    // Add approval node with a unique name so we can find it in the approvals list
-    await addApprovalNodeWithBranch(app, approvalNodeName)
-    await app.getByRole('button', { name: 'Save', exact: true }).click()
-    await expect(app.getByRole('button', { name: 'Run', exact: true })).toBeEnabled({ timeout: 15_000 })
-
-    // Run the workflow
-    await app.getByRole('button', { name: 'Run', exact: true }).click()
-    await app.getByRole('button', { name: /Run now|Save and run/ }).click()
-
-    const didNavigate = await app
-      .waitForURL(/\/executions\//, { timeout: 10_000 })
-      .then(() => true)
-      .catch(() => false)
-    test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
-
-    // Extract execution ID and poll API for "paused" status
-    const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
-    test.skip(!executionId, 'Could not extract execution ID from URL')
-
-    const reachedApproval = await pollExecutionStatus(app, executionId!, ['paused'])
-      .then(() => true)
-      .catch(() => false)
-    test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
-
-    // Navigate to the approvals queue and find our approval
-    await app.goto(toAppUrl('/approvals'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
-
-    const approvalsTable = app.getByRole('grid', { name: 'Approvals table' })
-    await approvalsTable.waitFor({ state: 'visible', timeout: 15_000 })
-
-    // Filter by the unique approval node name
-    await app.getByPlaceholder('Filter by name').fill(approvalNodeName)
-    await app.getByRole('button', { name: 'Apply filter' }).click()
-
-    const approvalBtn = approvalsTable.getByRole('button', { name: approvalNodeName })
-    await approvalBtn.waitFor({ state: 'visible', timeout: 15_000 })
-
-    // Click approval — navigates to execution detail with side panel
-    await approvalBtn.click()
-    await expect(app).toHaveURL(/\/executions\/[^?]+\?approval=/)
-    await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
-
-    // Approve with notes
-    await app.getByRole('button', { name: 'Approve' }).click()
-    await app.getByPlaceholder(/Explain the reason for approving/i).fill('Approved in E2E test')
-    await app.getByRole('button', { name: 'Submit decision' }).click()
-
-    // Verify approval was submitted and execution resumes
-    await expect(app.getByText('Approval submitted')).toBeVisible({ timeout: 15_000 })
-    await expect(app.getByText('Completed')).toBeVisible({ timeout: 30_000 })
-  } finally {
-    if (workflowId) {
-      await apiRequest(app, 'delete', `/workflows/${workflowId}`).catch(() => {})
+      // Step 7: Deselect to clean up
+      await row.getByRole('checkbox').uncheck()
+      await expect(app.getByText('1 selected')).not.toBeVisible()
+    } finally {
+      // Cleanup: delete created workflow
+      await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
     }
-  }
-})
+  })
+
+  test('user changes decision from approve to reject (undo)', async ({ app }) => {
+    // Create a pending approval to test undo behavior
+    const approval = await createPendingApproval(app)
+
+    try {
+      // Navigate to approvals page
+      await app.goto(toAppUrl('/approvals'))
+      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+
+      const table = app.getByRole('grid', { name: 'Approvals table' })
+      await table.waitFor({ state: 'visible', timeout: 15_000 })
+
+      // Filter to show only our test approval
+      await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
+
+      // Step 1: Click on the pending approval to open side panel
+      const approvalBtn = table.getByRole('button', { name: approval.approvalName })
+      await approvalBtn.waitFor({ state: 'visible', timeout: 10_000 })
+      await approvalBtn.click()
+
+      // Step 2: Verify navigation to execution detail with side panel
+      await expect(app).toHaveURL(/\/executions\/[^?]+\?approval=/)
+      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
+
+      // Step 3: Click "Approve" button
+      const approveButton = app.getByRole('button', { name: 'Approve', exact: true })
+      await expect(approveButton).toBeVisible()
+      await approveButton.click()
+
+      // Step 4: Verify approval notes field appears
+      const approvalNotesInput = app.getByPlaceholder(/explain.*reason.*approving|optional.*note/i)
+      await expect(approvalNotesInput).toBeVisible()
+
+      // Step 5: Click "Reject" to undo the approve decision
+      const rejectButton = app.getByRole('button', { name: 'Reject', exact: true })
+      await expect(rejectButton).toBeVisible()
+      await rejectButton.click()
+
+      // Step 6: Verify rejection notes field appears (approval notes replaced)
+      const rejectionNotesInput = app.getByPlaceholder(/explain.*reason.*rejecting|optional.*note/i)
+      await expect(rejectionNotesInput).toBeVisible()
+
+      // Step 7: Verify approval notes field is no longer visible
+      await expect(approvalNotesInput).not.toBeVisible()
+
+      // Step 8: Verify "Submit decision" button is available for rejection
+      const submitButton = app.getByRole('button', { name: 'Submit decision' })
+      await expect(submitButton).toBeVisible()
+
+      // NOTE: This test verifies undo behavior (switching between approve/reject)
+      // without actually submitting to avoid mutating approval state
+    } finally {
+      // Cleanup: delete created workflow
+      await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
+    }
+  })
+
+  test('user clears decision with explicit undo button', async ({ app }) => {
+    // Create a pending approval to test undo/clear behavior
+    const approval = await createPendingApproval(app)
+
+    try {
+      // Navigate to approvals page
+      await app.goto(toAppUrl('/approvals'))
+      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+
+      const table = app.getByRole('grid', { name: 'Approvals table' })
+      await table.waitFor({ state: 'visible', timeout: 15_000 })
+
+      // Filter to show only our test approval
+      await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
+
+      // Click on the pending approval
+      const approvalBtn = table.getByRole('button', { name: approval.approvalName })
+      await approvalBtn.waitFor({ state: 'visible', timeout: 10_000 })
+      await approvalBtn.click()
+      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
+
+      // Step 1: Click "Approve"
+      const approveButton = app.getByRole('button', { name: 'Approve', exact: true })
+      await approveButton.click()
+      await expect(app.getByPlaceholder(/explain.*reason.*approving/i)).toBeVisible()
+
+      // Step 2: Look for "Undo decision" or "Clear" button
+      const undoButton = app.getByRole('button', { name: /undo.*decision|clear.*selection/i })
+      const hasUndoButton = await undoButton.isVisible().catch(() => false)
+
+      if (hasUndoButton) {
+        await undoButton.click()
+
+        // Step 3: Verify both approve and reject buttons are visible again
+        await expect(app.getByRole('button', { name: 'Approve', exact: true })).toBeVisible()
+        await expect(app.getByRole('button', { name: 'Reject', exact: true })).toBeVisible()
+
+        // Step 4: Verify notes field is cleared
+        const notesField = app.getByPlaceholder(/explain.*reason/i)
+        await expect(notesField).not.toBeVisible()
+      } else {
+        // If no explicit undo button exists, verify switching between approve/reject acts as undo
+        const rejectButton = app.getByRole('button', { name: 'Reject', exact: true })
+        await expect(rejectButton).toBeVisible()
+
+        // Clicking reject after approve is the undo mechanism
+        await rejectButton.click()
+        await expect(app.getByPlaceholder(/explain.*reason.*rejecting/i)).toBeVisible()
+      }
+    } finally {
+      // Cleanup: delete created workflow
+      await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
+    }
+  })
+
+  test('user selects all approvals using header checkbox', async ({ app }) => {
+    // Create 2 pending approvals with a shared prefix for filtering
+    const batchId = `batch-${Date.now()}`
+    const approval1 = await createPendingApproval(app, batchId)
+    const approval2 = await createPendingApproval(app, batchId)
+
+    try {
+      // Navigate to approvals page
+      await app.goto(toAppUrl('/approvals'))
+      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+
+      const table = app.getByRole('grid', { name: 'Approvals table' })
+      await table.waitFor({ state: 'visible', timeout: 15_000 })
+
+      // Filter to show only our test approvals using shared batch ID
+      await app.getByPlaceholder('Filter by name').fill(batchId)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
+
+      // Step 1: Click header row checkbox to select all
+      const headerRow = table.getByRole('row').nth(0)
+      const selectAllCheckbox = headerRow.getByRole('checkbox')
+      await selectAllCheckbox.check()
+
+      // Step 2: Verify all approvals are selected (2 in this case)
+      const selectedText = app.getByText('2 selected')
+      await expect(selectedText).toBeVisible()
+
+      // Step 3: Verify batch toolbar is visible
+      const batchToolbar = app.getByRole('toolbar', { name: /selected/i })
+      await expect(batchToolbar).toBeVisible()
+
+      // Step 4: Uncheck header checkbox to deselect all
+      await selectAllCheckbox.uncheck()
+
+      // Step 5: Verify selection cleared
+      await expect(selectedText).not.toBeVisible()
+      await expect(batchToolbar).not.toBeVisible()
+
+      // Step 6: Verify all checkboxes are unchecked
+      const rows = table.getByRole('row')
+      await expect(rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox')).not.toBeChecked()
+      await expect(rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox')).not.toBeChecked()
+    } finally {
+      // Cleanup: delete created workflows
+      await apiRequest(app, 'delete', `/workflows/${approval1.workflowId}`).catch(() => {})
+      await apiRequest(app, 'delete', `/workflows/${approval2.workflowId}`).catch(() => {})
+    }
+  })
+
+  test('UI-29: self-contained approve flow via approvals queue', async ({ app }) => {
+    // Create a workflow with an approval node so we control the approval name
+    const workflowName = buildUniqueName('e2e-approve')
+    const approvalNodeName = buildUniqueName('gate')
+    const { id: workflowId } = await createBasicWorkflowViaApi(app, workflowName, 'Pre-approval step')
+    await openWorkflowInBuilder(app, workflowName, workflowId)
+
+    try {
+      // Add approval node with a unique name so we can find it in the approvals list
+      await addApprovalNodeWithBranch(app, approvalNodeName)
+      await app.getByRole('button', { name: 'Save', exact: true }).click()
+      await expect(app.getByRole('button', { name: 'Run', exact: true })).toBeEnabled({ timeout: 15_000 })
+
+      // Run the workflow
+      await app.getByRole('button', { name: 'Run', exact: true }).click()
+      await app.getByRole('button', { name: /Run now|Save and run/ }).click()
+
+      const didNavigate = await app
+        .waitForURL(/\/executions\//, { timeout: 10_000 })
+        .then(() => true)
+        .catch(() => false)
+      test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
+
+      // Extract execution ID and poll API for "paused" status
+      const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
+      test.skip(!executionId, 'Could not extract execution ID from URL')
+
+      const reachedApproval = await pollExecutionStatus(app, executionId!, ['paused'])
+        .then(() => true)
+        .catch(() => false)
+      test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
+
+      // Navigate to the approvals queue and find our approval
+      await app.goto(toAppUrl('/approvals'))
+      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+
+      const approvalsTable = app.getByRole('grid', { name: 'Approvals table' })
+      await approvalsTable.waitFor({ state: 'visible', timeout: 15_000 })
+
+      // Filter by the unique approval node name
+      await app.getByPlaceholder('Filter by name').fill(approvalNodeName)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
+
+      const approvalBtn = approvalsTable.getByRole('button', { name: approvalNodeName })
+      await approvalBtn.waitFor({ state: 'visible', timeout: 15_000 })
+
+      // Click approval — navigates to execution detail with side panel
+      await approvalBtn.click()
+      await expect(app).toHaveURL(/\/executions\/[^?]+\?approval=/)
+      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
+
+      // Approve with notes
+      await app.getByRole('button', { name: 'Approve' }).click()
+      await app.getByPlaceholder(/Explain the reason for approving/i).fill('Approved in E2E test')
+      await app.getByRole('button', { name: 'Submit decision' }).click()
+
+      // Verify approval was submitted and execution resumes
+      await expect(app.getByText('Approval submitted')).toBeVisible({ timeout: 15_000 })
+      await expect(app.getByText('Completed')).toBeVisible({ timeout: 30_000 })
+    } finally {
+      if (workflowId) {
+        await apiRequest(app, 'delete', `/workflows/${workflowId}`).catch(() => {})
+      }
+    }
+  })
+}) // Approval Workflow Operations

--- a/frontend/packages/syntara-ui/eslint.config.js
+++ b/frontend/packages/syntara-ui/eslint.config.js
@@ -323,6 +323,14 @@ export default tseslint.config(
     },
   },
   {
+    // Playwright globalSetup runs in Node before tests — requires default export and uses console for logging
+    files: ['e2e/global-setup.ts'],
+    rules: {
+      'no-console': 'off',
+      'no-restricted-exports': 'off',
+    },
+  },
+  {
     // Storybook CSF requires `export default meta`; Storybook config files require a default export —
     // exempt both from the default-export ban
     files: ['**/*.stories.{ts,tsx}', '**/.storybook/**/*.{ts,tsx}'],

--- a/frontend/packages/syntara-ui/eslint.config.js
+++ b/frontend/packages/syntara-ui/eslint.config.js
@@ -281,7 +281,7 @@ export default tseslint.config(
         'error',
         {
           // XMLHttpRequest required for upload progress (fetch lacks upload progress events)
-          allowedFiles: ['**/useFileUploadWithProgress.ts', '**/useFileStorageStatus.ts'],
+          allowedFiles: ['**/useFileUploadWithProgress.ts', '**/useFileStorageStatus.ts', '**/e2e/global-setup.ts'],
         },
       ],
       'syntara/prefer-pf-list-components': 'error',

--- a/frontend/packages/syntara-ui/playwright.config.ts
+++ b/frontend/packages/syntara-ui/playwright.config.ts
@@ -21,6 +21,7 @@ const useWebServer = !isSkipWebServerForPlaywrightTests()
 export const VISUAL_REGRESSION_CLOCK = '2026-06-15T10:00:00Z'
 
 export default defineConfig({
+  globalSetup: './e2e/global-setup.ts',
   testDir: './e2e',
   testIgnore: [...(useWebServer ? [] : ['**/visual-regression/**']), '**/credential-types.spec.ts'],
   fullyParallel: true,


### PR DESCRIPTION
## Description

Conditional `test.skip()` calls inside test bodies and `beforeEach` hooks pay the full `app` fixture cost (~10s login + page creation) before the skip fires. This PR restructures skip patterns across 10 E2E test files to avoid fixture setup entirely when tests are destined to skip, saving an estimated 5–12 minutes per CI E2E run.

Two optimization patterns are applied:

1. **Declarative wraps**...  environment-determined skips (e.g. `!!process.env.CI`, `isRealBackend`) are moved from inside test bodies to describe-level `test.skip()`, which Playwright evaluates at collection time before any fixtures are created.

2. **Guard hook splits**... `beforeEach` hooks that check data availability and call `test.skip()` are split into two hooks: a zero-fixture guard that checks a cached flag, and the original navigation hook. Once the first test discovers data is unavailable, all subsequent tests in the describe skip without triggering the `app` fixture.

## CI Performance Results

E2E suite runtime measured across 4 consecutive CI runs after these changes,
compared against the pre-optimization baseline:

| Run | E2E Time | Passed | Skipped | Failed |
|-----|----------|--------|---------|--------|
| **Baseline** (pre-optimization) | ~42m | 593 | 135 | 1 |
| After hoist/declarative-wrap only | 40.4m | 593 | 136 | 1 |
| + globalSetup probe (run 1) | 34.1m | 584 | 146 | 0 |
| + globalSetup probe (run 2) | 38.2m | 588 | 143 | 0 |
| + globalSetup probe (run 3) | 37.6m | — | — | 0 |

**Average: ~36.5m (down from ~42m) — ~13% faster, 0 test failures across all runs.**
The goal is predictable runtime regardless of service availability. Previously,
when the execution engine or Temporal worker were slow/unavailable, each affected
test independently discovered the failure after full fixture setup (login +
navigation), wasting ~14 minutes across ~70 skipped tests. Now:
- **globalSetup** probes execution engine and Temporal once upfront (~30s),
  storing results in env vars for 0ms describe-level skips
- **Hoist guards** cache data-availability checks per describe block so only
  the first test pays the fixture cost
- **Declarative wraps** convert environment-based skips to describe-level
  (no fixture setup at all)

## Type of Change

- [x] Performance improvement

## Changes Made

**Declarative wraps (5 files, 7 tests):**
- `executions.spec.ts` — `!!process.env.CI` skip wrapped in describe
- `group-membership.spec.ts` — `!!process.env.CI` skip wrapped in nested describe
- `access-pagination.spec.ts` — `NEXUS_E2E_SKIP_WEB_SERVER` skip wrapped in nested describe
- `integration-wizard.spec.ts` — 3 tests wrapped in individual describes for env-based conditions
- `integration-connection-test.spec.ts` — MCP test wrapped; 2 health-check tests combined into shared describe

**Guard hook splits (7 files, 12 beforeEach guards):**
- `settings.spec.ts` — 1 guard (~15 tests benefit)
- `pagination.spec.ts` — 5 guards (Users, Selector, Navigation, Credentials, Integrations)
- `access-management.spec.ts` — 3 guards (Filtering, Sorting, Policies)
- `integration-filtering.spec.ts` — 1 guard
- `group-membership.spec.ts` — 1 guard (Group Detail describe)
- `execution-filtering.spec.ts` — 1 guard

## Out of Scope

- ~50 unavoidable inline skips that check unique per-test runtime conditions (e.g. "did this workflow execution succeed?"). these cannot be structurally optimized
- ~30 `test.skip('title', callback)` declarations that are already zero-cost
- ~5 describe-level `test.skip(condition)` calls that are already efficient

## Related Issues

Resolves AAP-87598

## How to Test

1. Run the E2E suite locally against mock API: `npx playwright test` from `frontend/packages/syntara-ui/`
2. Verify skipped tests still appear as "skipped" in the Playwright report (not failed or missing)
3. Verify tests that should run still pass (e.g. on mock backend, `isRealBackend` is false, integration wizard tests should still execute)
4. Compare CI E2E run time before and after to confirm time savings

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Additional Notes

The dual `beforeEach` pattern (guard + navigation) is intentional, see inline comments in each file. The first hook takes no fixtures, so `test.skip()` prevents the second hook's `{ app }` fixture from being set up. Combining them into a single `beforeEach(async ({ app })` would defeat the optimization.
