### PR TITLE
chore: remove old health endpoint

### DIFF
--- a/.claude/skills/frontend-run-e2e/SKILL.md
+++ b/.claude/skills/frontend-run-e2e/SKILL.md
@@ -43,7 +43,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 | UI project path | `$REPO_ROOT/frontend/packages/syntara-ui` | `ls $REPO_ROOT/frontend/packages/syntara-ui/playwright.config.ts` |
 | Admin password path | `$REPO_ROOT/backend/.secrets/admin-password` | `test -f $REPO_ROOT/backend/.secrets/admin-password` |
 | CA cert path | `$REPO_ROOT/backend/.secrets/certs/ca.pem` | `test -f $REPO_ROOT/backend/.secrets/certs/ca.pem` |
-| Backend URL | `https://localhost:8000` | `curl -sf --cacert $REPO_ROOT/backend/.secrets/certs/ca.pem https://localhost:8000/health` |
+| Backend URL | `https://localhost:8000` | `curl -sf --cacert $REPO_ROOT/backend/.secrets/certs/ca.pem https://localhost:8000/healthz/ready` |
 | Frontend URL | `http://localhost:5173` | `curl -sf http://localhost:5173 -o /dev/null` |
 
 Use the results to inform the wizard — if a check fails, mention it in the question so the user knows something needs attention.
@@ -100,7 +100,7 @@ Before running, verify the environment is ready. For real backend mode, the skil
 test -f $REPO_ROOT/backend/.secrets/admin-password && echo "OK: password file found" || echo "FAIL: password file not found — run: make -C backend secrets"
 
 # 2. Backend is responding
-curl -sf --cacert $REPO_ROOT/backend/.secrets/certs/ca.pem https://localhost:8000/health -o /dev/null && echo "OK: backend responding" || echo "FAIL: backend not responding — run: make run-all"
+curl -sf --cacert $REPO_ROOT/backend/.secrets/certs/ca.pem https://localhost:8000/healthz/ready -o /dev/null && echo "OK: backend responding" || echo "FAIL: backend not responding — run: make run-all"
 
 # 3. Frontend is responding — start it if not
 curl -sf http://localhost:5173 -o /dev/null && echo "OK: frontend responding"

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Verify Syntara API is reachable
         run: |
-          curl -sf http://localhost:8000/health
+          curl -sf http://localhost:8000/healthz/ready
 
       - name: Create results directory
         run: mkdir -p backend/dast/results

--- a/backend/docs/file-storage.md
+++ b/backend/docs/file-storage.md
@@ -197,8 +197,8 @@ The storage status endpoint (`GET /api/v1/files/storage_status`) reports a `stat
 
 Object storage is deliberately **absent** from the readiness probe (`GET /healthz/ready`). It is not a
 hard dependency — an unconfigured or degraded S3 backend only disables file uploads while the rest of
-the API serves normally — so it must never take a replica out of rotation. The deprecated `GET /health`
-still reports it as `checks.file_storage` until that endpoint is removed.
+the API serves normally — so it must never take a replica out of rotation. Its status is reported by
+`GET /api/v1/files/storage_status` instead.
 
 ### Startup Validation
 

--- a/backend/docs/standards/access-control.md
+++ b/backend/docs/standards/access-control.md
@@ -43,7 +43,7 @@ async def list_credentials(
 ### How it works
 
 1. Creates a lightweight FastAPI app with router discovery (no DB or Docker needed)
-2. Iterates all `APIRoute` instances, skipping infrastructure paths (`/health`, `/metrics`, etc.)
+2. Iterates all `APIRoute` instances, skipping infrastructure paths (`/healthz/*`, `/metrics`, etc.)
 3. Inspects each route's dependency tree for RBAC types
 4. Routes without RBAC must be in one of two exclusion lists:
    - `AUTHENTICATED_EXCLUSIONS` — requires JWT, no RBAC (e.g. reference data catalogs, AAP proxy)

--- a/backend/docs/standards/observability.md
+++ b/backend/docs/standards/observability.md
@@ -358,7 +358,7 @@ app.add_middleware(MetricsMiddleware, recorder=metrics_recorder)
 
 **Excluded paths:**
 - `/metrics` (avoid self-instrumentation loops)
-- `/health`, `/healthz/live`, `/healthz/ready` (high-volume, low-signal)
+- `/healthz/live`, `/healthz/ready` (high-volume, low-signal)
 
 ### Interface Tagging (API vs UI)
 
@@ -561,7 +561,7 @@ When adding a new component:
 
 **Enforced by tooling:**
 
-- `MetricsMiddleware` automatically instruments all HTTP endpoints (except `/metrics`, `/health`, `/healthz/*`)
+- `MetricsMiddleware` automatically instruments all HTTP endpoints (except `/metrics`, `/healthz/*`)
 - `TelemetryMiddleware` automatically captures API call telemetry
 - `AuditEventDispatcher` enforces fire-and-forget (never raises, logs failures)
 - `discover_handlers()` auto-discovers and registers handlers at startup

--- a/backend/src/syntara/api/constants.py
+++ b/backend/src/syntara/api/constants.py
@@ -26,7 +26,6 @@ OIDC_CALLBACK_PATH = f"{API_V1_PATH_PREFIX}/auth/oidc/callback"
 # data.
 EXCLUDED_PATHS: frozenset[str] = frozenset(
     {
-        "/health",
         "/healthz/live",
         "/healthz/ready",
         "/api",

--- a/backend/src/syntara/api/main.py
+++ b/backend/src/syntara/api/main.py
@@ -14,7 +14,7 @@ from typing import Annotated, Any
 
 import structlog
 import uvicorn
-from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
@@ -67,7 +67,7 @@ from syntara.core.models.user import User
 from syntara.core.router_discovery import _get_lock_file_path, discover_and_register_routers, iter_api_routes
 from syntara.core.websocket.manager import get_connection_lifecycle_manager
 from syntara.core.websocket.router import build_websocket_router
-from syntara.files.health import check_file_storage_health, validate_file_storage_at_startup
+from syntara.files.health import validate_file_storage_at_startup
 from syntara.files.workers.file_cleanup import get_multipart_cleanup_worker
 from syntara.metrics.cleanup import get_metrics_cleanup_worker
 from syntara.metrics.completion_poller import get_completion_poller
@@ -479,9 +479,9 @@ async def _check_database() -> str:
     limit how long the probe *holds* a slot rather than only how long it
     waits for one.
 
-    The outcome is cached for ``DB_PROBE_CACHE_TTL_SECONDS``.  Three probes
-    (startup, readiness, and the deprecated ``/health``) can fire within the
-    same second, and without a cache each one opens its own connection —
+    The outcome is cached for ``DB_PROBE_CACHE_TTL_SECONDS``.  Startup and
+    readiness probes can fire within the same second, and without a cache
+    each one opens its own connection —
     precisely when the pool is most contended.  Failures are cached too, so
     an outage does not turn every probe into another query against a
     database that is already struggling.  The TTL is short enough that
@@ -524,55 +524,6 @@ async def _check_database() -> str:
         error_detail=error_detail,
     )
     return _db_probe_cache.resolve()
-
-
-@app.get("/health", tags=["Health"], include_in_schema=False, deprecated=True)
-async def health_check(request: Request) -> dict[str, Any]:  # noqa: ARG001
-    """Health check endpoint with database connectivity test.
-
-    Deprecated: use ``/healthz/live`` for liveness and ``/healthz/ready``
-    for readiness.  This endpoint is retained until every consumer (the
-    operator's probes in particular) has migrated, and is removed in a
-    follow-up change.
-
-    Returns:
-        dict: Health status with database status
-
-    Responses:
-        200: Service is healthy and database is connected
-        503: Database unreachable or too slow. The body is an RFC 9457
-            problem document, not the 200 payload shape.
-
-    Example:
-        ```bash
-        curl http://localhost:8000/health
-        ```
-
-        Response:
-        ```json
-        {
-            "status": "healthy",
-            "timestamp": "2025-10-09T12:00:00Z",
-            "checks": {
-                "database": "ok",
-                "file_storage": "ok"
-            }
-        }
-        ```
-
-    """
-    timestamp = datetime.now(UTC).isoformat()
-    db_status = await _check_database()
-    file_storage_status = await check_file_storage_health()
-
-    return {
-        "status": "healthy",
-        "timestamp": timestamp,
-        "checks": {
-            "database": db_status,
-            "file_storage": file_storage_status,
-        },
-    }
 
 
 @app.get("/healthz/live", tags=["Health"], include_in_schema=False)

--- a/backend/src/syntara/audit/middleware.py
+++ b/backend/src/syntara/audit/middleware.py
@@ -129,7 +129,7 @@ class AuditMiddleware:
             A normalized, sanitized, and length-capped path string.
 
         """
-        # Decode percent-encoded characters so that e.g. /%68ealth → /health
+        # Decode percent-encoded characters so that e.g. /%68ealthz/live → /healthz/live
         decoded = unquote(path)
         # Normalize path traversals and redundant separators
         normalized = normpath(decoded)

--- a/backend/test-sdk/src/orchestrator_test_sdk/app/live.py
+++ b/backend/test-sdk/src/orchestrator_test_sdk/app/live.py
@@ -183,7 +183,7 @@ def syntara_client(syntara_base_url: str) -> AuthenticatedClient:
     last_exc: Exception | None = None
     for attempt in range(_MAX_RETRIES + 1):
         try:
-            response = httpx.get(f"{syntara_base_url}/health", timeout=5, verify=ssl_ctx)
+            response = httpx.get(f"{syntara_base_url}/healthz/ready", timeout=5, verify=ssl_ctx)
             print(f"[syntara_client] health check attempt {attempt + 1}: {response.status_code}", flush=True)  # noqa: T201
             response.raise_for_status()
             last_exc = None

--- a/backend/test-sdk/src/orchestrator_test_sdk/e2e/fixtures.py
+++ b/backend/test-sdk/src/orchestrator_test_sdk/e2e/fixtures.py
@@ -89,7 +89,7 @@ def syntara_client(syntara_base_url: str) -> AuthenticatedClient:
     base_url = syntara_base_url
 
     try:
-        response = httpx.get(f"{base_url}/health", timeout=5, verify=e2e_ssl_context())
+        response = httpx.get(f"{base_url}/healthz/ready", timeout=5, verify=e2e_ssl_context())
         response.raise_for_status()
     except (httpx.RequestError, httpx.HTTPStatusError) as exc:
         pytest.exit(

--- a/backend/tests/e2e/workflows/test_workflow_nodes.py
+++ b/backend/tests/e2e/workflows/test_workflow_nodes.py
@@ -101,7 +101,7 @@ def test_http_request_node(syntara_api: SyntaraApiRegistry):
 
     Note: targets an external URL because SSRF mitigation (AAP-79016) blocks
     private IPs until the allowlist for worker_base_url is propagated by the
-    Operator. Revert to worker_base_url/health once the allowlist is confirmed
+    Operator. Revert to worker_base_url/healthz/live once the allowlist is confirmed
     working in CI.
     """
     result = create_and_run_workflow(
@@ -598,7 +598,7 @@ def test_http_request_then_agentic(
 
     Note: targets an external URL because SSRF mitigation (AAP-79016) blocks
     private IPs until the allowlist for worker_base_url is propagated by the
-    Operator. Revert to worker_base_url/health once the allowlist is confirmed
+    Operator. Revert to worker_base_url/healthz/live once the allowlist is confirmed
     working in CI.
     """
     result = create_and_run_workflow(

--- a/backend/tests/integration/api/test_health_endpoint.py
+++ b/backend/tests/integration/api/test_health_endpoint.py
@@ -1,11 +1,11 @@
-"""Integration tests for the /health and /healthz/{live,ready} endpoints."""
+"""Integration tests for the /healthz/{live,ready} endpoints."""
 
 from __future__ import annotations
 
 import asyncio
 import time
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -26,49 +26,6 @@ def _clear_db_probe_cache() -> Iterator[None]:
     """
     with patch("syntara.api.main._db_probe_cache", None):
         yield
-
-
-class TestHealthEndpointFileStorage:
-    """Verify that /health includes file_storage in its response."""
-
-    @pytest.mark.asyncio
-    async def test_includes_file_storage_field_when_unconfigured(
-        self,
-        base_client: AsyncClient,
-    ) -> None:
-        """Regression guard: /health must return checks.file_storage.
-
-        The frontend's useFileStorageStatus hook gates the upload UI on this
-        field — if absent it fails open and shows upload as available even
-        when S3 is not configured.
-        """
-        mock_fm = MagicMock()
-        type(mock_fm).s3_configured = PropertyMock(return_value=False)
-
-        with patch("syntara.files.health.get_file_manager", return_value=mock_fm):
-            resp = await base_client.get("/health")
-
-        assert resp.status_code == 200
-        body = resp.json()
-        assert "file_storage" in body["checks"], "/health response is missing 'file_storage' in checks"
-        assert body["checks"]["file_storage"] == "unconfigured"
-
-    @pytest.mark.asyncio
-    async def test_includes_file_storage_field_when_configured(
-        self,
-        base_client: AsyncClient,
-    ) -> None:
-        mock_fm = MagicMock()
-        type(mock_fm).s3_configured = PropertyMock(return_value=True)
-        mock_retriever = MagicMock()
-        mock_retriever.health_check = AsyncMock(return_value=True)
-        mock_fm.get_retriever.return_value = mock_retriever
-
-        with patch("syntara.files.health.get_file_manager", return_value=mock_fm):
-            resp = await base_client.get("/health")
-
-        assert resp.status_code == 200
-        assert resp.json()["checks"]["file_storage"] == "ok"
 
 
 class TestLivenessEndpoint:
@@ -258,7 +215,7 @@ class TestReadinessProbeCache:
 
     @pytest.mark.asyncio
     async def test_repeat_probes_within_ttl_query_the_database_once(self, base_client: AsyncClient) -> None:
-        """Startup, readiness and /health can fire in the same second.
+        """Startup and readiness probes can fire in the same second.
 
         Without the memo each opens its own connection, exactly when the
         pool is most contended.
@@ -268,10 +225,9 @@ class TestReadinessProbeCache:
         with patch("syntara.api.main.AsyncSessionLocal", self._counting_session_factory(opened)):
             first = await base_client.get("/healthz/ready")
             second = await base_client.get("/healthz/ready")
-            third = await base_client.get("/health")
 
-        assert first.status_code == second.status_code == third.status_code == 200
-        assert len(opened) == 1, f"expected one database query across three probes, got {len(opened)}"
+        assert first.status_code == second.status_code == 200
+        assert len(opened) == 1, f"expected one database query across two probes, got {len(opened)}"
 
     @pytest.mark.asyncio
     async def test_probes_query_again_once_the_ttl_expires(self, base_client: AsyncClient) -> None:

--- a/backend/tests/integration/files/helpers.py
+++ b/backend/tests/integration/files/helpers.py
@@ -11,13 +11,9 @@ import time
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-import httpx
-
 from tests.integration.helpers.perf import generate_pdf_content, generate_text_content
 
 if TYPE_CHECKING:
-    import ssl
-
     from syntara_api_client.api import SyntaraApiRegistry
 
     from syntara.files.models import FileMetadata
@@ -64,23 +60,6 @@ def make_file_metadata(content: bytes, suffix: str = ".txt") -> FileMetadata:
         size_bytes=len(content),
         status=FileStatus.PENDING_CONVERSION,
     )
-
-
-def check_health(
-    base_url: str,
-    *,
-    verify_ssl: bool | ssl.SSLContext = False,
-    timeout: float = 10.0,
-) -> tuple[float, bool]:
-    """Send GET /health and return (elapsed_ms, is_healthy)."""
-    start = time.monotonic()
-    try:
-        response = httpx.get(f"{base_url}/health", timeout=timeout, verify=verify_ssl)
-        elapsed_ms = (time.monotonic() - start) * 1000
-        return elapsed_ms, response.status_code == 200
-    except Exception:
-        elapsed_ms = (time.monotonic() - start) * 1000
-        return elapsed_ms, False
 
 
 def _make_file_payload(descriptor: dict[str, Any], index: int) -> tuple[str, io.BytesIO, str]:

--- a/backend/tests/integration/telemetry/test_api_analytics.py
+++ b/backend/tests/integration/telemetry/test_api_analytics.py
@@ -55,9 +55,13 @@ def _create_test_app() -> FastAPI:
     async def get_workflow(workflow_id: str) -> dict[str, str]:
         return {"id": workflow_id}
 
-    @app.get("/health")
-    async def health() -> dict[str, str]:
-        return {"status": "healthy"}
+    @app.get("/healthz/live")
+    async def liveness() -> dict[str, str]:
+        return {"status": "alive"}
+
+    @app.get("/healthz/ready")
+    async def readiness() -> dict[str, str]:
+        return {"status": "ready"}
 
     @app.get("/api")
     async def api_discovery() -> dict[str, str]:
@@ -163,14 +167,15 @@ class TestEndToEndMiddleware:
 class TestExcludedPathsIntegration:
     """Test that excluded paths produce no events end-to-end."""
 
-    async def test_health_check_no_event(self, test_app: FastAPI, mock_registry: MagicMock) -> None:
+    @pytest.mark.parametrize("path", ["/healthz/live", "/healthz/ready"])
+    async def test_health_check_no_event(self, path: str, test_app: FastAPI, mock_registry: MagicMock) -> None:
         transport = ASGITransport(app=test_app)
         with (
             patch(_SETTINGS_PATH, return_value=_make_settings_mock(enabled=True)),
             patch(_REGISTRY_PATH, return_value=mock_registry),
         ):
             async with AsyncClient(transport=transport, base_url="http://test") as client:
-                response = await client.get("/health")
+                response = await client.get(path)
 
         assert response.status_code == 200
         mock_registry.send_event.assert_not_called()

--- a/backend/tests/unit/api/compliance/test_auth_compliance.py
+++ b/backend/tests/unit/api/compliance/test_auth_compliance.py
@@ -69,7 +69,7 @@ def _has_authn(route: object) -> bool:
 # ---------------------------------------------------------------------------
 
 _INFRA_PATH_PREFIXES = (
-    "/health",
+    "/healthz/",
     "/metrics",
     "/_internal/",
     "/api_docs/",

--- a/backend/tests/unit/api/test_docs_endpoints.py
+++ b/backend/tests/unit/api/test_docs_endpoints.py
@@ -380,7 +380,7 @@ class TestProductionAppWiring:
 
     @pytest.mark.parametrize(
         "path",
-        ["/health", "/healthz/live", "/healthz/ready"],
+        ["/healthz/live", "/healthz/ready"],
     )
     def test_infra_endpoints_excluded_from_schema(self, path: str) -> None:
         """Infrastructure probe endpoints must never appear in the public OpenAPI spec."""

--- a/backend/tests/unit/audit/test_middleware.py
+++ b/backend/tests/unit/audit/test_middleware.py
@@ -340,7 +340,8 @@ class TestAuditMiddlewareExclusions:
         assert mock_emit.call_count == 0
 
     @pytest.mark.asyncio
-    async def test_excluded_paths_still_pass_to_app(self) -> None:
+    @pytest.mark.parametrize("path", sorted(EXCLUDED_PATHS))
+    async def test_excluded_paths_still_pass_to_app(self, path: str) -> None:
         """Excluded paths are still forwarded to the underlying app."""
         call_count = 0
 
@@ -349,7 +350,7 @@ class TestAuditMiddlewareExclusions:
             call_count += 1
 
         middleware = AuditMiddleware(counting_app, _make_fastapi_app())
-        await middleware(_make_scope(path="/health"), AsyncMock(), AsyncMock())
+        await middleware(_make_scope(path=path), AsyncMock(), AsyncMock())
 
         assert call_count == 1
 
@@ -1236,9 +1237,11 @@ class TestAuditMiddlewareSanitization:
     @pytest.mark.parametrize(
         "encoded_path",
         [
-            "/%68ealth",  # /health
-            "/%68%65alth",  # /health (multiple encoded chars)
-            "/hea%6Cth",  # /health
+            "/%68ealthz/live",  # /healthz/live
+            "/%68%65althz/live",  # /healthz/live (multiple encoded chars)
+            "/hea%6Cthz/live",  # /healthz/live
+            "/%68ealthz/ready",  # /healthz/ready
+            "/healthz/%72eady",  # /healthz/ready
         ],
     )
     async def test_percent_encoded_excluded_path_still_excluded(self, encoded_path: str) -> None:

--- a/backend/tests/unit/auth/test_cert_middleware.py
+++ b/backend/tests/unit/auth/test_cert_middleware.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 import pytest
 
+from syntara.api.constants import EXCLUDED_PATHS
 from syntara.auth.cert_middleware import (
     CertificateValidationError,
     ClientCertAuthMiddleware,
@@ -247,11 +248,12 @@ class TestClientCertAuthMiddleware:
 
     @pytest.mark.usefixtures("_tls_enabled")
     @pytest.mark.asyncio
-    async def test_health_route_bypassed(self) -> None:
-        """Health routes skip cert processing entirely."""
+    @pytest.mark.parametrize("path", sorted(EXCLUDED_PATHS))
+    async def test_excluded_route_bypassed(self, path: str) -> None:
+        """Excluded routes, including both healthz probes, skip cert processing entirely."""
         app = AsyncMock()
         middleware = ClientCertAuthMiddleware(app)
-        scope = _make_scope(path="/health")
+        scope = _make_scope(path=path)
 
         await middleware(scope, AsyncMock(), AsyncMock())
 

--- a/backend/tests/unit/metrics/test_middleware.py
+++ b/backend/tests/unit/metrics/test_middleware.py
@@ -503,7 +503,8 @@ class TestMetricsMiddlewareExclusions:
         assert len(results) == 0
 
     @pytest.mark.asyncio
-    async def test_excluded_path_strips_auth_failure_header(self, recorder: MetricsRecorder) -> None:
+    @pytest.mark.parametrize("path", sorted(EXCLUDED_PATHS))
+    async def test_excluded_path_strips_auth_failure_header(self, path: str, recorder: MetricsRecorder) -> None:
         """X-Auth-Failure-Type header is stripped even on excluded paths."""
         captured_headers: list[tuple[bytes, bytes]] = []
 
@@ -525,14 +526,15 @@ class TestMetricsMiddlewareExclusions:
                 captured_headers.extend(message.get("headers", []))
 
         middleware = MetricsMiddleware(auth_failure_app, recorder=recorder)  # type: ignore[arg-type]
-        await middleware(_make_scope(path="/health"), AsyncMock(), capturing_send)
+        await middleware(_make_scope(path=path), AsyncMock(), capturing_send)
 
         header_names = [name for name, _ in captured_headers]
         assert b"x-auth-failure-type" not in header_names
         assert b"content-type" in header_names
 
     @pytest.mark.asyncio
-    async def test_excluded_paths_still_pass_to_app(self, recorder: MetricsRecorder) -> None:
+    @pytest.mark.parametrize("path", sorted(EXCLUDED_PATHS))
+    async def test_excluded_paths_still_pass_to_app(self, path: str, recorder: MetricsRecorder) -> None:
         """Excluded paths are still forwarded to the underlying app."""
         call_count = 0
 
@@ -541,7 +543,7 @@ class TestMetricsMiddlewareExclusions:
             call_count += 1
 
         middleware = MetricsMiddleware(counting_app, recorder=recorder)  # type: ignore[arg-type]
-        await middleware(_make_scope(path="/health"), AsyncMock(), AsyncMock())
+        await middleware(_make_scope(path=path), AsyncMock(), AsyncMock())
 
         assert call_count == 1
 

--- a/backend/tests/unit/rate_limiting/test_middleware.py
+++ b/backend/tests/unit/rate_limiting/test_middleware.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import pytest
 from redis.exceptions import ConnectionError as RedisConnectionError
 
+from syntara.api.constants import EXCLUDED_PATHS
 from syntara.audit.emitter import AuditActorContext, actor_context_var
 from syntara.rate_limiting.middleware import RateLimitMiddleware
 from syntara.rate_limiting.token_bucket import TokenBucketResult
@@ -106,8 +107,9 @@ class TestRateLimitMiddleware:
         send.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_pass_through_excluded_path(self, middleware: RateLimitMiddleware) -> None:
-        scope = _make_scope(path="/health")
+    @pytest.mark.parametrize("path", sorted(EXCLUDED_PATHS))
+    async def test_pass_through_excluded_path(self, path: str, middleware: RateLimitMiddleware) -> None:
+        scope = _make_scope(path=path)
         send = AsyncMock()
 
         await middleware(scope, AsyncMock(), send)

--- a/backend/tools/authz-seed-demo-data.sh
+++ b/backend/tools/authz-seed-demo-data.sh
@@ -42,7 +42,7 @@ if ! command -v jq &>/dev/null; then
     exit 1
 fi
 
-if ! curl -sf "${APP_CLI_URL:-http://localhost:8000}/health" > /dev/null 2>&1; then
+if ! curl -sf "${APP_CLI_URL:-http://localhost:8000}/healthz/ready" > /dev/null 2>&1; then
     echo "ERROR: Backend not reachable at ${APP_CLI_URL:-http://localhost:8000}"
     echo "Start it with: make run"
     exit 1

--- a/backend/tools/ci/known_orphan_modules.json
+++ b/backend/tools/ci/known_orphan_modules.json
@@ -30,7 +30,7 @@
     "syntara/integrations/lib/credential_resolver.py": "Statically imported by integration_service.py and invocation_executor.py; pyan3 does not trace through session-factory closures into background tasks",
     "syntara/core/tls/protocol.py": "Loaded by uvicorn via --http string import at runtime, not via Python import",
     "syntara/core/tls/certs.py": "Imported by scripts/generate_local_certs.py and tests/helpers/tls.py — both outside src/",
-    "syntara/files/health.py": "File storage health check — registered at app startup via health router",
+    "syntara/files/health.py": "File storage health check — imported by files/router.py for GET /files/storage_status and by api/main.py for startup validation; pyan3 does not trace either edge",
     "syntara/files/workers/file_cleanup.py": "Background worker — invoked via scheduled task, not direct import",
     "syntara/authz/_rego_runtime.py": "Isolated regopy runtime — imported by evaluator.py; kept separate to avoid C extension memory leak"
   }

--- a/backend/tools/scripts/e2e-run.sh
+++ b/backend/tools/scripts/e2e-run.sh
@@ -96,7 +96,7 @@ echo "✅ Infrastructure ready"
 
 echo "⏳ Waiting for API server to be ready..."
 TRIES=0
-until curl -sf --cacert .secrets/certs/ca.pem https://localhost:8000/health 2>/dev/null | grep -q '"status":"healthy"'; do
+until curl -sf --cacert .secrets/certs/ca.pem https://localhost:8000/healthz/ready 2>/dev/null | grep -q '"status":"ready"'; do
     sleep 1
     TRIES=$((TRIES + 1))
     if [[ $TRIES -ge 60 ]]; then

--- a/frontend/packages/syntara-ui/vite.config.ts
+++ b/frontend/packages/syntara-ui/vite.config.ts
@@ -32,11 +32,6 @@ export default defineConfig(({ mode }) => {
       changeOrigin: true,
       secure: false,
     },
-    '/health': {
-      target: backendTarget,
-      changeOrigin: true,
-      secure: false,
-    },
     '/ws': {
       target: env.VITE_WS_URL || backendTarget,
       changeOrigin: true,

--- a/frontend/tools/workflow-creator/create_workflow.py
+++ b/frontend/tools/workflow-creator/create_workflow.py
@@ -58,7 +58,7 @@ def load_json(source: str) -> dict:
 def check_api_health(api_url: str) -> bool:
     """Check if the API is healthy."""
     try:
-        req = urllib.request.Request(f"{api_url}/health", method="GET")
+        req = urllib.request.Request(f"{api_url}/healthz/ready", method="GET")
         with urllib.request.urlopen(req, timeout=5) as response:
             return response.status == 200
     except (urllib.error.URLError, urllib.error.HTTPError) as e:


### PR DESCRIPTION
Remove the old health endpoint, follows up 649c0d020041529730aae9edb35cb56a19b51b08 — feat(health): add /healthz/live and /healthz/ready probe endpoints (#967)
requires E2E test updates already applied. 
Jira: https://redhat.atlassian.net/browse/AAP-84838 