### PR TITLE
feat(e2e): add dynamic xfail from URL for Playwright tests

### DIFF
--- a/frontend/packages/syntara-ui/e2e/fixtures.ts
+++ b/frontend/packages/syntara-ui/e2e/fixtures.ts
@@ -4,6 +4,7 @@ import { expect, test as base, type Page, type Request } from '@playwright/test'
 import { APP_TITLE } from './helpers/appTitle'
 import { isSkipWebServerForPlaywrightTests } from './playwrightWebServerEnv'
 import { type RoleSetupResult, setupRoleUsers } from './utils/roleSetup'
+import { type XfailEntry, loadXfailEntries, matchesXfail } from './xfailFromUrl'
 
 const processEnv: Record<string, string | undefined> = (
   process as unknown as { env: Record<string, string | undefined> }
@@ -68,7 +69,38 @@ const currentsBase = base.extend<CurrentsFixtures, CurrentsWorkerFixtures>({
   ...fixtures.actionFixtures,
 })
 
-export const test = currentsBase.extend<
+// Dynamic xfail from a remote Markdown file (same pattern as backend xfail_from_url.py).
+// Set NEXUS_E2E_XFAIL_URL to enable; the URL is fetched once per worker and matching
+// tests are marked as expected failures via test.fail().
+const xfailBase = currentsBase.extend<{ _xfailCheck: void }, { _xfailEntries: XfailEntry[] }>({
+  _xfailEntries: [
+    async (_deps, use) => {
+      const source = processEnv['SYNTARA_PLAYWRIGHT_XFAIL_SOURCE']
+      if (!source) {
+        await use([])
+        return
+      }
+      const entries = await loadXfailEntries(source)
+      if (entries.length > 0) {
+        process.stderr.write(`xfail: loaded ${entries.length} pattern(s) from ${source}\n`)
+      }
+      await use(entries)
+    },
+    { scope: 'worker' },
+  ],
+  _xfailCheck: [
+    async ({ _xfailEntries }, use, testInfo) => {
+      const match = matchesXfail(testInfo, _xfailEntries)
+      if (match) {
+        test.fail(true, `xfail: ${match.reason}`)
+      }
+      await use()
+    },
+    { auto: true },
+  ],
+})
+
+export const test = xfailBase.extend<
   { app: Page; auditorApp: Page; viewerApp: Page; userApp: Page; projectAdminApp: Page },
   { roleSetup: RoleSetupResult | null }
 >({

--- a/frontend/packages/syntara-ui/e2e/xfailFromUrl.ts
+++ b/frontend/packages/syntara-ui/e2e/xfailFromUrl.ts
@@ -1,0 +1,94 @@
+import { readFile } from 'node:fs/promises'
+
+import type { TestInfo } from '@playwright/test'
+
+export type XfailEntry = {
+  pattern: string
+  reason: string
+}
+
+const HEADING_RE = /^#\s+(.+)$/
+
+export function parseXfailEntries(content: string): XfailEntry[] {
+  const entries: XfailEntry[] = []
+  let currentPattern: string | null = null
+  const reasonLines: string[] = []
+
+  function flush(): void {
+    if (currentPattern !== null) {
+      const reason = reasonLines.join(' ').trim() || 'listed in xfail list'
+      entries.push({ pattern: currentPattern, reason })
+    }
+  }
+
+  for (const line of content.split('\n')) {
+    const match = HEADING_RE.exec(line.trim())
+    if (match) {
+      flush()
+      currentPattern = match[1].trim()
+      reasonLines.length = 0
+    } else if (currentPattern !== null) {
+      const stripped = line.trim()
+      if (stripped) {
+        reasonLines.push(stripped)
+      }
+    }
+  }
+  flush()
+  return entries
+}
+
+function isFilePath(source: string): boolean {
+  return source.startsWith('/') || source.startsWith('./') || source.startsWith('../')
+}
+
+export async function loadXfailEntries(source: string): Promise<XfailEntry[]> {
+  try {
+    let content: string
+    if (isFilePath(source)) {
+      content = await readFile(source, 'utf-8')
+    } else {
+      const nodeFetch = globalThis.fetch
+      const response = await nodeFetch(source, { signal: AbortSignal.timeout(30_000) })
+      if (!response.ok) {
+        process.stderr.write(`xfail: failed to fetch ${source}: ${response.status} ${response.statusText}\n`)
+        return []
+      }
+      content = await response.text()
+    }
+    return parseXfailEntries(content)
+  } catch (error) {
+    process.stderr.write(`xfail: failed to load ${source}: ${String(error)}\n`)
+    return []
+  }
+}
+
+function buildTestId(testInfo: TestInfo): string {
+  const testDir = testInfo.project.testDir
+  let relPath = testInfo.file
+  if (testDir && relPath.startsWith(testDir)) {
+    relPath = relPath.slice(testDir.length).replace(/^[/\\]/, '')
+  }
+  const titles = testInfo.titlePath.filter(Boolean)
+  return [relPath, ...titles].join(' > ')
+}
+
+export function matchesXfail(
+  testInfo: TestInfo,
+  entries: XfailEntry[]
+): XfailEntry | null {
+  if (entries.length === 0) return null
+  const testId = buildTestId(testInfo)
+  for (const entry of entries) {
+    if (entry.pattern.includes(' > ')) {
+      if (testId === entry.pattern || testId.endsWith(entry.pattern)) {
+        return entry
+      }
+    } else {
+      if (testId.startsWith(entry.pattern)) {
+        return entry
+      }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
Add xfailFromUrl.ts module that fetches a Markdown file listing
known-failing tests (H1 headings as test identifiers) and integrates
it into the Playwright fixture chain as an auto fixture. Matching
tests are marked as expected failures via test.fail().

Enabled by setting SYNTARA_PLAYRIGHT_XFAIL_URL; disabled by default.
Mirrors the backend xfail_from_url.py pattern.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
