### PR TITLE
refactor: migrate Temporal schedule prefix to syntara-sched

### DIFF
--- a/backend/docs/workflow-engine/triggers/scheduled-trigger.md
+++ b/backend/docs/workflow-engine/triggers/scheduled-trigger.md
@@ -11,7 +11,7 @@ Scheduled triggers follow a publish-driven lifecycle. Temporal Schedules are cre
 ```mermaid
 flowchart TD
     PUB["Workflow published"] --> SYNC["ScheduledTriggerService.sync_scheduled_triggers()"]
-    SYNC --> TS["Create/update Temporal Schedule<br/>ID: nexus-sched-{workflow_id}-{trigger_node_id}"]
+    SYNC --> TS["Create/update Temporal Schedule<br/>ID: syntara-sched-{workflow_id}-{trigger_node_id}"]
     TS --> FIRE["Schedule fires<br/>(cron or interval)"]
     FIRE --> LAUNCH["ScheduledWorkflowLauncher workflow starts"]
     LAUNCH --> ACT["ScheduledExecutionLauncher activity"]
@@ -36,7 +36,7 @@ flowchart TD
 
 ### Deterministic schedule IDs — no database model
 
-Schedule IDs follow the format `nexus-sched-{workflow_id}-{trigger_node_id}`. This deterministic convention eliminates the need for a database lookup table — the schedule can always be located by its ID. Cleanup uses a prefix scan on `nexus-sched-{workflow_id}-` to find all schedules for a workflow.
+Schedule IDs follow the format `syntara-sched-{workflow_id}-{trigger_node_id}`. This deterministic convention eliminates the need for a database lookup table — the schedule can always be located by its ID. Cleanup uses a prefix scan on `syntara-sched-{workflow_id}-` to find all schedules for a workflow.
 
 ### Post-commit schedule creation
 

--- a/backend/src/syntara/workflows/services/scheduled_trigger_service.py
+++ b/backend/src/syntara/workflows/services/scheduled_trigger_service.py
@@ -2,7 +2,7 @@
 
 Scheduled triggers are managed entirely through Temporal Schedules. No database
 model is needed because the schedule ID is deterministic:
-``nexus-sched-{workflow_id}-{trigger_node_id}``.
+``syntara-sched-{workflow_id}-{trigger_node_id}``.
 
 This service synchronises Temporal Schedules when workflows are created,
 updated, published, unpublished, or deleted.
@@ -34,6 +34,7 @@ from syntara.core.config.base import get_settings
 from syntara.core.tls.temporal import build_temporal_tls_config
 from syntara.workflows.exceptions import ScheduledTriggerSyncError, TriggerValidationError
 from syntara.workflows.utils.schedule_parser import (
+    _LEGACY_SCHEDULE_ID_PREFIX,
     SCHEDULE_ID_PREFIX,
     build_schedule_id,
     config_to_temporal_schedule,
@@ -487,13 +488,16 @@ class ScheduledTriggerService:
     async def list_schedules_by_prefix(client: Client, prefix: str = "") -> set[str]:
         """List nexus-managed Temporal Schedule IDs, optionally narrowed by *prefix*.
 
-        Matches IDs starting with ``nexus-sched-{prefix}-`` when *prefix*
-        is given, or ``nexus-sched-`` when omitted.
+        Matches IDs starting with ``syntara-sched-{prefix}-`` when *prefix*
+        is given, or ``syntara-sched-`` when omitted.  Also matches the
+        legacy ``nexus-sched-`` prefix so that old schedules are found
+        during the transition period.
         """
-        full_prefix = f"{SCHEDULE_ID_PREFIX}{prefix}-" if prefix else SCHEDULE_ID_PREFIX
+        current = f"{SCHEDULE_ID_PREFIX}{prefix}-" if prefix else SCHEDULE_ID_PREFIX
+        legacy = f"{_LEGACY_SCHEDULE_ID_PREFIX}{prefix}-" if prefix else _LEGACY_SCHEDULE_ID_PREFIX
         schedule_ids: set[str] = set()
         async for entry in await client.list_schedules():
-            if entry.id.startswith(full_prefix):
+            if entry.id.startswith(current) or entry.id.startswith(legacy):
                 schedule_ids.add(entry.id)
         return schedule_ids
 

--- a/backend/src/syntara/workflows/utils/schedule_parser.py
+++ b/backend/src/syntara/workflows/utils/schedule_parser.py
@@ -304,13 +304,14 @@ def build_schedule_policy(missed_policy: MissedSchedulePolicy) -> SchedulePolicy
     return SchedulePolicy(catchup_window=catchup, overlap=overlap)
 
 
-SCHEDULE_ID_PREFIX = "nexus-sched-"
+SCHEDULE_ID_PREFIX = "syntara-sched-"
+_LEGACY_SCHEDULE_ID_PREFIX = "nexus-sched-"
 
 
 def build_schedule_id(workflow_id: str, trigger_node_id: str) -> str:
     """Build a deterministic Temporal Schedule ID.
 
-    Convention: ``nexus-sched-{workflow_id}-{trigger_node_id}``
+    Convention: ``syntara-sched-{workflow_id}-{trigger_node_id}``
 
     Args:
         workflow_id: The workflow UUID (as string).

--- a/backend/src/syntara/workflows/workers/schedule_reconciliation.py
+++ b/backend/src/syntara/workflows/workers/schedule_reconciliation.py
@@ -4,7 +4,7 @@ Runs a diff-based reconciliation cycle that:
 
 1. Queries the database for all published workflow versions with scheduled
    triggers to build the *expected* set of Temporal Schedule IDs.
-2. Lists all ``nexus-sched-*`` Temporal Schedules to build the *actual* set.
+2. Lists all ``syntara-sched-*`` Temporal Schedules to build the *actual* set.
 3. Creates missing schedules (from failed publishes) and deletes orphans
    (from unpublish/delete that couldn't reach Temporal).
 

--- a/backend/tests/e2e/workflows/test_scheduled_trigger.py
+++ b/backend/tests/e2e/workflows/test_scheduled_trigger.py
@@ -9,7 +9,7 @@ we confirm:
 - A workflow with an interval-based scheduled trigger publishes without error.
 
 The underlying ``ScheduledTriggerService`` creates a Temporal Schedule on
-publish (format ``nexus-sched-{workflow_id}-{trigger_node_id}``) and deletes
+publish (format ``syntara-sched-{workflow_id}-{trigger_node_id}``) and deletes
 it on unpublish/delete.  The ``workflow_factory`` fixture handles cleanup.
 
 Run with:

--- a/backend/tests/unit/workflows/services/test_scheduled_trigger_service.py
+++ b/backend/tests/unit/workflows/services/test_scheduled_trigger_service.py
@@ -156,7 +156,7 @@ class TestSyncScheduledTriggers:
         client.create_schedule.assert_called_once()
         # Verify the schedule ID convention
         call_args = client.create_schedule.call_args
-        assert call_args[0][0] == "nexus-sched-wf-123-trigger_1"
+        assert call_args[0][0] == "syntara-sched-wf-123-trigger_1"
 
     async def test_schedule_action_targets_launcher_workflow(self) -> None:
         """The schedule action must target 'scheduled_workflow_launcher'.
@@ -324,8 +324,8 @@ class TestSyncScheduledTriggers:
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_1"),
-                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_old"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_old"),
                 ]
             )
         )
@@ -343,7 +343,7 @@ class TestSyncScheduledTriggers:
         )
 
         # Should request handle for the stale schedule and delete it
-        client.get_schedule_handle.assert_any_call("nexus-sched-wf-123-trigger_old")
+        client.get_schedule_handle.assert_any_call("syntara-sched-wf-123-trigger_old")
         handle.delete.assert_called_once()
 
     async def test_sync_skips_trigger_with_missing_id(self) -> None:
@@ -407,8 +407,8 @@ class TestSyncScheduledTriggers:
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_1"),
-                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_old"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_old"),
                 ]
             )
         )
@@ -436,8 +436,8 @@ class TestDeleteTriggersForWorkflow:
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_1"),
-                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_2"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_2"),
                 ]
             )
         )
@@ -459,7 +459,7 @@ class TestDeleteTriggersForWorkflow:
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_1"),
                 ]
             )
         )
@@ -478,7 +478,7 @@ class TestDeleteTriggersForWorkflow:
         """RPCError that is not NOT_FOUND or a connection error should propagate."""
         client = _make_mock_client()
         client.list_schedules = AsyncMock(
-            return_value=_async_iter_from([_make_schedule_list_entry("nexus-sched-wf-123-trigger_1")])
+            return_value=_async_iter_from([_make_schedule_list_entry("syntara-sched-wf-123-trigger_1")])
         )
         handle = client.get_schedule_handle.return_value
         handle.delete = AsyncMock(side_effect=RPCError("internal", RPCStatusCode.INTERNAL, b""))
@@ -529,7 +529,7 @@ class TestGracefulTemporalUnavailability:
         """Connection RPCError during deletion should invalidate cache and wrap as ScheduledTriggerSyncError."""
         client = _make_mock_client()
         client.list_schedules = AsyncMock(
-            return_value=_async_iter_from([_make_schedule_list_entry("nexus-sched-wf-123-trigger_1")])
+            return_value=_async_iter_from([_make_schedule_list_entry("syntara-sched-wf-123-trigger_1")])
         )
         handle = client.get_schedule_handle.return_value
         handle.delete = AsyncMock(side_effect=RPCError("conn error", status, b""))
@@ -784,7 +784,7 @@ class TestListWorkflowSchedulesOptimized:
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_1"),
                 ]
             )
         )
@@ -792,7 +792,7 @@ class TestListWorkflowSchedulesOptimized:
         service = ScheduledTriggerService(temporal_client=client)
         result = await service._list_workflow_schedules(client, "wf-123")
 
-        assert result == {"nexus-sched-wf-123-trigger_1"}
+        assert result == {"syntara-sched-wf-123-trigger_1"}
         client.list_schedules.assert_called_once_with(query='NexusWorkflowId = "wf-123"')
 
     async def test_falls_back_to_prefix_scan(self) -> None:
@@ -803,8 +803,8 @@ class TestListWorkflowSchedulesOptimized:
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_1"),
-                    _make_schedule_list_entry("nexus-sched-other-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-other-trigger_1"),
                 ]
             )
         )
@@ -812,7 +812,7 @@ class TestListWorkflowSchedulesOptimized:
         service = ScheduledTriggerService(temporal_client=client)
         result = await service._list_workflow_schedules(client, "wf-123")
 
-        assert result == {"nexus-sched-wf-123-trigger_1"}
+        assert result == {"syntara-sched-wf-123-trigger_1"}
         client.list_schedules.assert_called_once_with()
 
     async def test_query_error_falls_back_to_prefix(self) -> None:
@@ -831,8 +831,8 @@ class TestListWorkflowSchedulesOptimized:
                 raise query_error
             return _async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_1"),
-                    _make_schedule_list_entry("nexus-sched-other-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-other-trigger_1"),
                 ]
             )
 
@@ -841,7 +841,7 @@ class TestListWorkflowSchedulesOptimized:
         service = ScheduledTriggerService(temporal_client=client)
         result = await service._list_workflow_schedules(client, "wf-123")
 
-        assert result == {"nexus-sched-wf-123-trigger_1"}
+        assert result == {"syntara-sched-wf-123-trigger_1"}
         assert client.list_schedules.call_count == 2
 
     async def test_connection_error_in_query_reraises(self) -> None:
@@ -875,12 +875,12 @@ class TestListWorkflowSchedulesOptimized:
     async def test_invalid_workflow_id_falls_back_to_prefix_scan(self, bad_id: str) -> None:
         """Invalid workflow_id should skip search attr and fall back to prefix scan."""
         client = _make_mock_client(search_attr_available=True)
-        expected_id = f"nexus-sched-{bad_id}-trigger_1"
+        expected_id = f"syntara-sched-{bad_id}-trigger_1"
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
                     _make_schedule_list_entry(expected_id),
-                    _make_schedule_list_entry("nexus-sched-other-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-other-trigger_1"),
                 ]
             )
         )
@@ -1005,7 +1005,7 @@ class TestCreateSchedule:
             config={"schedule_type": "cron", "cron": "0 9 * * *"},
         )
 
-        assert schedule_id == "nexus-sched-wf-123-trigger_1"
+        assert schedule_id == "syntara-sched-wf-123-trigger_1"
         client.create_schedule.assert_called_once()
 
     async def test_temporal_unavailable_raises_runtime_error(self) -> None:
@@ -1044,8 +1044,8 @@ class TestListAllSchedules:
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-1-t1"),
-                    _make_schedule_list_entry("nexus-sched-wf-2-t1"),
+                    _make_schedule_list_entry("syntara-sched-wf-1-t1"),
+                    _make_schedule_list_entry("syntara-sched-wf-2-t1"),
                 ]
             )
         )
@@ -1053,7 +1053,7 @@ class TestListAllSchedules:
         service = ScheduledTriggerService(temporal_client=client)
         result = await service.list_all_schedules(client)
 
-        assert result == {"nexus-sched-wf-1-t1", "nexus-sched-wf-2-t1"}
+        assert result == {"syntara-sched-wf-1-t1", "syntara-sched-wf-2-t1"}
         client.list_schedules.assert_called_once_with(query='NexusWorkflowId != ""')
 
     async def test_falls_back_to_prefix_scan_when_search_attr_unavailable(self) -> None:
@@ -1064,7 +1064,7 @@ class TestListAllSchedules:
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-1-t1"),
+                    _make_schedule_list_entry("syntara-sched-wf-1-t1"),
                     _make_schedule_list_entry("unrelated-schedule"),
                 ]
             )
@@ -1073,7 +1073,7 @@ class TestListAllSchedules:
         service = ScheduledTriggerService(temporal_client=client)
         result = await service.list_all_schedules(client)
 
-        assert result == {"nexus-sched-wf-1-t1"}
+        assert result == {"syntara-sched-wf-1-t1"}
         client.list_schedules.assert_called_once_with()
 
     async def test_query_error_falls_back_to_prefix_scan(self) -> None:
@@ -1090,7 +1090,7 @@ class TestListAllSchedules:
                 raise RPCError(msg, RPCStatusCode.INVALID_ARGUMENT, b"")
             return _async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-1-t1"),
+                    _make_schedule_list_entry("syntara-sched-wf-1-t1"),
                     _make_schedule_list_entry("other-system-schedule"),
                 ]
             )
@@ -1100,7 +1100,7 @@ class TestListAllSchedules:
         service = ScheduledTriggerService(temporal_client=client)
         result = await service.list_all_schedules(client)
 
-        assert result == {"nexus-sched-wf-1-t1"}
+        assert result == {"syntara-sched-wf-1-t1"}
         assert client.list_schedules.call_count == 2
 
 
@@ -1113,8 +1113,8 @@ class TestListSchedulesByPrefix:
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-1-t1"),
-                    _make_schedule_list_entry("nexus-sched-wf-2-t2"),
+                    _make_schedule_list_entry("syntara-sched-wf-1-t1"),
+                    _make_schedule_list_entry("syntara-sched-wf-2-t2"),
                     _make_schedule_list_entry("other-system-schedule"),
                 ]
             )
@@ -1122,7 +1122,7 @@ class TestListSchedulesByPrefix:
 
         result = await ScheduledTriggerService.list_schedules_by_prefix(client)
 
-        assert result == {"nexus-sched-wf-1-t1", "nexus-sched-wf-2-t2"}
+        assert result == {"syntara-sched-wf-1-t1", "syntara-sched-wf-2-t2"}
 
     async def test_with_prefix_narrows_to_workflow(self) -> None:
         """Non-empty prefix should match only schedules for that workflow."""
@@ -1130,12 +1130,27 @@ class TestListSchedulesByPrefix:
         client.list_schedules = AsyncMock(
             return_value=_async_iter_from(
                 [
-                    _make_schedule_list_entry("nexus-sched-wf-123-t1"),
-                    _make_schedule_list_entry("nexus-sched-wf-456-t1"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-t1"),
+                    _make_schedule_list_entry("syntara-sched-wf-456-t1"),
                 ]
             )
         )
 
         result = await ScheduledTriggerService.list_schedules_by_prefix(client, "wf-123")
 
-        assert result == {"nexus-sched-wf-123-t1"}
+        assert result == {"syntara-sched-wf-123-t1"}
+
+    async def test_legacy_nexus_prefix_still_matched(self) -> None:
+        """Legacy nexus-sched- schedules are found during transition."""
+        client = _make_mock_client()
+        client.list_schedules = AsyncMock(
+            return_value=_async_iter_from(
+                [
+                    _make_schedule_list_entry("nexus-sched-wf-123-trigger_1"),
+                    _make_schedule_list_entry("syntara-sched-wf-123-trigger_2"),
+                    _make_schedule_list_entry("other-schedule"),
+                ]
+            )
+        )
+        result = await ScheduledTriggerService.list_schedules_by_prefix(client, "wf-123")
+        assert result == {"nexus-sched-wf-123-trigger_1", "syntara-sched-wf-123-trigger_2"}

--- a/backend/tests/unit/workflows/utils/test_schedule_parser.py
+++ b/backend/tests/unit/workflows/utils/test_schedule_parser.py
@@ -230,7 +230,7 @@ class TestBuildScheduleId:
     async def test_basic_id(self) -> None:
         """Schedule ID should follow convention."""
         schedule_id = build_schedule_id("abc-123", "trigger_1")
-        assert schedule_id == "nexus-sched-abc-123-trigger_1"
+        assert schedule_id == "syntara-sched-abc-123-trigger_1"
 
     async def test_id_is_deterministic(self) -> None:
         """Same inputs should always produce the same ID."""

--- a/backend/tests/unit/workflows/workers/test_schedule_reconciliation.py
+++ b/backend/tests/unit/workflows/workers/test_schedule_reconciliation.py
@@ -69,8 +69,8 @@ class TestExtractExpectedSchedules:
         lookup = _extract_expected_schedules([(wf_id, triggers)])
 
         assert len(lookup) == 2
-        assert f"nexus-sched-{wf_id}-t1" in lookup
-        assert f"nexus-sched-{wf_id}-t2" in lookup
+        assert f"syntara-sched-{wf_id}-t1" in lookup
+        assert f"syntara-sched-{wf_id}-t2" in lookup
 
     def test_ignores_non_scheduled_triggers(self) -> None:
         wf_id = str(uuid4())
@@ -95,7 +95,7 @@ class TestReconcileScheduledTriggers:
         triggers = _make_triggers(scheduled_triggers=[{"id": "t1"}])
         session_factory = _make_session_factory([(wf_id, triggers)])
 
-        expected_schedule_id = f"nexus-sched-{wf_id}-t1"
+        expected_schedule_id = f"syntara-sched-{wf_id}-t1"
 
         with patch(_PATCH_SVC) as mock_svc_cls:
             mock_svc = mock_svc_cls.return_value
@@ -131,7 +131,7 @@ class TestReconcileScheduledTriggers:
     async def test_deletes_orphan_schedules(self) -> None:
         """Orphan schedules (actual - expected) should be deleted."""
         session_factory = _make_session_factory([])
-        orphan_id = "nexus-sched-dead-workflow-trigger_1"
+        orphan_id = "syntara-sched-dead-workflow-trigger_1"
 
         with patch(_PATCH_SVC) as mock_svc_cls:
             mock_client = MagicMock()
@@ -151,9 +151,9 @@ class TestReconcileScheduledTriggers:
         triggers = _make_triggers(scheduled_triggers=[{"id": "t1"}])
         session_factory = _make_session_factory([(wf_id, triggers)])
 
-        expected_id = f"nexus-sched-{wf_id}-t1"
-        stale_id = f"nexus-sched-{wf_id}-old_trigger"
-        orphan_id = "nexus-sched-dead-wf-orphan"
+        expected_id = f"syntara-sched-{wf_id}-t1"
+        stale_id = f"syntara-sched-{wf_id}-old_trigger"
+        orphan_id = "syntara-sched-dead-wf-orphan"
 
         with patch(_PATCH_SVC) as mock_svc_cls:
             mock_client = MagicMock()
@@ -194,7 +194,7 @@ class TestReconcileScheduledTriggers:
     async def test_no_published_workflows_checks_orphans_only(self) -> None:
         """With no published workflows, should still clean up orphans."""
         session_factory = _make_session_factory([])
-        orphan_id = "nexus-sched-old-wf-old-trigger"
+        orphan_id = "syntara-sched-old-wf-old-trigger"
 
         with patch(_PATCH_SVC) as mock_svc_cls:
             mock_client = MagicMock()
@@ -239,8 +239,8 @@ class TestReconcileScheduledTriggers:
     async def test_delete_error_does_not_block_others(self) -> None:
         """A failure deleting one schedule should not prevent others from being deleted."""
         session_factory = _make_session_factory([])
-        orphan_a = "nexus-sched-dead-wf-a"
-        orphan_b = "nexus-sched-dead-wf-b"
+        orphan_a = "syntara-sched-dead-wf-a"
+        orphan_b = "syntara-sched-dead-wf-b"
 
         call_count = 0
 

--- a/backend/tests/unit/workflows/workflow_engine/test_scheduled_launcher.py
+++ b/backend/tests/unit/workflows/workflow_engine/test_scheduled_launcher.py
@@ -100,7 +100,7 @@ class TestExecutionMetadata:
         metadata = execution.execution_metadata
         assert metadata is not None
         assert metadata["trigger_type"] == ActivityName.SCHEDULED_TRIGGER
-        assert metadata["schedule_id"] == f"nexus-sched-{workflow_id}-trigger_1"
+        assert metadata["schedule_id"] == f"syntara-sched-{workflow_id}-trigger_1"
         assert metadata["scheduled_at"] == scheduled_at.isoformat()
         assert metadata["triggered_at"] == triggered_at.isoformat()
 


### PR DESCRIPTION
## Summary

- Renames the Temporal schedule ID prefix from `nexus-sched-` to `syntara-sched-`
- Adds a `_LEGACY_SCHEDULE_ID_PREFIX` constant so `list_schedules_by_prefix()` matches both old and new prefixes during the transition
- Existing `nexus-sched-*` schedules are cleaned up naturally when each workflow is next published (sync deletes old-prefix, creates new-prefix)
- Includes a test verifying legacy prefix matching

### How the transition works

1. `build_schedule_id()` creates new IDs with `syntara-sched-`
2. `list_schedules_by_prefix()` scans **both** prefixes — old schedules are visible to sync and reconciliation
3. When a workflow is re-published, `sync_scheduled_triggers()` finds the old-prefix schedule as "stale" and deletes it, then creates the new-prefix replacement
4. The reconciliation worker sees both prefixes, so orphaned `nexus-sched-*` schedules are cleaned up

The `_LEGACY_SCHEDULE_ID_PREFIX` constant can be removed after all environments have completed at least one full reconciliation cycle.

## Test plan

- [ ] Unit tests pass (`test_scheduled_trigger_service.py`, `test_schedule_parser.py`, `test_schedule_reconciliation.py`)
- [ ] New test `test_legacy_nexus_prefix_still_matched` verifies dual-prefix scanning
- [ ] Integration: publish a workflow with a scheduled trigger, verify new schedule uses `syntara-sched-` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)