### PR TITLE
fix(AAP-85461): empty state for transfer identity wizard

### DIFF
--- a/frontend/packages/syntara-ui/e2e/transfer-identity-wizard.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/transfer-identity-wizard.spec.ts
@@ -7,7 +7,7 @@
  * Critical paths covered:
  * - Wizard navigation: button on identities tab, page title, step nav
  * - Step 1: Next disabled until user selected, filtering, user selection
- * - Step 2: empty state, Transfer identity disabled until identity selected
+ * - Step 2: empty state (no selection heading/filters when source has no identities)
  * - Back from Step 2 clears selections and returns to Step 1
  * - Cancel navigates back to identities tab
  * - Full attach flow tested in user-identity-admin-actions.spec.ts (route-intercepted)
@@ -207,7 +207,9 @@ test.describe('Transfer Identity Wizard (AAP-75585)', () => {
     await app.getByText(`${prefix}-source@test.com`).click()
     await app.getByRole('button', { name: 'Next', exact: true }).click()
 
-    await expect(app.getByRole('heading', { level: 2, name: 'Select an identity' })).toBeVisible({ timeout: 10_000 })
+    // Seeded source users have no federated identities, so Step 2 is the empty state
+    // (selection heading/filters are hidden until there is something to select).
+    await expect(app.getByText('No identities')).toBeVisible({ timeout: 10_000 })
 
     await app.getByRole('button', { name: 'Back' }).click()
 
@@ -225,7 +227,7 @@ test.describe('Transfer Identity Wizard (AAP-75585)', () => {
     await app.getByRole('button', { name: 'Apply filter' }).click()
     await app.getByText(`${prefix}-source@test.com`).click()
     await app.getByRole('button', { name: 'Next', exact: true }).click()
-    await expect(app.getByRole('heading', { level: 2, name: 'Select an identity' })).toBeVisible({ timeout: 10_000 })
+    await expect(app.getByText('No identities')).toBeVisible({ timeout: 10_000 })
 
     await app.getByRole('button', { name: 'Back' }).click()
     await expect(app.getByRole('heading', { level: 2, name: 'Select a user' })).toBeVisible({ timeout: 10_000 })
@@ -235,11 +237,11 @@ test.describe('Transfer Identity Wizard (AAP-75585)', () => {
     await app.getByText(`${prefix}-source2@test.com`).click()
     await app.getByRole('button', { name: 'Next', exact: true }).click()
 
-    await expect(app.getByRole('heading', { level: 2, name: 'Select an identity' })).toBeVisible({ timeout: 10_000 })
+    await expect(app.getByText('No identities')).toBeVisible({ timeout: 10_000 })
     await expect(app.getByRole('button', { name: 'Transfer identity' })).toBeDisabled()
   })
 
-  test('Step 2 shows step heading and description with selected user name', async ({ app }) => {
+  test('step 2 empty state hides selection heading and description', async ({ app }) => {
     expect(targetUserId && sourceUserId, 'Backend seeding failed').toBeTruthy()
 
     await app.goto(toAppUrl(`${ACCESS_URL}/${targetUserId}/transfer-identity`))
@@ -250,7 +252,8 @@ test.describe('Transfer Identity Wizard (AAP-75585)', () => {
     await app.getByText(`${prefix}-source@test.com`).click()
     await app.getByRole('button', { name: 'Next', exact: true }).click()
 
-    await expect(app.getByRole('heading', { level: 2, name: 'Select an identity' })).toBeVisible({ timeout: 10_000 })
-    await expect(app.getByText(/federated identities to attach to the current user/i)).toBeVisible()
+    await expect(app.getByText('No identities')).toBeVisible({ timeout: 10_000 })
+    await expect(app.getByRole('heading', { level: 2, name: 'Select an identity' })).not.toBeVisible()
+    await expect(app.getByText(/federated identities to attach to the current user/i)).not.toBeVisible()
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/TransferIdentityWizard.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/TransferIdentityWizard.test.tsx
@@ -130,11 +130,24 @@ function setupAccessClientMock() {
   })
 }
 
-function setupMocks({ identities = mockIdentities }: { identities?: unknown[] } = {}) {
-  vi.mocked(usersClient.useQuery).mockImplementation((_method, path) => {
+function setupMocks({
+  identities = mockIdentities,
+  users = mockUsers,
+  emptyUsersWhenFiltered = false,
+}: {
+  identities?: unknown[]
+  users?: typeof mockUsers
+  emptyUsersWhenFiltered?: boolean
+} = {}) {
+  vi.mocked(usersClient.useQuery).mockImplementation((_method, path, options) => {
     if (path === '/users') {
+      const query = (options as { params?: { query?: Record<string, unknown> } } | undefined)?.params?.query ?? {}
+      const hasApiFilters = Object.keys(query).some(
+        (key) => key !== 'limit' && key !== 'include_total' && key !== 'cursor'
+      )
+      const data = emptyUsersWhenFiltered && hasApiFilters ? { resources: [], next: null, total: 0 } : users
       return {
-        data: mockUsers,
+        data,
         isPending: false,
         isError: false,
         error: null,
@@ -233,6 +246,51 @@ describe('TransferIdentityWizard', () => {
       const radios = screen.getAllByRole('radio')
       expect(radios.length).toBeGreaterThan(0)
     })
+
+    it('shows no-data empty state when no selectable users exist', () => {
+      setupMocks({
+        users: {
+          resources: [
+            {
+              id: 'target-user',
+              username: 'targetuser',
+              email: 'target@example.com',
+              first_name: 'Target',
+              last_name: 'User',
+            },
+          ],
+          next: null,
+          total: 1,
+        },
+      })
+      render(<TransferIdentityWizard />, { wrapper })
+
+      expect(screen.getByText('No users yet')).toBeInTheDocument()
+      expect(
+        screen.getByText('There must be at least one other user before you can transfer a federated identity.')
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(/Choose the user whose federated identity you want to transfer/i)
+      ).not.toBeInTheDocument()
+      expect(screen.queryByRole('search', { name: 'Filters' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('columnheader', { name: /Username/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('columnheader', { name: /Email/i })).not.toBeInTheDocument()
+    })
+
+    it('shows filter empty state when no users match active filters', async () => {
+      setupMocks({ emptyUsersWhenFiltered: true })
+      const user = userEvent.setup()
+      render(<TransferIdentityWizard />, { wrapper })
+
+      const usernameInput = screen.getByRole('textbox', { name: /username filter/i })
+      await user.type(usernameInput, 'zzz-nonexistent')
+      await user.keyboard('{Enter}')
+
+      expect(await screen.findByText('No results found')).toBeInTheDocument()
+      expect(screen.getByText(/Choose the user whose federated identity you want to transfer/i)).toBeInTheDocument()
+      expect(screen.getByRole('search', { name: 'Filters' })).toBeInTheDocument()
+      expect(screen.queryByText('No users yet')).not.toBeInTheDocument()
+    })
   })
 
   describe('Step 2 - Select an identity', () => {
@@ -271,6 +329,22 @@ describe('TransferIdentityWizard', () => {
 
       expect(screen.getByText('No identities')).toBeInTheDocument()
       expect(screen.getByText('This user has no federated identities to attach.')).toBeInTheDocument()
+      expect(screen.queryByText(/Choose one of/i)).not.toBeInTheDocument()
+      expect(screen.queryByRole('search', { name: 'Filters' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('columnheader', { name: /Provider/i })).not.toBeInTheDocument()
+    })
+
+    it('shows filter empty state when no identities match active filters', async () => {
+      const user = await goToStep2()
+
+      const providerInput = screen.getByRole('textbox', { name: /provider filter/i })
+      await user.type(providerInput, 'zzz-nonexistent')
+      await user.keyboard('{Enter}')
+
+      expect(await screen.findByText('No results found')).toBeInTheDocument()
+      expect(screen.getByText(/Choose one of/i)).toBeInTheDocument()
+      expect(screen.getByRole('search', { name: 'Filters' })).toBeInTheDocument()
+      expect(screen.queryByText('No identities')).not.toBeInTheDocument()
     })
 
     it('has Transfer identity button disabled until an identity is selected', async () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/TransferIdentityWizard.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/TransferIdentityWizard.test.tsx
@@ -329,6 +329,7 @@ describe('TransferIdentityWizard', () => {
 
       expect(screen.getByText('No identities')).toBeInTheDocument()
       expect(screen.getByText('This user has no federated identities to attach.')).toBeInTheDocument()
+      expect(screen.queryByRole('heading', { level: 2, name: 'Select an identity' })).not.toBeInTheDocument()
       expect(screen.queryByText(/Choose one of/i)).not.toBeInTheDocument()
       expect(screen.queryByRole('search', { name: 'Filters' })).not.toBeInTheDocument()
       expect(screen.queryByRole('columnheader', { name: /Provider/i })).not.toBeInTheDocument()

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/transferIdentitySteps.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/transferIdentitySteps.tsx
@@ -1,5 +1,5 @@
 import { Content, ContentVariants, EmptyState, EmptyStateBody, Label, StackItem, Title } from '@patternfly/react-core'
-import { RhUiKeyIcon } from '@patternfly/react-icons'
+import { RhUiCubesFillIcon, RhUiKeyIcon } from '@patternfly/react-icons'
 import { Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import { useCallback, useState } from 'react'
 
@@ -73,35 +73,50 @@ export function SelectUserStep({
   onSelect: (user: UserSummary) => void
 }>) {
   const hasActiveFilters = usersFilter.filters.length > 0
+  const showSelectionUi = users.length > 0 || hasActiveFilters
 
   return (
     <NxPanelContentStack>
-      <StackItem>
-        <Title headingLevel="h2" className={styles.stepTitle}>
-          Select a user
-        </Title>
-        <Content component={ContentVariants.p} className={styles.stepDescription}>
-          Choose the user whose federated identity you want to transfer. The selected identity will be moved from this
-          user to <strong>{targetUsername}</strong>.
-        </Content>
-      </StackItem>
-      <StackItem className={styles.filterBar}>
-        <FilterBar
-          fieldDefinitions={USER_FILTER_DEFS}
-          filters={usersFilter.filters}
-          onFilterChange={(f) => {
-            usersFilter.setAllFilters(f)
-            onResetPage()
-          }}
-          showClearAll
-          isCompact
-        />
-      </StackItem>
-      {users.length === 0 && hasActiveFilters ? (
+      {showSelectionUi && (
+        <>
+          <StackItem>
+            <Title headingLevel="h2" className={styles.stepTitle}>
+              Select a user
+            </Title>
+            <Content component={ContentVariants.p} className={styles.stepDescription}>
+              Choose the user whose federated identity you want to transfer. The selected identity will be moved from
+              this user to <strong>{targetUsername}</strong>.
+            </Content>
+          </StackItem>
+          <StackItem className={styles.filterBar}>
+            <FilterBar
+              fieldDefinitions={USER_FILTER_DEFS}
+              filters={usersFilter.filters}
+              onFilterChange={(f) => {
+                usersFilter.setAllFilters(f)
+                onResetPage()
+              }}
+              showClearAll
+              isCompact
+            />
+          </StackItem>
+        </>
+      )}
+      {!showSelectionUi && (
+        <StackItem isFilled style={flexCenteredBothAxes}>
+          <EmptyState headingLevel="h4" titleText="No users yet" icon={RhUiCubesFillIcon} variant="sm">
+            <EmptyStateBody>
+              There must be at least one other user before you can transfer a federated identity.
+            </EmptyStateBody>
+          </EmptyState>
+        </StackItem>
+      )}
+      {users.length === 0 && hasActiveFilters && (
         <StackItem isFilled style={flexCenteredBothAxes}>
           <NxEmptyStateFilter clearAllFilters={usersFilter.clearAllFilters} />
         </StackItem>
-      ) : (
+      )}
+      {users.length > 0 && (
         <NxScrollableTableContainer caption="Select a user" footer={footerProps} useFixedLayout={false}>
           <Thead>
             <Tr>
@@ -172,42 +187,47 @@ export function SelectIdentityStep({
   const paginatedIdentities = identities.slice((page - 1) * perPage, page * perPage)
 
   const hasActiveFilters = identitiesFilter.filters.length > 0
+  const showSelectionUi = identities.length > 0 || hasActiveFilters
 
   return (
     <NxPanelContentStack>
-      <StackItem>
-        <Title headingLevel="h2" className={styles.stepTitle}>
-          Select an identity
-        </Title>
-        <Content component={ContentVariants.p} className={styles.stepDescription}>
-          Choose one of <strong>{selectedUserDisplayName}</strong>&apos;s federated identities to attach to the current
-          user. This will log <strong>{selectedUserDisplayName}</strong> out of any pre-existing sessions.
-        </Content>
-      </StackItem>
-      <StackItem className={styles.filterBar}>
-        <FilterBar
-          fieldDefinitions={IDENTITY_FILTER_DEFS}
-          filters={identitiesFilter.filters}
-          onFilterChange={(f) => {
-            identitiesFilter.setAllFilters(f)
-            setPage(1)
-          }}
-          clearAllFilters={() => {
-            identitiesFilter.clearAllFilters()
-            setPage(1)
-          }}
-          showClearAll
-          isCompact
-        />
-      </StackItem>
+      {showSelectionUi && (
+        <>
+          <StackItem>
+            <Title headingLevel="h2" className={styles.stepTitle}>
+              Select an identity
+            </Title>
+            <Content component={ContentVariants.p} className={styles.stepDescription}>
+              Choose one of <strong>{selectedUserDisplayName}</strong>&apos;s federated identities to attach to the
+              current user. This will log <strong>{selectedUserDisplayName}</strong> out of any pre-existing sessions.
+            </Content>
+          </StackItem>
+          <StackItem className={styles.filterBar}>
+            <FilterBar
+              fieldDefinitions={IDENTITY_FILTER_DEFS}
+              filters={identitiesFilter.filters}
+              onFilterChange={(f) => {
+                identitiesFilter.setAllFilters(f)
+                setPage(1)
+              }}
+              clearAllFilters={() => {
+                identitiesFilter.clearAllFilters()
+                setPage(1)
+              }}
+              showClearAll
+              isCompact
+            />
+          </StackItem>
+        </>
+      )}
       {identities.length === 0 && hasActiveFilters && (
         <StackItem isFilled style={flexCenteredBothAxes}>
           <NxEmptyStateFilter clearAllFilters={identitiesFilter.clearAllFilters} />
         </StackItem>
       )}
-      {identities.length === 0 && !hasActiveFilters && (
+      {!showSelectionUi && (
         <StackItem isFilled style={flexCenteredBothAxes}>
-          <EmptyState headingLevel="h4" titleText="No identities" icon={RhUiKeyIcon}>
+          <EmptyState headingLevel="h4" titleText="No identities" icon={RhUiKeyIcon} variant="sm">
             <EmptyStateBody>This user has no federated identities to attach.</EmptyStateBody>
           </EmptyState>
         </StackItem>


### PR DESCRIPTION
## Description

when the transfer identity wizard has no selectable source users, step 1 showed a blank table and misleading pagination instead of a proper empty state. this adds the nexus three-state pattern for both wizard steps.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] step 1: true no-data empty state (`No users yet`) hides step title, description, and filter bar
- [x] filter miss still shows header + FilterBar + `NxEmptyStateFilter`
- [x] step 2 uses the same `showSelectionUi` pattern for `No identities`
- [x] unit coverage for no-data and filter-miss on both steps

## Out of Scope

- cancel button footer alignment (AAP-85450)
- backend / API changes
- create-user CTA on the wizard empty state

## Related Issues

Fixes AAP-85461

## How to Test

1. log in as admin
2. go to Access Management → Users → open a user → Identities → Transfer identity
3. with other users available: table + filters look normal
4. apply a username filter that matches nothing: header + filters stay, `No results found` shows
5. with only the target user (or target + builtin) selectable: `No users yet`, no step copy, no filter bar, no table headers
6. pick a user with no federated identities → Next: `No identities` without step copy / provider filter

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

with data (no change):
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/6e7b24fd-1672-4dc3-8c99-66c2c657a871" />

filter miss:
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/1328f35a-2ff7-4d93-8f1d-1264a0af1c8e" />

no users
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/85f1e93c-842b-4f0c-8fae-9f185e8d731d" />

no identities
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/502bd56c-550e-4617-86df-eb4b6d8c8bef" />


## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->