### PR TITLE
fix(renovate): enable tekton manager for ao-ui-tests and ao-api-tests bundle SHA updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,8 +62,15 @@
       "automerge": true
     },
     {
-      "description": "Disable all renovate updates on the early-access branch",
+      "description": "Keep ao-ui-tests and ao-api-tests bundle SHAs up to date in Tekton files",
+      "matchManagers": ["tekton"],
+      "matchFileNames": [".tekton/**"],
+      "automerge": true
+    },
+    {
+      "description": "Disable all renovate updates on the early-access branch except Tekton bundle digest updates",
       "matchBaseBranches": ["early-access"],
+      "matchManagers": ["!tekton"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
## Summary

- Add an explicit `tekton` manager rule scoped to `.tekton/**` so Renovate reliably detects and updates `ao-ui-tests` and `ao-api-tests` bundle digest SHAs, instead of relying on auto-detection of the dot-prefixed directory
- Narrow the `early-access` branch disable rule from a blanket disable to `matchManagers: ["!tekton"]`, so bundle SHAs in early-access Tekton files are also kept in sync

## Test plan

- [ ] Verify Renovate opens a PR against `devel` when a new `ao-ui-tests` or `ao-api-tests` bundle digest is published
- [ ] Verify Renovate opens a PR against `early-access` for the same bundle digest updates
- [ ] Verify that Python and npm dependency updates remain disabled on `early-access`

🤖 Generated with [Claude Code](https://claude.com/claude-code)