### PR TITLE
fix(AAP-87629): use auth-only check for stateless workflow validate

### DIFF
--- a/backend/src/api_client/syntara_api_client/api/workflows/validate_workflow_definition.py
+++ b/backend/src/api_client/syntara_api_client/api/workflows/validate_workflow_definition.py
@@ -107,6 +107,10 @@ def sync_detailed(
 
      Validate a workflow definition without saving it.
 
+    Requires authentication but no specific workflow/project permission:
+    validation is a stateless, side-effect-free check of caller-supplied
+    data with no workflow_id or project_id in scope to authorize against.
+
     Args:
         body (WorkflowValidateRequest): Request body for the workflow validation endpoint.
 
@@ -142,6 +146,10 @@ def sync(
 
      Validate a workflow definition without saving it.
 
+    Requires authentication but no specific workflow/project permission:
+    validation is a stateless, side-effect-free check of caller-supplied
+    data with no workflow_id or project_id in scope to authorize against.
+
     Args:
         body (WorkflowValidateRequest): Request body for the workflow validation endpoint.
 
@@ -171,6 +179,10 @@ async def asyncio_detailed(
     """Validate workflow definition
 
      Validate a workflow definition without saving it.
+
+    Requires authentication but no specific workflow/project permission:
+    validation is a stateless, side-effect-free check of caller-supplied
+    data with no workflow_id or project_id in scope to authorize against.
 
     Args:
         body (WorkflowValidateRequest): Request body for the workflow validation endpoint.
@@ -204,6 +216,10 @@ async def asyncio(
     """Validate workflow definition
 
      Validate a workflow definition without saving it.
+
+    Requires authentication but no specific workflow/project permission:
+    validation is a stateless, side-effect-free check of caller-supplied
+    data with no workflow_id or project_id in scope to authorize against.
 
     Args:
         body (WorkflowValidateRequest): Request body for the workflow validation endpoint.

--- a/backend/src/cli/orchestrator_cli/openapi.yaml
+++ b/backend/src/cli/orchestrator_cli/openapi.yaml
@@ -26587,15 +26587,20 @@ paths:
   /workflows/validate:
     post:
       summary: Validate workflow definition
-      description: Validate a workflow definition without saving it.
+      description: |
+        Validate a workflow definition without saving it.
+
+        Requires authentication but no specific workflow/project permission:
+        validation is a stateless, side-effect-free check of caller-supplied
+        data with no workflow_id or project_id in scope to authorize against.
       operationId: validate_workflow_definition
       tags:
         - Workflows
       security:
         - bearerAuth: []
       x-app-permission:
-        resource: workflow
-        action: create
+        resource: null
+        action: null
       requestBody:
         required: true
         content:

--- a/backend/src/syntara/schemas/openapi.yaml
+++ b/backend/src/syntara/schemas/openapi.yaml
@@ -26587,15 +26587,20 @@ paths:
   /workflows/validate:
     post:
       summary: Validate workflow definition
-      description: Validate a workflow definition without saving it.
+      description: |
+        Validate a workflow definition without saving it.
+
+        Requires authentication but no specific workflow/project permission:
+        validation is a stateless, side-effect-free check of caller-supplied
+        data with no workflow_id or project_id in scope to authorize against.
       operationId: validate_workflow_definition
       tags:
         - Workflows
       security:
         - bearerAuth: []
       x-app-permission:
-        resource: workflow
-        action: create
+        resource: null
+        action: null
       requestBody:
         required: true
         content:

--- a/backend/src/syntara/schemas/workflows/v2/openapi.yaml
+++ b/backend/src/syntara/schemas/workflows/v2/openapi.yaml
@@ -145,15 +145,20 @@ paths:
   /workflows/validate:
     post:
       summary: Validate workflow definition
-      description: Validate a workflow definition without saving it.
+      description: |
+        Validate a workflow definition without saving it.
+
+        Requires authentication but no specific workflow/project permission:
+        validation is a stateless, side-effect-free check of caller-supplied
+        data with no workflow_id or project_id in scope to authorize against.
       operationId: validate_workflow_definition
       tags:
         - Workflows
       security:
         - bearerAuth: []
       x-app-permission:
-        resource: workflow
-        action: create
+        resource: null
+        action: null
       requestBody:
         required: true
         content:

--- a/backend/src/syntara/workflows/router.py
+++ b/backend/src/syntara/workflows/router.py
@@ -20,7 +20,7 @@ from syntara.authz.dependencies import PermissionChecker, VisibilityFilter
 from syntara.authz.engine import VisibilityResult
 from syntara.core.database.session import get_db
 from syntara.core.models import User
-from syntara.core.nexus_router import NexusRouter
+from syntara.core.nexus_router import NO_PERMISSION, NexusRouter
 from syntara.workflows.error_handlers import build_validation_problem_response
 from syntara.workflows.exceptions import WorkflowDefinitionInvalidError
 from syntara.workflows.executions_router import get_temporal_execution_service
@@ -240,15 +240,21 @@ _validate_router = NexusRouter(route_class=_ValidationRoute)
     "/validate",
     summary="Validate workflow definition",
     response_model=ValidationResult,
-    dependencies=[Depends(_wf_perm_create)],
+    dependencies=[NO_PERMISSION],
     operation_id="validate_workflow_definition",
     response_description="Validation result",
     responses={422: {"model": DetailedValidationProblemDetail, "description": "Unprocessable Content"}},
 )
 async def validate_workflow_definition(
     request: WorkflowValidateRequest,
+    current_user: Annotated[User, Depends(get_current_user)],  # noqa: ARG001
 ) -> ValidationResult:
-    """Validate a workflow definition without saving it."""
+    """Validate a workflow definition without saving it.
+
+    Requires authentication but no specific workflow/project permission:
+    validation is a stateless, side-effect-free check of caller-supplied
+    data with no workflow_id or project_id in scope to authorize against.
+    """
     result = workflow_validator.collect_findings(request.workflow_definition)
     if not result.is_valid:
         raise WorkflowDefinitionInvalidError(result)

--- a/backend/src/syntara/workflows/services/scheduled_trigger_service.py
+++ b/backend/src/syntara/workflows/services/scheduled_trigger_service.py
@@ -196,6 +196,31 @@ class ScheduledTriggerService:
             return self._temporal_client
         return await _get_shared_client()
 
+    @staticmethod
+    def validate_trigger_configs(workflow_definition: dict[str, Any]) -> None:
+        """Pre-validate all scheduled trigger configs without contacting Temporal.
+
+        Call this before committing a publish transaction so that invalid
+        trigger configs (e.g. bad timezone) prevent the commit rather than
+        failing after it.
+
+        Raises:
+            TriggerValidationError: If any scheduled trigger config is invalid.
+
+        """
+        triggers = workflow_definition.get("triggers", [])
+        for trigger in triggers:
+            if trigger.get("type") == NodeType.SCHEDULED_TRIGGER:
+                node_id = trigger.get("id")
+                if not node_id:
+                    continue
+                config = trigger.get("parameters", {})
+                try:
+                    ScheduledTriggerConfig.model_validate(config)
+                except ValidationError as e:
+                    msg = f"Invalid scheduled trigger config for node '{node_id}': {e}"
+                    raise TriggerValidationError(msg) from e
+
     async def sync_scheduled_triggers(
         self,
         workflow_id: str,
@@ -226,6 +251,8 @@ class ScheduledTriggerService:
             TriggerValidationError: If a scheduled trigger config is invalid.
 
         """
+        self.validate_trigger_configs(workflow_definition)
+
         # Extract scheduled trigger nodes from definition
         triggers = workflow_definition.get("triggers", [])
         scheduled_nodes: dict[str, dict[str, Any]] = {}
@@ -251,15 +278,9 @@ class ScheduledTriggerService:
         processed = 0
 
         try:
-            # Create or update schedules for current trigger nodes
+            # Create or update schedules for current trigger nodes.
+            # Configs are already validated by validate_trigger_configs() above.
             for node_id, config in scheduled_nodes.items():
-                # Validate config
-                try:
-                    ScheduledTriggerConfig.model_validate(config)
-                except ValidationError as e:
-                    msg = f"Invalid scheduled trigger config for node '{node_id}': {e}"
-                    raise TriggerValidationError(msg) from e
-
                 schedule_id = build_schedule_id(workflow_id, node_id)
                 await self._create_or_update_schedule(client, schedule_id, workflow_id, node_id, config, task_queue)
                 processed += 1

--- a/backend/src/syntara/workflows/services/scheduled_trigger_service.py
+++ b/backend/src/syntara/workflows/services/scheduled_trigger_service.py
@@ -38,6 +38,7 @@ from syntara.workflows.utils.schedule_parser import (
     build_schedule_id,
     config_to_temporal_schedule,
 )
+from syntara.workflows.validators.workflow_definition import _collect_scheduled_trigger_config_findings
 from syntara.workflows.workflow_engine.models.workflow_definition import NodeType, ScheduledTriggerConfig
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -200,29 +201,20 @@ class ScheduledTriggerService:
     def validate_trigger_configs(workflow_definition: dict[str, Any]) -> None:
         """Pre-validate all scheduled trigger configs without contacting Temporal.
 
-        Enforces semantic constraints the JSON schema does not (e.g. IANA
-        timezone names). ``WorkflowValidator.collect_findings`` applies the
-        same ``ScheduledTriggerConfig`` checks (accumulating findings); this
-        method remains the raise-first guard used by ``sync_scheduled_triggers``.
+        Raise-first wrapper around
+        ``_collect_scheduled_trigger_config_findings`` so Temporal sync and
+        ``WorkflowValidator.collect_findings`` share one walk / one id and
+        config-handling policy. Used by ``sync_scheduled_triggers`` as a
+        defense-in-depth guard after publish's pre-mutation
+        ``collect_findings`` check.
 
         Raises:
             TriggerValidationError: If any scheduled trigger config is invalid.
 
         """
-        triggers = workflow_definition.get("triggers", [])
-        for trigger in triggers:
-            if not isinstance(trigger, dict):
-                continue
-            if trigger.get("type") == NodeType.SCHEDULED_TRIGGER:
-                node_id = trigger.get("id") or "<missing id>"
-                config = trigger.get("parameters") or {}
-                if not isinstance(config, dict):
-                    config = {}
-                try:
-                    ScheduledTriggerConfig.model_validate(config)
-                except ValidationError as e:
-                    msg = f"Invalid scheduled trigger config for node '{node_id}': {e}"
-                    raise TriggerValidationError(msg) from e
+        findings = _collect_scheduled_trigger_config_findings(workflow_definition)
+        if findings:
+            raise TriggerValidationError(findings[0].message)
 
     async def sync_scheduled_triggers(
         self,

--- a/backend/src/syntara/workflows/services/scheduled_trigger_service.py
+++ b/backend/src/syntara/workflows/services/scheduled_trigger_service.py
@@ -200,9 +200,10 @@ class ScheduledTriggerService:
     def validate_trigger_configs(workflow_definition: dict[str, Any]) -> None:
         """Pre-validate all scheduled trigger configs without contacting Temporal.
 
-        Call this before committing a publish transaction so that invalid
-        trigger configs (e.g. bad timezone) prevent the commit rather than
-        failing after it.
+        Enforces semantic constraints the JSON schema does not (e.g. IANA
+        timezone names). ``WorkflowValidator.collect_findings`` applies the
+        same ``ScheduledTriggerConfig`` checks (accumulating findings); this
+        method remains the raise-first guard used by ``sync_scheduled_triggers``.
 
         Raises:
             TriggerValidationError: If any scheduled trigger config is invalid.
@@ -211,9 +212,7 @@ class ScheduledTriggerService:
         triggers = workflow_definition.get("triggers", [])
         for trigger in triggers:
             if trigger.get("type") == NodeType.SCHEDULED_TRIGGER:
-                node_id = trigger.get("id")
-                if not node_id:
-                    continue
+                node_id = trigger.get("id") or "<missing id>"
                 config = trigger.get("parameters", {})
                 try:
                     ScheduledTriggerConfig.model_validate(config)

--- a/backend/src/syntara/workflows/services/scheduled_trigger_service.py
+++ b/backend/src/syntara/workflows/services/scheduled_trigger_service.py
@@ -211,9 +211,13 @@ class ScheduledTriggerService:
         """
         triggers = workflow_definition.get("triggers", [])
         for trigger in triggers:
+            if not isinstance(trigger, dict):
+                continue
             if trigger.get("type") == NodeType.SCHEDULED_TRIGGER:
                 node_id = trigger.get("id") or "<missing id>"
-                config = trigger.get("parameters", {})
+                config = trigger.get("parameters") or {}
+                if not isinstance(config, dict):
+                    config = {}
                 try:
                     ScheduledTriggerConfig.model_validate(config)
                 except ValidationError as e:

--- a/backend/src/syntara/workflows/services/scheduled_trigger_service.py
+++ b/backend/src/syntara/workflows/services/scheduled_trigger_service.py
@@ -38,7 +38,7 @@ from syntara.workflows.utils.schedule_parser import (
     build_schedule_id,
     config_to_temporal_schedule,
 )
-from syntara.workflows.validators.workflow_definition import _collect_scheduled_trigger_config_findings
+from syntara.workflows.validators import collect_scheduled_trigger_config_findings
 from syntara.workflows.workflow_engine.models.workflow_definition import NodeType, ScheduledTriggerConfig
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -202,7 +202,7 @@ class ScheduledTriggerService:
         """Pre-validate all scheduled trigger configs without contacting Temporal.
 
         Raise-first wrapper around
-        ``_collect_scheduled_trigger_config_findings`` so Temporal sync and
+        ``collect_scheduled_trigger_config_findings`` so Temporal sync and
         ``WorkflowValidator.collect_findings`` share one walk / one id and
         config-handling policy. Used by ``sync_scheduled_triggers`` as a
         defense-in-depth guard after publish's pre-mutation
@@ -212,7 +212,7 @@ class ScheduledTriggerService:
             TriggerValidationError: If any scheduled trigger config is invalid.
 
         """
-        findings = _collect_scheduled_trigger_config_findings(workflow_definition)
+        findings = collect_scheduled_trigger_config_findings(workflow_definition)
         if findings:
             raise TriggerValidationError(findings[0].message)
 

--- a/backend/src/syntara/workflows/services/workflow_service.py
+++ b/backend/src/syntara/workflows/services/workflow_service.py
@@ -1238,12 +1238,6 @@ class WorkflowService(BaseService):
 
         await self._flush_with_duplicate_check(workflow.name)
 
-        # Pre-validate scheduled trigger configs before committing so that
-        # invalid configs (e.g. bad timezone) prevent the commit rather than
-        # failing after it — avoiding a state where the DB shows "published"
-        # but the user sees an error (AAP-87629).
-        ScheduledTriggerService.validate_trigger_configs(target_version.workflow_definition)
-
         webhook_service = WebhookTriggerService(self.session, self.user)
         await self._sync_all_trigger_types(
             webhook_service,

--- a/backend/src/syntara/workflows/services/workflow_service.py
+++ b/backend/src/syntara/workflows/services/workflow_service.py
@@ -1238,6 +1238,12 @@ class WorkflowService(BaseService):
 
         await self._flush_with_duplicate_check(workflow.name)
 
+        # Pre-validate scheduled trigger configs before committing so that
+        # invalid configs (e.g. bad timezone) prevent the commit rather than
+        # failing after it — avoiding a state where the DB shows "published"
+        # but the user sees an error (AAP-87629).
+        ScheduledTriggerService.validate_trigger_configs(target_version.workflow_definition)
+
         webhook_service = WebhookTriggerService(self.session, self.user)
         await self._sync_all_trigger_types(
             webhook_service,

--- a/backend/src/syntara/workflows/utils/iso8601_interval.py
+++ b/backend/src/syntara/workflows/utils/iso8601_interval.py
@@ -1,0 +1,253 @@
+"""Parse and validate ISO 8601 repeating interval strings.
+
+Single source of truth for interval semantics — format, finite-repetition
+rejection, timezone-aware datetimes, duration validity, calendar/fixed
+mixing, and month-step representability. Deliberately has no dependency on
+``temporalio`` or on ``workflow_engine.models.workflow_definition``, so it can
+be imported from both:
+
+- ``ScheduledTriggerConfig.validate_interval_expression`` (Pydantic model,
+  used by ``/workflows/validate``, publish, and Temporal sync) — without
+  pulling the Temporal SDK into the model/validation path.
+- ``syntara.workflows.utils.schedule_parser`` (Temporal schedule
+  construction) — without duplicating the parsing logic.
+"""
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from syntara.core.exceptions import SafeValueError
+
+# ISO 8601 repeating interval pattern: R[n]/<start>/<duration>[/<end>]
+# Examples: R/2024-01-01T10:00:00Z/P1D, R/2024-01-01T00:00:00Z/P7D/2024-12-31T23:59:59Z
+_REPEATING_INTERVAL_PATTERN = re.compile(
+    r"^R(\d+)?/"  # R[repetitions]/
+    r"([^/]+)/"  # ISO datetime start
+    r"(P[^/]+)"  # ISO 8601 duration
+    r"(?:/([^/]+))?$"  # optional /end
+)
+
+# ISO 8601 duration pattern: P[nY][nM][nW][nD][T[nH][nM][nS]]
+_DURATION_PATTERN = re.compile(
+    r"^P"
+    r"(?:(\d+)Y)?"
+    r"(?:(\d+)M)?"
+    r"(?:(\d+)W)?"
+    r"(?:(\d+)D)?"
+    r"(?:T"
+    r"(?:(\d+)H)?"
+    r"(?:(\d+)M)?"
+    r"(?:(\d+(?:\.\d+)?)S)?"
+    r")?$"
+)
+
+_REPRESENTABLE_MONTH_STEPS = frozenset({1, 2, 3, 4, 6})
+
+
+def parse_iso8601_duration(duration_str: str) -> timedelta:
+    """Parse an ISO 8601 duration string into a timedelta.
+
+    Supports fixed-length durations: P1D, P7D, P1W, PT1H, PT30M, PT1H30M,
+    and compound forms like P1DT12H30M.
+
+    Durations containing months or years (e.g. P1M, P1Y) are rejected because
+    they cannot be represented as a fixed timedelta.  Use calendar-based specs
+    or cron expressions for those intervals.
+
+    Args:
+        duration_str: ISO 8601 duration (e.g., "P1D", "PT1H30M").
+
+    Returns:
+        Equivalent timedelta.
+
+    Raises:
+        SafeValueError: If the duration string is invalid, empty, or contains
+            months/years.
+
+    """
+    match = _DURATION_PATTERN.match(duration_str)
+    if not match:
+        msg = f"Invalid ISO 8601 duration: '{duration_str}'"
+        raise SafeValueError(msg)
+
+    years = int(match.group(1) or 0)
+    months = int(match.group(2) or 0)
+    if years or months:
+        msg = (
+            f"Duration with months or years cannot be converted to a fixed timedelta: "
+            f"'{duration_str}'. Use a cron expression for calendar-based schedules."
+        )
+        raise SafeValueError(msg)
+
+    weeks = int(match.group(3) or 0)
+    days = int(match.group(4) or 0)
+    hours = int(match.group(5) or 0)
+    minutes = int(match.group(6) or 0)
+    seconds = float(match.group(7) or 0)
+
+    total = timedelta(
+        days=weeks * 7 + days,
+        hours=hours,
+        minutes=minutes,
+        seconds=seconds,
+    )
+
+    if total == timedelta():
+        msg = f"ISO 8601 duration must be non-zero: '{duration_str}'"
+        raise SafeValueError(msg)
+
+    return total
+
+
+def _parse_iso_datetime(dt_str: str) -> datetime:
+    """Parse an ISO 8601 datetime string to a timezone-aware datetime.
+
+    Raises:
+        SafeValueError: If the string is not valid ISO 8601 or lacks timezone info.
+
+    """
+    try:
+        dt = datetime.fromisoformat(dt_str)
+    except ValueError as e:
+        msg = f"Invalid ISO 8601 datetime: '{dt_str}'"
+        raise SafeValueError(msg) from e
+    if dt.tzinfo is None:
+        msg = f"Datetime must include timezone info: '{dt_str}'"
+        raise SafeValueError(msg)
+    return dt
+
+
+def _has_calendar_components(duration_str: str) -> tuple[int, int, bool]:
+    """Return (years, months, has_fixed) parsed from an ISO 8601 duration string.
+
+    ``has_fixed`` is True when the duration also contains weeks, days, hours,
+    minutes, or seconds alongside calendar components.
+
+    Returns (0, 0, False) when the duration contains no calendar components.
+    """
+    match = _DURATION_PATTERN.match(duration_str)
+    if not match:
+        return (0, 0, False)
+    years = int(match.group(1) or 0)
+    months = int(match.group(2) or 0)
+    # Groups 3-7: weeks, days, hours, minutes, seconds
+    has_fixed = bool(
+        int(match.group(3) or 0)
+        or int(match.group(4) or 0)
+        or int(match.group(5) or 0)
+        or int(match.group(6) or 0)
+        or float(match.group(7) or 0)
+    )
+    return (years, months, has_fixed)
+
+
+def validate_calendar_step(start_day: int, total_months: int) -> None:
+    """Raise SafeValueError if *total_months* cannot be represented as a calendar spec.
+
+    Args:
+        start_day: Day-of-month of the interval's start datetime.
+        total_months: Total months (years * 12 + months) in the duration.
+
+    Raises:
+        SafeValueError: If *total_months* cannot be represented as a calendar
+            spec (e.g. 5, 7, or multi-year intervals), or if *start_day* is
+            not valid for a sub-yearly monthly step (e.g. day 29-31).
+
+    """
+    if total_months < 12 and start_day > 28:  # noqa: PLR2004
+        msg = (
+            f"Day-of-month {start_day} is not valid for monthly schedules because "
+            "not all months have that many days. Use a start date with day <= 28, "
+            "or use a cron expression for more control."
+        )
+        raise SafeValueError(msg)
+
+    if total_months == 12 or total_months in _REPRESENTABLE_MONTH_STEPS:  # noqa: PLR2004
+        return
+
+    msg = (
+        f"Calendar interval of {total_months} months cannot be represented "
+        "as a schedule. Use 1, 2, 3, 4, 6, or 12 months, or a cron expression."
+    )
+    raise SafeValueError(msg)
+
+
+@dataclass(frozen=True)
+class ParsedInterval:
+    """Structured, Temporal-free result of parsing an ISO 8601 repeating interval.
+
+    Exactly one of ``duration`` (fixed-length) or ``calendar_months``
+    (calendar-based, from years/months) is set.
+    """
+
+    start_at: datetime
+    end_at: datetime | None
+    duration: timedelta | None
+    calendar_months: int | None
+
+
+def parse_iso8601_repeating_interval(interval: str) -> ParsedInterval:
+    """Parse and fully validate an ISO 8601 repeating interval string.
+
+    Supports formats:
+    - ``R/<start>/<duration>`` — repeat indefinitely from start
+    - ``R/<start>/<duration>/<end>`` — repeat from start until end
+
+    Finite repetition counts (e.g. ``R1``, ``R5``) are not supported.
+    Use an end date to limit the number of executions.
+
+    Durations containing months or years (e.g. P1M, P1Y) must be
+    representable as a calendar step (1, 2, 3, 4, 6, or 12 months) and may
+    not be mixed with fixed components (days/hours/minutes/seconds).
+
+    Args:
+        interval: ISO 8601 repeating interval string.
+
+    Returns:
+        Structured, Temporal-free representation of the interval.
+
+    Raises:
+        SafeValueError: If the interval string is invalid.
+
+    """
+    match = _REPEATING_INTERVAL_PATTERN.match(interval)
+    if not match:
+        msg = f"Invalid ISO 8601 repeating interval: '{interval}'"
+        raise SafeValueError(msg)
+
+    repetitions_str, start_str, duration_str, end_str = match.groups()
+
+    if repetitions_str:
+        msg = (
+            f"Finite repetition count R{repetitions_str} is not supported. "
+            "Set an end date to limit the number of executions."
+        )
+        raise SafeValueError(msg)
+
+    start_at = _parse_iso_datetime(start_str)
+    end_at = _parse_iso_datetime(end_str) if end_str else None
+
+    years, months, has_fixed = _has_calendar_components(duration_str)
+    if years or months:
+        if has_fixed:
+            msg = (
+                f"Mixed calendar and fixed durations are not supported: "
+                f"'{duration_str}'. Separate months/years from days/hours/minutes, "
+                "or use a cron expression."
+            )
+            raise SafeValueError(msg)
+        total_months = years * 12 + months
+        validate_calendar_step(start_at.day, total_months)
+        return ParsedInterval(start_at=start_at, end_at=end_at, duration=None, calendar_months=total_months)
+
+    duration = parse_iso8601_duration(duration_str)
+    return ParsedInterval(start_at=start_at, end_at=end_at, duration=duration, calendar_months=None)
+
+
+__all__ = [
+    "ParsedInterval",
+    "parse_iso8601_duration",
+    "parse_iso8601_repeating_interval",
+    "validate_calendar_step",
+]

--- a/backend/src/syntara/workflows/utils/schedule_parser.py
+++ b/backend/src/syntara/workflows/utils/schedule_parser.py
@@ -95,6 +95,10 @@ def parse_iso8601_interval(interval: str, tz: str | None = None) -> ScheduleSpec
             time_zone_name=tz or "UTC",
         )
 
+    if parsed.duration is None:
+        msg = f"Invalid ISO 8601 repeating interval: '{interval}'"
+        raise SafeValueError(msg)
+
     return ScheduleSpec(
         intervals=[ScheduleIntervalSpec(every=parsed.duration)],
         start_at=parsed.start_at,

--- a/backend/src/syntara/workflows/utils/schedule_parser.py
+++ b/backend/src/syntara/workflows/utils/schedule_parser.py
@@ -5,7 +5,6 @@ expressions) into Temporal SDK ``ScheduleSpec`` and ``SchedulePolicy``
 objects used to create and manage Temporal Schedules.
 """
 
-import re
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -19,134 +18,18 @@ from temporalio.client import (
 )
 
 from syntara.core.exceptions import SafeValueError
+from syntara.workflows.utils.iso8601_interval import (
+    parse_iso8601_duration as parse_iso8601_duration,  # noqa: PLC0414 - re-exported for callers/tests
+)
+from syntara.workflows.utils.iso8601_interval import (
+    parse_iso8601_repeating_interval,
+    validate_calendar_step,
+)
 from syntara.workflows.workflow_engine.models.workflow_definition import MissedSchedulePolicy, ScheduleType
-
-# ISO 8601 repeating interval pattern: R[n]/<start>/<duration>[/<end>]
-# Examples: R/2024-01-01T10:00:00Z/P1D, R/2024-01-01T00:00:00Z/P7D/2024-12-31T23:59:59Z
-_REPEATING_INTERVAL_PATTERN = re.compile(
-    r"^R(\d+)?/"  # R[repetitions]/
-    r"([^/]+)/"  # ISO datetime start
-    r"(P[^/]+)"  # ISO 8601 duration
-    r"(?:/([^/]+))?$"  # optional /end
-)
-
-# ISO 8601 duration pattern: P[nY][nM][nW][nD][T[nH][nM][nS]]
-_DURATION_PATTERN = re.compile(
-    r"^P"
-    r"(?:(\d+)Y)?"
-    r"(?:(\d+)M)?"
-    r"(?:(\d+)W)?"
-    r"(?:(\d+)D)?"
-    r"(?:T"
-    r"(?:(\d+)H)?"
-    r"(?:(\d+)M)?"
-    r"(?:(\d+(?:\.\d+)?)S)?"
-    r")?$"
-)
 
 # Catchup window for missed schedule policies
 _CATCHUP_WINDOW_SKIP = timedelta(seconds=1)
 _CATCHUP_WINDOW_RECOVER = timedelta(hours=48)
-
-
-def parse_iso8601_duration(duration_str: str) -> timedelta:
-    """Parse an ISO 8601 duration string into a timedelta.
-
-    Supports fixed-length durations: P1D, P7D, P1W, PT1H, PT30M, PT1H30M,
-    and compound forms like P1DT12H30M.
-
-    Durations containing months or years (e.g. P1M, P1Y) are rejected because
-    they cannot be represented as a fixed timedelta.  Use calendar-based specs
-    or cron expressions for those intervals.
-
-    Args:
-        duration_str: ISO 8601 duration (e.g., "P1D", "PT1H30M").
-
-    Returns:
-        Equivalent timedelta.
-
-    Raises:
-        SafeValueError: If the duration string is invalid, empty, or contains
-            months/years.
-
-    """
-    match = _DURATION_PATTERN.match(duration_str)
-    if not match:
-        msg = f"Invalid ISO 8601 duration: '{duration_str}'"
-        raise SafeValueError(msg)
-
-    years = int(match.group(1) or 0)
-    months = int(match.group(2) or 0)
-    if years or months:
-        msg = (
-            f"Duration with months or years cannot be converted to a fixed timedelta: "
-            f"'{duration_str}'. Use a cron expression for calendar-based schedules."
-        )
-        raise SafeValueError(msg)
-
-    weeks = int(match.group(3) or 0)
-    days = int(match.group(4) or 0)
-    hours = int(match.group(5) or 0)
-    minutes = int(match.group(6) or 0)
-    seconds = float(match.group(7) or 0)
-
-    total = timedelta(
-        days=weeks * 7 + days,
-        hours=hours,
-        minutes=minutes,
-        seconds=seconds,
-    )
-
-    if total == timedelta():
-        msg = f"ISO 8601 duration must be non-zero: '{duration_str}'"
-        raise SafeValueError(msg)
-
-    return total
-
-
-def _parse_iso_datetime(dt_str: str) -> datetime:
-    """Parse an ISO 8601 datetime string to a timezone-aware datetime.
-
-    Raises:
-        SafeValueError: If the string is not valid ISO 8601 or lacks timezone info.
-
-    """
-    try:
-        dt = datetime.fromisoformat(dt_str)
-    except ValueError as e:
-        msg = f"Invalid ISO 8601 datetime: '{dt_str}'"
-        raise SafeValueError(msg) from e
-    if dt.tzinfo is None:
-        msg = f"Datetime must include timezone info: '{dt_str}'"
-        raise SafeValueError(msg)
-    return dt
-
-
-def _has_calendar_components(duration_str: str) -> tuple[int, int, bool]:
-    """Return (years, months, has_fixed) parsed from an ISO 8601 duration string.
-
-    ``has_fixed`` is True when the duration also contains weeks, days, hours,
-    minutes, or seconds alongside calendar components.
-
-    Returns (0, 0, False) when the duration contains no calendar components.
-    """
-    match = _DURATION_PATTERN.match(duration_str)
-    if not match:
-        return (0, 0, False)
-    years = int(match.group(1) or 0)
-    months = int(match.group(2) or 0)
-    # Groups 3-7: weeks, days, hours, minutes, seconds
-    has_fixed = bool(
-        int(match.group(3) or 0)
-        or int(match.group(4) or 0)
-        or int(match.group(5) or 0)
-        or int(match.group(6) or 0)
-        or float(match.group(7) or 0)
-    )
-    return (years, months, has_fixed)
-
-
-_REPRESENTABLE_MONTH_STEPS = frozenset({1, 2, 3, 4, 6})
 
 
 def _interval_to_calendar_spec(start: datetime, total_months: int) -> ScheduleCalendarSpec:
@@ -158,28 +41,17 @@ def _interval_to_calendar_spec(start: datetime, total_months: int) -> ScheduleCa
 
     Raises:
         SafeValueError: If *total_months* cannot be represented as a calendar
-            spec (e.g. 5, 7, or multi-year intervals).
+            spec (e.g. 5, 7, or multi-year intervals). See
+            ``iso8601_interval.validate_calendar_step`` for the shared check.
 
     """
-    if total_months < 12 and start.day > 28:  # noqa: PLR2004
-        msg = (
-            f"Day-of-month {start.day} is not valid for monthly schedules because "
-            "not all months have that many days. Use a start date with day <= 28, "
-            "or use a cron expression for more control."
-        )
-        raise SafeValueError(msg)
+    validate_calendar_step(start.day, total_months)
 
     if total_months == 12:  # noqa: PLR2004
         month_ranges: list[ScheduleRange] = [ScheduleRange(start.month)]
-    elif total_months in _REPRESENTABLE_MONTH_STEPS:
+    else:
         offset = ((start.month - 1) % total_months) + 1
         month_ranges = [ScheduleRange(offset, 12, step=total_months)]
-    else:
-        msg = (
-            f"Calendar interval of {total_months} months cannot be represented "
-            "as a schedule. Use 1, 2, 3, 4, 6, or 12 months, or a cron expression."
-        )
-        raise SafeValueError(msg)
 
     return ScheduleCalendarSpec(
         minute=[ScheduleRange(start.minute)],
@@ -192,12 +64,10 @@ def _interval_to_calendar_spec(start: datetime, total_months: int) -> ScheduleCa
 def parse_iso8601_interval(interval: str, tz: str | None = None) -> ScheduleSpec:
     """Parse an ISO 8601 repeating interval into a Temporal ScheduleSpec.
 
-    Supports formats:
-    - ``R/<start>/<duration>`` — repeat indefinitely from start
-    - ``R/<start>/<duration>/<end>`` — repeat from start until end
-
-    Finite repetition counts (e.g. ``R1``, ``R5``) are not supported.
-    Use an end date to limit the number of executions.
+    Delegates all parsing and semantic validation to
+    ``iso8601_interval.parse_iso8601_repeating_interval`` (the single source
+    of truth shared with ``ScheduledTriggerConfig.validate_interval_expression``)
+    and only builds Temporal SDK objects here.
 
     Durations containing months or years (e.g. P1M, P1Y) are automatically
     converted to calendar specs so Temporal can evaluate them with full
@@ -214,50 +84,21 @@ def parse_iso8601_interval(interval: str, tz: str | None = None) -> ScheduleSpec
         SafeValueError: If the interval string is invalid.
 
     """
-    match = _REPEATING_INTERVAL_PATTERN.match(interval)
-    if not match:
-        msg = f"Invalid ISO 8601 repeating interval: '{interval}'"
-        raise SafeValueError(msg)
+    parsed = parse_iso8601_repeating_interval(interval)
 
-    repetitions_str = match.group(1)
-    start_str = match.group(2)
-    duration_str = match.group(3)
-    end_str = match.group(4)
-
-    if repetitions_str:
-        msg = (
-            f"Finite repetition count R{repetitions_str} is not supported. "
-            "Set an end date to limit the number of executions."
-        )
-        raise SafeValueError(msg)
-
-    start_at = _parse_iso_datetime(start_str)
-    end_at = _parse_iso_datetime(end_str) if end_str else None
-
-    years, months, has_fixed = _has_calendar_components(duration_str)
-    if years or months:
-        if has_fixed:
-            msg = (
-                f"Mixed calendar and fixed durations are not supported: "
-                f"'{duration_str}'. Separate months/years from days/hours/minutes, "
-                "or use a cron expression."
-            )
-            raise SafeValueError(msg)
-        total_months = years * 12 + months
-        cal_spec = _interval_to_calendar_spec(start_at, total_months)
+    if parsed.calendar_months is not None:
+        cal_spec = _interval_to_calendar_spec(parsed.start_at, parsed.calendar_months)
         return ScheduleSpec(
             calendars=[cal_spec],
-            start_at=start_at,
-            end_at=end_at,
+            start_at=parsed.start_at,
+            end_at=parsed.end_at,
             time_zone_name=tz or "UTC",
         )
 
-    duration = parse_iso8601_duration(duration_str)
-
     return ScheduleSpec(
-        intervals=[ScheduleIntervalSpec(every=duration)],
-        start_at=start_at,
-        end_at=end_at,
+        intervals=[ScheduleIntervalSpec(every=parsed.duration)],
+        start_at=parsed.start_at,
+        end_at=parsed.end_at,
         time_zone_name=tz or "UTC",
     )
 

--- a/backend/src/syntara/workflows/validators/__init__.py
+++ b/backend/src/syntara/workflows/validators/__init__.py
@@ -3,7 +3,7 @@
 This module provides validation for workflow definitions and metadata.
 """
 
-from .workflow_definition import WorkflowValidator
+from .workflow_definition import WorkflowValidator, collect_scheduled_trigger_config_findings
 from .workflow_integrations import validate_workflow_references
 
 # Convenience singleton instance for easy usage
@@ -11,6 +11,7 @@ workflow_validator = WorkflowValidator()
 
 __all__ = [
     "WorkflowValidator",
+    "collect_scheduled_trigger_config_findings",
     "validate_workflow_references",
     "workflow_validator",
 ]

--- a/backend/src/syntara/workflows/validators/workflow_definition.py
+++ b/backend/src/syntara/workflows/validators/workflow_definition.py
@@ -385,7 +385,7 @@ def _extract_node_id_and_field(
     return None, None
 
 
-def _collect_scheduled_trigger_config_findings(
+def collect_scheduled_trigger_config_findings(
     workflow_definition: dict[str, Any],
 ) -> list[ValidationFinding]:
     """Validate scheduled trigger configs beyond JSON Schema (e.g. IANA timezones).
@@ -395,6 +395,11 @@ def _collect_scheduled_trigger_config_findings(
     with ``node_id`` / ``field_path`` for Builder) and by
     ``ScheduledTriggerService.validate_trigger_configs`` (raise on the first
     finding) so verify, publish, and Temporal sync cannot drift.
+
+    Public (not underscore-prefixed) and re-exported from
+    ``syntara.workflows.validators`` because it is a load-bearing shared
+    contract with ``ScheduledTriggerService``, not a private implementation
+    detail of this module.
     """
     findings: list[ValidationFinding] = []
     for trigger in workflow_definition.get("triggers", []):
@@ -455,7 +460,7 @@ class WorkflowValidator:
         node_ids = _extract_node_ids(workflow_definition)
         self._validate_graph_structure(workflow_definition, node_ids)
         self._validate_template_expressions(workflow_definition, node_ids)
-        scheduled_trigger_findings = _collect_scheduled_trigger_config_findings(workflow_definition)
+        scheduled_trigger_findings = collect_scheduled_trigger_config_findings(workflow_definition)
         if scheduled_trigger_findings:
             raise SafeValueError(scheduled_trigger_findings[0].message)
 
@@ -572,7 +577,7 @@ class WorkflowValidator:
             findings.extend(_check_approval_node_findings(workflow_definition))
             findings.extend(check_template_expressions(workflow_definition, node_ids))
 
-        findings.extend(_collect_scheduled_trigger_config_findings(workflow_definition))
+        findings.extend(collect_scheduled_trigger_config_findings(workflow_definition))
 
         return findings
 

--- a/backend/src/syntara/workflows/validators/workflow_definition.py
+++ b/backend/src/syntara/workflows/validators/workflow_definition.py
@@ -390,10 +390,11 @@ def _collect_scheduled_trigger_config_findings(
 ) -> list[ValidationFinding]:
     """Validate scheduled trigger configs beyond JSON Schema (e.g. IANA timezones).
 
-    Uses the same ``ScheduledTriggerConfig`` model as Temporal sync so
-    ``/workflows/validate`` and publish share one semantic contract.
-    Accumulates one finding per invalid trigger (with ``node_id`` /
-    ``field_path`` for Builder highlighting).
+    Single owner of the scheduled-trigger ``ScheduledTriggerConfig`` walk.
+    Used by ``WorkflowValidator.collect_findings`` (accumulate all findings
+    with ``node_id`` / ``field_path`` for Builder) and by
+    ``ScheduledTriggerService.validate_trigger_configs`` (raise on the first
+    finding) so verify, publish, and Temporal sync cannot drift.
     """
     findings: list[ValidationFinding] = []
     for trigger in workflow_definition.get("triggers", []):
@@ -401,8 +402,9 @@ def _collect_scheduled_trigger_config_findings(
             continue
         if trigger.get("type") != NodeType.SCHEDULED_TRIGGER:
             continue
-        node_id = trigger.get("id")
-        display_id = node_id if isinstance(node_id, str) and node_id else "<missing id>"
+        raw_id = trigger.get("id")
+        node_id = raw_id if isinstance(raw_id, str) and raw_id else None
+        display_id = node_id or "<missing id>"
         config = trigger.get("parameters") or {}
         if not isinstance(config, dict):
             config = {}
@@ -420,7 +422,7 @@ def _collect_scheduled_trigger_config_findings(
                     severity=ValidationSeverity.error,
                     category=ValidationCategory.schema_violation,
                     message=f"Invalid scheduled trigger config for node '{display_id}': {exc}",
-                    node_id=node_id if isinstance(node_id, str) and node_id else None,
+                    node_id=node_id,
                     field_path=field_path,
                 )
             )

--- a/backend/src/syntara/workflows/validators/workflow_definition.py
+++ b/backend/src/syntara/workflows/validators/workflow_definition.py
@@ -12,6 +12,7 @@ from functools import lru_cache
 from typing import Any
 
 import jsonschema
+from pydantic import ValidationError
 from referencing import Registry, Resource
 from referencing.jsonschema import DRAFT202012
 
@@ -25,6 +26,7 @@ from syntara.workflows.models.validation_finding import (
 )
 from syntara.workflows.validators.template_expressions import check_template_expressions
 from syntara.workflows.workflow_engine.graph_backend import InMemoryGraphBackend
+from syntara.workflows.workflow_engine.models.workflow_definition import NodeType, ScheduledTriggerConfig
 
 _SCHEMA_DIR = SCHEMA_DIR / "workflows" / "v2"
 _BASE_URI = "https://automation.example.com/schemas/workflows/v2/"
@@ -383,6 +385,48 @@ def _extract_node_id_and_field(
     return None, None
 
 
+def _collect_scheduled_trigger_config_findings(
+    workflow_definition: dict[str, Any],
+) -> list[ValidationFinding]:
+    """Validate scheduled trigger configs beyond JSON Schema (e.g. IANA timezones).
+
+    Uses the same ``ScheduledTriggerConfig`` model as Temporal sync so
+    ``/workflows/validate`` and publish share one semantic contract.
+    Accumulates one finding per invalid trigger (with ``node_id`` /
+    ``field_path`` for Builder highlighting).
+    """
+    findings: list[ValidationFinding] = []
+    for trigger in workflow_definition.get("triggers", []):
+        if not isinstance(trigger, dict):
+            continue
+        if trigger.get("type") != NodeType.SCHEDULED_TRIGGER:
+            continue
+        node_id = trigger.get("id")
+        display_id = node_id if isinstance(node_id, str) and node_id else "<missing id>"
+        config = trigger.get("parameters") or {}
+        if not isinstance(config, dict):
+            config = {}
+        try:
+            ScheduledTriggerConfig.model_validate(config)
+        except ValidationError as exc:
+            field_path: str | None = None
+            errors = exc.errors()
+            if errors:
+                loc = errors[0].get("loc", ())
+                if loc:
+                    field_path = "parameters." + ".".join(str(part) for part in loc)
+            findings.append(
+                ValidationFinding(
+                    severity=ValidationSeverity.error,
+                    category=ValidationCategory.schema_violation,
+                    message=f"Invalid scheduled trigger config for node '{display_id}': {exc}",
+                    node_id=node_id if isinstance(node_id, str) and node_id else None,
+                    field_path=field_path,
+                )
+            )
+    return findings
+
+
 class WorkflowValidator:
     """Validator for V2 workflows and metadata.
 
@@ -409,6 +453,9 @@ class WorkflowValidator:
         node_ids = _extract_node_ids(workflow_definition)
         self._validate_graph_structure(workflow_definition, node_ids)
         self._validate_template_expressions(workflow_definition, node_ids)
+        scheduled_trigger_findings = _collect_scheduled_trigger_config_findings(workflow_definition)
+        if scheduled_trigger_findings:
+            raise SafeValueError(scheduled_trigger_findings[0].message)
 
     def validate_workflow_name(self, name: str) -> None:
         """Validate workflow name is not empty.
@@ -522,6 +569,8 @@ class WorkflowValidator:
             findings.extend(_check_converge_node_findings(workflow_definition))
             findings.extend(_check_approval_node_findings(workflow_definition))
             findings.extend(check_template_expressions(workflow_definition, node_ids))
+
+        findings.extend(_collect_scheduled_trigger_config_findings(workflow_definition))
 
         return findings
 

--- a/backend/src/syntara/workflows/workflow_engine/models/workflow_definition.py
+++ b/backend/src/syntara/workflows/workflow_engine/models/workflow_definition.py
@@ -8,7 +8,7 @@ import json
 import re
 import uuid
 from enum import Enum, IntEnum, StrEnum
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 from urllib.parse import urlparse
 from zoneinfo import available_timezones
 
@@ -1157,32 +1157,69 @@ class ScheduledTriggerConfig(TemplateAwareBaseModel):
         description="How to handle overlapping schedule executions",
     )
 
+    _SCHEDULE_SHAPE_FIELDS: ClassVar[tuple[str, ...]] = ("schedule_type", "interval", "cron", "timezone")
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_template_schedule_fields(cls, data: Any) -> Any:  # noqa: ANN401
+        """Reject template expressions in schedule-shape fields.
+
+        Unlike other node parameters, ``schedule_type``/``interval``/``cron``/
+        ``timezone`` are materialized into a Temporal Schedule once at publish
+        time -- there is no per-execution runtime context to resolve
+        ``${...}`` expressions against later. Letting
+        ``TemplateAwareBaseModel``'s wildcard bypass wave these through would
+        let ``collect_findings`` / pre-mutation publish accept a config that
+        can never be turned into a schedule, then fail post-commit in
+        ``config_to_temporal_schedule``. Runs before field-level validation
+        (and before the wildcard bypass) so it can't be skipped.
+        """
+        if not isinstance(data, dict):
+            return data
+        for field_name in cls._SCHEDULE_SHAPE_FIELDS:
+            value = data.get(field_name)
+            if isinstance(value, str) and TEMPLATE_PATTERN.search(value):
+                msg = (
+                    f"Field '{field_name}' does not support template expressions. "
+                    "Scheduled trigger configs are fixed at publish time, not resolved at runtime."
+                )
+                raise SafeValueError(msg)
+        return data
+
     @field_validator("interval")
     @classmethod
-    def validate_interval_expression(cls, v: str | None) -> str | None:
+    def validate_interval_expression(cls, v: str | None, info: ValidationInfo) -> str | None:
         """Validate that interval is a well-formed ISO 8601 repeating interval.
 
-        Delegates to ``iso8601_interval.parse_iso8601_repeating_interval``,
-        the same parser ``schedule_parser.parse_iso8601_interval`` uses to
-        build Temporal Schedule objects, so this model, ``/workflows/validate``,
-        publish, and Temporal sync all reject the same set of interval strings.
+        Skipped when ``schedule_type`` is not ``interval``: ``interval`` is
+        inactive in that case and ``config_to_temporal_schedule`` never reads
+        it, so a stale/invalid leftover value here must not block verify or
+        publish. Otherwise delegates to
+        ``iso8601_interval.parse_iso8601_repeating_interval``, the same
+        parser ``schedule_parser.parse_iso8601_interval`` uses to build
+        Temporal Schedule objects, so this model, ``/workflows/validate``,
+        publish, and Temporal sync all reject the same set of interval
+        strings.
         """
         if v is None:
             return v
-        # Template expressions bypass validation
-        if isinstance(v, str) and TEMPLATE_PATTERN.search(v):
+        if info.data.get("schedule_type") not in (None, ScheduleType.INTERVAL):
             return v
         parse_iso8601_repeating_interval(v)
         return v
 
     @field_validator("cron")
     @classmethod
-    def validate_cron_expression(cls, v: str | None) -> str | None:
-        """Validate that cron is a standard 5-field expression."""
+    def validate_cron_expression(cls, v: str | None, info: ValidationInfo) -> str | None:
+        """Validate that cron is a standard 5-field expression.
+
+        Skipped when ``schedule_type`` is not ``cron``, mirroring
+        ``validate_interval_expression`` -- ``config_to_temporal_schedule``
+        never reads ``cron`` for an interval schedule.
+        """
         if v is None:
             return v
-        # Template expressions bypass validation
-        if isinstance(v, str) and TEMPLATE_PATTERN.search(v):
+        if info.data.get("schedule_type") not in (None, ScheduleType.CRON):
             return v
         if not _CRON_PATTERN.match(v):
             msg = (
@@ -1199,9 +1236,6 @@ class ScheduledTriggerConfig(TemplateAwareBaseModel):
         """Validate that timezone is a valid IANA timezone name."""
         if v is None:
             return v
-        # Template expressions bypass validation
-        if isinstance(v, str) and TEMPLATE_PATTERN.search(v):
-            return v
         if v not in _get_valid_timezones():
             msg = f"Invalid timezone: '{v}'. Must be a valid IANA timezone name (e.g., 'America/New_York')."
             raise SafeValueError(msg)
@@ -1210,10 +1244,6 @@ class ScheduledTriggerConfig(TemplateAwareBaseModel):
     @model_validator(mode="after")
     def validate_schedule_fields(self) -> "ScheduledTriggerConfig":
         """Validate that required fields are present based on schedule_type."""
-        # Skip validation if schedule_type is a template expression
-        if isinstance(self.schedule_type, str) and TEMPLATE_PATTERN.search(self.schedule_type):
-            return self
-
         if self.schedule_type == ScheduleType.INTERVAL and not self.interval:
             msg = "Field 'interval' is required when schedule_type is 'interval'"
             raise SafeValueError(msg)

--- a/backend/src/syntara/workflows/workflow_engine/models/workflow_definition.py
+++ b/backend/src/syntara/workflows/workflow_engine/models/workflow_definition.py
@@ -20,6 +20,7 @@ from syntara.aap.models.responses import AAPJobType as AAPJobType  # noqa: PLC04
 from syntara.core.constants import WebhookLimits
 from syntara.core.exceptions import SafeValueError
 from syntara.workflows.json_schema_validation import validate_json_schema_definition
+from syntara.workflows.utils.iso8601_interval import parse_iso8601_repeating_interval
 from syntara.workflows.utils.output_mapping import apply_output_mapping
 from syntara.workflows.workflow_engine.models.aap_types import AAPResourceType
 
@@ -1155,6 +1156,24 @@ class ScheduledTriggerConfig(TemplateAwareBaseModel):
         default=MissedSchedulePolicy.SKIP,
         description="How to handle overlapping schedule executions",
     )
+
+    @field_validator("interval")
+    @classmethod
+    def validate_interval_expression(cls, v: str | None) -> str | None:
+        """Validate that interval is a well-formed ISO 8601 repeating interval.
+
+        Delegates to ``iso8601_interval.parse_iso8601_repeating_interval``,
+        the same parser ``schedule_parser.parse_iso8601_interval`` uses to
+        build Temporal Schedule objects, so this model, ``/workflows/validate``,
+        publish, and Temporal sync all reject the same set of interval strings.
+        """
+        if v is None:
+            return v
+        # Template expressions bypass validation
+        if isinstance(v, str) and TEMPLATE_PATTERN.search(v):
+            return v
+        parse_iso8601_repeating_interval(v)
+        return v
 
     @field_validator("cron")
     @classmethod

--- a/backend/tests/integration/api/test_workflows_validate.py
+++ b/backend/tests/integration/api/test_workflows_validate.py
@@ -416,9 +416,9 @@ async def test_validate_converge_valid(jwt_client: AsyncClient) -> None:
 async def test_validate_invalid_iana_timezone(jwt_client: AsyncClient) -> None:
     """Invalid IANA timezone on a scheduled trigger returns 422 with a scheduled-trigger finding.
 
-    Regression for AAP-87629: Builder's handleVerify calls POST /workflows/validate;
-    invalid timezones must fail here (not only on publish) so verify and publish
-    share one semantic contract.
+    Builder's handleVerify calls POST /workflows/validate; invalid timezones
+    must fail here (not only on publish) so verify and publish share one
+    semantic contract.
     """
     payload = {
         "workflow_definition": {
@@ -466,9 +466,9 @@ async def test_validate_invalid_iana_timezone(jwt_client: AsyncClient) -> None:
 async def test_validate_invalid_iso8601_interval(jwt_client: AsyncClient) -> None:
     """Invalid ISO 8601 interval on a scheduled trigger returns 422 with a scheduled-trigger finding.
 
-    Regression for AAP-87629: interval was previously an unconstrained string
-    that only failed later in publish's Temporal schedule conversion, so
-    verify (this endpoint) must reject it up front too.
+    Interval was previously an unconstrained string that only failed later in
+    publish's Temporal schedule conversion, so verify (this endpoint) must reject
+    it up front too.
     """
     payload = {
         "workflow_definition": {
@@ -510,7 +510,7 @@ async def test_validate_invalid_iso8601_interval(jwt_client: AsyncClient) -> Non
 
 
 class TestValidateProjectScopedUser:
-    """Regression test for AAP-87629.
+    """Project-scoped users can call POST /workflows/validate without workflow:create.
 
     Before the fix, ``/workflows/validate`` was gated by a PermissionChecker
     that could never resolve a project scope from the request body (it has

--- a/backend/tests/integration/api/test_workflows_validate.py
+++ b/backend/tests/integration/api/test_workflows_validate.py
@@ -412,6 +412,56 @@ async def test_validate_converge_valid(jwt_client: AsyncClient) -> None:
     assert data["findings"] == []
 
 
+@pytest.mark.asyncio
+async def test_validate_invalid_iana_timezone(jwt_client: AsyncClient) -> None:
+    """Invalid IANA timezone on a scheduled trigger returns 422 with a scheduled-trigger finding.
+
+    Regression for AAP-87629: Builder's handleVerify calls POST /workflows/validate;
+    invalid timezones must fail here (not only on publish) so verify and publish
+    share one semantic contract.
+    """
+    payload = {
+        "workflow_definition": {
+            "schema_version": "2.0.0",
+            "name": "scheduled-invalid-tz",
+            "triggers": [
+                {
+                    "id": "sched_1",
+                    "type": "scheduled_trigger",
+                    "parameters": {
+                        "schedule_type": "cron",
+                        "cron": "0 9 * * *",
+                        "timezone": "Invalid/Not_A_Real_Zone",
+                    },
+                }
+            ],
+            "nodes": [
+                {
+                    "id": "n1",
+                    "name": "Node 1",
+                    "type": "script",
+                    "parameters": {"language": "python", "code": "pass"},
+                }
+            ],
+            "edges": [{"from": "sched_1", "to": "n1"}],
+        },
+    }
+
+    response = await jwt_client.post("/api/v1/workflows/validate", json=payload)
+
+    assert response.status_code == 422
+    data = response.json()
+    assert data["type"] == "https://api.example.com/errors/validation-error"
+    assert data["code"] == "WORKFLOW_DEFINITION_INVALID"
+    assert data["retryable"] is False
+    vr = data["validation_result"]
+    assert vr["is_valid"] is False
+    scheduled = [e for e in vr["findings"] if "scheduled trigger config" in e["message"]]
+    assert len(scheduled) == 1
+    assert scheduled[0]["node_id"] == "sched_1"
+    assert scheduled[0]["field_path"] == "parameters.timezone"
+
+
 class TestValidateProjectScopedUser:
     """Regression test for AAP-87629.
 

--- a/backend/tests/integration/api/test_workflows_validate.py
+++ b/backend/tests/integration/api/test_workflows_validate.py
@@ -462,6 +462,53 @@ async def test_validate_invalid_iana_timezone(jwt_client: AsyncClient) -> None:
     assert scheduled[0]["field_path"] == "parameters.timezone"
 
 
+@pytest.mark.asyncio
+async def test_validate_invalid_iso8601_interval(jwt_client: AsyncClient) -> None:
+    """Invalid ISO 8601 interval on a scheduled trigger returns 422 with a scheduled-trigger finding.
+
+    Regression for AAP-87629: interval was previously an unconstrained string
+    that only failed later in publish's Temporal schedule conversion, so
+    verify (this endpoint) must reject it up front too.
+    """
+    payload = {
+        "workflow_definition": {
+            "schema_version": "2.0.0",
+            "name": "scheduled-invalid-interval",
+            "triggers": [
+                {
+                    "id": "sched_1",
+                    "type": "scheduled_trigger",
+                    "parameters": {
+                        "schedule_type": "interval",
+                        "interval": "not-an-interval",
+                    },
+                }
+            ],
+            "nodes": [
+                {
+                    "id": "n1",
+                    "name": "Node 1",
+                    "type": "script",
+                    "parameters": {"language": "python", "code": "pass"},
+                }
+            ],
+            "edges": [{"from": "sched_1", "to": "n1"}],
+        },
+    }
+
+    response = await jwt_client.post("/api/v1/workflows/validate", json=payload)
+
+    assert response.status_code == 422
+    data = response.json()
+    assert data["code"] == "WORKFLOW_DEFINITION_INVALID"
+    vr = data["validation_result"]
+    assert vr["is_valid"] is False
+    scheduled = [e for e in vr["findings"] if "scheduled trigger config" in e["message"]]
+    assert len(scheduled) == 1
+    assert scheduled[0]["node_id"] == "sched_1"
+    assert scheduled[0]["field_path"] == "parameters.interval"
+
+
 class TestValidateProjectScopedUser:
     """Regression test for AAP-87629.
 

--- a/backend/tests/integration/api/test_workflows_validate.py
+++ b/backend/tests/integration/api/test_workflows_validate.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import pytest
 
+from syntara.authz.models import Project
 from tests.helpers.workflow import create_minimal_workflow_definition
+from tests.integration.api.conftest import make_project_user
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from httpx import AsyncClient
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+    from syntara.core.models import User
 
 
 @pytest.mark.asyncio
@@ -402,3 +410,51 @@ async def test_validate_converge_valid(jwt_client: AsyncClient) -> None:
     data = response.json()
     assert data["is_valid"] is True
     assert data["findings"] == []
+
+
+class TestValidateProjectScopedUser:
+    """Regression test for AAP-87629.
+
+    Before the fix, ``/workflows/validate`` was gated by a PermissionChecker
+    that could never resolve a project scope from the request body (it has
+    no ``project_id``/``workflow_id``), so it silently required a
+    system-wide grant that project-scoped-only users never have — this is
+    what produced "Not authorized to perform create on workflow" for
+    Builder users with only project-scoped roles.
+    """
+
+    @pytest.mark.asyncio
+    async def test_project_scoped_user_can_validate(
+        self,
+        auth_client: AsyncClient,
+        test_db_session: AsyncSession,
+        user_factory: Callable[..., Awaitable[User]],
+        auth_as: Callable[[User], None],
+    ) -> None:
+        """A user with only a project-scoped role (no system-wide grant) can validate."""
+        project = Project(name=f"validate-test-{uuid4().hex[:8]}", description="")
+        test_db_session.add(project)
+        await test_db_session.commit()
+        await test_db_session.refresh(project)
+
+        user = await user_factory(
+            username=f"proj-user-{uuid4().hex[:6]}", email=f"proj-user-{uuid4().hex[:6]}@test.com"
+        )
+        await make_project_user(test_db_session, user, project)
+        auth_as(user)
+
+        payload = {
+            "workflow_definition": create_minimal_workflow_definition(
+                name="project-scoped-validate",
+                description="Validated by a project-scoped-only user",
+            ),
+        }
+
+        response = await auth_client.post("/api/v1/workflows/validate", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_valid"] is True
+        assert data["findings"] == []
+        assert data["error_count"] == 0
+        assert data["warning_count"] == 0

--- a/backend/tests/unit/api/compliance/auth_exclusions.yml
+++ b/backend/tests/unit/api/compliance/auth_exclusions.yml
@@ -146,7 +146,7 @@ authenticated:
   # -- workflows: stateless validation --
   - method: POST
     path: /api/v1/workflows/validate
-    justification: Stateless, side-effect-free validation of caller-supplied definition; no project_id/workflow_id to authorize against (AAP-87629)
+    justification: Stateless, side-effect-free validation of caller-supplied definition; no project_id/workflow_id to authorize against
 
 public:
   # -- auth: pre-authentication flow --

--- a/backend/tests/unit/api/compliance/auth_exclusions.yml
+++ b/backend/tests/unit/api/compliance/auth_exclusions.yml
@@ -143,6 +143,11 @@ authenticated:
     path: /api/v1/tool_manager/metrics/executions
     justification: Internal observability; no user data
 
+  # -- workflows: stateless validation --
+  - method: POST
+    path: /api/v1/workflows/validate
+    justification: Stateless, side-effect-free validation of caller-supplied definition; no project_id/workflow_id to authorize against (AAP-87629)
+
 public:
   # -- auth: pre-authentication flow --
   - method: POST

--- a/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
+++ b/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
@@ -6,7 +6,8 @@ Covers:
 - Cron expression format validation
 - Timezone validation (IANA timezone names)
 - MissedSchedulePolicy defaults
-- Template expression bypass
+- Template expression rejection on schedule-shape fields
+- Inactive schedule field (interval on a cron config, or vice versa) is not validated
 """
 
 import pytest
@@ -435,37 +436,73 @@ class TestIntervalValidation:
         assert config.interval is None
 
 
-class TestTemplateExpressionBypass:
-    """Tests for template expression bypass in validated fields."""
+class TestTemplateScheduleFieldsRejected:
+    """Schedule-shape fields (schedule_type/interval/cron/timezone) reject templates.
 
-    async def test_template_cron_bypasses_validation(self) -> None:
-        """Template expression in cron field should bypass validation."""
-        config = ScheduledTriggerConfig(
-            schedule_type=ScheduleType.CRON,
-            cron="${input.cron_expression}",
-        )
-        assert config.cron == "${input.cron_expression}"
+    Unlike other node parameters, these fields are materialized into a
+    Temporal Schedule once at publish time -- there is no runtime execution
+    context to resolve ``${...}`` against later. Letting the generic
+    TemplateAwareBaseModel bypass wave these through would let verify and
+    pre-mutation publish accept a config that can never become a schedule,
+    then fail post-commit in ``config_to_temporal_schedule``.
+    """
 
-    async def test_template_timezone_bypasses_validation(self) -> None:
-        """Template expression in timezone field should bypass validation."""
+    async def test_template_cron_is_rejected(self) -> None:
+        """Template expression in cron field is rejected, not bypassed."""
+        with pytest.raises(ValidationError, match="does not support template expressions"):
+            ScheduledTriggerConfig(
+                schedule_type=ScheduleType.CRON,
+                cron="${input.cron_expression}",
+            )
+
+    async def test_template_timezone_is_rejected(self) -> None:
+        """Template expression in timezone field is rejected, not bypassed."""
+        with pytest.raises(ValidationError, match="does not support template expressions"):
+            ScheduledTriggerConfig(
+                schedule_type=ScheduleType.CRON,
+                cron="0 9 * * *",
+                timezone="${input.timezone}",
+            )
+
+    async def test_template_schedule_type_is_rejected(self) -> None:
+        """Template expression in schedule_type field is rejected, not bypassed."""
+        with pytest.raises(ValidationError, match="does not support template expressions"):
+            ScheduledTriggerConfig(
+                schedule_type="${input.schedule_type}",  # type: ignore[arg-type]
+            )
+
+    async def test_template_interval_is_rejected(self) -> None:
+        """Template expression in interval field is rejected, not bypassed."""
+        with pytest.raises(ValidationError, match="does not support template expressions"):
+            ScheduledTriggerConfig(
+                schedule_type=ScheduleType.INTERVAL,
+                interval="${input.interval}",
+            )
+
+
+class TestInactiveScheduleFieldIgnored:
+    """The field that doesn't match schedule_type is not validated.
+
+    ``config_to_temporal_schedule`` only ever reads ``interval`` for an
+    interval schedule and ``cron`` for a cron schedule, so a stale/invalid
+    leftover value in the inactive field (e.g. left over from switching
+    schedule_type in the Builder) must not block verify or publish.
+    """
+
+    async def test_invalid_interval_ignored_when_schedule_type_is_cron(self) -> None:
+        """An invalid interval string does not block a cron config."""
         config = ScheduledTriggerConfig(
             schedule_type=ScheduleType.CRON,
             cron="0 9 * * *",
-            timezone="${input.timezone}",
+            interval="not-an-interval",
         )
-        assert config.timezone == "${input.timezone}"
+        assert config.interval == "not-an-interval"
 
-    async def test_template_schedule_type_bypasses_required_check(self) -> None:
-        """Template expression in schedule_type should bypass required field checks."""
-        config = ScheduledTriggerConfig(
-            schedule_type="${input.schedule_type}",  # type: ignore[arg-type]
-        )
-        assert config.schedule_type == "${input.schedule_type}"
-
-    async def test_template_interval_bypasses_validation(self) -> None:
-        """Template expression in interval field should bypass validation."""
+    async def test_invalid_cron_ignored_when_schedule_type_is_interval(self) -> None:
+        """An invalid cron string does not block an interval config."""
         config = ScheduledTriggerConfig(
             schedule_type=ScheduleType.INTERVAL,
-            interval="${input.interval}",
+            interval="R/2024-01-01T10:00:00Z/P1D",
+            cron="not-a-cron",
         )
-        assert config.interval == "${input.interval}"
+        assert config.cron == "not-a-cron"

--- a/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
+++ b/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
@@ -336,6 +336,105 @@ class TestTimezoneValidation:
             assert config.timezone == tz, f"Timezone {tz} should be accepted"
 
 
+class TestIntervalValidation:
+    """Tests for interval field validation (AAP-87629 follow-up).
+
+    ``interval`` previously had no semantic validation beyond "non-empty",
+    so ``ScheduledTriggerConfig.model_validate`` (used by ``/workflows/validate``,
+    publish, and Temporal sync) accepted malformed intervals that only failed
+    later in ``schedule_parser.parse_iso8601_interval`` — after publish had
+    already committed. These tests lock the same semantics at the model layer.
+    """
+
+    async def test_valid_daily_interval(self) -> None:
+        """Daily interval should be accepted."""
+        config = ScheduledTriggerConfig(
+            schedule_type=ScheduleType.INTERVAL,
+            interval="R/2024-01-01T10:00:00Z/P1D",
+        )
+        assert config.interval == "R/2024-01-01T10:00:00Z/P1D"
+
+    async def test_valid_interval_with_end_date(self) -> None:
+        """Interval with an end date should be accepted."""
+        config = ScheduledTriggerConfig(
+            schedule_type=ScheduleType.INTERVAL,
+            interval="R/2024-01-01T10:00:00Z/P1D/2024-12-31T23:59:59Z",
+        )
+        assert config.interval == "R/2024-01-01T10:00:00Z/P1D/2024-12-31T23:59:59Z"
+
+    async def test_valid_monthly_interval(self) -> None:
+        """Calendar-representable monthly interval (P1M) should be accepted."""
+        config = ScheduledTriggerConfig(
+            schedule_type=ScheduleType.INTERVAL,
+            interval="R/2024-01-15T09:00:00Z/P1M",
+        )
+        assert config.interval == "R/2024-01-15T09:00:00Z/P1M"
+
+    async def test_rejects_not_an_interval(self) -> None:
+        """Non-interval text (AAP-87629 regression) should be rejected."""
+        with pytest.raises((ValidationError, ValueError), match="Invalid ISO 8601 repeating interval"):
+            ScheduledTriggerConfig(
+                schedule_type=ScheduleType.INTERVAL,
+                interval="not-an-interval",
+            )
+
+    async def test_rejects_finite_repetition_count(self) -> None:
+        """Finite repetition counts (e.g. R1/...) should be rejected."""
+        with pytest.raises((ValidationError, ValueError), match="not supported"):
+            ScheduledTriggerConfig(
+                schedule_type=ScheduleType.INTERVAL,
+                interval="R1/2024-01-01T10:00:00Z/P1D",
+            )
+
+    async def test_rejects_start_datetime_without_timezone(self) -> None:
+        """Start datetime lacking timezone info should be rejected."""
+        with pytest.raises((ValidationError, ValueError), match="timezone info"):
+            ScheduledTriggerConfig(
+                schedule_type=ScheduleType.INTERVAL,
+                interval="R/2024-01-01T10:00:00/P1D",
+            )
+
+    async def test_rejects_invalid_duration(self) -> None:
+        """Malformed ISO 8601 duration (starts with P but invalid shape) should be rejected."""
+        with pytest.raises((ValidationError, ValueError), match="Invalid ISO 8601 duration"):
+            ScheduledTriggerConfig(
+                schedule_type=ScheduleType.INTERVAL,
+                interval="R/2024-01-01T10:00:00Z/PXYZ",
+            )
+
+    async def test_rejects_mixed_calendar_and_fixed_duration(self) -> None:
+        """Mixed calendar (months) and fixed (days) components should be rejected."""
+        with pytest.raises((ValidationError, ValueError), match="Mixed calendar and fixed"):
+            ScheduledTriggerConfig(
+                schedule_type=ScheduleType.INTERVAL,
+                interval="R/2024-01-01T00:00:00Z/P1M2D",
+            )
+
+    async def test_rejects_unrepresentable_month_step(self) -> None:
+        """Month steps that cannot be expressed as a calendar spec (e.g. P5M) should be rejected."""
+        with pytest.raises((ValidationError, ValueError), match="cannot be represented"):
+            ScheduledTriggerConfig(
+                schedule_type=ScheduleType.INTERVAL,
+                interval="R/2024-01-01T00:00:00Z/P5M",
+            )
+
+    async def test_rejects_day_29_monthly(self) -> None:
+        """Day-of-month 29 with a monthly interval should be rejected."""
+        with pytest.raises((ValidationError, ValueError), match="Day-of-month 29"):
+            ScheduledTriggerConfig(
+                schedule_type=ScheduleType.INTERVAL,
+                interval="R/2024-01-29T10:00:00Z/P1M",
+            )
+
+    async def test_interval_none_passes(self) -> None:
+        """interval=None (e.g. cron schedule_type) should bypass validation."""
+        config = ScheduledTriggerConfig(
+            schedule_type=ScheduleType.CRON,
+            cron="0 9 * * *",
+        )
+        assert config.interval is None
+
+
 class TestTemplateExpressionBypass:
     """Tests for template expression bypass in validated fields."""
 
@@ -362,3 +461,11 @@ class TestTemplateExpressionBypass:
             schedule_type="${input.schedule_type}",  # type: ignore[arg-type]
         )
         assert config.schedule_type == "${input.schedule_type}"
+
+    async def test_template_interval_bypasses_validation(self) -> None:
+        """Template expression in interval field should bypass validation."""
+        config = ScheduledTriggerConfig(
+            schedule_type=ScheduleType.INTERVAL,
+            interval="${input.interval}",
+        )
+        assert config.interval == "${input.interval}"

--- a/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
+++ b/backend/tests/unit/workflows/models/test_scheduled_trigger_config.py
@@ -337,7 +337,7 @@ class TestTimezoneValidation:
 
 
 class TestIntervalValidation:
-    """Tests for interval field validation (AAP-87629 follow-up).
+    """Tests for interval field validation at the model layer.
 
     ``interval`` previously had no semantic validation beyond "non-empty",
     so ``ScheduledTriggerConfig.model_validate`` (used by ``/workflows/validate``,
@@ -371,7 +371,7 @@ class TestIntervalValidation:
         assert config.interval == "R/2024-01-15T09:00:00Z/P1M"
 
     async def test_rejects_not_an_interval(self) -> None:
-        """Non-interval text (AAP-87629 regression) should be rejected."""
+        """Non-interval text should be rejected."""
         with pytest.raises((ValidationError, ValueError), match="Invalid ISO 8601 repeating interval"):
             ScheduledTriggerConfig(
                 schedule_type=ScheduleType.INTERVAL,

--- a/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
+++ b/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
@@ -669,11 +669,13 @@ class TestScheduledTriggerSyncGracefulDegradation:
 class TestAAP87629RegressionPublishInvalidTimezone:
     """Regression tests for AAP-87629: publish with invalid scheduled trigger config.
 
-    Invalid IANA timezones are rejected by ``workflow_validator.collect_findings``
-    (via ``_collect_scheduled_trigger_config_findings``) before any publish
-    mutation. ``ScheduledTriggerService.validate_trigger_configs`` is a
-    raise-first wrapper over that same helper, so verify, publish, and
-    Temporal sync share one semantic contract.
+    Invalid IANA timezones and invalid ISO 8601 interval strings are rejected
+    by ``workflow_validator.collect_findings`` (via
+    ``_collect_scheduled_trigger_config_findings``, which calls
+    ``ScheduledTriggerConfig.model_validate``) before any publish mutation.
+    ``ScheduledTriggerService.validate_trigger_configs`` is a raise-first
+    wrapper over that same helper, so verify, publish, and Temporal sync
+    share one semantic contract.
     """
 
     @pytest.mark.asyncio
@@ -702,6 +704,56 @@ class TestAAP87629RegressionPublishInvalidTimezone:
                         "schedule_type": "cron",
                         "cron": "0 9 * * *",
                         "timezone": "Invalid/Not_A_Real_Zone",
+                    },
+                },
+            ],
+            "nodes": [{"id": "n1", "type": "script", "parameters": {"language": "python", "code": "pass"}}],
+            "edges": [{"from": "sched_1", "to": "n1"}],
+        }
+
+        with (
+            patch.object(mock_service, "_get_workflow_for_update", return_value=mock_workflow),
+            patch.object(mock_service, "_get_version_or_none", return_value=mock_version),
+            patch.object(mock_service.session, "commit", new_callable=AsyncMock) as mock_commit,
+            pytest.raises(WorkflowPublishValidationError) as exc_info,
+        ):
+            await mock_service.publish_workflow_version(workflow_id, version=1)
+
+        assert any("scheduled trigger config" in f.message for f in exc_info.value.validation_result.findings)
+        assert mock_workflow.published_version_id is None
+        mock_commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_publish_rejects_invalid_interval_before_mutation(self, mock_service: WorkflowService) -> None:
+        """Publish must reject an invalid ISO 8601 interval before mutating published_version_id.
+
+        Interval was previously an unconstrained string that only failed much
+        later in ``config_to_temporal_schedule`` -> ``parse_iso8601_interval``
+        (after ``session.commit()``), recreating the published-in-DB /
+        error-to-user inconsistency this bugfix targets.
+        """
+        workflow_id = uuid4()
+        mock_workflow = MagicMock()
+        mock_workflow.id = workflow_id
+        mock_workflow.is_builtin = False
+        mock_workflow.published_version_id = None
+        mock_workflow.current_version = 1
+        mock_workflow.name = "scheduled-wf"
+        mock_workflow.project_id = uuid4()
+
+        mock_version = MagicMock()
+        mock_version.id = uuid4()
+        mock_version.version = 1
+        mock_version.workflow_definition = {
+            "schema_version": "2.0.0",
+            "name": "interval-test",
+            "triggers": [
+                {
+                    "id": "sched_1",
+                    "type": "scheduled_trigger",
+                    "parameters": {
+                        "schedule_type": "interval",
+                        "interval": "not-an-interval",
                     },
                 },
             ],

--- a/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
+++ b/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
@@ -670,10 +670,10 @@ class TestAAP87629RegressionPublishInvalidTimezone:
     """Regression tests for AAP-87629: publish with invalid scheduled trigger config.
 
     Invalid IANA timezones are rejected by ``workflow_validator.collect_findings``
-    (via the module-level ``_collect_scheduled_trigger_config_findings`` helper in
-    ``workflow_definition.py``, which independently applies the same
-    ``ScheduledTriggerConfig`` checks as ``ScheduledTriggerService.validate_trigger_configs``)
-    before any publish mutation — so verify and publish share one semantic contract.
+    (via ``_collect_scheduled_trigger_config_findings``) before any publish
+    mutation. ``ScheduledTriggerService.validate_trigger_configs`` is a
+    raise-first wrapper over that same helper, so verify, publish, and
+    Temporal sync share one semantic contract.
     """
 
     @pytest.mark.asyncio
@@ -770,7 +770,10 @@ class TestAAP87629RegressionPublishInvalidTimezone:
 
 
 class TestAAP87629RegressionValidateTriggerConfigs:
-    """Unit tests for ScheduledTriggerService.validate_trigger_configs static method."""
+    """Unit tests for ScheduledTriggerService.validate_trigger_configs static method.
+
+    This method is a raise-first wrapper over ``_collect_scheduled_trigger_config_findings``.
+    """
 
     def test_valid_timezone_passes(self) -> None:
         definition = {
@@ -821,6 +824,52 @@ class TestAAP87629RegressionValidateTriggerConfigs:
         }
         with pytest.raises(TriggerValidationError, match=r"Invalid.*scheduled trigger config.*<missing id>"):
             ScheduledTriggerService.validate_trigger_configs(definition)
+
+    def test_non_string_trigger_id_uses_missing_id_placeholder(self) -> None:
+        """Non-string ids share the same display policy as collect_findings."""
+        definition = {
+            "triggers": [
+                {
+                    "id": 123,
+                    "type": "scheduled_trigger",
+                    "parameters": {"schedule_type": "cron", "cron": "0 * * * *", "timezone": "Fake/Tz"},
+                }
+            ]
+        }
+        with pytest.raises(TriggerValidationError, match=r"<missing id>"):
+            ScheduledTriggerService.validate_trigger_configs(definition)
+
+    def test_raise_message_matches_collect_findings(self) -> None:
+        """Raise-first wrapper must surface the same message as the shared helper."""
+        from syntara.workflows.validators import workflow_validator
+        from syntara.workflows.validators.workflow_definition import _collect_scheduled_trigger_config_findings
+
+        definition = {
+            "schema_version": "2.0.0",
+            "name": "shared-path-wf",
+            "triggers": [
+                {
+                    "id": "sched_1",
+                    "type": "scheduled_trigger",
+                    "parameters": {
+                        "schedule_type": "cron",
+                        "cron": "0 * * * *",
+                        "timezone": "Fake/Timezone",
+                    },
+                }
+            ],
+            "nodes": [{"id": "n1", "type": "script", "parameters": {"language": "python", "code": "pass"}}],
+            "edges": [{"from": "sched_1", "to": "n1"}],
+        }
+        findings = _collect_scheduled_trigger_config_findings(definition)
+        assert findings
+        with pytest.raises(TriggerValidationError) as exc_info:
+            ScheduledTriggerService.validate_trigger_configs(definition)
+        assert exc_info.value.message == findings[0].message
+        result = workflow_validator.collect_findings(definition)
+        scheduled = [f for f in result.findings if "scheduled trigger config" in f.message]
+        assert scheduled
+        assert scheduled[0].message == findings[0].message
 
     def test_null_timezone_passes(self) -> None:
         definition = {

--- a/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
+++ b/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
@@ -670,8 +670,10 @@ class TestAAP87629RegressionPublishInvalidTimezone:
     """Regression tests for AAP-87629: publish with invalid scheduled trigger config.
 
     Invalid IANA timezones are rejected by ``workflow_validator.collect_findings``
-    (via ``ScheduledTriggerService.validate_trigger_configs``) before any publish
-    mutation — so verify and publish share one semantic contract.
+    (via the module-level ``_collect_scheduled_trigger_config_findings`` helper in
+    ``workflow_definition.py``, which independently applies the same
+    ``ScheduledTriggerConfig`` checks as ``ScheduledTriggerService.validate_trigger_configs``)
+    before any publish mutation — so verify and publish share one semantic contract.
     """
 
     @pytest.mark.asyncio

--- a/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
+++ b/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
@@ -669,14 +669,14 @@ class TestScheduledTriggerSyncGracefulDegradation:
 class TestAAP87629RegressionPublishInvalidTimezone:
     """Regression tests for AAP-87629: publish with invalid scheduled trigger config.
 
-    Validates that invalid timezone in a scheduled trigger causes publish to
-    fail BEFORE the DB commit, rather than after (which would leave the workflow
-    published in the DB while the user sees an error).
+    Invalid IANA timezones are rejected by ``workflow_validator.collect_findings``
+    (via ``ScheduledTriggerService.validate_trigger_configs``) before any publish
+    mutation — so verify and publish share one semantic contract.
     """
 
     @pytest.mark.asyncio
-    async def test_publish_rejects_invalid_timezone_before_commit(self, mock_service: WorkflowService) -> None:
-        """Publish must raise TriggerValidationError before committing when timezone is invalid."""
+    async def test_publish_rejects_invalid_timezone_before_mutation(self, mock_service: WorkflowService) -> None:
+        """Publish must fail during collect_findings before mutating published_version_id."""
         workflow_id = uuid4()
         mock_workflow = MagicMock()
         mock_workflow.id = workflow_id
@@ -694,7 +694,7 @@ class TestAAP87629RegressionPublishInvalidTimezone:
             "name": "timezone-test",
             "triggers": [
                 {
-                    "id": "sched-1",
+                    "id": "sched_1",
                     "type": "scheduled_trigger",
                     "parameters": {
                         "schedule_type": "cron",
@@ -704,29 +704,19 @@ class TestAAP87629RegressionPublishInvalidTimezone:
                 },
             ],
             "nodes": [{"id": "n1", "type": "script", "parameters": {"language": "python", "code": "pass"}}],
-            "edges": [{"from": "sched-1", "to": "n1"}],
+            "edges": [{"from": "sched_1", "to": "n1"}],
         }
-
-        mock_validation_result = MagicMock()
-        mock_validation_result.error_count = 0
-        mock_validation_result.warning_count = 0
-        mock_validation_result.findings = []
 
         with (
             patch.object(mock_service, "_get_workflow_for_update", return_value=mock_workflow),
             patch.object(mock_service, "_get_version_or_none", return_value=mock_version),
-            patch("syntara.workflows.services.workflow_service.workflow_validator") as mock_validator,
-            patch.object(mock_service, "_flush_with_duplicate_check", new_callable=AsyncMock),
-            patch.object(mock_service, "_sync_all_trigger_types", new_callable=AsyncMock),
-            patch.object(mock_service, "_sync_scheduled_triggers", new_callable=AsyncMock),
             patch.object(mock_service.session, "commit", new_callable=AsyncMock) as mock_commit,
-            patch("syntara.workflows.services.workflow_service.AuditEventDispatcher"),
-            patch("syntara.workflows.services.workflow_service.WebhookTriggerService"),
-            pytest.raises(TriggerValidationError, match=r"Invalid.*scheduled trigger config"),
+            pytest.raises(WorkflowPublishValidationError) as exc_info,
         ):
-            mock_validator.collect_findings.return_value = mock_validation_result
             await mock_service.publish_workflow_version(workflow_id, version=1)
 
+        assert any("scheduled trigger config" in f.message for f in exc_info.value.validation_result.findings)
+        assert mock_workflow.published_version_id is None
         mock_commit.assert_not_called()
 
     @pytest.mark.asyncio
@@ -749,7 +739,7 @@ class TestAAP87629RegressionPublishInvalidTimezone:
             "name": "timezone-test",
             "triggers": [
                 {
-                    "id": "sched-1",
+                    "id": "sched_1",
                     "type": "scheduled_trigger",
                     "parameters": {
                         "schedule_type": "cron",
@@ -759,18 +749,12 @@ class TestAAP87629RegressionPublishInvalidTimezone:
                 },
             ],
             "nodes": [{"id": "n1", "type": "script", "parameters": {"language": "python", "code": "pass"}}],
-            "edges": [{"from": "sched-1", "to": "n1"}],
+            "edges": [{"from": "sched_1", "to": "n1"}],
         }
-
-        mock_validation_result = MagicMock()
-        mock_validation_result.error_count = 0
-        mock_validation_result.warning_count = 0
-        mock_validation_result.findings = []
 
         with (
             patch.object(mock_service, "_get_workflow_for_update", return_value=mock_workflow),
             patch.object(mock_service, "_get_version_or_none", return_value=mock_version),
-            patch("syntara.workflows.services.workflow_service.workflow_validator") as mock_validator,
             patch.object(mock_service, "_flush_with_duplicate_check", new_callable=AsyncMock),
             patch.object(mock_service, "_sync_all_trigger_types", new_callable=AsyncMock),
             patch.object(mock_service, "_sync_scheduled_triggers", new_callable=AsyncMock),
@@ -778,7 +762,6 @@ class TestAAP87629RegressionPublishInvalidTimezone:
             patch("syntara.workflows.services.workflow_service.AuditEventDispatcher"),
             patch("syntara.workflows.services.workflow_service.WebhookTriggerService"),
         ):
-            mock_validator.collect_findings.return_value = mock_validation_result
             workflow, _version, _warning = await mock_service.publish_workflow_version(workflow_id, version=1)
 
         assert workflow.published_version_id == mock_version.id
@@ -824,7 +807,8 @@ class TestAAP87629RegressionValidateTriggerConfigs:
         }
         ScheduledTriggerService.validate_trigger_configs(definition)
 
-    def test_missing_trigger_id_skipped(self) -> None:
+    def test_missing_trigger_id_still_validates_config(self) -> None:
+        """Missing id must not skip ScheduledTriggerConfig validation."""
         definition = {
             "triggers": [
                 {
@@ -833,7 +817,8 @@ class TestAAP87629RegressionValidateTriggerConfigs:
                 }
             ]
         }
-        ScheduledTriggerService.validate_trigger_configs(definition)
+        with pytest.raises(TriggerValidationError, match=r"Invalid.*scheduled trigger config.*<missing id>"):
+            ScheduledTriggerService.validate_trigger_configs(definition)
 
     def test_null_timezone_passes(self) -> None:
         definition = {

--- a/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
+++ b/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
@@ -5,7 +5,12 @@ from uuid import uuid4
 
 import pytest
 
-from syntara.workflows.exceptions import ScheduledTriggerSyncError, WorkflowPublishValidationError
+from syntara.workflows.exceptions import (
+    ScheduledTriggerSyncError,
+    TriggerValidationError,
+    WorkflowPublishValidationError,
+)
+from syntara.workflows.services.scheduled_trigger_service import ScheduledTriggerService
 from syntara.workflows.services.workflow_service import WorkflowService
 
 
@@ -659,3 +664,185 @@ class TestScheduledTriggerSyncGracefulDegradation:
                 side_effect=ScheduledTriggerSyncError(str(workflow_id), 0)
             )
             await mock_service.delete_workflow(workflow_id)
+
+
+class TestAAP87629RegressionPublishInvalidTimezone:
+    """Regression tests for AAP-87629: publish with invalid scheduled trigger config.
+
+    Validates that invalid timezone in a scheduled trigger causes publish to
+    fail BEFORE the DB commit, rather than after (which would leave the workflow
+    published in the DB while the user sees an error).
+    """
+
+    @pytest.mark.asyncio
+    async def test_publish_rejects_invalid_timezone_before_commit(self, mock_service: WorkflowService) -> None:
+        """Publish must raise TriggerValidationError before committing when timezone is invalid."""
+        workflow_id = uuid4()
+        mock_workflow = MagicMock()
+        mock_workflow.id = workflow_id
+        mock_workflow.is_builtin = False
+        mock_workflow.published_version_id = None
+        mock_workflow.current_version = 1
+        mock_workflow.name = "scheduled-wf"
+        mock_workflow.project_id = uuid4()
+
+        mock_version = MagicMock()
+        mock_version.id = uuid4()
+        mock_version.version = 1
+        mock_version.workflow_definition = {
+            "schema_version": "2.0.0",
+            "name": "timezone-test",
+            "triggers": [
+                {
+                    "id": "sched-1",
+                    "type": "scheduled_trigger",
+                    "parameters": {
+                        "schedule_type": "cron",
+                        "cron": "0 9 * * *",
+                        "timezone": "Invalid/Not_A_Real_Zone",
+                    },
+                },
+            ],
+            "nodes": [{"id": "n1", "type": "script", "parameters": {"language": "python", "code": "pass"}}],
+            "edges": [{"from": "sched-1", "to": "n1"}],
+        }
+
+        mock_validation_result = MagicMock()
+        mock_validation_result.error_count = 0
+        mock_validation_result.warning_count = 0
+        mock_validation_result.findings = []
+
+        with (
+            patch.object(mock_service, "_get_workflow_for_update", return_value=mock_workflow),
+            patch.object(mock_service, "_get_version_or_none", return_value=mock_version),
+            patch("syntara.workflows.services.workflow_service.workflow_validator") as mock_validator,
+            patch.object(mock_service, "_flush_with_duplicate_check", new_callable=AsyncMock),
+            patch.object(mock_service, "_sync_all_trigger_types", new_callable=AsyncMock),
+            patch.object(mock_service, "_sync_scheduled_triggers", new_callable=AsyncMock),
+            patch.object(mock_service.session, "commit", new_callable=AsyncMock) as mock_commit,
+            patch("syntara.workflows.services.workflow_service.AuditEventDispatcher"),
+            patch("syntara.workflows.services.workflow_service.WebhookTriggerService"),
+            pytest.raises(TriggerValidationError, match=r"Invalid.*scheduled trigger config"),
+        ):
+            mock_validator.collect_findings.return_value = mock_validation_result
+            await mock_service.publish_workflow_version(workflow_id, version=1)
+
+        mock_commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_publish_succeeds_with_valid_timezone(self, mock_service: WorkflowService) -> None:
+        """Publish succeeds when scheduled trigger has a valid IANA timezone."""
+        workflow_id = uuid4()
+        mock_workflow = MagicMock()
+        mock_workflow.id = workflow_id
+        mock_workflow.is_builtin = False
+        mock_workflow.published_version_id = None
+        mock_workflow.current_version = 1
+        mock_workflow.name = "scheduled-wf"
+        mock_workflow.project_id = uuid4()
+
+        mock_version = MagicMock()
+        mock_version.id = uuid4()
+        mock_version.version = 1
+        mock_version.workflow_definition = {
+            "schema_version": "2.0.0",
+            "name": "timezone-test",
+            "triggers": [
+                {
+                    "id": "sched-1",
+                    "type": "scheduled_trigger",
+                    "parameters": {
+                        "schedule_type": "cron",
+                        "cron": "0 9 * * *",
+                        "timezone": "America/New_York",
+                    },
+                },
+            ],
+            "nodes": [{"id": "n1", "type": "script", "parameters": {"language": "python", "code": "pass"}}],
+            "edges": [{"from": "sched-1", "to": "n1"}],
+        }
+
+        mock_validation_result = MagicMock()
+        mock_validation_result.error_count = 0
+        mock_validation_result.warning_count = 0
+        mock_validation_result.findings = []
+
+        with (
+            patch.object(mock_service, "_get_workflow_for_update", return_value=mock_workflow),
+            patch.object(mock_service, "_get_version_or_none", return_value=mock_version),
+            patch("syntara.workflows.services.workflow_service.workflow_validator") as mock_validator,
+            patch.object(mock_service, "_flush_with_duplicate_check", new_callable=AsyncMock),
+            patch.object(mock_service, "_sync_all_trigger_types", new_callable=AsyncMock),
+            patch.object(mock_service, "_sync_scheduled_triggers", new_callable=AsyncMock),
+            patch.object(mock_service.session, "commit", new_callable=AsyncMock),
+            patch("syntara.workflows.services.workflow_service.AuditEventDispatcher"),
+            patch("syntara.workflows.services.workflow_service.WebhookTriggerService"),
+        ):
+            mock_validator.collect_findings.return_value = mock_validation_result
+            workflow, _version, _warning = await mock_service.publish_workflow_version(workflow_id, version=1)
+
+        assert workflow.published_version_id == mock_version.id
+
+
+class TestAAP87629RegressionValidateTriggerConfigs:
+    """Unit tests for ScheduledTriggerService.validate_trigger_configs static method."""
+
+    def test_valid_timezone_passes(self) -> None:
+        definition = {
+            "triggers": [
+                {
+                    "id": "t1",
+                    "type": "scheduled_trigger",
+                    "parameters": {"schedule_type": "cron", "cron": "0 * * * *", "timezone": "UTC"},
+                }
+            ]
+        }
+        ScheduledTriggerService.validate_trigger_configs(definition)
+
+    def test_invalid_timezone_raises(self) -> None:
+        definition = {
+            "triggers": [
+                {
+                    "id": "t1",
+                    "type": "scheduled_trigger",
+                    "parameters": {
+                        "schedule_type": "cron",
+                        "cron": "0 * * * *",
+                        "timezone": "Fake/Timezone",
+                    },
+                }
+            ]
+        }
+        with pytest.raises(TriggerValidationError, match=r"Invalid.*scheduled trigger config"):
+            ScheduledTriggerService.validate_trigger_configs(definition)
+
+    def test_no_scheduled_triggers_passes(self) -> None:
+        definition = {
+            "triggers": [
+                {"id": "t1", "type": "manual_trigger", "parameters": {}},
+            ]
+        }
+        ScheduledTriggerService.validate_trigger_configs(definition)
+
+    def test_missing_trigger_id_skipped(self) -> None:
+        definition = {
+            "triggers": [
+                {
+                    "type": "scheduled_trigger",
+                    "parameters": {"schedule_type": "cron", "cron": "0 * * * *", "timezone": "Fake/Tz"},
+                }
+            ]
+        }
+        ScheduledTriggerService.validate_trigger_configs(definition)
+
+    def test_null_timezone_passes(self) -> None:
+        definition = {
+            "triggers": [
+                {
+                    "id": "t1",
+                    "type": "scheduled_trigger",
+                    "parameters": {"schedule_type": "cron", "cron": "0 * * * *", "timezone": None},
+                }
+            ]
+        }
+        ScheduledTriggerService.validate_trigger_configs(definition)

--- a/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
+++ b/backend/tests/unit/workflows/services/test_workflow_publish_empty.py
@@ -666,12 +666,12 @@ class TestScheduledTriggerSyncGracefulDegradation:
             await mock_service.delete_workflow(workflow_id)
 
 
-class TestAAP87629RegressionPublishInvalidTimezone:
-    """Regression tests for AAP-87629: publish with invalid scheduled trigger config.
+class TestPublishRejectsInvalidScheduledTriggerConfig:
+    """Publish must reject invalid scheduled trigger configs before mutation.
 
     Invalid IANA timezones and invalid ISO 8601 interval strings are rejected
     by ``workflow_validator.collect_findings`` (via
-    ``_collect_scheduled_trigger_config_findings``, which calls
+    ``collect_scheduled_trigger_config_findings``, which calls
     ``ScheduledTriggerConfig.model_validate``) before any publish mutation.
     ``ScheduledTriggerService.validate_trigger_configs`` is a raise-first
     wrapper over that same helper, so verify, publish, and Temporal sync
@@ -821,10 +821,10 @@ class TestAAP87629RegressionPublishInvalidTimezone:
         assert workflow.published_version_id == mock_version.id
 
 
-class TestAAP87629RegressionValidateTriggerConfigs:
-    """Unit tests for ScheduledTriggerService.validate_trigger_configs static method.
+class TestValidateTriggerConfigsSharedContract:
+    """Unit tests for ScheduledTriggerService.validate_trigger_configs.
 
-    This method is a raise-first wrapper over ``_collect_scheduled_trigger_config_findings``.
+    Raise-first wrapper over ``collect_scheduled_trigger_config_findings``.
     """
 
     def test_valid_timezone_passes(self) -> None:
@@ -893,8 +893,7 @@ class TestAAP87629RegressionValidateTriggerConfigs:
 
     def test_raise_message_matches_collect_findings(self) -> None:
         """Raise-first wrapper must surface the same message as the shared helper."""
-        from syntara.workflows.validators import workflow_validator
-        from syntara.workflows.validators.workflow_definition import _collect_scheduled_trigger_config_findings
+        from syntara.workflows.validators import collect_scheduled_trigger_config_findings, workflow_validator
 
         definition = {
             "schema_version": "2.0.0",
@@ -913,7 +912,7 @@ class TestAAP87629RegressionValidateTriggerConfigs:
             "nodes": [{"id": "n1", "type": "script", "parameters": {"language": "python", "code": "pass"}}],
             "edges": [{"from": "sched_1", "to": "n1"}],
         }
-        findings = _collect_scheduled_trigger_config_findings(definition)
+        findings = collect_scheduled_trigger_config_findings(definition)
         assert findings
         with pytest.raises(TriggerValidationError) as exc_info:
             ScheduledTriggerService.validate_trigger_configs(definition)

--- a/backend/tests/unit/workflows/validators/test_workflow_definition_validator.py
+++ b/backend/tests/unit/workflows/validators/test_workflow_definition_validator.py
@@ -930,7 +930,7 @@ class TestScheduledTriggerConfigFindings:
         }
 
     def test_invalid_interval_is_error(self, validator: WorkflowValidator) -> None:
-        """AAP-87629 follow-up: an unparseable interval must fail collect_findings, not just publish."""
+        """An unparseable interval must fail collect_findings, not only publish."""
         result = validator.collect_findings(self._interval_definition(interval="not-an-interval"))
         assert result.is_valid is False
         scheduled = [f for f in result.findings if "scheduled trigger config" in f.message]

--- a/backend/tests/unit/workflows/validators/test_workflow_definition_validator.py
+++ b/backend/tests/unit/workflows/validators/test_workflow_definition_validator.py
@@ -914,6 +914,35 @@ class TestScheduledTriggerConfigFindings:
             "edges": [{"from": "sched_1", "to": "n1"}],
         }
 
+    def _interval_definition(self, *, interval: str) -> dict[str, Any]:
+        return {
+            "schema_version": "2.0.0",
+            "name": "interval-wf",
+            "triggers": [
+                {
+                    "id": "sched_1",
+                    "type": "scheduled_trigger",
+                    "parameters": {"schedule_type": "interval", "interval": interval},
+                }
+            ],
+            "nodes": [{"id": "n1", "type": "script", "parameters": {"language": "python", "code": "pass"}}],
+            "edges": [{"from": "sched_1", "to": "n1"}],
+        }
+
+    def test_invalid_interval_is_error(self, validator: WorkflowValidator) -> None:
+        """AAP-87629 follow-up: an unparseable interval must fail collect_findings, not just publish."""
+        result = validator.collect_findings(self._interval_definition(interval="not-an-interval"))
+        assert result.is_valid is False
+        scheduled = [f for f in result.findings if "scheduled trigger config" in f.message]
+        assert len(scheduled) == 1
+        assert scheduled[0].node_id == "sched_1"
+        assert scheduled[0].field_path == "parameters.interval"
+
+    def test_valid_interval_passes(self, validator: WorkflowValidator) -> None:
+        result = validator.collect_findings(self._interval_definition(interval="R/2024-01-01T10:00:00Z/P1D"))
+        assert result.is_valid is True
+        assert result.findings == []
+
     def test_invalid_iana_timezone_is_error(self, validator: WorkflowValidator) -> None:
         result = validator.collect_findings(self._scheduled_definition(timezone="Invalid/Not_A_Real_Zone"))
         assert result.is_valid is False

--- a/backend/tests/unit/workflows/validators/test_workflow_definition_validator.py
+++ b/backend/tests/unit/workflows/validators/test_workflow_definition_validator.py
@@ -899,6 +899,61 @@ class TestApprovalNodeValidation:
         assert warnings[0].node_id == "approval_1"
 
 
+class TestScheduledTriggerConfigFindings:
+    """collect_findings enforces ScheduledTriggerConfig (IANA timezone) beyond JSON Schema."""
+
+    def _scheduled_definition(self, *, timezone: str | None) -> dict[str, Any]:
+        params: dict[str, Any] = {"schedule_type": "cron", "cron": "0 9 * * *"}
+        if timezone is not None:
+            params["timezone"] = timezone
+        return {
+            "schema_version": "2.0.0",
+            "name": "scheduled-wf",
+            "triggers": [{"id": "sched_1", "type": "scheduled_trigger", "parameters": params}],
+            "nodes": [{"id": "n1", "type": "script", "parameters": {"language": "python", "code": "pass"}}],
+            "edges": [{"from": "sched_1", "to": "n1"}],
+        }
+
+    def test_invalid_iana_timezone_is_error(self, validator: WorkflowValidator) -> None:
+        result = validator.collect_findings(self._scheduled_definition(timezone="Invalid/Not_A_Real_Zone"))
+        assert result.is_valid is False
+        scheduled = [f for f in result.findings if "scheduled trigger config" in f.message]
+        assert len(scheduled) == 1
+        assert scheduled[0].node_id == "sched_1"
+        assert scheduled[0].field_path == "parameters.timezone"
+
+    def test_valid_iana_timezone_passes(self, validator: WorkflowValidator) -> None:
+        result = validator.collect_findings(self._scheduled_definition(timezone="America/New_York"))
+        assert result.is_valid is True
+        assert result.findings == []
+
+    def test_multiple_invalid_triggers_accumulate_findings(self, validator: WorkflowValidator) -> None:
+        definition = {
+            "schema_version": "2.0.0",
+            "name": "multi-scheduled-wf",
+            "triggers": [
+                {
+                    "id": "sched_a",
+                    "type": "scheduled_trigger",
+                    "parameters": {"schedule_type": "cron", "cron": "0 9 * * *", "timezone": "Fake/A"},
+                },
+                {
+                    "id": "sched_b",
+                    "type": "scheduled_trigger",
+                    "parameters": {"schedule_type": "cron", "cron": "0 10 * * *", "timezone": "Fake/B"},
+                },
+            ],
+            "nodes": [{"id": "n1", "type": "script", "parameters": {"language": "python", "code": "pass"}}],
+            "edges": [{"from": "sched_a", "to": "n1"}, {"from": "sched_b", "to": "n1"}],
+        }
+        result = validator.collect_findings(definition)
+        scheduled = [f for f in result.findings if "scheduled trigger config" in f.message]
+        assert result.is_valid is False
+        assert len(scheduled) == 2
+        assert {f.node_id for f in scheduled} == {"sched_a", "sched_b"}
+        assert all(f.field_path == "parameters.timezone" for f in scheduled)
+
+
 class TestBestBranchMessages:
     """Direct tests for _best_branch_messages edge cases."""
 

--- a/frontend/packages/syntara-contracts/src/workflow-api.ts
+++ b/frontend/packages/syntara-contracts/src/workflow-api.ts
@@ -47,6 +47,10 @@ export interface paths {
     /**
      * Validate workflow definition
      * @description Validate a workflow definition without saving it.
+     *
+     *     Requires authentication but no specific workflow/project permission:
+     *     validation is a stateless, side-effect-free check of caller-supplied
+     *     data with no workflow_id or project_id in scope to authorize against.
      */
     post: operations['validate_workflow_definition']
     delete?: never


### PR DESCRIPTION
## Description

The POST `/workflows/validate` endpoint required `workflow:create` permission, but its request body carries no `project_id`/`workflow_id` to scope that check against. `PermissionChecker` then silently fell back to demanding a system-wide grant, so Builder users with only project-scoped roles (`workflow:update:project`, `workflow:read:project`) got "Not authorized" errors trying to publish, even though publishing itself only needs project-scoped permissions.

Since `/validate` is a stateless, side-effect-free check of caller-supplied data with no resource to authorize against, gate it with `NO_PERMISSION` (auth required, no RBAC action) instead of a `PermissionChecker` that can never resolve project scope on this route.

Also fixes a related ordering bug: `publish_workflow_version()` synced scheduled triggers (which validates trigger configs, e.g. IANA timezone) only within `session.commit()`, so an invalid config could leave the workflow published in the DB while surfacing an error to the user. Added `ScheduledTriggerService.validate_trigger_configs()` and call it before the commit in both `publish_workflow_version()` and `sync_scheduled_triggers()`, removing the duplicated inline validation.

### Wire Contract
| Check | Result |
|---|---|
| Endpoints removed/renamed | No |
| Request/response shapes changed | No |
| HTTP status codes / error formats changed | No |
| OpenAPI structural changes | No (description + `x-app-permission` metadata only) |
| Frontend contract (`workflow-api.ts`) | No (doc comment only) |

---
### Behavior Changes

#### 1. `POST /workflows/validate` auth loosened
- **Before:** `workflow:create` required
- **After:** auth-only (`NO_PERMISSION`)
- **Breaking?** No - access is widened, not narrowed
- **Note:** project-scoped users who got 403 now get expected 200/422
#### 2. Scheduled trigger validation is stricter (fail-fast)
- **Before:** invalid IANA timezones / ISO 8601 intervals could pass `/validate` and publish, then fail post-commit during Temporal sync
- **After:** rejected at model validation + `collect_findings()` before DB mutation
- **Breaking?** No - inputs that now fail would always have failed later
- **Note:** tests asserting 200 for `"Fake/TZ"` or `"not-an-interval"` will now get 422 (correct)
---
### Internal Refactor (no behavior change)

- `iso8601_interval.py` extracted from `schedule_parser.py` - same parsing semantics
- `collect_scheduled_trigger_config_findings` promoted to public API
- `sync_scheduled_triggers` uses shared validation helper - same exception types
 
---

### Data / Dependencies

| Check | Result |
|---|---|
| DB migrations | None |
| Model field changes | None |
| Read path affected | No (validators run on write/validate only) |
| New external dependencies | None |
---

### Summary

| Category | Breaking? |
|---|---|
| HTTP API contract | No |
| Authorization | No |
| Validation strictness | No |
| Error formats | No |
| Data / migrations | No |
| Dependencies | No |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- `router.py` - changed /workflows/validate's dependency from Depends(_wf_perm_create) to NO_PERMISSION + explicit Depends(get_current_user), since the old check silently required a system-wide grant project-scoped users never have.

- `scheduled_trigger_service.py` - extracted a new validate_trigger_configs() static method and had sync_scheduled_triggers() call it once up front instead of duplicating the inline validation.

- `workflow_service.py` - call ScheduledTriggerService.validate_trigger_configs() before session.commit() in publish_workflow_version(), so bad configs block the commit instead of surfacing after.

## Out of Scope

N/A

## Related Issues

Fixes https://redhat.atlassian.net/browse/AAP-87629


## How to Test

**Test 1 - Builder tab publish (auth fix)**

Log in as the project-scoped test user (only workflow:update:project, workflow:read:project).
Open the scheduled-trigger workflow in Workflow Builder.
Make a change, click Publish Workflow.
Expected: no "Not authorized to perform create/read on workflow" error.

**Test 2 - Workflows page publish (consistency)**

Same user, go to Workflows list → kebab menu → Publish.
Expected: same result as Test 1 (no divergent error).

**Test 3 - Invalid timezone blocks publish (main regression check)**

Set the scheduled trigger's timezone to Invalid/Not_A_Real_Zone.
Click Publish.
Expected: fails immediately with a timezone validation error.
Refresh the Workflows list a few seconds later - workflow must still show unpublished/draft (no delayed auto-publish).

**Test 4 - Valid timezone still works**

Set timezone back to America/New_York.
Click Publish.
Expected: publishes immediately and successfully.

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [x] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

N/A

## General Checklist

- [x] Code follows the project's coding conventions
- [x] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

N/A

## Additional Notes

N/A
