### PR TITLE
fix(tekton): bump quay.io/aap-ci bundle SHAs across all pipelines

### DIFF
--- a/.tekton/ansible-automation-orchestrator-backend-devel-pull-request.yaml
+++ b/.tekton/ansible-automation-orchestrator-backend-devel-pull-request.yaml
@@ -57,7 +57,7 @@ spec:
       - name: name
         value: container
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:c7436f23e24b0e383eb60ea4d1601d69c1c596035f8ab0402226ada75ac112a4
+        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:401c54b0f4afcdb48e423de491a96a5d2155f4a781f8d7922097542b4ee7d6a7
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/ansible-automation-orchestrator-backend-devel-push.yaml
+++ b/.tekton/ansible-automation-orchestrator-backend-devel-push.yaml
@@ -54,7 +54,7 @@ spec:
       - name: name
         value: container
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:c7436f23e24b0e383eb60ea4d1601d69c1c596035f8ab0402226ada75ac112a4
+        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:401c54b0f4afcdb48e423de491a96a5d2155f4a781f8d7922097542b4ee7d6a7
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/ansible-automation-orchestrator-backend-early-access-pull-request.yaml
+++ b/.tekton/ansible-automation-orchestrator-backend-early-access-pull-request.yaml
@@ -57,7 +57,7 @@ spec:
       - name: name
         value: container
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:c7436f23e24b0e383eb60ea4d1601d69c1c596035f8ab0402226ada75ac112a4
+        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:401c54b0f4afcdb48e423de491a96a5d2155f4a781f8d7922097542b4ee7d6a7
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/ansible-automation-orchestrator-backend-early-access-push.yaml
+++ b/.tekton/ansible-automation-orchestrator-backend-early-access-push.yaml
@@ -54,7 +54,7 @@ spec:
       - name: name
         value: container
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:c7436f23e24b0e383eb60ea4d1601d69c1c596035f8ab0402226ada75ac112a4
+        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:401c54b0f4afcdb48e423de491a96a5d2155f4a781f8d7922097542b4ee7d6a7
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/ansible-automation-orchestrator-ui-devel-pull-request.yaml
+++ b/.tekton/ansible-automation-orchestrator-ui-devel-pull-request.yaml
@@ -55,7 +55,7 @@ spec:
       - name: name
         value: container
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:c7436f23e24b0e383eb60ea4d1601d69c1c596035f8ab0402226ada75ac112a4
+        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:401c54b0f4afcdb48e423de491a96a5d2155f4a781f8d7922097542b4ee7d6a7
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/ansible-automation-orchestrator-ui-devel-push.yaml
+++ b/.tekton/ansible-automation-orchestrator-ui-devel-push.yaml
@@ -52,7 +52,7 @@ spec:
       - name: name
         value: container
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:c7436f23e24b0e383eb60ea4d1601d69c1c596035f8ab0402226ada75ac112a4
+        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:401c54b0f4afcdb48e423de491a96a5d2155f4a781f8d7922097542b4ee7d6a7
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/ansible-automation-orchestrator-ui-early-access-pull-request.yaml
+++ b/.tekton/ansible-automation-orchestrator-ui-early-access-pull-request.yaml
@@ -54,7 +54,7 @@ spec:
       - name: name
         value: container
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:c7436f23e24b0e383eb60ea4d1601d69c1c596035f8ab0402226ada75ac112a4
+        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:401c54b0f4afcdb48e423de491a96a5d2155f4a781f8d7922097542b4ee7d6a7
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/ansible-automation-orchestrator-ui-early-access-push.yaml
+++ b/.tekton/ansible-automation-orchestrator-ui-early-access-push.yaml
@@ -51,7 +51,7 @@ spec:
       - name: name
         value: container
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:c7436f23e24b0e383eb60ea4d1601d69c1c596035f8ab0402226ada75ac112a4
+        value: quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2@sha256:401c54b0f4afcdb48e423de491a96a5d2155f4a781f8d7922097542b4ee7d6a7
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:7d6d243c00d41f28e864637927c655d5a9749ce7c03f7ad1a826e3a512e96b99
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:684a2f7577051e03f5a575a16ec31738ea66b54cef453bda56046e21a82fdef3
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-api-tests-early-access-pull-request.yaml
+++ b/.tekton/automation-orchestrator-api-tests-early-access-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:7d6d243c00d41f28e864637927c655d5a9749ce7c03f7ad1a826e3a512e96b99
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:684a2f7577051e03f5a575a16ec31738ea66b54cef453bda56046e21a82fdef3
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:84b17fd102a04132817641b9fca960aeed681007c0b5d8da488a08e004f599ae
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:554162895215bc46aed2de97701340a3202b300962e5b7157914f80504f905c4
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-ui-tests-early-access-pull-request.yaml
+++ b/.tekton/automation-orchestrator-ui-tests-early-access-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:84b17fd102a04132817641b9fca960aeed681007c0b5d8da488a08e004f599ae
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:554162895215bc46aed2de97701340a3202b300962e5b7157914f80504f905c4
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
## Summary

Update digests for three images across all 12 \`.tekton\` pipeline files:

- \`quay.io/aap-ci/tekton-catalog/pipeline/build/container:0.2\`: \`c7436f23\` → \`401c54b0\`
- \`quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1\`: \`7d6d243c\` → \`684a2f75\`
- \`quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1\`: \`84b17fd1\` → \`55416289\`

Images from \`registry.redhat.io\` and \`quay.io/redhat-user-workloads\` are not updated here (require separate registry credentials).

## Test plan

- [ ] Verify Konflux picks up the new bundle SHAs on the next PR targeting \`devel\`
- [ ] Verify the same on a PR targeting \`early-access\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)