### PR TITLE
fix(agentic): improve signal callback reliability and e2e keyword match

### DIFF
--- a/backend/src/syntara/agent_orchestrator/utils/workflow_signal_client.py
+++ b/backend/src/syntara/agent_orchestrator/utils/workflow_signal_client.py
@@ -4,6 +4,7 @@ This module provides a centralized client for agent orchestrator services
 to send activity completion signals (both success and failure) to workflows.
 """
 
+import asyncio
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlparse
@@ -17,6 +18,8 @@ from syntara.core.tls.http_client import build_internal_http_client
 logger = structlog.stdlib.get_logger(__name__)
 
 _SIGNAL_HTTP_TIMEOUT_SECONDS = 10.0
+_SIGNAL_MAX_ATTEMPTS = 3
+_SIGNAL_RETRY_BACKOFF_BASE = 0.5
 
 
 def validate_signal_url(callback_url: str) -> None:
@@ -94,19 +97,46 @@ def validate_signal_url(callback_url: str) -> None:
 
 
 async def _post_signal(callback_url: str, payload: dict[str, Any], invocation_id: UUID) -> None:
-    """POST a signal payload to a callback URL with mTLS auth."""
+    """POST a signal payload to a callback URL with mTLS auth.
+
+    Retries on transient failures (network errors, timeouts, 5xx) up to
+    ``_SIGNAL_MAX_ATTEMPTS`` times with exponential backoff.
+    """
     async with build_internal_http_client(timeout=_SIGNAL_HTTP_TIMEOUT_SECONDS) as client:
-        response = await client.post(
-            callback_url,
-            json=payload,
-            headers={"Content-Type": "application/json"},
-        )
-        logger.info(
-            "Signal HTTP response received",
-            invocation_id=invocation_id,
-            status_code=response.status_code,
-        )
-        response.raise_for_status()
+        for attempt in range(_SIGNAL_MAX_ATTEMPTS):
+            try:
+                response = await client.post(
+                    callback_url,
+                    json=payload,
+                    headers={"Content-Type": "application/json"},
+                )
+                logger.info(
+                    "Signal HTTP response received",
+                    invocation_id=invocation_id,
+                    status_code=response.status_code,
+                    attempt=attempt + 1,
+                )
+                if response.is_server_error and attempt < _SIGNAL_MAX_ATTEMPTS - 1:
+                    logger.warning(
+                        "Signal POST server error, retrying",
+                        invocation_id=invocation_id,
+                        status_code=response.status_code,
+                        attempt=attempt + 1,
+                    )
+                    await asyncio.sleep(_SIGNAL_RETRY_BACKOFF_BASE * (2**attempt))
+                    continue
+                response.raise_for_status()
+                return
+            except (httpx.NetworkError, httpx.TimeoutException):
+                if attempt < _SIGNAL_MAX_ATTEMPTS - 1:
+                    logger.warning(
+                        "Signal POST transient failure, retrying",
+                        invocation_id=invocation_id,
+                        attempt=attempt + 1,
+                    )
+                    await asyncio.sleep(_SIGNAL_RETRY_BACKOFF_BASE * (2**attempt))
+                    continue
+                raise
 
 
 class WorkflowSignalClient:

--- a/backend/tests/e2e/workflows/test_workflow_agentic_e2e.py
+++ b/backend/tests/e2e/workflows/test_workflow_agentic_e2e.py
@@ -1006,7 +1006,7 @@ def test_unreachable_llm_endpoint_produces_identifiable_error(
         }, f"Expected failure with unreachable endpoint, got: {result.status}"
 
         error_text = str(result.error_details or "")
-        error_keywords = ("connect", "unreachable", "timeout", "refused", "resolve", "dns")
+        error_keywords = ("connect", "unreachable", "timeout", "timed out", "refused", "resolve", "dns")
         assert any(kw in error_text.lower() for kw in error_keywords), (
             f"Expected identifiable connection error, got: {error_text}"
         )

--- a/backend/tests/unit/agent_orchestrator/utils/test_workflow_signal_client.py
+++ b/backend/tests/unit/agent_orchestrator/utils/test_workflow_signal_client.py
@@ -1,6 +1,7 @@
 """Unit tests for WorkflowSignalClient."""
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 import httpx
@@ -154,7 +155,8 @@ class TestWorkflowSignalClientSendSuccessSignal:
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_send_success_signal_raises_on_http_error(self) -> None:
+    @patch("syntara.agent_orchestrator.utils.workflow_signal_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_send_success_signal_raises_on_http_error(self, _mock_sleep: AsyncMock) -> None:  # noqa: PT019
         """Test that send_success_signal raises on HTTP error."""
         invocation_id = UUID(_EXEC_UUID)
         result = {"content": "Test"}
@@ -166,7 +168,8 @@ class TestWorkflowSignalClientSendSuccessSignal:
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_send_success_signal_raises_on_connection_error(self) -> None:
+    @patch("syntara.agent_orchestrator.utils.workflow_signal_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_send_success_signal_raises_on_connection_error(self, _mock_sleep: AsyncMock) -> None:  # noqa: PT019
         """Test that send_success_signal raises on connection error."""
         invocation_id = UUID(_EXEC_UUID)
         result = {"content": "Test"}
@@ -175,6 +178,22 @@ class TestWorkflowSignalClientSendSuccessSignal:
 
         with pytest.raises(httpx.ConnectError):
             await WorkflowSignalClient.send_success_signal(_SIGNAL_URL, invocation_id, result)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("syntara.agent_orchestrator.utils.workflow_signal_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_send_success_signal_retries_then_succeeds(self, _mock_sleep: AsyncMock) -> None:  # noqa: PT019
+        """Transient 503 followed by 200 delivers the signal."""
+        invocation_id = UUID(_EXEC_UUID)
+        result = {"content": "Test"}
+
+        route = respx.post(_SIGNAL_URL).mock(
+            side_effect=[httpx.Response(503), httpx.Response(200)],
+        )
+
+        await WorkflowSignalClient.send_success_signal(_SIGNAL_URL, invocation_id, result)
+
+        assert route.call_count == 2
 
     @pytest.mark.asyncio
     @respx.mock
@@ -243,7 +262,8 @@ class TestWorkflowSignalClientSendFailureSignal:
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_send_failure_signal_swallows_http_error(self) -> None:
+    @patch("syntara.agent_orchestrator.utils.workflow_signal_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_send_failure_signal_swallows_http_error(self, _mock_sleep: AsyncMock) -> None:  # noqa: PT019
         """Test that send_failure_signal swallows HTTP errors (best-effort)."""
         invocation_id = UUID(_EXEC_UUID)
         error = RuntimeError("Something went wrong")
@@ -254,7 +274,8 @@ class TestWorkflowSignalClientSendFailureSignal:
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_send_failure_signal_swallows_connection_error(self) -> None:
+    @patch("syntara.agent_orchestrator.utils.workflow_signal_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_send_failure_signal_swallows_connection_error(self, _mock_sleep: AsyncMock) -> None:  # noqa: PT019
         """Test that send_failure_signal swallows connection errors (best-effort)."""
         invocation_id = UUID(_EXEC_UUID)
         error = Exception("Test error")
@@ -265,7 +286,8 @@ class TestWorkflowSignalClientSendFailureSignal:
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_send_failure_signal_swallows_timeout(self) -> None:
+    @patch("syntara.agent_orchestrator.utils.workflow_signal_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_send_failure_signal_swallows_timeout(self, _mock_sleep: AsyncMock) -> None:  # noqa: PT019
         """Test that send_failure_signal swallows timeout errors (best-effort)."""
         invocation_id = UUID(_EXEC_UUID)
         error = TimeoutError("Request timed out")


### PR DESCRIPTION
## Summary

- **Signal retry logic**: Add retry with exponential backoff to `_post_signal()` for transient failures (network errors, timeouts, 5xx). Worst-case latency increases from ~10s to ~33.5s when all 3 attempts fail. This addresses silent signal loss when `send_failure_signal()` swallows POST errors, which caused agentic executions to fall through to Temporal timeout instead of surfacing the actual error.
- **Broader network error coverage**: Catch `httpx.NetworkError` (parent of `ConnectError`, `ReadError`, `WriteError`, `CloseError`) instead of just `ConnectError`.
- **E2e keyword fix**: Add `"timed out"` to `test_unreachable_llm_endpoint_produces_identifiable_error` keyword list — the error text changed from `"timeout"` to `"timed out"`.

## Review feedback addressed

- Renamed `_SIGNAL_MAX_RETRIES` → `_SIGNAL_MAX_ATTEMPTS` (3 = total attempts, not retries)
- Widened exception catch from `httpx.ConnectError` to `httpx.NetworkError`
- Added `logger.warning` on 5xx retry path (matches network error path)
- Added "retry then succeed" unit test (503 → 200, asserts `call_count == 2`)

## Test plan

- [x] Existing unit tests pass with retry logic (sleep patched to avoid delays)
- [x] New unit test covers "retry then succeed" path
- [x] `ruff check` and `mypy` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)