### PR TITLE
fix(AAP-87602): Add status poll to cancel-execution test beforeAll setup

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
@@ -23,7 +23,7 @@ async function pollExecutionStatus(
   executionId: string,
   token: string,
   expectedStatuses: string[],
-  timeout = 30_000
+  timeout = 90_000
 ): Promise<void> {
   await expect(async () => {
     const resp = await apiRequest(page, 'get', `/executions/${executionId}`, { token })

--- a/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
@@ -18,12 +18,18 @@ import { apiRequest, createWorkflowViaApi, deleteWorkflowViaApi, ensureProject, 
 
 const TERMINAL_STATUSES = ['completed', 'failed', 'cancelled']
 
-async function pollExecutionUntilDone(page: Page, executionId: string, token: string): Promise<void> {
+async function pollExecutionStatus(
+  page: Page,
+  executionId: string,
+  token: string,
+  expectedStatuses: string[],
+  timeout = 30_000
+): Promise<void> {
   await expect(async () => {
     const resp = await apiRequest(page, 'get', `/executions/${executionId}`, { token })
     const exec = (await resp.json()) as { status: string }
-    expect(TERMINAL_STATUSES).toContain(exec.status)
-  }).toPass({ timeout: 30_000, intervals: [1_000] })
+    expect(expectedStatuses).toContain(exec.status)
+  }).toPass({ timeout, intervals: [1_000] })
 }
 
 let sleepWorkflowId: string | null = null
@@ -62,6 +68,7 @@ test.beforeAll(async ({ browser }) => {
     if (runResp.ok()) {
       const body = (await runResp.json()) as { id: string }
       runningExecutionId = body.id
+      await pollExecutionStatus(page, runningExecutionId, token, ['running'], 60_000)
     }
 
     const echoName = buildUniqueName('e2e-cancel-echo')
@@ -87,7 +94,7 @@ test.beforeAll(async ({ browser }) => {
     if (echoRunResp.ok()) {
       const body = (await echoRunResp.json()) as { id: string }
       completedExecutionId = body.id
-      await pollExecutionUntilDone(page, completedExecutionId, token)
+      await pollExecutionStatus(page, completedExecutionId, token, TERMINAL_STATUSES)
     }
   } finally {
     await page.close()
@@ -116,7 +123,7 @@ test.afterAll(async ({ browser }) => {
   }
 })
 
-test.describe.skip('Cancel Execution', () => {
+test.describe('Cancel Execution', () => {
   test.describe.configure({ mode: 'serial' })
 
   test('cancel button is visible for a running execution', async ({ app }) => {


### PR DESCRIPTION
## Description

Fixes the flaky cancel-execution E2E test by adding a status poll in `beforeAll` to confirm the sleep workflow execution reaches `"running"` before tests begin. Previously, `beforeAll` fired off the execution and immediately moved on, creating a race condition where the test could navigate to the execution page before Temporal picked it up.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Generalized `pollExecutionUntilDone` → `pollExecutionStatus` with configurable `expectedStatuses` and `timeout` params
- Added `pollExecutionStatus(page, runningExecutionId, token, ['running'], 60_000)` in `beforeAll` after starting the sleep workflow — ensures Temporal has picked it up before tests begin
- Removed `test.describe.skip` to re-enable the quarantined tests

## Out of Scope

- The separate `cancel-execution` quarantine via Currents (AAP-87644). if this fix stabilizes the test, that quarantine can be lifted separately

## Related Issues

Fixes AAP-87602

## How to Test

1. CI should run the cancel-execution tests (no longer skipped)
2. Verify all 3 tests pass: cancel button visible, cancel transitions status, cancel button hidden for completed
3. Run multiple CI builds to confirm consistency

## Frontend Checklist

- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps
