### PR TITLE
feat(tests): add dynamic xfail from URL for pytest and Playwright

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -387,6 +387,7 @@ jobs:
       UV_PYTHON: ${{ matrix.python-version }}
       DOCKER_HOST: unix:///var/run/docker.sock
       TESTCONTAINERS_RYUK_DISABLED: "true"
+      SYNTARA_XFAIL_SOURCE: https://raw.githubusercontent.com/syntara-orchestration/syntara-ci/refs/heads/main/
 
     steps:
       - name: Checkout code
@@ -428,6 +429,7 @@ jobs:
       UV_PYTHON: ${{ matrix.python-version }}
       DOCKER_HOST: unix:///var/run/docker.sock
       TESTCONTAINERS_RYUK_DISABLED: "true"
+      SYNTARA_XFAIL_SOURCE: https://raw.githubusercontent.com/syntara-orchestration/syntara-ci/refs/heads/main/
 
     steps:
       - name: Checkout code
@@ -474,6 +476,7 @@ jobs:
       AUDIT_DRAIN_CYCLE_BASELINE_MS: "2000"
       TOKEN_CONCURRENT_P95_THRESHOLD_MS: "15000"
       TOKEN_CONCURRENT_CAPACITY_P95_THRESHOLD_MS: "20000"
+      SYNTARA_XFAIL_SOURCE: https://raw.githubusercontent.com/syntara-orchestration/syntara-ci/refs/heads/main/
 
     steps:
       - name: Checkout code
@@ -519,6 +522,8 @@ jobs:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      SYNTARA_XFAIL_SOURCE: https://raw.githubusercontent.com/syntara-orchestration/syntara-ci/refs/heads/main/
     steps:
       - name: Free disk space
         run: |

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -529,6 +529,7 @@ jobs:
           NEXUS_E2E_SKIP_WEB_SERVER: '1'
           NEXUS_E2E_BASE_URL: http://localhost:8080
           NEXUS_E2E_PASSWORD: ${{ env.NEXUS_E2E_PASSWORD }}
+          SYNTARA_XFAIL_SOURCE: https://raw.githubusercontent.com/syntara-orchestration/syntara-ci/refs/heads/main/
           CURRENTS_PROJECT_ID: ${{ secrets.CURRENTS_PROJECT_ID }}
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
           CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -19,6 +19,7 @@ REDIS_IMAGE ?= mirror.gcr.io/library/redis:6
 APP_IMAGE ?= localhost/syntara:latest
 APP_UI_IMAGE ?= quay.io/ansible/syntara-ui
 APP_UI_VERSION ?= latest
+XFAIL_ARGS := $(if $(SYNTARA_XFAIL_SOURCE),--xfail-from-url $(SYNTARA_XFAIL_SOURCE)backend.md,)
 ifeq ($(shell uname -s),Darwin)
 # macOS: try podman machine inspect first (works for any machine name),
 # then the standard symlink, then Homebrew's common location
@@ -100,7 +101,7 @@ define run-tests
 @PODMAN_SOCK="$(PODMAN_SOCK)" POSTGRES_IMAGE="$(POSTGRES_IMAGE)" REDIS_IMAGE="$(REDIS_IMAGE)" \
 	APP_JWT_PRIVATE_KEY_PATH=.secrets/jwt-primary.pem \
 	./tools/scripts/run-with-testcontainers.sh --label "🧪 Running tests" -- \
-	uv run --no-sync pytest $(1)
+	uv run --no-sync pytest $(XFAIL_ARGS) $(1)
 endef
 
 
@@ -130,7 +131,16 @@ ifndef APP_BASE_URL
 	$(call _e2e-run,tests/ -v -m "mcp")
 else
 	@echo "🧪 Running MCP tests..."
-	uv run --no-sync pytest tests/ -v -m "mcp"
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/ -v -m "mcp"
+endif
+
+.PHONY: test-performance
+test-performance: check-deps ## Run performance tests only (excluded from default test runs)
+ifndef APP_BASE_URL
+	$(call _e2e-run,tests/performance/ -v --run-performance)
+else
+	@echo "🧪 Running performance tests..."
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/performance/ -v --run-performance
 endif
 
 
@@ -180,7 +190,7 @@ test-all: check-deps ## Run all tests (unit + integration; E2E runs separately v
 # Usage: $(call _e2e-run,<pytest-args>)
 define _e2e-run
 @COMPOSE_CMD="$(COMPOSE_FINAL_CMD)" \
-	./tools/scripts/e2e-run.sh $(1)
+	./tools/scripts/e2e-run.sh $(XFAIL_ARGS) $(1)
 endef
 
 # Default to empty so it runs all tests if not provided
@@ -194,7 +204,7 @@ ifndef APP_BASE_URL
 	$(call _e2e-run,tests/e2e/$(E2E_TARGET) -v -m "not global_revocation" $(E2E_ARGS))
 else
 	@echo "🧪 Running E2E tests $(if $(PHASE),for phase $(PHASE),$(if $(EXCLUDE),excluding phase $(EXCLUDE),))..."
-	uv run --no-sync pytest tests/e2e/$(E2E_TARGET) -v -m "not global_revocation" $(E2E_ARGS)
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/e2e/$(E2E_TARGET) -v -m "not global_revocation" $(E2E_ARGS)
 endif
 
 .PHONY: test-e2e-global-revocation
@@ -203,7 +213,7 @@ ifndef APP_BASE_URL
 	$(call _e2e-run,tests/e2e/ -v -m global_revocation)
 else
 	@echo "🧪 Running global revocation E2E tests..."
-	uv run --no-sync pytest tests/e2e/ -v -m global_revocation; \
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/e2e/ -v -m global_revocation; \
 	exitcode=$$?; \
 	if [ $$exitcode -eq 5 ]; then echo "⚠️  No global revocation tests found — all migrated downstream"; exit 0; fi; \
 	exit $$exitcode
@@ -221,11 +231,11 @@ test-e2e-exclude-pr-check: ## Run E2E tests excluding PR checks (alias for: make
 .PHONY: test-e2e-telemetry
 test-e2e-telemetry: check-deps ## Run telemetry E2E tests only
 ifndef APP_BASE_URL
-	$(call _e2e-run,tests/e2e/telemetry/ -v -n auto --dist loadscope --ignore=tests/e2e/telemetry/test_performance_and_resilience.py && APP_BASE_URL=$${APP_BASE_URL:-http://localhost:8000} uv run --no-sync pytest tests/e2e/telemetry/test_performance_and_resilience.py -v)
+	$(call _e2e-run,tests/e2e/telemetry/ -v -n auto --dist loadscope --ignore=tests/e2e/telemetry/test_performance_and_resilience.py && APP_BASE_URL=$${APP_BASE_URL:-http://localhost:8000} uv run --no-sync pytest $(XFAIL_ARGS) tests/e2e/telemetry/test_performance_and_resilience.py -v)
 else
 	@echo "🧪 Running telemetry E2E tests..."
-	uv run --no-sync pytest tests/e2e/telemetry/ -v -n auto --dist loadscope --ignore=tests/e2e/telemetry/test_performance_and_resilience.py && \
-	uv run --no-sync pytest tests/e2e/telemetry/test_performance_and_resilience.py -v
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/e2e/telemetry/ -v -n auto --dist loadscope --ignore=tests/e2e/telemetry/test_performance_and_resilience.py && \
+	uv run --no-sync pytest $(XFAIL_ARGS) tests/e2e/telemetry/test_performance_and_resilience.py -v
 endif
 
 # Development workflow

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -306,6 +306,7 @@ markers = [
     "compliance: marks tests as compliance tests (auth coverage, API contract enforcement)",
     "destructive: marks tests that mutate live cluster state (e.g. HPA autoscaling) — excluded from routine runs",
     "k8s_required: marks tests that need KUBECONFIG + PERF_K8S_NAMESPACE to reach a Kubernetes cluster",
+    "xfail_from_url: dynamically applied by --xfail-from-url from a remote URL",
 ]
 
 # Coverage configuration

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,8 @@ syntara.* imports happen AFTER pytest-cov starts its coverage tracer.
 pytest_plugins = [
     # Logging setup, performance marker, worker_id fixture, and cleanup hooks
     "tests.fixtures.hooks",
+    # Dynamic xfail from remote URL (enabled via --xfail-from-url)
+    "tests.fixtures.xfail_from_url",
     # Shared fixtures used across unit, integration, performance, and E2E tests
     "tests.fixtures.database",
     "tests.fixtures.users",

--- a/backend/tests/fixtures/xfail_from_url.py
+++ b/backend/tests/fixtures/xfail_from_url.py
@@ -1,0 +1,121 @@
+"""Dynamically xfail tests listed at a remote URL.
+
+When ``--xfail-from-url`` is passed, fetches a Markdown file and parses
+``# `` headings as test node-id patterns.  The text below each heading is
+used as the xfail reason.  Each entry can be a directory, file, or full
+test node-id — matching tests are marked *xfail*.
+
+If the fetch fails (network, auth, …) the run continues without marking
+anything (fail-open).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import httpx
+import pytest
+import structlog
+
+logger = structlog.stdlib.get_logger(__name__)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("url_xfail", "dynamic xfail from URL")
+    group.addoption(
+        "--xfail-from-url",
+        default=None,
+        help="URL or file path of a Markdown file listing tests to mark as xfail",
+    )
+
+
+def _is_file_path(source: str) -> bool:
+    return source.startswith(("/", "./", "../"))
+
+
+def _load_xfail_file(source: str) -> str | None:
+    """Load the xfail Markdown file from a URL or local path."""
+    if _is_file_path(source):
+        path = Path(source)
+        try:
+            return path.read_text()
+        except OSError as exc:
+            logger.warning("url_xfail: failed to read file", path=str(path), error=str(exc))
+            return None
+
+    try:
+        response = httpx.get(source, timeout=30, follow_redirects=True)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning("url_xfail: failed to fetch file", url=source, error=str(exc))
+        return None
+
+    return response.text
+
+
+_HEADING_RE = re.compile(r"^#\s+(.+)$")
+
+
+def _parse_xfail_entries(content: str) -> list[tuple[str, str]]:
+    """Parse H1 headings as test node-ids with the following text as the reason."""
+    entries: list[tuple[str, str]] = []
+    current_pattern: str | None = None
+    reason_lines: list[str] = []
+
+    def _flush() -> None:
+        if current_pattern is not None:
+            reason = " ".join(reason_lines).strip() or "listed in xfail list"
+            entries.append((current_pattern, reason))
+
+    for line in content.splitlines():
+        match = _HEADING_RE.match(line.strip())
+        if match:
+            _flush()
+            current_pattern = match.group(1).strip()
+            reason_lines = []
+        elif current_pattern is not None:
+            stripped = line.strip()
+            if stripped:
+                reason_lines.append(stripped)
+
+    _flush()
+    return entries
+
+
+def _matches(nodeid: str, pattern: str) -> bool:
+    """Check whether *nodeid* matches *pattern*.
+
+    A pattern is treated as a prefix when it looks like a directory or file
+    path (no ``::``), and as an exact match otherwise.
+    """
+    if "::" in pattern:
+        return nodeid == pattern
+    return nodeid.startswith(pattern)
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    source: str | None = config.getoption("--xfail-from-url")
+    if not source:
+        return
+    content = _load_xfail_file(source)
+    if content is None:
+        return
+
+    entries = _parse_xfail_entries(content)
+    if not entries:
+        logger.info("url_xfail: no patterns found in file")
+        return
+
+    patterns = [e[0] for e in entries]
+    logger.info("url_xfail: loaded patterns", count=len(entries), patterns=patterns)
+
+    matched = 0
+    for item in items:
+        for pattern, reason in entries:
+            if _matches(item.nodeid, pattern):
+                item.add_marker(pytest.mark.xfail(reason=f"url xfail: {reason}"))
+                matched += 1
+                break
+
+    logger.info("url_xfail: marked tests", matched=matched, total=len(items))

--- a/backend/tests/unit/fixtures/test_xfail_from_url.py
+++ b/backend/tests/unit/fixtures/test_xfail_from_url.py
@@ -1,0 +1,89 @@
+"""Unit tests for the xfail-from-url pytest plugin's pure logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fixtures.xfail_from_url import _matches, _parse_xfail_entries
+
+
+class TestParseXfailEntries:
+    """Tests for _parse_xfail_entries."""
+
+    def test_single_heading_with_reason(self) -> None:
+        content = "# tests/unit/test_foo.py\nflaky on CI"
+        assert _parse_xfail_entries(content) == [("tests/unit/test_foo.py", "flaky on CI")]
+
+    def test_multiple_headings(self) -> None:
+        content = "# pattern-one\nreason one\n\n# pattern-two\nreason two"
+        assert _parse_xfail_entries(content) == [
+            ("pattern-one", "reason one"),
+            ("pattern-two", "reason two"),
+        ]
+
+    def test_default_reason_when_body_empty(self) -> None:
+        content = "# some-pattern\n"
+        assert _parse_xfail_entries(content) == [("some-pattern", "listed in xfail list")]
+
+    def test_joins_multi_line_reason(self) -> None:
+        content = "# pattern\nline one\nline two"
+        assert _parse_xfail_entries(content) == [("pattern", "line one line two")]
+
+    def test_skips_blank_lines_in_reason(self) -> None:
+        content = "# pattern\nfirst\n\nsecond"
+        assert _parse_xfail_entries(content) == [("pattern", "first second")]
+
+    def test_trims_whitespace_from_headings(self) -> None:
+        content = "#   spaced-pattern  \nreason"
+        assert _parse_xfail_entries(content) == [("spaced-pattern", "reason")]
+
+    def test_no_headings_returns_empty(self) -> None:
+        assert _parse_xfail_entries("just some text\nno headings here") == []
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert _parse_xfail_entries("") == []
+
+    def test_ignores_non_h1_headings(self) -> None:
+        content = "## h2 heading\ntext\n### h3 heading\nmore text"
+        assert _parse_xfail_entries(content) == []
+
+
+class TestMatches:
+    """Tests for _matches."""
+
+    def test_prefix_match_directory(self) -> None:
+        assert _matches("tests/unit/test_foo.py::test_bar", "tests/unit/") is True
+
+    def test_prefix_match_file(self) -> None:
+        assert _matches("tests/unit/test_foo.py::test_bar", "tests/unit/test_foo.py") is True
+
+    def test_prefix_no_match(self) -> None:
+        assert _matches("tests/unit/test_foo.py::test_bar", "tests/integration/") is False
+
+    def test_exact_match_with_node_id(self) -> None:
+        assert _matches("tests/unit/test_foo.py::test_bar", "tests/unit/test_foo.py::test_bar") is True
+
+    def test_exact_match_rejects_partial(self) -> None:
+        assert _matches("tests/unit/test_foo.py::test_bar", "tests/unit/test_foo.py::test_baz") is False
+
+    @pytest.mark.parametrize(
+        ("nodeid", "pattern"),
+        [
+            ("tests/unit/test_foo.py::TestClass::test_method", "tests/unit/test_foo.py::TestClass::test_method"),
+            ("tests/unit/test_foo.py::test_bar", "tests/unit/"),
+            ("tests/unit/test_foo.py::test_bar", "tests/"),
+        ],
+    )
+    def test_various_valid_matches(self, nodeid: str, pattern: str) -> None:
+        assert _matches(nodeid, pattern) is True
+
+    @pytest.mark.parametrize(
+        ("nodeid", "pattern"),
+        [
+            ("tests/unit/test_foo.py::test_bar", "tests/unit/test_foo.py::test_other"),
+            ("tests/unit/test_foo.py::test_bar", "tests/integration/test_foo.py"),
+            ("tests/unit/test_foo.py::test_bar", "tests/unit/test_foo.py::test_bar_extended"),
+        ],
+    )
+    def test_various_non_matches(self, nodeid: str, pattern: str) -> None:
+        assert _matches(nodeid, pattern) is False

--- a/frontend/packages/syntara-ui/e2e/fixtures.ts
+++ b/frontend/packages/syntara-ui/e2e/fixtures.ts
@@ -90,7 +90,7 @@ const xfailBase = currentsBase.extend<{ _xfailCheck: void }, { _xfailEntries: Xf
     async ({ _xfailEntries }, use, testInfo) => {
       const match = matchesXfail(testInfo, _xfailEntries)
       if (match) {
-        test.fail(true, `xfail: ${match.reason}`)
+        testInfo.fail(true, `xfail: ${match.reason}`)
       }
       await use()
     },

--- a/frontend/packages/syntara-ui/e2e/fixtures.ts
+++ b/frontend/packages/syntara-ui/e2e/fixtures.ts
@@ -4,6 +4,7 @@ import { expect, test as base, type Page, type Request } from '@playwright/test'
 import { APP_TITLE } from './helpers/appTitle'
 import { isSkipWebServerForPlaywrightTests } from './playwrightWebServerEnv'
 import { type RoleSetupResult, setupRoleUsers } from './utils/roleSetup'
+import { type XfailEntry, loadXfailEntries, matchesXfail } from './xfailFromUrl'
 
 const processEnv: Record<string, string | undefined> = (
   process as unknown as { env: Record<string, string | undefined> }
@@ -68,7 +69,36 @@ const currentsBase = base.extend<CurrentsFixtures, CurrentsWorkerFixtures>({
   ...fixtures.actionFixtures,
 })
 
-export const test = currentsBase.extend<
+const xfailBase = currentsBase.extend<{ _xfailCheck: void }, { _xfailEntries: XfailEntry[] }>({
+  _xfailEntries: [
+    async ({}, use) => {
+      const base = processEnv['SYNTARA_XFAIL_SOURCE']
+      if (!base) {
+        await use([])
+        return
+      }
+      const source = base.endsWith('/') ? `${base}playwright.md` : `${base}/playwright.md`
+      const entries = await loadXfailEntries(source)
+      if (entries.length > 0) {
+        process.stderr.write(`xfail: loaded ${entries.length} pattern(s) from ${source}\n`)
+      }
+      await use(entries)
+    },
+    { scope: 'worker' },
+  ],
+  _xfailCheck: [
+    async ({ _xfailEntries }, use, testInfo) => {
+      const match = matchesXfail(testInfo, _xfailEntries)
+      if (match) {
+        test.fail(true, `xfail: ${match.reason}`)
+      }
+      await use()
+    },
+    { auto: true },
+  ],
+})
+
+export const test = xfailBase.extend<
   { app: Page; auditorApp: Page; viewerApp: Page; userApp: Page; projectAdminApp: Page },
   { roleSetup: RoleSetupResult | null }
 >({

--- a/frontend/packages/syntara-ui/e2e/xfailFromUrl.ts
+++ b/frontend/packages/syntara-ui/e2e/xfailFromUrl.ts
@@ -16,7 +16,7 @@ export function parseXfailEntries(content: string): XfailEntry[] {
 
   function flush(): void {
     if (currentPattern !== null) {
-      const reason = reasonLines.join(' ').trim() || 'listed in xfail list'
+      const reason = reasonLines.join('\n').trim() || 'listed in xfail list'
       entries.push({ pattern: currentPattern, reason })
     }
   }
@@ -73,18 +73,32 @@ function buildTestId(testInfo: TestInfo): string {
   return [relPath, ...titles].join(' > ')
 }
 
+export function matchPattern(testId: string, pattern: string): boolean {
+  const colonIdx = pattern.indexOf(': ')
+  if (colonIdx !== -1) {
+    const filePrefix = pattern.slice(0, colonIdx)
+    if (filePrefix.includes('/') || filePrefix.endsWith('.ts') || filePrefix.endsWith('.js')) {
+      const titlePart = pattern.slice(colonIdx + 2)
+      if (!titlePart) {
+        return testId.startsWith(filePrefix)
+      }
+      const fullPattern = `${filePrefix} > ${titlePart}`
+      return testId === fullPattern || (testId.startsWith(`${filePrefix} > `) && testId.endsWith(` > ${titlePart}`))
+    }
+  }
+
+  if (pattern.includes(' > ')) {
+    return testId === pattern || testId.endsWith(` > ${pattern}`)
+  }
+  return testId.startsWith(pattern)
+}
+
 export function matchesXfail(testInfo: TestInfo, entries: XfailEntry[]): XfailEntry | null {
   if (entries.length === 0) return null
   const testId = buildTestId(testInfo)
   for (const entry of entries) {
-    if (entry.pattern.includes(' > ')) {
-      if (testId === entry.pattern || testId.endsWith(entry.pattern)) {
-        return entry
-      }
-    } else {
-      if (testId.startsWith(entry.pattern)) {
-        return entry
-      }
+    if (matchPattern(testId, entry.pattern)) {
+      return entry
     }
   }
   return null

--- a/frontend/packages/syntara-ui/e2e/xfailFromUrl.ts
+++ b/frontend/packages/syntara-ui/e2e/xfailFromUrl.ts
@@ -1,0 +1,91 @@
+import { readFile } from 'node:fs/promises'
+
+import type { TestInfo } from '@playwright/test'
+
+export type XfailEntry = {
+  pattern: string
+  reason: string
+}
+
+const HEADING_RE = /^#\s+(.+)$/
+
+export function parseXfailEntries(content: string): XfailEntry[] {
+  const entries: XfailEntry[] = []
+  let currentPattern: string | null = null
+  const reasonLines: string[] = []
+
+  function flush(): void {
+    if (currentPattern !== null) {
+      const reason = reasonLines.join(' ').trim() || 'listed in xfail list'
+      entries.push({ pattern: currentPattern, reason })
+    }
+  }
+
+  for (const line of content.split('\n')) {
+    const match = HEADING_RE.exec(line.trim())
+    if (match) {
+      flush()
+      currentPattern = match[1].trim()
+      reasonLines.length = 0
+    } else if (currentPattern !== null) {
+      const stripped = line.trim()
+      if (stripped) {
+        reasonLines.push(stripped)
+      }
+    }
+  }
+  flush()
+  return entries
+}
+
+function isFilePath(source: string): boolean {
+  return source.startsWith('/') || source.startsWith('./') || source.startsWith('../')
+}
+
+export async function loadXfailEntries(source: string): Promise<XfailEntry[]> {
+  try {
+    let content: string
+    if (isFilePath(source)) {
+      content = await readFile(source, 'utf-8')
+    } else {
+      const nodeFetch = globalThis.fetch
+      const response = await nodeFetch(source, { signal: AbortSignal.timeout(30_000) })
+      if (!response.ok) {
+        process.stderr.write(`xfail: failed to fetch ${source}: ${response.status} ${response.statusText}\n`)
+        return []
+      }
+      content = await response.text()
+    }
+    return parseXfailEntries(content)
+  } catch (error) {
+    process.stderr.write(`xfail: failed to load ${source}: ${String(error)}\n`)
+    return []
+  }
+}
+
+function buildTestId(testInfo: TestInfo): string {
+  const testDir = testInfo.project.testDir
+  let relPath = testInfo.file
+  if (testDir && relPath.startsWith(testDir)) {
+    relPath = relPath.slice(testDir.length).replace(/^[/\\]/, '')
+  }
+  const titles = testInfo.titlePath.filter(Boolean)
+  return [relPath, ...titles].join(' > ')
+}
+
+export function matchesXfail(testInfo: TestInfo, entries: XfailEntry[]): XfailEntry | null {
+  if (entries.length === 0) return null
+  const testId = buildTestId(testInfo)
+  for (const entry of entries) {
+    if (entry.pattern.includes(' > ')) {
+      if (testId === entry.pattern || testId.endsWith(entry.pattern)) {
+        return entry
+      }
+    } else {
+      if (testId.startsWith(entry.pattern)) {
+        return entry
+      }
+    }
+  }
+  return null
+}

--- a/frontend/packages/syntara-ui/eslint.config.js
+++ b/frontend/packages/syntara-ui/eslint.config.js
@@ -505,6 +505,8 @@ export default tseslint.config(
       'react-refresh/only-export-components': 'off',
       // Testing Library rules target RTL/vitest patterns; Playwright specs use locator-based APIs
       'testing-library/prefer-screen-queries': 'off',
+      // Playwright worker-scoped fixtures require destructured first arg even when no deps are needed
+      'no-empty-pattern': 'off',
     },
   },
   {

--- a/frontend/packages/syntara-ui/src/utils/xfailFromUrl.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/xfailFromUrl.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+
+import { matchPattern, parseXfailEntries } from '../../e2e/xfailFromUrl'
+
+describe('parseXfailEntries', () => {
+  it('parses a single heading with reason', () => {
+    const content = '# tests/unit/test_foo.py\nflaky on CI'
+    expect(parseXfailEntries(content)).toEqual([{ pattern: 'tests/unit/test_foo.py', reason: 'flaky on CI' }])
+  })
+
+  it('parses multiple headings', () => {
+    const content = ['# pattern-one', 'reason one', '', '# pattern-two', 'reason two'].join('\n')
+    expect(parseXfailEntries(content)).toEqual([
+      { pattern: 'pattern-one', reason: 'reason one' },
+      { pattern: 'pattern-two', reason: 'reason two' },
+    ])
+  })
+
+  it('uses default reason when body is empty', () => {
+    const content = '# some-pattern\n'
+    expect(parseXfailEntries(content)).toEqual([{ pattern: 'some-pattern', reason: 'listed in xfail list' }])
+  })
+
+  it('preserves newlines in multi-line reason text', () => {
+    const content = '# pattern\nline one\nline two'
+    expect(parseXfailEntries(content)).toEqual([{ pattern: 'pattern', reason: 'line one\nline two' }])
+  })
+
+  it('skips blank lines in reason', () => {
+    const content = '# pattern\nfirst\n\nsecond'
+    expect(parseXfailEntries(content)).toEqual([{ pattern: 'pattern', reason: 'first\nsecond' }])
+  })
+
+  it('trims whitespace from headings', () => {
+    const content = '#   spaced-pattern  \nreason'
+    expect(parseXfailEntries(content)).toEqual([{ pattern: 'spaced-pattern', reason: 'reason' }])
+  })
+
+  it('returns empty array for content with no headings', () => {
+    expect(parseXfailEntries('just some text\nno headings here')).toEqual([])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(parseXfailEntries('')).toEqual([])
+  })
+
+  it('ignores non-h1 headings', () => {
+    const content = '## h2 heading\ntext\n### h3 heading\nmore text'
+    expect(parseXfailEntries(content)).toEqual([])
+  })
+})
+
+describe('matchPattern', () => {
+  describe('prefix matching (directory/file patterns)', () => {
+    it('matches when testId starts with pattern', () => {
+      expect(matchPattern('auth/login.spec.ts > login > works', 'auth/')).toBe(true)
+    })
+
+    it('matches exact file path', () => {
+      expect(matchPattern('auth/login.spec.ts > login > works', 'auth/login.spec.ts')).toBe(true)
+    })
+
+    it('does not match unrelated prefix', () => {
+      expect(matchPattern('auth/login.spec.ts > login > works', 'settings/')).toBe(false)
+    })
+  })
+
+  describe('title matching with " > " (no file prefix)', () => {
+    it('matches exact full testId', () => {
+      expect(matchPattern('auth/login.spec.ts > login > works', 'auth/login.spec.ts > login > works')).toBe(true)
+    })
+
+    it('matches as suffix (endsWith)', () => {
+      expect(matchPattern('auth/login.spec.ts > login > works', 'login > works')).toBe(true)
+    })
+
+    it('requires segment boundary for suffix match', () => {
+      expect(matchPattern('auth/login.spec.ts > login > works', 'ogin > works')).toBe(false)
+    })
+
+    it('does not match unrelated title', () => {
+      expect(matchPattern('auth/login.spec.ts > login > works', 'login > fails')).toBe(false)
+    })
+  })
+
+  describe('file:title syntax ("file.ts: title")', () => {
+    it('matches exact file + full title path', () => {
+      expect(
+        matchPattern(
+          'auth/login.spec.ts > login form > should succeed',
+          'auth/login.spec.ts: login form > should succeed'
+        )
+      ).toBe(true)
+    })
+
+    it('matches file + title suffix', () => {
+      expect(
+        matchPattern('auth/login.spec.ts > login form > should succeed', 'auth/login.spec.ts: should succeed')
+      ).toBe(true)
+    })
+
+    it('does not match wrong file with correct title', () => {
+      expect(
+        matchPattern('auth/login.spec.ts > login form > should succeed', 'settings/profile.spec.ts: should succeed')
+      ).toBe(false)
+    })
+
+    it('does not match correct file with wrong title', () => {
+      expect(matchPattern('auth/login.spec.ts > login form > should succeed', 'auth/login.spec.ts: should fail')).toBe(
+        false
+      )
+    })
+
+    it('scopes match to the specified file (fixes cross-file ambiguity)', () => {
+      const testIdA = 'auth/login.spec.ts > login form > should succeed'
+      const testIdB = 'other/login.spec.ts > login form > should succeed'
+      const pattern = 'auth/login.spec.ts: login form > should succeed'
+
+      expect(matchPattern(testIdA, pattern)).toBe(true)
+      expect(matchPattern(testIdB, pattern)).toBe(false)
+    })
+
+    it('works with .js extension', () => {
+      expect(matchPattern('tests/foo.js > bar > baz', 'tests/foo.js: bar > baz')).toBe(true)
+    })
+
+    it('works with bare filename (no directory)', () => {
+      expect(matchPattern('login.spec.ts > form > submit', 'login.spec.ts: form > submit')).toBe(true)
+    })
+
+    it('treats empty title after colon as file prefix match', () => {
+      expect(matchPattern('auth/login.spec.ts > form > submit', 'auth/login.spec.ts: ')).toBe(true)
+    })
+
+    it('does not treat colon in non-file context as file:title syntax', () => {
+      expect(matchPattern('file.spec.ts > API status: 200 > works', 'API status: 200 > works')).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Add a unified SYNTARA_XFAIL_SOURCE env var (base URL or local folder)
that both test runners use to load xfail lists:

- Backend: pytest plugin (--xfail-from-url) parses Markdown H1 headings
  as test node-id patterns; the Makefile appends backend.md to the source.
- Frontend: Playwright worker fixture appends playwright.md, fetches
  the file once per worker, and marks matching tests via test.fail().

Both support URLs (HTTP fetch) and local file paths (fs read).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
