### PR TITLE
docs: document Konflux SBOM path

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -40,3 +40,9 @@ For the complete security policy, including what qualifies as a reportable vulne
 This project is stewarded by **Red Hat, Inc.**, an open-source software steward as defined in Article 3(14) of the [EU Cyber Resilience Act (Regulation 2024/2847)](https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng).
 
 Contact: [cra-steward@redhat.com](mailto:cra-steward@redhat.com)
+
+## Software Bill of Materials (SBOM)
+
+Container image SBOMs for this repository are generated on the Konflux build
+path. See [docs/sbom.md](../docs/sbom.md) for production and consumption
+details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,13 @@ By signing off, you agree to the [Developer Certificate of Origin](https://devel
 
 All changes require review before merging. Backend-only changes need backend reviewer approval; frontend-only changes need frontend reviewer approval. Cross-cutting changes need both.
 
+## Software Bill of Materials (SBOM)
+
+Container image SBOMs are produced by Konflux `.tekton` builds (AAP catalog
+`build/container`), not by GitHub Actions or Renovate/MintMaker. See
+[docs/sbom.md](docs/sbom.md) for where artifacts are published and how to
+inspect them (Conforma, Konflux UI, `cosign download sbom`).
+
 ## Getting Help
 
 Have a question or need guidance? Start a conversation in [GitHub Discussions](https://github.com/orgs/syntara-orchestration/discussions) before opening an issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,9 @@ All changes require review before merging. Backend-only changes need backend rev
 
 ## Software Bill of Materials (SBOM)
 
-Container image SBOMs are produced by Konflux `.tekton` builds (AAP catalog
-`build/container`), not by GitHub Actions or Renovate/MintMaker. See
-[docs/sbom.md](docs/sbom.md) for where artifacts are published and how to
+Container image SBOMs are produced by Konflux `.tekton` builds (Konflux /
+Tekton catalog `build/container`), not by GitHub Actions or Renovate/MintMaker.
+See [docs/sbom.md](docs/sbom.md) for where artifacts are published and how to
 inspect them (Conforma, Konflux UI, `cosign download sbom`).
 
 ## Getting Help

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -7,7 +7,7 @@ Renovate, or MintMaker.
 ## Produced by
 
 Konflux Pipelines-as-Code (PAC) builds under [`.tekton/`](../.tekton/) invoke the
-AAP Tekton catalog pipeline `build/container`
+Konflux / Tekton catalog build pipeline `build/container`
 (`quay.io/aap-ci/tekton-catalog/pipeline/build/container`).
 
 That catalog pipeline generates and publishes an SBOM by default (alongside the
@@ -20,8 +20,9 @@ Relevant examples:
 - UI push (devel): `.tekton/ansible-automation-orchestrator-ui-devel-push.yaml`
 - Matching pull-request PipelineRuns under `.tekton/` for the same components
 
-Built images are pushed to Quay under
-`quay.io/redhat-user-workloads/nexus-tenant/ansible-automation-platform/`.
+Built images are pushed to Quay under the Konflux `redhat-user-workloads`
+registry. Exact image refs are defined by each PipelineRun’s `output-image`
+parameter (and appear on successful PipelineRun results in the Konflux UI).
 
 ## Consumed by
 
@@ -42,12 +43,12 @@ Built images are pushed to Quay under
    `pipeline/build/container` and do not disable SBOM generation.
 2. **Konflux UI:** After a successful image build, open the PipelineRun →
    **View SBOM**.
-3. **CLI (requires Quay access):**
+3. **CLI (requires Quay access):** Copy a digest image reference from the
+   PipelineRun / Konflux UI, then:
 
    ```bash
-   cosign download sbom \
-     quay.io/redhat-user-workloads/nexus-tenant/ansible-automation-platform/<image>@sha256:<digest>
+   cosign download sbom <image-ref>@sha256:<digest>
    ```
 
-   Registry access to `redhat-user-workloads` is restricted; unauthenticated
-   downloads return `UNAUTHORIZED`.
+   Registry access to Konflux `redhat-user-workloads` images is restricted;
+   unauthenticated downloads return `UNAUTHORIZED`.

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -1,0 +1,53 @@
+# Software Bill of Materials (SBOM)
+
+Container images built for this repository include an SBOM as part of the
+Konflux build path. SBOM generation is **not** handled by GitHub Actions,
+Renovate, or MintMaker.
+
+## Produced by
+
+Konflux Pipelines-as-Code (PAC) builds under [`.tekton/`](../.tekton/) invoke the
+AAP Tekton catalog pipeline `build/container`
+(`quay.io/aap-ci/tekton-catalog/pipeline/build/container`).
+
+That catalog pipeline generates and publishes an SBOM by default (alongside the
+image). PipelineRuns in this repo do **not** set `SKIP_SBOM_GENERATION`; leaving
+the default keeps SBOM generation enabled.
+
+Relevant examples:
+
+- Backend push (devel): `.tekton/ansible-automation-orchestrator-backend-devel-push.yaml`
+- UI push (devel): `.tekton/ansible-automation-orchestrator-ui-devel-push.yaml`
+- Matching pull-request PipelineRuns under `.tekton/` for the same components
+
+Built images are pushed to Quay under
+`quay.io/redhat-user-workloads/nexus-tenant/ansible-automation-platform/`.
+
+## Consumed by
+
+| Consumer | How |
+| --- | --- |
+| **Conforma** (Enterprise Contract) | PR integration tests such as `conforma-on-pull-request-devel` verify image policy, including supply-chain metadata. GitHub CI waits on these checks via the Konflux gate jobs in `.github/workflows/ci-backend.yml` and `.github/workflows/ci-frontend.yml`. |
+| **Konflux UI** | Open a successful component PipelineRun and use **View SBOM** to inspect the attached SBOM. |
+| **`cosign download sbom`** | With registry credentials that can read the image: `cosign download sbom <image-ref>`. Prefer digest refs when available. |
+
+## Not produced by
+
+- **Renovate / MintMaker** — dependency update bots only; they do not generate or publish image SBOMs (`renovate.json` and MintMaker PRs are unrelated to this path).
+- **GitHub Actions app CI** — lint, test, typecheck, and related workflows do not emit container SBOMs.
+
+## How to verify
+
+1. **Pipeline config (no auth):** Confirm `.tekton/` PipelineRuns reference
+   `pipeline/build/container` and do not disable SBOM generation.
+2. **Konflux UI:** After a successful image build, open the PipelineRun →
+   **View SBOM**.
+3. **CLI (requires Quay access):**
+
+   ```bash
+   cosign download sbom \
+     quay.io/redhat-user-workloads/nexus-tenant/ansible-automation-platform/<image>@sha256:<digest>
+   ```
+
+   Registry access to `redhat-user-workloads` is restricted; unauthenticated
+   downloads return `UNAUTHORIZED`.


### PR DESCRIPTION
## Summary
- Document that container image SBOMs are produced by Konflux `.tekton` PAC pipelines via the Konflux / Tekton catalog `build/container` pipeline (default SBOM; not GitHub Actions or Renovate/MintMaker)
- Describe consumption via Conforma PR gates, Konflux UI **View SBOM**, and `cosign download sbom`
- Link the new guide from `CONTRIBUTING.md` and `.github/SECURITY.md`

## Test plan
- [ ] Read `docs/sbom.md` for accuracy against current `.tekton/` PipelineRuns
- [ ] Confirm links from CONTRIBUTING / SECURITY resolve
- [ ] Optional: with Quay access, `cosign download sbom` on a digest image ref from a recent PipelineRun, or confirm **View SBOM** in Konflux UI