### PR TITLE
refactor: rename nexus to syntara across frontend code

### DIFF
--- a/.claude/skills/frontend-patternfly-ux/SKILL.md
+++ b/.claude/skills/frontend-patternfly-ux/SKILL.md
@@ -1774,7 +1774,7 @@ The run history panel displays execution history for a workflow using a scrollab
 - **Dropzone layout:** Use vertical layout for `MultipleFileUpload` (not `isHorizontal`)
 - **Collapsible file list:** Use `ExpandableSection` (not `MultipleFileUploadStatus`) for the attached file list. The section auto-expands when new files are dropped and can start collapsed via `defaultStatusExpanded={false}`.
 - **Status text:** Use "N files attached" (or "1 file attached") when all files are successfully uploaded — not "N/N files uploaded". Show "N/M files uploaded" only during active upload or when errors occur.
-- **Disabled opacity:** Use `var(--nexus-disabled-opacity)` CSS variable for disabled dropzone opacity, not hardcoded `0.5`.
+- **Disabled opacity:** Use `var(--syntara-disabled-opacity)` CSS variable for disabled dropzone opacity, not hardcoded `0.5`.
 - **Post-upload download:** Once a file has successfully uploaded, show a download icon button on its list item that fetches the file and triggers a browser download preserving the server-provided filename. While the download is in progress, show a loading spinner plus a "Cancel" link in place of the download button, and hide the remove action for that item until the download finishes or is cancelled.
 
 ### Schedule Trigger Form

--- a/frontend/packages/syntara-contracts/.gitignore
+++ b/frontend/packages/syntara-contracts/.gitignore
@@ -1,1 +1,1 @@
-nexus
+syntara

--- a/frontend/packages/syntara-contracts/scripts/generate-node-output-schemas.mjs
+++ b/frontend/packages/syntara-contracts/scripts/generate-node-output-schemas.mjs
@@ -139,7 +139,7 @@ let output = `/**
  * Auto-generated from backend JSON Schema files.
  * DO NOT EDIT — run \`npm run gen\` to regenerate.
  *
- * Source: nexus/src/syntara/schemas/workflows/v2/
+ * Source: syntara/src/syntara/schemas/workflows/v2/
  */
 
 export interface OutputFieldDef {

--- a/frontend/packages/syntara-contracts/src/node-output-schemas.ts
+++ b/frontend/packages/syntara-contracts/src/node-output-schemas.ts
@@ -2,7 +2,7 @@
  * Auto-generated from backend JSON Schema files.
  * DO NOT EDIT — run `npm run gen` to regenerate.
  *
- * Source: nexus/src/syntara/schemas/workflows/v2/
+ * Source: syntara/src/syntara/schemas/workflows/v2/
  */
 
 export interface OutputFieldDef {

--- a/frontend/packages/syntara-ui/e2e/visual-regression/page-entries-interactive.ts
+++ b/frontend/packages/syntara-ui/e2e/visual-regression/page-entries-interactive.ts
@@ -117,7 +117,7 @@ async function openStepEditorFromCanvasTitle(page: Page, title: string | RegExp)
 export async function selectDefaultProject(page: Page) {
   await page.evaluate(() => {
     localStorage.setItem(
-      'nexus-selected-project',
+      'syntara-selected-project',
       JSON.stringify({
         state: { selectedProjectId: 'p-001', selectedProjectName: 'default', favoriteProjectIds: [] },
         version: 1,

--- a/frontend/packages/syntara-ui/e2e/visual-regression/page-screenshots.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/visual-regression/page-screenshots.spec.ts
@@ -38,7 +38,7 @@ test.describe.configure({ mode: 'default' })
 
 test.describe('Page screenshots', { tag: '@local-only' }, () => {
   // Baselines require the mock API with known seed data; skip when running
-  // against a real backend (the E2E workflow sets NEXUS_E2E_SKIP_WEB_SERVER=1).
+  // against a real backend (the E2E workflow sets SYNTARA_E2E_SKIP_WEB_SERVER=1).
   // The Visual Regression manual workflow uses the mock API, so CI=true
   // alone is not a valid skip condition.
   test.skip(
@@ -89,7 +89,7 @@ test.describe('Page screenshots', { tag: '@local-only' }, () => {
 
       // Clear persisted project-selector state so every screenshot starts from
       // the same "All projects" baseline regardless of test ordering.
-      await page.evaluate(() => localStorage.removeItem('nexus-selected-project'))
+      await page.evaluate(() => localStorage.removeItem('syntara-selected-project'))
 
       // Navigate to the target page
       await page.goto(toAppUrl(entry.path))

--- a/frontend/packages/syntara-ui/src/app/AppDockedNav.module.css
+++ b/frontend/packages/syntara-ui/src/app/AppDockedNav.module.css
@@ -4,7 +4,7 @@
 }
 
 .expandedLogo {
-  height: var(--nexus-nav-logo-size);
+  height: var(--syntara-nav-logo-size);
   width: auto;
   margin-left: var(--pf-t--global--spacer--sm);
 }
@@ -14,8 +14,8 @@
 }
 
 .collapsedLogo {
-  height: var(--nexus-nav-logo-size);
-  width: var(--nexus-nav-logo-size);
+  height: var(--syntara-nav-logo-size);
+  width: var(--syntara-nav-logo-size);
   object-fit: contain;
 }
 

--- a/frontend/packages/syntara-ui/src/app/AppMobileMasthead.module.css
+++ b/frontend/packages/syntara-ui/src/app/AppMobileMasthead.module.css
@@ -1,5 +1,5 @@
 .collapsedLogo {
-  height: var(--nexus-nav-logo-size);
-  width: var(--nexus-nav-logo-size);
+  height: var(--syntara-nav-logo-size);
+  width: var(--syntara-nav-logo-size);
   object-fit: contain;
 }

--- a/frontend/packages/syntara-ui/src/components/panels/list/NxListPanel.module.css
+++ b/frontend/packages/syntara-ui/src/components/panels/list/NxListPanel.module.css
@@ -12,7 +12,7 @@
 }
 
 .toolbarDisabled {
-  opacity: var(--nexus-disabled-opacity);
+  opacity: var(--syntara-disabled-opacity);
   cursor: not-allowed;
 }
 

--- a/frontend/packages/syntara-ui/src/index.css
+++ b/frontend/packages/syntara-ui/src/index.css
@@ -2,9 +2,9 @@
 @import '@patternfly/react-core/dist/styles/base.css';
 
 :root {
-  --nexus-form-max-width: 600px;
-  --nexus-disabled-opacity: 0.5;
-  --nexus-nav-logo-size: 28px;
+  --syntara-form-max-width: 600px;
+  --syntara-disabled-opacity: 0.5;
+  --syntara-nav-logo-size: 28px;
 }
 
 /* Pin the login container to the top so the brand logo does not jump

--- a/frontend/packages/syntara-ui/src/providers/alerts/AlertProvider.tsx
+++ b/frontend/packages/syntara-ui/src/providers/alerts/AlertProvider.tsx
@@ -18,7 +18,7 @@ type ToastAlertItemProps = Readonly<{
 }>
 
 function ToastAlertItem({ alert, onDismiss }: ToastAlertItemProps) {
-  const alertDomId = `nexus-alert-${useId()}`
+  const alertDomId = `syntara-alert-${useId()}`
 
   return (
     <Alert

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/ClaimMappingFields.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/ClaimMappingFields.test.tsx
@@ -250,7 +250,7 @@ describe('UserClaimMappingFields', () => {
     expect(screen.getByDisplayValue('sub')).toBeInTheDocument()
   })
 
-  it('handles claimAliases with no matching nexus field key', () => {
+  it('handles claimAliases with no matching syntara field key', () => {
     const claimsSupported = ['sub', 'email', 'name']
     const claimAliases = { unrelated_field: ['something'] }
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/ClaimMappingFields.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/ClaimMappingFields.tsx
@@ -30,13 +30,13 @@ export type ClaimMappingFieldsProps = {
 }
 
 function buildOptions(
-  nexusField: string,
+  syntaraField: string,
   claimsSupported: string[] | null | undefined,
   claimAliases: Record<string, string[]> | null | undefined
 ): string[] | null {
   if (!claimsSupported) return null
 
-  const aliases = claimAliases?.[nexusField] ?? []
+  const aliases = claimAliases?.[syntaraField] ?? []
   const aliasSet = new Set(aliases)
   const matched = claimsSupported.filter((c) => aliasSet.has(c))
   const rest = claimsSupported.filter((c) => !aliasSet.has(c))

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/EditGroupMapping.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/EditGroupMapping.test.tsx
@@ -77,7 +77,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   </QueryClientProvider>
 )
 
-const mockNexusGroups = [
+const mockMappedGroups = [
   { id: MOCK_GROUP_ID, name: 'admin', description: 'Admins', created_at: '2026-01-01T00:00:00Z' },
   { id: MOCK_GROUP_ID_2, name: 'users', description: 'Users', created_at: '2026-01-02T00:00:00Z' },
 ]
@@ -102,7 +102,7 @@ describe('EditGroupMapping', () => {
     routerTestState.navigate.mockClear()
     vi.mocked(useCanI).mockReturnValue({ allowed: true, isChecking: false, isError: false })
     vi.mocked(useAllGroups).mockReturnValue({
-      groups: mockNexusGroups.map((g) => ({
+      groups: mockMappedGroups.map((g) => ({
         ...g,
         is_builtin: false,
         updated_at: g.created_at,
@@ -113,12 +113,12 @@ describe('EditGroupMapping', () => {
     })
 
     vi.mocked(usersClient.useQuery).mockReturnValue({
-      data: { resources: mockNexusGroups },
+      data: { resources: mockMappedGroups },
       isPending: false,
       isError: false,
       error: null,
       isFetching: false,
-      refetch: vi.fn().mockResolvedValue({ data: { resources: mockNexusGroups } }),
+      refetch: vi.fn().mockResolvedValue({ data: { resources: mockMappedGroups } }),
     } as never)
 
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue({
@@ -149,7 +149,7 @@ describe('EditGroupMapping', () => {
         ...mockProvider,
         configuration: {
           ...mockProvider.configuration,
-          group_mapping_entries: [{ idp_group_value: 'admin', nexus_group_id: MOCK_GROUP_ID }],
+          group_mapping_entries: [{ idp_group_value: 'admin', mapped_group_id: MOCK_GROUP_ID }],
         },
       },
       isLoading: false,
@@ -220,7 +220,7 @@ describe('EditGroupMapping', () => {
         configuration: {
           ...mockProvider.configuration,
           group_jmespath_expression: 'groups[*]',
-          group_mapping_entries: [{ idp_group_value: 'admin', nexus_group_id: MOCK_GROUP_ID }],
+          group_mapping_entries: [{ idp_group_value: 'admin', mapped_group_id: MOCK_GROUP_ID }],
         },
       },
       isLoading: false,
@@ -262,7 +262,7 @@ describe('EditGroupMapping', () => {
         ...mockProvider,
         configuration: {
           ...mockProvider.configuration,
-          group_mapping_entries: [{ idp_group_value: 'admin', nexus_group_id: MOCK_GROUP_ID }],
+          group_mapping_entries: [{ idp_group_value: 'admin', mapped_group_id: MOCK_GROUP_ID }],
         },
       },
       isLoading: false,
@@ -296,7 +296,7 @@ describe('EditGroupMapping', () => {
         ...mockProvider,
         configuration: {
           ...mockProvider.configuration,
-          group_mapping_entries: [{ idp_group_value: 'admin', nexus_group_id: MOCK_GROUP_ID }],
+          group_mapping_entries: [{ idp_group_value: 'admin', mapped_group_id: MOCK_GROUP_ID }],
         },
       },
       isLoading: false,

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingComponents.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingComponents.test.tsx
@@ -16,16 +16,16 @@ import {
 } from './GroupMappingComponents'
 import type { MappingTableProps } from './GroupMappingComponents'
 import { groupMappingEditFormSchema } from './groupMappingEditFormSchema'
-import type { GroupMappingEntry, NexusGroup } from './groupMappingUtils'
+import type { GroupMappingEntry, MappedGroup } from './groupMappingUtils'
 
-const mockNexusGroups: NexusGroup[] = [
+const mockMappedGroups: MappedGroup[] = [
   { id: 'g1', name: 'admin', description: 'Administrators' },
   { id: 'g2', name: 'users', description: 'Regular users' },
 ]
 
 const mockEntries: GroupMappingEntry[] = [
-  { key: 'k1', idpGroupValue: 'idp-admin', nexusGroupId: 'g1' },
-  { key: 'k2', idpGroupValue: 'idp-users', nexusGroupId: 'g2' },
+  { key: 'k1', idpGroupValue: 'idp-admin', mappedGroupId: 'g1' },
+  { key: 'k2', idpGroupValue: 'idp-users', mappedGroupId: 'g2' },
 ]
 
 describe('EmptyMappingState', () => {
@@ -81,7 +81,7 @@ describe('AdvancedSection', () => {
     defaultValues,
     ...props
   }: {
-    defaultValues?: { expression: string; entries: { idpGroupValue: string; nexusGroupId: string }[] }
+    defaultValues?: { expression: string; entries: { idpGroupValue: string; mappedGroupId: string }[] }
     defaultExpression: string | null
     idpType?: string | null
     rawClaims: string | null
@@ -240,13 +240,13 @@ describe('GroupMappingFormActions', () => {
 })
 
 const mockRows = [
-  { rowId: 'k1', index: 0, idpGroupValue: 'idp-admin', nexusGroupId: 'g1' },
-  { rowId: 'k2', index: 1, idpGroupValue: 'idp-users', nexusGroupId: 'g2' },
+  { rowId: 'k1', index: 0, idpGroupValue: 'idp-admin', mappedGroupId: 'g1' },
+  { rowId: 'k2', index: 1, idpGroupValue: 'idp-users', mappedGroupId: 'g2' },
 ]
 
 const editFormEntries = [
-  { idpGroupValue: 'idp-admin', nexusGroupId: 'g1' },
-  { idpGroupValue: 'idp-users', nexusGroupId: 'g2' },
+  { idpGroupValue: 'idp-admin', mappedGroupId: 'g1' },
+  { idpGroupValue: 'idp-users', mappedGroupId: 'g2' },
 ]
 
 function MappingTableFormHarness({
@@ -258,7 +258,7 @@ function MappingTableFormHarness({
   ...tableProps
 }: Omit<MappingTableProps, 'control' | 'rows'> & {
   rows?: MappingTableProps['rows']
-  entries?: { idpGroupValue: string; nexusGroupId: string }[]
+  entries?: { idpGroupValue: string; mappedGroupId: string }[]
 }) {
   const form = useForm({
     resolver: zodResolver(groupMappingEditFormSchema),
@@ -274,7 +274,7 @@ function MappingTableFormHarness({
 
 describe('MappingTable', () => {
   const defaultProps = {
-    nexusGroups: mockNexusGroups,
+    mappedGroups: mockMappedGroups,
     onRemove: vi.fn(),
     onAdd: vi.fn(),
     onCreateGroup: vi.fn(),
@@ -335,7 +335,7 @@ describe('MappingTable', () => {
       <MappingTableFormHarness
         {...defaultProps}
         rows={[{ rowId: 'k1', index: 0 }]}
-        entries={[{ idpGroupValue: '', nexusGroupId: '' }]}
+        entries={[{ idpGroupValue: '', mappedGroupId: '' }]}
       />
     )
 
@@ -366,7 +366,7 @@ describe('MappingTable', () => {
 describe('ReadOnlyView', () => {
   const readOnlyDefaults = {
     entries: mockEntries,
-    nexusGroups: mockNexusGroups,
+    mappedGroups: mockMappedGroups,
     onEditMapping: vi.fn(),
   }
 
@@ -378,7 +378,7 @@ describe('ReadOnlyView', () => {
   })
 
   it('hides Edit group mapping when onEditMapping is omitted', () => {
-    render(<ReadOnlyView entries={mockEntries} nexusGroups={mockNexusGroups} />)
+    render(<ReadOnlyView entries={mockEntries} mappedGroups={mockMappedGroups} />)
 
     expect(screen.getByPlaceholderText('Filter by keyword')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /edit group mapping/i })).not.toBeInTheDocument()
@@ -448,7 +448,7 @@ describe('ReadOnlyView', () => {
     const manyEntries: GroupMappingEntry[] = Array.from({ length: 21 }, (_, i) => ({
       key: `km${i}`,
       idpGroupValue: `idp-row-${i}`,
-      nexusGroupId: 'g1',
+      mappedGroupId: 'g1',
     }))
 
     render(<ReadOnlyView {...readOnlyDefaults} entries={manyEntries} />)

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingComponents.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingComponents.tsx
@@ -36,14 +36,14 @@ import { HintOrError } from './formFieldHelpers'
 import type { GroupMappingEditFormValues } from './groupMappingEditFormSchema'
 import { EditMappingRow, MappingRow } from './groupMappingFields'
 import { GroupMappingTableHead } from './groupMappingTableHead'
-import type { GroupMappingEntry, NexusGroup } from './groupMappingUtils'
+import type { GroupMappingEntry, MappedGroup } from './groupMappingUtils'
 import { idpHelp } from './idpFieldHelp'
 import { IDP_TYPE_PRESETS } from './idpTypePresets'
 
 function entryFieldErrorMessage(
   entryErrors: GroupMappingEditFormValues['entries'] | undefined,
   index: number,
-  field: 'idpGroupValue' | 'nexusGroupId'
+  field: 'idpGroupValue' | 'mappedGroupId'
 ): string | undefined {
   if (!Array.isArray(entryErrors)) return undefined
   const row = entryErrors[index]
@@ -180,13 +180,13 @@ export type MappingTableRow = {
   index: number
   /** Read-only list rows include display values */
   idpGroupValue?: string
-  nexusGroupId?: string
+  mappedGroupId?: string
 }
 
 export type MappingTableProps = {
   rows: MappingTableRow[]
   control?: Control<GroupMappingEditFormValues>
-  nexusGroups: NexusGroup[]
+  mappedGroups: MappedGroup[]
   isReadOnly?: boolean
   showValidation?: boolean
   entryErrors?: GroupMappingEditFormValues['entries']
@@ -200,7 +200,7 @@ export type MappingTableProps = {
 export function MappingTable({
   rows,
   control,
-  nexusGroups,
+  mappedGroups,
   isReadOnly,
   showValidation,
   entryErrors,
@@ -226,19 +226,19 @@ export function MappingTable({
             const entry: GroupMappingEntry = {
               key: row.rowId,
               idpGroupValue: row.idpGroupValue ?? '',
-              nexusGroupId: row.nexusGroupId ?? '',
+              mappedGroupId: row.mappedGroupId ?? '',
             }
             return (
               <MappingRow
                 key={row.rowId}
                 entry={entry}
                 index={row.index}
-                nexusGroups={nexusGroups}
+                mappedGroups={mappedGroups}
                 isReadOnly={isReadOnly}
                 readOnlyPlainCells={Boolean(isReadOnly)}
                 showValidation={showValidation}
                 idpErrorMessage={entryFieldErrorMessage(entryErrors, row.index, 'idpGroupValue')}
-                nexusErrorMessage={entryFieldErrorMessage(entryErrors, row.index, 'nexusGroupId')}
+                groupErrorMessage={entryFieldErrorMessage(entryErrors, row.index, 'mappedGroupId')}
                 onRemove={onRemove}
                 onCreateGroup={onCreateGroup}
               />
@@ -253,7 +253,7 @@ export function MappingTable({
               rowId={row.rowId}
               index={row.index}
               control={control}
-              nexusGroups={nexusGroups}
+              mappedGroups={mappedGroups}
               onRemove={onRemove}
               onCreateGroup={onCreateGroup}
             />
@@ -312,7 +312,7 @@ export function GroupMappingFormActions({ onAdd, onReDiscover, isListening }: Re
 const noopIdpGroupValueChange: (index: number, value: string) => void = () => {
   /* Read-only list view: controls are disabled; handler required by MappingRow */
 }
-const noopNexusGroupIdChange: (index: number, nexusGroupId: string) => void = () => {
+const noopMappedGroupIdChange: (index: number, mappedGroupId: string) => void = () => {
   /* Read-only list view */
 }
 const noopCreateGroup: (index: number) => void = () => {
@@ -359,12 +359,12 @@ function GroupMappingReadOnlyToolbar({
 
 export type ReadOnlyViewProps = {
   entries: GroupMappingEntry[]
-  nexusGroups: NexusGroup[]
+  mappedGroups: MappedGroup[]
   /** When undefined, the "Edit group mapping" button is hidden (read-only mode). */
   onEditMapping?: () => void
 }
 
-export function ReadOnlyView({ entries, nexusGroups, onEditMapping }: Readonly<ReadOnlyViewProps>) {
+export function ReadOnlyView({ entries, mappedGroups, onEditMapping }: Readonly<ReadOnlyViewProps>) {
   const [filters, setFilters] = useState<FilterConfig[]>([])
   const [page, setPage] = useState(1)
   const [perPage, setPerPage] = useState(20)
@@ -395,10 +395,10 @@ export function ReadOnlyView({ entries, nexusGroups, onEditMapping }: Readonly<R
   const filteredEntries = useMemo(() => {
     if (!filterTerm) return entries
     return entries.filter((e) => {
-      const groupName = nexusGroups.find((g) => g.id === e.nexusGroupId)?.name ?? ''
+      const groupName = mappedGroups.find((g) => g.id === e.mappedGroupId)?.name ?? ''
       return e.idpGroupValue.toLowerCase().includes(filterTerm) || groupName.toLowerCase().includes(filterTerm)
     })
-  }, [entries, filterTerm, nexusGroups])
+  }, [entries, filterTerm, mappedGroups])
 
   const paginatedEntries = useMemo(() => {
     const start = (page - 1) * perPage
@@ -447,12 +447,12 @@ export function ReadOnlyView({ entries, nexusGroups, onEditMapping }: Readonly<R
                 key={entry.key}
                 entry={entry}
                 index={index}
-                nexusGroups={nexusGroups}
+                mappedGroups={mappedGroups}
                 isReadOnly
                 readOnlyPlainCells
                 showValidation={false}
                 onIdpGroupValueChange={noopIdpGroupValueChange}
-                onNexusGroupIdChange={noopNexusGroupIdChange}
+                onMappedGroupIdChange={noopMappedGroupIdChange}
                 onRemove={noopRemoveMapping}
                 onCreateGroup={noopCreateGroup}
               />

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingEditPanel.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingEditPanel.test.tsx
@@ -34,7 +34,7 @@ const defaultPanelProps: Omit<GroupMappingEditPanelProps, 'control'> = {
   signInAlert: null,
   onDismissSignInAlert: () => undefined,
   mappingRows: [{ rowId: 'e1', index: 0 }],
-  nexusGroups: [{ id: MOCK_GROUP_ID, name: 'admin' }],
+  mappedGroups: [{ id: MOCK_GROUP_ID, name: 'admin' }],
   onRemove: () => undefined,
   onAdd: () => undefined,
   onCreateGroup: () => undefined,
@@ -53,7 +53,7 @@ function EditPanelHarness(props: Partial<GroupMappingEditPanelProps> = {}) {
     resolver: zodResolver(groupMappingEditFormSchema),
     defaultValues: {
       expression: 'groups[*]',
-      entries: [{ idpGroupValue: 'admin', nexusGroupId: MOCK_GROUP_ID }],
+      entries: [{ idpGroupValue: 'admin', mappedGroupId: MOCK_GROUP_ID }],
     },
   })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingEditPanel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingEditPanel.tsx
@@ -6,14 +6,14 @@ import { GroupFormModal } from '../../GroupFormModal'
 import { AdvancedSection, GroupMappingFormActions, MappingTable } from './GroupMappingComponents'
 import type { GroupMappingEditFormValues } from './groupMappingEditFormSchema'
 import { signInAlertTitle } from './groupMappingFormUtils'
-import type { NexusGroup } from './groupMappingUtils'
+import type { MappedGroup } from './groupMappingUtils'
 
 export type GroupMappingEditPanelProps = {
   signInAlert: { variant: 'success' | 'warning' | 'danger'; message: string } | null
   onDismissSignInAlert: () => void
   control: Control<GroupMappingEditFormValues>
   mappingRows: { rowId: string; index: number }[]
-  nexusGroups: NexusGroup[]
+  mappedGroups: MappedGroup[]
   onRemove: (index: number) => void
   onAdd: () => void
   onCreateGroup: (index: number) => void
@@ -48,7 +48,7 @@ export function GroupMappingEditPanel({
   onDismissSignInAlert,
   control,
   mappingRows,
-  nexusGroups,
+  mappedGroups,
   onRemove,
   onAdd,
   onCreateGroup,
@@ -81,7 +81,7 @@ export function GroupMappingEditPanel({
             <MappingTable
               rows={mappingRows}
               control={control}
-              nexusGroups={nexusGroups}
+              mappedGroups={mappedGroups}
               onRemove={onRemove}
               onAdd={onAdd}
               onCreateGroup={onCreateGroup}

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingStep.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingStep.test.tsx
@@ -31,12 +31,12 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
 
-const mockNexusGroups = [
+const mockMappedGroups = [
   { id: 'g1', name: 'admin' },
   { id: 'g2', name: 'users' },
 ]
 
-const mockAllGroups = mockNexusGroups.map((g) => ({
+const mockAllGroups = mockMappedGroups.map((g) => ({
   ...g,
   description: null,
   is_builtin: false,
@@ -83,7 +83,7 @@ describe('GroupMappingStep', () => {
     })
 
     vi.mocked(usersClient.useQuery).mockReturnValue({
-      data: { resources: mockNexusGroups },
+      data: { resources: mockMappedGroups },
       isPending: false,
       isError: false,
       error: null,
@@ -261,7 +261,7 @@ describe('GroupMappingStep', () => {
 
       // Simulate the popup writing claims to localStorage (picked up by polling)
       const claims = { groups: ['admin', 'users'] }
-      localStorage.setItem('nexus-test-signin', JSON.stringify({ type: 'test-signin', nonce: TEST_NONCE, claims }))
+      localStorage.setItem('syntara-test-signin', JSON.stringify({ type: 'test-signin', nonce: TEST_NONCE, claims }))
 
       // Should show success alert with discovered groups
       expect(await screen.findByRole('heading', { name: /groups discovered/i })).toBeInTheDocument()
@@ -284,7 +284,7 @@ describe('GroupMappingStep', () => {
 
       // Simulate the popup writing claims with no groups
       const claims = { roles: ['admin'] } // no 'groups' key
-      localStorage.setItem('nexus-test-signin', JSON.stringify({ type: 'test-signin', nonce: TEST_NONCE, claims }))
+      localStorage.setItem('syntara-test-signin', JSON.stringify({ type: 'test-signin', nonce: TEST_NONCE, claims }))
 
       expect(await screen.findByRole('heading', { name: /no groups found/i })).toBeInTheDocument()
     })
@@ -334,7 +334,7 @@ describe('GroupMappingStep', () => {
       await user.click(screen.getByRole('button', { name: /discover groups/i }))
 
       const storageEvent = new StorageEvent('storage', {
-        key: 'nexus-test-signin',
+        key: 'syntara-test-signin',
         newValue: 'not-valid-json',
       })
       act(() => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingStep.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingStep.tsx
@@ -36,23 +36,23 @@ import { type IdentityProviderFormData } from './identityProviderFormSchema'
 import { idpHelp } from './idpFieldHelp'
 import { useTestSignIn } from './useTestSignIn'
 
-function NexusGroupSelect({
+function MappedGroupSelect({
   value,
   onChange,
   onBlur,
-  nexusGroups,
+  mappedGroups,
   ariaLabel,
   validated,
 }: {
   value: string
   onChange: (value: string) => void
   onBlur?: () => void
-  nexusGroups: { id?: string; name?: string }[]
+  mappedGroups: { id?: string; name?: string }[]
   ariaLabel: string
   validated?: 'error' | 'default'
 }) {
   const [isOpen, setIsOpen] = useState(false)
-  const selectedLabel = nexusGroups.find((g) => g.id === value)?.name ?? value
+  const selectedLabel = mappedGroups.find((g) => g.id === value)?.name ?? value
   return (
     <NxSelect
       isOpen={isOpen}
@@ -80,7 +80,7 @@ function NexusGroupSelect({
       )}
     >
       <SelectList>
-        {nexusGroups.map((g) => (
+        {mappedGroups.map((g) => (
           <SelectOption key={g.id} value={g.id}>
             {g.name ?? g.id ?? ''}
           </SelectOption>
@@ -93,11 +93,11 @@ function NexusGroupSelect({
 type MappingEntryRowProps = {
   index: number
   control: Control<IdentityProviderFormData>
-  nexusGroups: { id?: string; name?: string }[]
+  mappedGroups: { id?: string; name?: string }[]
   onRemove: () => void
 }
 
-function MappingEntryRow({ index, control, nexusGroups, onRemove }: Readonly<MappingEntryRowProps>) {
+function MappingEntryRow({ index, control, mappedGroups, onRemove }: Readonly<MappingEntryRowProps>) {
   return (
     <div style={mappingRowStyle}>
       <Controller
@@ -115,15 +115,15 @@ function MappingEntryRow({ index, control, nexusGroups, onRemove }: Readonly<Map
         )}
       />
       <Controller
-        name={`groupMapping.entries.${index}.nexusGroupId`}
+        name={`groupMapping.entries.${index}.mappedGroupId`}
         control={control}
         render={({ field, fieldState }) => (
           <div style={flexOneStyle}>
-            <NexusGroupSelect
+            <MappedGroupSelect
               value={field.value}
               onChange={field.onChange}
               onBlur={field.onBlur}
-              nexusGroups={nexusGroups}
+              mappedGroups={mappedGroups}
               ariaLabel={`${APP_TITLE} group ${index + 1}`}
               validated={fieldState.error ? 'error' : 'default'}
             />
@@ -176,7 +176,7 @@ export function GroupMappingStep({ control, setValue, providerId }: Readonly<Gro
 
   const { fields, append, remove, replace } = useFieldArray({ control, name: 'groupMapping.entries' })
 
-  const { groups: nexusGroups } = useAllGroups()
+  const { groups: mappedGroups } = useAllGroups()
 
   const handleTestResult = useCallback(
     (claims: Record<string, unknown>) => {
@@ -185,11 +185,11 @@ export function GroupMappingStep({ control, setValue, providerId }: Readonly<Gro
         key: nextKey(),
         ...e,
       }))
-      const result = processDiscoveredGroups(claims, expression, currentEntries, nexusGroups)
-      replace(result.newEntries.map(({ idpGroupValue, nexusGroupId }) => ({ idpGroupValue, nexusGroupId })))
+      const result = processDiscoveredGroups(claims, expression, currentEntries, mappedGroups)
+      replace(result.newEntries.map(({ idpGroupValue, mappedGroupId }) => ({ idpGroupValue, mappedGroupId })))
       setSignInAlert({ variant: result.variant, message: result.message })
     },
-    [groupMapping, nexusGroups, replace]
+    [groupMapping, mappedGroups, replace]
   )
 
   const handleTestError = useCallback(() => {
@@ -252,11 +252,11 @@ export function GroupMappingStep({ control, setValue, providerId }: Readonly<Gro
             key={field.id}
             index={index}
             control={control}
-            nexusGroups={nexusGroups}
+            mappedGroups={mappedGroups}
             onRemove={() => remove(index)}
           />
         ))}
-        <Button variant="link" icon={<PlusIcon />} onClick={() => append({ idpGroupValue: '', nexusGroupId: '' })}>
+        <Button variant="link" icon={<PlusIcon />} onClick={() => append({ idpGroupValue: '', mappedGroupId: '' })}>
           Add mapping
         </Button>
       </FormGroup>

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingTab.test.tsx
@@ -38,7 +38,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   </QueryClientProvider>
 )
 
-const mockNexusGroups = [
+const mockMappedGroups = [
   { id: 'g1', name: 'admin', description: 'Admins', created_at: '2026-01-01T00:00:00Z' },
   { id: 'g2', name: 'users', description: 'Users', created_at: '2026-01-02T00:00:00Z' },
 ]
@@ -52,7 +52,7 @@ describe('GroupMappingTab', () => {
   beforeEach(() => {
     routerTestState.navigate.mockClear()
     vi.mocked(useAllGroups).mockReturnValue({
-      groups: mockNexusGroups.map((g) => ({
+      groups: mockMappedGroups.map((g) => ({
         ...g,
         is_builtin: false,
         updated_at: g.created_at,
@@ -63,7 +63,7 @@ describe('GroupMappingTab', () => {
     })
 
     vi.mocked(usersClient.useQuery).mockReturnValue({
-      data: { resources: mockNexusGroups },
+      data: { resources: mockMappedGroups },
       isPending: false,
       isError: false,
       error: null,
@@ -108,8 +108,8 @@ describe('GroupMappingTab', () => {
     const existingMapping = {
       group_jmespath_expression: 'groups[*]',
       group_mapping_entries: [
-        { idp_group_value: 'idp-admin', nexus_group_id: 'g1' },
-        { idp_group_value: 'idp-users', nexus_group_id: 'g2' },
+        { idp_group_value: 'idp-admin', mapped_group_id: 'g1' },
+        { idp_group_value: 'idp-users', mapped_group_id: 'g2' },
       ],
     }
 
@@ -144,7 +144,7 @@ describe('GroupMappingTab', () => {
 
     it('hides Edit group mapping when readOnly and mappings exist', () => {
       const existingMapping = {
-        group_mapping_entries: [{ idp_group_value: 'idp-admin', nexus_group_id: 'g1' }],
+        group_mapping_entries: [{ idp_group_value: 'idp-admin', mapped_group_id: 'g1' }],
       }
       render(<GroupMappingTab {...defaultProps} groupMapping={existingMapping} readOnly />, { wrapper })
 
@@ -163,7 +163,7 @@ describe('GroupMappingTab', () => {
 
     it('has no accessibility violations in read-only view', async () => {
       const existingMapping = {
-        group_mapping_entries: [{ idp_group_value: 'admin', nexus_group_id: 'g1' }],
+        group_mapping_entries: [{ idp_group_value: 'admin', mapped_group_id: 'g1' }],
       }
       const { container } = render(<GroupMappingTab {...defaultProps} groupMapping={existingMapping} />, { wrapper })
       const results = await axe(container)

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingTab.tsx
@@ -19,7 +19,7 @@ type GroupMappingTabProps = {
 export function GroupMappingTab({ providerId, groupMapping, readOnly = false }: Readonly<GroupMappingTabProps>) {
   const navigate = useNavigate()
   const { groups: allGroupsRaw } = useAllGroups()
-  const nexusGroups = useMemo(
+  const mappedGroups = useMemo(
     () => allGroupsRaw.filter((g) => g.name !== BUILTIN_AUTHENTICATED_GROUP_NAME),
     [allGroupsRaw]
   )
@@ -44,7 +44,7 @@ export function GroupMappingTab({ providerId, groupMapping, readOnly = false }: 
   return (
     <ReadOnlyView
       entries={entries}
-      nexusGroups={nexusGroups}
+      mappedGroups={mappedGroups}
       onEditMapping={readOnly ? undefined : () => navigateToEdit()}
     />
   )

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.test.tsx
@@ -383,6 +383,121 @@ describe('IdentityProviderForm', () => {
 
       expect(screen.getByLabelText(/Disable TLS certificate verification/)).not.toBeChecked()
     })
+
+    it('defaults mappedGroupId to empty string when mapped_group_id is null in API response', () => {
+      const providerWithNullMapping = {
+        id: 'provider-1',
+        name: 'Azure AD',
+        enabled: true,
+        configuration: {
+          provider_type: 'oidc',
+          auto_discovery: true,
+          issuer_url: 'https://login.microsoftonline.com/tenant',
+          client_id: 'client-123',
+          scopes: 'openid profile email',
+          group_jmespath_expression: 'groups[*]',
+          group_mapping_entries: [{ idp_group_value: 'admins', mapped_group_id: null as unknown as string }],
+        },
+      }
+      vi.mocked(identityProvidersClient.useQuery).mockReturnValue({
+        data: providerWithNullMapping,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as never)
+      vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
+        mutate: vi.fn(),
+        isPending: false,
+      } as never)
+
+      // Should render without crashing — null mapped_group_id defaults to ''
+      render(<IdentityProviderForm mode="edit" />, { wrapper })
+      expect(screen.getByRole('heading', { name: 'Edit OIDC provider' })).toBeInTheDocument()
+    })
+
+    it('populates group mapping form values from provider group_mapping_entries', () => {
+      const providerWithMappings = {
+        id: 'provider-1',
+        name: 'Azure AD',
+        enabled: true,
+        configuration: {
+          provider_type: 'oidc',
+          auto_discovery: true,
+          issuer_url: 'https://login.microsoftonline.com/tenant',
+          client_id: 'client-123',
+          scopes: 'openid profile email',
+          group_jmespath_expression: 'groups[*]',
+          group_mapping_entries: [
+            { idp_group_value: 'admins', mapped_group_id: '3fa85f64-5717-4562-b3fc-2c963f66afa6' },
+          ],
+        },
+      }
+      vi.mocked(identityProvidersClient.useQuery).mockReturnValue({
+        data: providerWithMappings,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as never)
+      vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
+        mutate: vi.fn(),
+        isPending: false,
+      } as never)
+
+      render(<IdentityProviderForm mode="edit" />, { wrapper })
+
+      // Form renders without error — group mapping data was correctly deserialized
+      expect(screen.getByRole('heading', { name: 'Edit OIDC provider' })).toBeInTheDocument()
+    })
+
+    it('includes mapped_group_id in patch payload when group mapping entries are present', async () => {
+      const mockPatch = vi.fn()
+      const providerWithMappings = {
+        id: 'provider-1',
+        name: 'Azure AD',
+        enabled: true,
+        configuration: {
+          provider_type: 'oidc',
+          auto_discovery: true,
+          issuer_url: 'https://login.microsoftonline.com/tenant',
+          client_id: 'client-123',
+          scopes: 'openid profile email',
+          group_jmespath_expression: 'groups[*]',
+          group_mapping_entries: [
+            { idp_group_value: 'admins', mapped_group_id: '3fa85f64-5717-4562-b3fc-2c963f66afa6' },
+          ],
+        },
+      }
+      mockUseParams.mockReturnValue({ providerId: 'provider-1' })
+      vi.mocked(identityProvidersClient.useQuery).mockReturnValue({
+        data: providerWithMappings,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as never)
+      vi.mocked(identityProvidersClient.useMutation).mockImplementation(((method: string) => {
+        if (method === 'patch') {
+          return { mutate: mockPatch, isPending: false }
+        }
+        return { mutate: vi.fn(), isPending: false }
+      }) as never)
+
+      const user = userEvent.setup()
+      render(<IdentityProviderForm mode="edit" />, { wrapper })
+
+      await user.click(screen.getByRole('button', { name: 'Claim mapping' }))
+      await user.click(screen.getByRole('button', { name: 'Save provider' }))
+
+      await waitFor(() => expect(mockPatch).toHaveBeenCalled())
+
+      const body = (mockPatch.mock.calls[0] as [{ body: { configuration: { group_mapping_entries: unknown[] } } }])[0]
+        .body.configuration
+      expect(body.group_mapping_entries).toEqual([
+        { idp_group_value: 'admins', mapped_group_id: '3fa85f64-5717-4562-b3fc-2c963f66afa6' },
+      ])
+    })
   })
 
   describe('submit and test connection', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.tsx
@@ -79,7 +79,7 @@ function groupMappingFields(formData: IdentityProviderFormData) {
     group_jmespath_expression: formData.groupMapping.jmespathExpression,
     group_mapping_entries: (formData.groupMapping.entries ?? []).map((e) => ({
       idp_group_value: e.idpGroupValue,
-      nexus_group_id: e.nexusGroupId,
+      mapped_group_id: e.mappedGroupId,
     })),
   }
 }
@@ -155,7 +155,7 @@ function toGroupMappingValues(config?: ProviderConfig): IdentityProviderFormData
     jmespathExpression: config?.group_jmespath_expression ?? 'groups[*]',
     entries: (entries ?? []).map((e) => ({
       idpGroupValue: e.idp_group_value ?? '',
-      nexusGroupId: e.nexus_group_id ?? '',
+      mappedGroupId: e.mapped_group_id ?? '',
     })),
   }
 }

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderFormFields.module.css
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderFormFields.module.css
@@ -1,3 +1,3 @@
 .formMaxWidth {
-  max-width: var(--nexus-form-max-width);
+  max-width: var(--syntara-form-max-width);
 }

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/TestSignInCallback.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/TestSignInCallback.test.tsx
@@ -37,12 +37,12 @@ describe('TestSignInCallback', () => {
     const json = JSON.stringify(claims)
     const base64 = btoa(json).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
     const nonce = 'test-nonce-123'
-    localStorage.setItem('nexus-test-signin-nonce', nonce)
+    localStorage.setItem('syntara-test-signin-nonce', nonce)
     globalThis.location.hash = `#${base64}`
 
     render(<TestSignInCallback />)
 
-    const stored = localStorage.getItem('nexus-test-signin')
+    const stored = localStorage.getItem('syntara-test-signin')
     expect(stored).not.toBeNull()
     const parsed = JSON.parse(stored!) as { type: string; nonce: string; claims: Record<string, unknown> }
     expect(parsed.type).toBe('test-signin')
@@ -53,12 +53,12 @@ describe('TestSignInCallback', () => {
   it('leaves the nonce in localStorage for the parent to clean up', () => {
     const claims = { sub: 'user-123' }
     const base64 = btoa(JSON.stringify(claims))
-    localStorage.setItem('nexus-test-signin-nonce', 'some-nonce')
+    localStorage.setItem('syntara-test-signin-nonce', 'some-nonce')
     globalThis.location.hash = `#${base64}`
 
     render(<TestSignInCallback />)
 
-    expect(localStorage.getItem('nexus-test-signin-nonce')).toBe('some-nonce')
+    expect(localStorage.getItem('syntara-test-signin-nonce')).toBe('some-nonce')
   })
 
   it('discards payload when no nonce is present in localStorage', () => {
@@ -68,25 +68,25 @@ describe('TestSignInCallback', () => {
 
     render(<TestSignInCallback />)
 
-    expect(localStorage.getItem('nexus-test-signin')).toBeNull()
+    expect(localStorage.getItem('syntara-test-signin')).toBeNull()
   })
 
   it('rejects non-object claims (array)', () => {
-    localStorage.setItem('nexus-test-signin-nonce', 'nonce')
+    localStorage.setItem('syntara-test-signin-nonce', 'nonce')
     globalThis.location.hash = `#${btoa(JSON.stringify(['not', 'an', 'object']))}`
 
     render(<TestSignInCallback />)
 
-    expect(localStorage.getItem('nexus-test-signin')).toBeNull()
+    expect(localStorage.getItem('syntara-test-signin')).toBeNull()
   })
 
   it('rejects non-object claims (primitive)', () => {
-    localStorage.setItem('nexus-test-signin-nonce', 'nonce')
+    localStorage.setItem('syntara-test-signin-nonce', 'nonce')
     globalThis.location.hash = `#${btoa(JSON.stringify('just a string'))}`
 
     render(<TestSignInCallback />)
 
-    expect(localStorage.getItem('nexus-test-signin')).toBeNull()
+    expect(localStorage.getItem('syntara-test-signin')).toBeNull()
   })
 
   it('closes the window after processing', () => {
@@ -101,22 +101,22 @@ describe('TestSignInCallback', () => {
   })
 
   it('handles invalid base64 gracefully and still closes', () => {
-    localStorage.setItem('nexus-test-signin-nonce', 'nonce')
+    localStorage.setItem('syntara-test-signin-nonce', 'nonce')
     globalThis.location.hash = '#not-valid-base64!!!'
     render(<TestSignInCallback />)
 
-    expect(localStorage.getItem('nexus-test-signin')).toBeNull()
+    expect(localStorage.getItem('syntara-test-signin')).toBeNull()
     expect(mockClose).toHaveBeenCalled()
   })
 
   it('handles invalid JSON in decoded base64 gracefully', () => {
-    localStorage.setItem('nexus-test-signin-nonce', 'nonce')
+    localStorage.setItem('syntara-test-signin-nonce', 'nonce')
     const base64 = btoa('not-json')
     globalThis.location.hash = `#${base64}`
 
     render(<TestSignInCallback />)
 
-    expect(localStorage.getItem('nexus-test-signin')).toBeNull()
+    expect(localStorage.getItem('syntara-test-signin')).toBeNull()
     expect(mockClose).toHaveBeenCalled()
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingEditFormSchema.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingEditFormSchema.test.ts
@@ -12,7 +12,7 @@ describe('groupMappingEditFormSchema', () => {
   it('accepts a complete mapping row and valid JMESPath expression', () => {
     const result = groupMappingEditFormSchema.safeParse({
       expression: 'groups[*]',
-      entries: [{ idpGroupValue: 'admin', nexusGroupId: VALID_GROUP_ID }],
+      entries: [{ idpGroupValue: 'admin', mappedGroupId: VALID_GROUP_ID }],
     })
 
     expect(result.success).toBe(true)
@@ -30,7 +30,7 @@ describe('groupMappingEditFormSchema', () => {
   it('accepts blank rows that are filtered out on save', () => {
     const result = groupMappingEditFormSchema.safeParse({
       expression: 'groups[*]',
-      entries: [{ idpGroupValue: '', nexusGroupId: '' }],
+      entries: [{ idpGroupValue: '', mappedGroupId: '' }],
     })
 
     expect(result.success).toBe(true)
@@ -39,16 +39,16 @@ describe('groupMappingEditFormSchema', () => {
   it('rejects IdP group values over the max length', () => {
     const result = groupMappingEditFormSchema.safeParse({
       expression: 'groups[*]',
-      entries: [{ idpGroupValue: 'a'.repeat(GROUP_MAPPING_IDP_GROUP_VALUE_MAX_LENGTH + 1), nexusGroupId: '' }],
+      entries: [{ idpGroupValue: 'a'.repeat(GROUP_MAPPING_IDP_GROUP_VALUE_MAX_LENGTH + 1), mappedGroupId: '' }],
     })
 
     expect(result.success).toBe(false)
   })
 
-  it('rejects invalid Nexus group IDs', () => {
+  it('rejects invalid Syntara group IDs', () => {
     const result = groupMappingEditFormSchema.safeParse({
       expression: 'groups[*]',
-      entries: [{ idpGroupValue: 'admin', nexusGroupId: 'not-a-uuid' }],
+      entries: [{ idpGroupValue: 'admin', mappedGroupId: 'not-a-uuid' }],
     })
 
     expect(result.success).toBe(false)
@@ -72,10 +72,10 @@ describe('groupMappingEditFormSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('rejects partial rows missing a Nexus group', () => {
+  it('rejects partial rows missing a Syntara group', () => {
     const result = groupMappingEditFormSchema.safeParse({
       expression: 'groups[*]',
-      entries: [{ idpGroupValue: 'admin', nexusGroupId: '' }],
+      entries: [{ idpGroupValue: 'admin', mappedGroupId: '' }],
     })
 
     expect(result.success).toBe(false)
@@ -84,7 +84,7 @@ describe('groupMappingEditFormSchema', () => {
   it('rejects partial rows missing an IdP group value', () => {
     const result = groupMappingEditFormSchema.safeParse({
       expression: 'groups[*]',
-      entries: [{ idpGroupValue: '', nexusGroupId: VALID_GROUP_ID }],
+      entries: [{ idpGroupValue: '', mappedGroupId: VALID_GROUP_ID }],
     })
 
     expect(result.success).toBe(false)

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingEditFormSchema.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingEditFormSchema.ts
@@ -11,7 +11,7 @@ const groupMappingEditEntrySchema = z.object({
   idpGroupValue: z
     .string()
     .max(GROUP_MAPPING_IDP_GROUP_VALUE_MAX_LENGTH, 'IdP group value must be at most 255 characters'),
-  nexusGroupId: z.union([z.literal(''), z.string().uuid(`Select a valid ${APP_TITLE} group`)]),
+  mappedGroupId: z.union([z.literal(''), z.string().uuid(`Select a valid ${APP_TITLE} group`)]),
 })
 
 export const groupMappingEditFormSchema = z
@@ -31,21 +31,21 @@ export const groupMappingEditFormSchema = z
   .superRefine((data, ctx) => {
     data.entries.forEach((entry, index) => {
       const hasIdp = entry.idpGroupValue.trim().length > 0
-      const hasNexus = entry.nexusGroupId.trim().length > 0
+      const hasMappedGroup = entry.mappedGroupId.trim().length > 0
 
-      if (!hasIdp && !hasNexus) {
+      if (!hasIdp && !hasMappedGroup) {
         return
       }
 
-      if (hasIdp && !hasNexus) {
+      if (hasIdp && !hasMappedGroup) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: `Select a ${APP_TITLE} group`,
-          path: ['entries', index, 'nexusGroupId'],
+          path: ['entries', index, 'mappedGroupId'],
         })
       }
 
-      if (!hasIdp && hasNexus) {
+      if (!hasIdp && hasMappedGroup) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'Enter an IdP group value',

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingFields.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingFields.test.tsx
@@ -4,10 +4,10 @@ import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
-import { IdpGroupValueInput, MappingRow, NexusGroupMappingSelect } from './groupMappingFields'
-import type { GroupMappingEntry, NexusGroup } from './groupMappingUtils'
+import { IdpGroupValueInput, MappingRow, MappedGroupMappingSelect } from './groupMappingFields'
+import type { GroupMappingEntry, MappedGroup } from './groupMappingUtils'
 
-const mockNexusGroups: NexusGroup[] = [
+const mockMappedGroups: MappedGroup[] = [
   { id: 'g1', name: 'admin', description: 'Administrators' },
   { id: 'g2', name: 'users', description: 'Regular users' },
   { id: 'g3', name: 'developers', description: 'Development team' },
@@ -75,36 +75,36 @@ describe('IdpGroupValueInput', () => {
   })
 })
 
-describe('NexusGroupMappingSelect', () => {
+describe('MappedGroupMappingSelect', () => {
   const defaultEntry: GroupMappingEntry = {
     key: 'k1',
     idpGroupValue: 'idp-admin',
-    nexusGroupId: '',
+    mappedGroupId: '',
   }
 
   const defaultProps = {
     entry: defaultEntry,
-    nexusGroups: mockNexusGroups,
+    mappedGroups: mockMappedGroups,
     onChange: vi.fn(),
     onCreateGroup: vi.fn(),
   }
 
   it('renders typeahead select with placeholder', () => {
-    render(<NexusGroupMappingSelect {...defaultProps} />)
+    render(<MappedGroupMappingSelect {...defaultProps} />)
 
     expect(screen.getByPlaceholderText('Select a group...')).toBeInTheDocument()
   })
 
   it('displays selected group name', () => {
-    const entry = { ...defaultEntry, nexusGroupId: 'g1' }
-    render(<NexusGroupMappingSelect {...defaultProps} entry={entry} />)
+    const entry = { ...defaultEntry, mappedGroupId: 'g1' }
+    render(<MappedGroupMappingSelect {...defaultProps} entry={entry} />)
 
     expect(screen.getByDisplayValue('admin')).toBeInTheDocument()
   })
 
   it('opens dropdown when clicked', async () => {
     const user = userEvent.setup()
-    render(<NexusGroupMappingSelect {...defaultProps} />)
+    render(<MappedGroupMappingSelect {...defaultProps} />)
 
     await user.click(screen.getByPlaceholderText('Select a group...'))
 
@@ -115,7 +115,7 @@ describe('NexusGroupMappingSelect', () => {
 
   it('filters groups by name when typing', async () => {
     const user = userEvent.setup()
-    render(<NexusGroupMappingSelect {...defaultProps} />)
+    render(<MappedGroupMappingSelect {...defaultProps} />)
 
     await user.click(screen.getByPlaceholderText('Select a group...'))
     await user.type(screen.getByPlaceholderText('Select a group...'), 'dev')
@@ -127,7 +127,7 @@ describe('NexusGroupMappingSelect', () => {
 
   it('shows "no match" message when filter has no results', async () => {
     const user = userEvent.setup()
-    render(<NexusGroupMappingSelect {...defaultProps} />)
+    render(<MappedGroupMappingSelect {...defaultProps} />)
 
     await user.click(screen.getByPlaceholderText('Select a group...'))
     await user.type(screen.getByPlaceholderText('Select a group...'), 'zzz-no-match')
@@ -138,17 +138,17 @@ describe('NexusGroupMappingSelect', () => {
   it('calls onChange when a group is selected', async () => {
     const onChange = vi.fn()
     const user = userEvent.setup()
-    render(<NexusGroupMappingSelect {...defaultProps} onChange={onChange} />)
+    render(<MappedGroupMappingSelect {...defaultProps} onChange={onChange} />)
 
     await user.click(screen.getByPlaceholderText('Select a group...'))
     await user.click(screen.getByRole('option', { name: /admin/i }))
 
-    expect(onChange).toHaveBeenCalledWith({ ...defaultEntry, nexusGroupId: 'g1' })
+    expect(onChange).toHaveBeenCalledWith({ ...defaultEntry, mappedGroupId: 'g1' })
   })
 
   it('displays "Create new group" option', async () => {
     const user = userEvent.setup()
-    render(<NexusGroupMappingSelect {...defaultProps} />)
+    render(<MappedGroupMappingSelect {...defaultProps} />)
 
     await user.click(screen.getByPlaceholderText('Select a group...'))
 
@@ -158,7 +158,7 @@ describe('NexusGroupMappingSelect', () => {
   it('calls onCreateGroup when "Create new group" is clicked', async () => {
     const onCreateGroup = vi.fn()
     const user = userEvent.setup()
-    render(<NexusGroupMappingSelect {...defaultProps} onCreateGroup={onCreateGroup} />)
+    render(<MappedGroupMappingSelect {...defaultProps} onCreateGroup={onCreateGroup} />)
 
     await user.click(screen.getByPlaceholderText('Select a group...'))
     await user.click(screen.getByRole('option', { name: /create new group/i }))
@@ -167,8 +167,8 @@ describe('NexusGroupMappingSelect', () => {
   })
 
   it('shows danger status when validation fails', () => {
-    const entry = { ...defaultEntry, idpGroupValue: 'admin' } // has IdP value but no Nexus group
-    render(<NexusGroupMappingSelect {...defaultProps} entry={entry} showValidation />)
+    const entry = { ...defaultEntry, idpGroupValue: 'admin' } // has IdP value but no Syntara group
+    render(<MappedGroupMappingSelect {...defaultProps} entry={entry} showValidation />)
 
     const filterInput = screen.getByPlaceholderText('Select a group...')
     // Traverse to our wrapper (data-group-mapping-invalid), not PatternFly layout classes
@@ -177,20 +177,20 @@ describe('NexusGroupMappingSelect', () => {
   })
 
   it('is disabled when isReadOnly is true', () => {
-    render(<NexusGroupMappingSelect {...defaultProps} isReadOnly />)
+    render(<MappedGroupMappingSelect {...defaultProps} isReadOnly />)
 
     expect(screen.getByPlaceholderText('Select a group...')).toBeDisabled()
   })
 
   it('has no accessibility violations', async () => {
-    const { container } = render(<NexusGroupMappingSelect {...defaultProps} />)
+    const { container } = render(<MappedGroupMappingSelect {...defaultProps} />)
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })
 
   it('has no accessibility violations when open', async () => {
     const user = userEvent.setup()
-    const { container } = render(<NexusGroupMappingSelect {...defaultProps} />)
+    const { container } = render(<MappedGroupMappingSelect {...defaultProps} />)
 
     await user.click(screen.getByPlaceholderText('Select a group...'))
 
@@ -203,15 +203,15 @@ describe('MappingRow', () => {
   const defaultEntry: GroupMappingEntry = {
     key: 'k1',
     idpGroupValue: 'idp-admin',
-    nexusGroupId: 'g1',
+    mappedGroupId: 'g1',
   }
 
   const defaultProps = {
     entry: defaultEntry,
     index: 0,
-    nexusGroups: mockNexusGroups,
+    mappedGroups: mockMappedGroups,
     onIdpGroupValueChange: vi.fn(),
-    onNexusGroupIdChange: vi.fn(),
+    onMappedGroupIdChange: vi.fn(),
     onRemove: vi.fn(),
     onCreateGroup: vi.fn(),
   }
@@ -254,7 +254,7 @@ describe('MappingRow', () => {
                 {...defaultProps}
                 entry={entry}
                 onIdpGroupValueChange={(_index, value) => setEntry((prev) => ({ ...prev, idpGroupValue: value }))}
-                onNexusGroupIdChange={(_index, nexusGroupId) => setEntry((prev) => ({ ...prev, nexusGroupId }))}
+                onMappedGroupIdChange={(_index, mappedGroupId) => setEntry((prev) => ({ ...prev, mappedGroupId }))}
               />
             </tbody>
           </table>
@@ -351,7 +351,7 @@ describe('MappingRow', () => {
       expect(screen.getByText('admin')).toBeInTheDocument()
     })
 
-    it('links Nexus group names to group detail pages', () => {
+    it('links Syntara group names to group detail pages', () => {
       render(
         <table>
           <tbody>
@@ -395,7 +395,7 @@ describe('MappingRow', () => {
     })
 
     it('displays em dash for empty values', () => {
-      const emptyEntry: GroupMappingEntry = { key: 'k2', idpGroupValue: '', nexusGroupId: '' }
+      const emptyEntry: GroupMappingEntry = { key: 'k2', idpGroupValue: '', mappedGroupId: '' }
       render(
         <table>
           <tbody>
@@ -422,8 +422,8 @@ describe('MappingRow', () => {
   })
 
   describe('Validation states', () => {
-    it('shows validation error when IdP has value but no Nexus group', () => {
-      const incompleteEntry = { ...defaultEntry, nexusGroupId: '' }
+    it('shows validation error when IdP has value but no Syntara group', () => {
+      const incompleteEntry = { ...defaultEntry, mappedGroupId: '' }
       render(
         <table>
           <tbody>

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingFields.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingFields.tsx
@@ -30,7 +30,7 @@ import { APP_TITLE } from '../../../../utils/appTitle'
 import { getGroupDetailPath } from '../../accessManagementPaths'
 
 import type { GroupMappingEditFormValues } from './groupMappingEditFormSchema'
-import type { GroupMappingEntry, NexusGroup } from './groupMappingUtils'
+import type { GroupMappingEntry, MappedGroup } from './groupMappingUtils'
 import { idpHelp } from './idpFieldHelp'
 
 const CREATE_GROUP_VALUE = '__create__' as const
@@ -89,9 +89,9 @@ export function IdpGroupValueInput({
   )
 }
 
-export type NexusGroupMappingSelectProps = {
+export type MappedGroupMappingSelectProps = {
   entry: GroupMappingEntry
-  nexusGroups: NexusGroup[]
+  mappedGroups: MappedGroup[]
   isReadOnly?: boolean
   showValidation?: boolean
   errorMessage?: string
@@ -100,7 +100,7 @@ export type NexusGroupMappingSelectProps = {
   toggleId?: string
 }
 
-type NexusGroupMappingSelectToggleProps = {
+type MappedGroupMappingSelectToggleProps = {
   toggleRef: Ref<MenuToggleElement>
   toggleId?: string
   isOpen: boolean
@@ -113,7 +113,7 @@ type NexusGroupMappingSelectToggleProps = {
   inputRef: RefObject<HTMLInputElement | null>
 }
 
-function NexusGroupMappingSelectToggle({
+function MappedGroupMappingSelectToggle({
   toggleRef,
   toggleId,
   isOpen,
@@ -124,7 +124,7 @@ function NexusGroupMappingSelectToggle({
   setFilterValue,
   setIsOpen,
   inputRef,
-}: Readonly<NexusGroupMappingSelectToggleProps>) {
+}: Readonly<MappedGroupMappingSelectToggleProps>) {
   return (
     <div style={{ display: 'contents' }} data-group-mapping-invalid={missingGroup ? 'true' : 'false'}>
       <MenuToggle
@@ -159,34 +159,34 @@ function NexusGroupMappingSelectToggle({
   )
 }
 
-export function NexusGroupMappingSelect({
+export function MappedGroupMappingSelect({
   entry,
-  nexusGroups,
+  mappedGroups,
   isReadOnly,
   showValidation,
   errorMessage,
   onChange,
   onCreateGroup,
   toggleId,
-}: Readonly<NexusGroupMappingSelectProps>) {
+}: Readonly<MappedGroupMappingSelectProps>) {
   const [isOpen, setIsOpen] = useState(false)
   const [filterValue, setFilterValue] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
-  const selectedGroup = nexusGroups.find((g) => g.id === entry.nexusGroupId)
+  const selectedGroup = mappedGroups.find((g) => g.id === entry.mappedGroupId)
   const missingGroup =
-    Boolean(errorMessage) || (showValidation === true && Boolean(entry.idpGroupValue) && entry.nexusGroupId === '')
+    Boolean(errorMessage) || (showValidation === true && Boolean(entry.idpGroupValue) && entry.mappedGroupId === '')
 
   const filteredGroups = useMemo(() => {
-    if (filterValue === '') return nexusGroups
+    if (filterValue === '') return mappedGroups
     const term = filterValue.toLowerCase()
-    return nexusGroups.filter((g) => g.name?.toLowerCase().includes(term))
-  }, [nexusGroups, filterValue])
+    return mappedGroups.filter((g) => g.name?.toLowerCase().includes(term))
+  }, [mappedGroups, filterValue])
 
   const selectedDisplayName = selectedGroup?.name ?? ''
 
   const renderToggle = useCallback(
     (toggleRef: Ref<MenuToggleElement>) => (
-      <NexusGroupMappingSelectToggle
+      <MappedGroupMappingSelectToggle
         toggleRef={toggleRef}
         toggleId={toggleId}
         isOpen={isOpen}
@@ -205,7 +205,7 @@ export function NexusGroupMappingSelect({
   return (
     <NxSelect
       isOpen={isOpen}
-      selected={entry.nexusGroupId || undefined}
+      selected={entry.mappedGroupId || undefined}
       onSelect={(_event, value) => {
         const val = String(value)
         if (val === CREATE_GROUP_VALUE) {
@@ -214,7 +214,7 @@ export function NexusGroupMappingSelect({
           setFilterValue('')
           return
         }
-        onChange({ ...entry, nexusGroupId: val })
+        onChange({ ...entry, mappedGroupId: val })
         setIsOpen(false)
         setFilterValue('')
       }}
@@ -233,7 +233,7 @@ export function NexusGroupMappingSelect({
               key={g.id}
               value={g.id}
               description={g.description ?? undefined}
-              isSelected={entry.nexusGroupId === g.id}
+              isSelected={entry.mappedGroupId === g.id}
             >
               {g.name}
             </SelectOption>
@@ -253,7 +253,7 @@ export function NexusGroupMappingSelect({
 type MappingRowProps = {
   entry: GroupMappingEntry
   index: number
-  nexusGroups: NexusGroup[]
+  mappedGroups: MappedGroup[]
   isReadOnly?: boolean
   /** When true with isReadOnly, show per-row delete (list view with actions column) */
   readOnlyAllowRemove?: boolean
@@ -261,9 +261,9 @@ type MappingRowProps = {
   readOnlyPlainCells?: boolean
   showValidation?: boolean
   idpErrorMessage?: string
-  nexusErrorMessage?: string
+  groupErrorMessage?: string
   onIdpGroupValueChange?: (index: number, value: string) => void
-  onNexusGroupIdChange?: (index: number, nexusGroupId: string) => void
+  onMappedGroupIdChange?: (index: number, mappedGroupId: string) => void
   onRemove: (index: number) => void
   onCreateGroup: (index: number) => void
 }
@@ -271,22 +271,22 @@ type MappingRowProps = {
 export function MappingRow({
   entry,
   index,
-  nexusGroups,
+  mappedGroups,
   isReadOnly,
   readOnlyAllowRemove,
   readOnlyPlainCells,
   showValidation,
   idpErrorMessage,
-  nexusErrorMessage,
+  groupErrorMessage,
   onIdpGroupValueChange,
-  onNexusGroupIdChange,
+  onMappedGroupIdChange,
   onRemove,
   onCreateGroup,
 }: Readonly<MappingRowProps>) {
   const showActionColumn = Boolean(isReadOnly !== true || readOnlyAllowRemove)
 
   if (isReadOnly === true && readOnlyPlainCells === true) {
-    const groupName = nexusGroups.find((g) => g.id === entry.nexusGroupId)?.name ?? ''
+    const groupName = mappedGroups.find((g) => g.id === entry.mappedGroupId)?.name ?? ''
     const idpDisplay = entry.idpGroupValue === '' ? '—' : entry.idpGroupValue
     const groupDisplay = groupName === '' ? '—' : groupName
     return (
@@ -295,8 +295,8 @@ export function MappingRow({
           <Content>{idpDisplay}</Content>
         </Td>
         <Td dataLabel={`${APP_TITLE} Group`}>
-          {entry.nexusGroupId !== '' && groupName !== '' ? (
-            <LinkCell href={getGroupDetailPath(entry.nexusGroupId)}>{groupDisplay}</LinkCell>
+          {entry.mappedGroupId !== '' && groupName !== '' ? (
+            <LinkCell href={getGroupDetailPath(entry.mappedGroupId)}>{groupDisplay}</LinkCell>
           ) : (
             <Content>{groupDisplay}</Content>
           )}
@@ -327,13 +327,13 @@ export function MappingRow({
         />
       </Td>
       <Td dataLabel={`${APP_TITLE} Group`}>
-        <NexusGroupMappingSelect
+        <MappedGroupMappingSelect
           entry={entry}
-          nexusGroups={nexusGroups}
+          mappedGroups={mappedGroups}
           isReadOnly={isReadOnly}
           showValidation={showValidation}
-          errorMessage={nexusErrorMessage}
-          onChange={(updated) => onNexusGroupIdChange?.(index, updated.nexusGroupId)}
+          errorMessage={groupErrorMessage}
+          onChange={(updated) => onMappedGroupIdChange?.(index, updated.mappedGroupId)}
           onCreateGroup={() => onCreateGroup(index)}
         />
       </Td>
@@ -355,7 +355,7 @@ export type EditMappingRowProps = {
   index: number
   rowId: string
   control: Control<GroupMappingEditFormValues>
-  nexusGroups: NexusGroup[]
+  mappedGroups: MappedGroup[]
   onRemove: (index: number) => void
   onCreateGroup: (index: number) => void
 }
@@ -364,7 +364,7 @@ export function EditMappingRow({
   index,
   rowId,
   control,
-  nexusGroups,
+  mappedGroups,
   onRemove,
   onCreateGroup,
 }: Readonly<EditMappingRowProps>) {
@@ -388,14 +388,14 @@ export function EditMappingRow({
       </Td>
       <Td dataLabel={`${APP_TITLE} Group`}>
         <Controller
-          name={`entries.${index}.nexusGroupId`}
+          name={`entries.${index}.mappedGroupId`}
           control={control}
           render={({ field, fieldState }) => (
-            <NexusGroupMappingSelect
-              entry={{ key: rowId, idpGroupValue, nexusGroupId: field.value }}
-              nexusGroups={nexusGroups}
+            <MappedGroupMappingSelect
+              entry={{ key: rowId, idpGroupValue, mappedGroupId: field.value }}
+              mappedGroups={mappedGroups}
               errorMessage={fieldState.error?.message}
-              onChange={(updated) => field.onChange(updated.nexusGroupId)}
+              onChange={(updated) => field.onChange(updated.mappedGroupId)}
               onCreateGroup={() => onCreateGroup(index)}
             />
           )}

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingFormUtils.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingFormUtils.test.ts
@@ -55,7 +55,7 @@ describe('groupMappingFormUtils', () => {
 
     it('returns server entries when present', () => {
       const entries = initialGroupMappingFormEntries({
-        group_mapping_entries: [{ idp_group_value: 'admins', nexus_group_id: 'g1' }],
+        group_mapping_entries: [{ idp_group_value: 'admins', mapped_group_id: 'g1' }],
       })
       expect(entries).toHaveLength(1)
       expect(entries[0]?.idpGroupValue).toBe('admins')
@@ -68,20 +68,20 @@ describe('groupMappingFormUtils', () => {
         buildGroupMappingFormDefaultValues(
           {
             group_jmespath_expression: 'groups[?@]',
-            group_mapping_entries: [{ idp_group_value: 'admins', nexus_group_id: 'g1' }],
+            group_mapping_entries: [{ idp_group_value: 'admins', mapped_group_id: 'g1' }],
           },
           'groups[*]'
         )
       ).toEqual({
         expression: 'groups[?@]',
-        entries: [{ idpGroupValue: 'admins', nexusGroupId: 'g1' }],
+        entries: [{ idpGroupValue: 'admins', mappedGroupId: 'g1' }],
       })
     })
 
     it('falls back to default expression when server has none', () => {
       expect(buildGroupMappingFormDefaultValues(null, 'groups[*]')).toEqual({
         expression: 'groups[*]',
-        entries: [{ idpGroupValue: '', nexusGroupId: '' }],
+        entries: [{ idpGroupValue: '', mappedGroupId: '' }],
       })
     })
   })

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingFormUtils.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingFormUtils.ts
@@ -22,7 +22,7 @@ export function parseGroupMappingFormSearch(search: string): { isAddFlow: boolea
 
 export type GroupMappingFormEntry = {
   idpGroupValue: string
-  nexusGroupId: string
+  mappedGroupId: string
 }
 
 export function initialGroupMappingFormEntries(
@@ -30,9 +30,9 @@ export function initialGroupMappingFormEntries(
 ): GroupMappingFormEntry[] {
   const fromServer = toFormEntries(groupMapping)
   if (fromServer.length > 0) {
-    return fromServer.map(({ idpGroupValue, nexusGroupId }) => ({ idpGroupValue, nexusGroupId }))
+    return fromServer.map(({ idpGroupValue, mappedGroupId }) => ({ idpGroupValue, mappedGroupId }))
   }
-  return [{ idpGroupValue: '', nexusGroupId: '' }]
+  return [{ idpGroupValue: '', mappedGroupId: '' }]
 }
 
 export function buildGroupMappingFormDefaultValues(

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingUtils.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingUtils.test.ts
@@ -9,7 +9,7 @@ import {
   validateGroupJmespathExpression,
   type GroupMappingConfig,
   type GroupMappingEntry,
-  type NexusGroup,
+  type MappedGroup,
 } from './groupMappingUtils'
 
 describe('groupMappingUtils', () => {
@@ -83,14 +83,14 @@ describe('groupMappingUtils', () => {
       const config: GroupMappingConfig = {
         group_jmespath_expression: 'groups[*]',
         group_mapping_entries: [
-          { idp_group_value: 'admin', nexus_group_id: 'g1' },
-          { idp_group_value: 'users', nexus_group_id: 'g2' },
+          { idp_group_value: 'admin', mapped_group_id: 'g1' },
+          { idp_group_value: 'users', mapped_group_id: 'g2' },
         ],
       }
       const result = toFormEntries(config)
       expect(result).toHaveLength(2)
-      expect(result[0]).toMatchObject({ idpGroupValue: 'admin', nexusGroupId: 'g1' })
-      expect(result[1]).toMatchObject({ idpGroupValue: 'users', nexusGroupId: 'g2' })
+      expect(result[0]).toMatchObject({ idpGroupValue: 'admin', mappedGroupId: 'g1' })
+      expect(result[1]).toMatchObject({ idpGroupValue: 'users', mappedGroupId: 'g2' })
       expect(result[0].key).toBeTruthy()
     })
 
@@ -117,9 +117,9 @@ describe('groupMappingUtils', () => {
         redirect_uri: 'http://localhost/callback',
       }
       const entries: GroupMappingEntry[] = [
-        { key: 'k1', idpGroupValue: 'admin', nexusGroupId: 'g1' },
-        { key: 'k2', idpGroupValue: '', nexusGroupId: '' },
-        { key: 'k3', idpGroupValue: 'users', nexusGroupId: 'g2' },
+        { key: 'k1', idpGroupValue: 'admin', mappedGroupId: 'g1' },
+        { key: 'k2', idpGroupValue: '', mappedGroupId: '' },
+        { key: 'k3', idpGroupValue: 'users', mappedGroupId: 'g2' },
       ]
       const result = buildSavePayload(providerConfig, 'groups[*]', entries)
 
@@ -128,14 +128,14 @@ describe('groupMappingUtils', () => {
         provider_type: 'oidc',
         group_jmespath_expression: 'groups[*]',
         group_mapping_entries: [
-          { idp_group_value: 'admin', nexus_group_id: 'g1' },
-          { idp_group_value: 'users', nexus_group_id: 'g2' },
+          { idp_group_value: 'admin', mapped_group_id: 'g1' },
+          { idp_group_value: 'users', mapped_group_id: 'g2' },
         ],
       })
     })
 
     it('filters entries where idpGroupValue is empty', () => {
-      const entries: GroupMappingEntry[] = [{ key: 'k1', idpGroupValue: '', nexusGroupId: 'g1' }]
+      const entries: GroupMappingEntry[] = [{ key: 'k1', idpGroupValue: '', mappedGroupId: 'g1' }]
       const result = buildSavePayload(
         { issuer_url: 'https://example.com', client_id: 'test-client', redirect_uri: 'http://localhost/callback' },
         'groups[*]',
@@ -144,8 +144,8 @@ describe('groupMappingUtils', () => {
       expect(result.configuration?.group_mapping_entries).toEqual([])
     })
 
-    it('filters entries where nexusGroupId is empty', () => {
-      const entries: GroupMappingEntry[] = [{ key: 'k1', idpGroupValue: 'admin', nexusGroupId: '' }]
+    it('filters entries where mappedGroupId is empty', () => {
+      const entries: GroupMappingEntry[] = [{ key: 'k1', idpGroupValue: 'admin', mappedGroupId: '' }]
       const result = buildSavePayload(
         { issuer_url: 'https://example.com', client_id: 'test-client', redirect_uri: 'http://localhost/callback' },
         'groups[*]',
@@ -156,66 +156,66 @@ describe('groupMappingUtils', () => {
   })
 
   describe('processDiscoveredGroups', () => {
-    const nexusGroups: NexusGroup[] = [
+    const mappedGroups: MappedGroup[] = [
       { id: 'g1', name: 'admin' },
       { id: 'g2', name: 'users' },
       { id: 'g3', name: 'devs', description: 'Developers' },
     ]
 
     it('returns warning when no groups found', () => {
-      const result = processDiscoveredGroups({}, 'groups[*]', [], nexusGroups)
+      const result = processDiscoveredGroups({}, 'groups[*]', [], mappedGroups)
       expect(result.variant).toBe('warning')
       expect(result.message).toContain('No groups found')
       expect(result.newEntries).toEqual([])
     })
 
-    it('auto-matches discovered groups to nexus groups by name', () => {
+    it('auto-matches discovered groups to mapped groups by name', () => {
       const claims = { groups: ['admin', 'users'] }
-      const result = processDiscoveredGroups(claims, 'groups[*]', [], nexusGroups)
+      const result = processDiscoveredGroups(claims, 'groups[*]', [], mappedGroups)
 
       expect(result.variant).toBe('success')
       expect(result.newEntries).toHaveLength(2)
-      expect(result.newEntries[0]).toMatchObject({ idpGroupValue: 'admin', nexusGroupId: 'g1' })
-      expect(result.newEntries[1]).toMatchObject({ idpGroupValue: 'users', nexusGroupId: 'g2' })
+      expect(result.newEntries[0]).toMatchObject({ idpGroupValue: 'admin', mappedGroupId: 'g1' })
+      expect(result.newEntries[1]).toMatchObject({ idpGroupValue: 'users', mappedGroupId: 'g2' })
       expect(result.message).toContain('Discovered 2 group(s)')
       expect(result.message).toContain('2 matched')
     })
 
     it('preserves existing entries for discovered groups', () => {
-      const existingEntries: GroupMappingEntry[] = [{ key: 'existing-1', idpGroupValue: 'admin', nexusGroupId: 'g3' }]
+      const existingEntries: GroupMappingEntry[] = [{ key: 'existing-1', idpGroupValue: 'admin', mappedGroupId: 'g3' }]
       const claims = { groups: ['admin', 'users'] }
-      const result = processDiscoveredGroups(claims, 'groups[*]', existingEntries, nexusGroups)
+      const result = processDiscoveredGroups(claims, 'groups[*]', existingEntries, mappedGroups)
 
       expect(result.newEntries).toHaveLength(2)
       // Existing entry preserved with its key and custom mapping
-      expect(result.newEntries[0]).toMatchObject({ key: 'existing-1', idpGroupValue: 'admin', nexusGroupId: 'g3' })
+      expect(result.newEntries[0]).toMatchObject({ key: 'existing-1', idpGroupValue: 'admin', mappedGroupId: 'g3' })
       // New entry auto-matched
-      expect(result.newEntries[1]).toMatchObject({ idpGroupValue: 'users', nexusGroupId: 'g2' })
+      expect(result.newEntries[1]).toMatchObject({ idpGroupValue: 'users', mappedGroupId: 'g2' })
     })
 
     it('keeps manually added entries not in discovered groups', () => {
       const existingEntries: GroupMappingEntry[] = [
-        { key: 'manual-1', idpGroupValue: 'custom-group', nexusGroupId: 'g1' },
+        { key: 'manual-1', idpGroupValue: 'custom-group', mappedGroupId: 'g1' },
       ]
       const claims = { groups: ['admin'] }
-      const result = processDiscoveredGroups(claims, 'groups[*]', existingEntries, nexusGroups)
+      const result = processDiscoveredGroups(claims, 'groups[*]', existingEntries, mappedGroups)
 
       expect(result.newEntries).toHaveLength(2)
-      expect(result.newEntries[0]).toMatchObject({ idpGroupValue: 'admin', nexusGroupId: 'g1' })
-      expect(result.newEntries[1]).toMatchObject({ idpGroupValue: 'custom-group', nexusGroupId: 'g1' })
+      expect(result.newEntries[0]).toMatchObject({ idpGroupValue: 'admin', mappedGroupId: 'g1' })
+      expect(result.newEntries[1]).toMatchObject({ idpGroupValue: 'custom-group', mappedGroupId: 'g1' })
     })
 
     it('returns success without match count when no auto-matches', () => {
       const claims = { groups: ['unknown-group'] }
-      const result = processDiscoveredGroups(claims, 'groups[*]', [], nexusGroups)
+      const result = processDiscoveredGroups(claims, 'groups[*]', [], mappedGroups)
 
       expect(result.variant).toBe('success')
       expect(result.message).toBe('Discovered 1 group(s).')
-      expect(result.newEntries[0]).toMatchObject({ idpGroupValue: 'unknown-group', nexusGroupId: '' })
+      expect(result.newEntries[0]).toMatchObject({ idpGroupValue: 'unknown-group', mappedGroupId: '' })
     })
 
-    it('handles nexus groups without id or name', () => {
-      const groups: NexusGroup[] = [
+    it('handles mapped groups without id or name', () => {
+      const groups: MappedGroup[] = [
         { id: undefined, name: 'no-id' },
         { id: 'g-no-name', name: undefined },
       ]
@@ -223,8 +223,8 @@ describe('groupMappingUtils', () => {
       const result = processDiscoveredGroups(claims, 'groups[*]', [], groups)
 
       // Neither should auto-match because id or name is missing
-      expect(result.newEntries[0].nexusGroupId).toBe('')
-      expect(result.newEntries[1].nexusGroupId).toBe('')
+      expect(result.newEntries[0].mappedGroupId).toBe('')
+      expect(result.newEntries[1].mappedGroupId).toBe('')
     })
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingUtils.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/groupMappingUtils.ts
@@ -11,13 +11,13 @@ type IdentityProviderPatch = IdentityProvidersAPI.components['schemas']['Identit
 export type GroupMappingEntry = {
   key: string
   idpGroupValue: string
-  nexusGroupId: string
+  mappedGroupId: string
 }
 
 /** Form/API row shape without react-hook-form field-array id */
-export type GroupMappingFormEntry = Pick<GroupMappingEntry, 'idpGroupValue' | 'nexusGroupId'>
+export type GroupMappingFormEntry = Pick<GroupMappingEntry, 'idpGroupValue' | 'mappedGroupId'>
 
-export type NexusGroup = {
+export type MappedGroup = {
   id?: string
   name?: string
   description?: string | null
@@ -51,12 +51,12 @@ export function validateGroupJmespathExpression(expression: string): string | nu
 
 export type GroupMappingConfig = {
   group_jmespath_expression?: string | null
-  group_mapping_entries?: { idp_group_value: string; nexus_group_id: string }[]
+  group_mapping_entries?: { idp_group_value: string; mapped_group_id: string }[]
 }
 
 type GroupMappingConfigSource = {
   group_jmespath_expression?: string | null
-  group_mapping_entries?: { idp_group_value: string; nexus_group_id: string }[]
+  group_mapping_entries?: { idp_group_value: string; mapped_group_id: string }[]
 }
 
 export function buildGroupMappingConfig(config: GroupMappingConfigSource | undefined): GroupMappingConfig | null {
@@ -76,7 +76,7 @@ export function toFormEntries(config: GroupMappingConfig | null | undefined): Gr
   return config.group_mapping_entries.map((e) => ({
     key: nextKey(),
     idpGroupValue: e.idp_group_value,
-    nexusGroupId: e.nexus_group_id,
+    mappedGroupId: e.mapped_group_id,
   }))
 }
 
@@ -94,8 +94,8 @@ export function buildSavePayload(
       redirect_uri: providerConfig.redirect_uri ?? '',
       group_jmespath_expression: expression,
       group_mapping_entries: entries
-        .filter((e) => e.idpGroupValue && e.nexusGroupId)
-        .map((e) => ({ idp_group_value: e.idpGroupValue, nexus_group_id: e.nexusGroupId })),
+        .filter((e) => e.idpGroupValue && e.mappedGroupId)
+        .map((e) => ({ idp_group_value: e.idpGroupValue, mapped_group_id: e.mappedGroupId })),
     },
   }
 }
@@ -104,7 +104,7 @@ export function processDiscoveredGroups(
   claims: Record<string, unknown>,
   expression: string,
   entries: GroupMappingFormEntry[],
-  nexusGroups: NexusGroup[]
+  mappedGroups: MappedGroup[]
 ): { newEntries: GroupMappingFormEntry[]; message: string; variant: 'success' | 'warning' } {
   const groups = searchGroups(claims, expression)
 
@@ -117,9 +117,9 @@ export function processDiscoveredGroups(
     }
   }
 
-  const nexusGroupByName = new Map<string, string>()
-  for (const g of nexusGroups) {
-    if (g.name && g.id) nexusGroupByName.set(g.name, g.id)
+  const mappedGroupByName = new Map<string, string>()
+  for (const g of mappedGroups) {
+    if (g.name && g.id) mappedGroupByName.set(g.name, g.id)
   }
 
   const existingByValue = new Map<string, GroupMappingFormEntry>()
@@ -133,11 +133,11 @@ export function processDiscoveredGroups(
       existingByValue.delete(g)
       return existing
     }
-    return { idpGroupValue: g, nexusGroupId: nexusGroupByName.get(g) ?? '' }
+    return { idpGroupValue: g, mappedGroupId: mappedGroupByName.get(g) ?? '' }
   })
 
   const newEntries = [...discoveredEntries, ...existingByValue.values()]
-  const autoMatched = newEntries.filter((e) => e.nexusGroupId).length
+  const autoMatched = newEntries.filter((e) => e.mappedGroupId).length
   const message =
     autoMatched > 0
       ? `Discovered ${String(groups.length)} group(s). ${String(autoMatched)} matched to groups.`

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/identityProviderFormSchema.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/identityProviderFormSchema.ts
@@ -12,7 +12,7 @@ const claimMappingSchema = z.object({
 
 const groupMappingEntrySchema = z.object({
   idpGroupValue: z.string().min(1, 'IdP group value is required'),
-  nexusGroupId: z.string().uuid('Must be a valid group ID'),
+  mappedGroupId: z.string().uuid('Must be a valid group ID'),
 })
 
 const groupMappingSchema = z

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useGroupMappingForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useGroupMappingForm.test.tsx
@@ -120,7 +120,7 @@ describe('useGroupMappingFormMetadata', () => {
         ...mockProvider,
         configuration: {
           ...mockProvider.configuration,
-          group_mapping_entries: [{ idp_group_value: 'admin', nexus_group_id: MOCK_GROUP_ID }],
+          group_mapping_entries: [{ idp_group_value: 'admin', mapped_group_id: MOCK_GROUP_ID }],
         },
       },
       isLoading: false,
@@ -317,11 +317,11 @@ describe('useGroupMappingEditForm', () => {
           providerId: VALID_PROVIDER_ID,
           config: {
             ...mockProvider.configuration,
-            group_mapping_entries: [{ idp_group_value: 'admin', nexus_group_id: MOCK_GROUP_ID }],
+            group_mapping_entries: [{ idp_group_value: 'admin', mapped_group_id: MOCK_GROUP_ID }],
           },
           defaultExpression: 'groups[*]',
           groupMappingConfig: {
-            group_mapping_entries: [{ idp_group_value: 'admin', nexus_group_id: MOCK_GROUP_ID }],
+            group_mapping_entries: [{ idp_group_value: 'admin', mapped_group_id: MOCK_GROUP_ID }],
           },
           idpType: 'custom',
         }),
@@ -410,7 +410,7 @@ describe('useGroupMappingEditForm', () => {
     expect(result.current.panel.rawClaims).toContain('"groups"')
   })
 
-  it('reports matched group count after discovery when groups align with Nexus names', () => {
+  it('reports matched group count after discovery when groups align with Syntara names', () => {
     vi.mocked(useAllGroups).mockReturnValue({
       groups: [
         { id: MOCK_GROUP_ID, name: 'admin', is_builtin: false, created_at: '2026-01-01', updated_at: '2026-01-01' },
@@ -482,7 +482,7 @@ describe('useGroupMappingEditForm', () => {
       await result.current.panel.onGroupCreated()
     })
 
-    expect(result.current.form.getValues('entries.0.nexusGroupId')).toBe(MOCK_NEW_GROUP_ID)
+    expect(result.current.form.getValues('entries.0.mappedGroupId')).toBe(MOCK_NEW_GROUP_ID)
     expect(result.current.panel.createGroupForIndex).toBeNull()
   })
 
@@ -515,7 +515,7 @@ describe('useGroupMappingEditForm', () => {
     expect(result.current.form.getValues('entries')).toHaveLength(entryCountBeforeAdd + 1)
     expect(result.current.form.getValues(`entries.${entryCountBeforeAdd}`)).toEqual({
       idpGroupValue: '',
-      nexusGroupId: '',
+      mappedGroupId: '',
     })
   })
 
@@ -575,11 +575,11 @@ describe('useGroupMappingEditForm', () => {
       await result.current.panel.onGroupCreated()
     })
 
-    expect(result.current.form.getValues('entries.0.nexusGroupId')).toBe('')
+    expect(result.current.form.getValues('entries.0.mappedGroupId')).toBe('')
     expect(result.current.panel.createGroupForIndex).toBeNull()
   })
 
-  it('filters the built-in authenticated group from nexus group options', () => {
+  it('filters the built-in authenticated group from Syntara group options', () => {
     vi.mocked(useAllGroups).mockReturnValue({
       groups: [
         { id: MOCK_GROUP_ID, name: 'admin', is_builtin: false, created_at: '2026-01-01', updated_at: '2026-01-01' },
@@ -608,7 +608,7 @@ describe('useGroupMappingEditForm', () => {
       { wrapper }
     )
 
-    expect(result.current.panel.nexusGroups.map((group) => group.name)).toEqual(['admin'])
+    expect(result.current.panel.mappedGroups.map((group) => group.name)).toEqual(['admin'])
   })
 
   it('invokes mutation error handler when save fails', async () => {
@@ -673,7 +673,7 @@ describe('useGroupMappingEditForm', () => {
       await result.current.panel.onGroupCreated()
     })
 
-    expect(result.current.form.getValues('entries.0.nexusGroupId')).toBe('')
+    expect(result.current.form.getValues('entries.0.mappedGroupId')).toBe('')
   })
 
   it('clears create-group modal when group creation completes without an active row', async () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useGroupMappingForm.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useGroupMappingForm.ts
@@ -42,7 +42,7 @@ export type GroupMappingEditPanelState = {
   onDismissSignInAlert: () => void
   control: Control<GroupMappingEditFormValues>
   mappingRows: { rowId: string; index: number }[]
-  nexusGroups: ReturnType<typeof useAllGroups>['groups']
+  mappedGroups: ReturnType<typeof useAllGroups>['groups']
   onRemove: (index: number) => void
   onAdd: () => void
   onCreateGroup: (index: number) => void
@@ -196,7 +196,7 @@ export function useGroupMappingEditForm({
   )
 
   const { groups: allGroupsRaw, refetch: refetchGroups } = useAllGroups()
-  const nexusGroups = useMemo(
+  const mappedGroups = useMemo(
     () => allGroupsRaw.filter((g) => g.name !== BUILTIN_AUTHENTICATED_GROUP_NAME),
     [allGroupsRaw]
   )
@@ -205,11 +205,11 @@ export function useGroupMappingEditForm({
     (claims: Record<string, unknown>) => {
       setRawClaims(JSON.stringify(claims, null, 2))
       const currentEntries = form.getValues('entries')
-      const result = processDiscoveredGroups(claims, form.getValues('expression'), currentEntries, nexusGroups)
+      const result = processDiscoveredGroups(claims, form.getValues('expression'), currentEntries, mappedGroups)
       replace(result.newEntries)
       setSignInAlert({ variant: result.variant, message: result.message })
     },
-    [form, nexusGroups, replace]
+    [form, mappedGroups, replace]
   )
 
   const handleTestError = useCallback(() => {
@@ -253,7 +253,7 @@ export function useGroupMappingEditForm({
       const entry = index !== null ? form.getValues(`entries.${index}`) : undefined
       if (entry && index !== null && newGroups.length > 0) {
         const newest = [...newGroups].sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))[0]
-        if (newest?.id) form.setValue(`entries.${index}.nexusGroupId`, newest.id, { shouldDirty: true })
+        if (newest?.id) form.setValue(`entries.${index}.mappedGroupId`, newest.id, { shouldDirty: true })
       }
     } finally {
       setCreateGroupForIndex(null)
@@ -265,9 +265,9 @@ export function useGroupMappingEditForm({
     onDismissSignInAlert: () => setSignInAlert(null),
     control: form.control,
     mappingRows,
-    nexusGroups,
+    mappedGroups,
     onRemove: remove,
-    onAdd: () => append({ idpGroupValue: '', nexusGroupId: '' }),
+    onAdd: () => append({ idpGroupValue: '', mappedGroupId: '' }),
     onCreateGroup: setCreateGroupForIndex,
     onReDiscover: openTestSignIn,
     isListening,

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useTestSignIn.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useTestSignIn.test.ts
@@ -7,7 +7,7 @@ import { useTestSignIn } from './useTestSignIn'
 
 vi.mock('../../../../utils/generateUUID', () => ({ generateUUID: vi.fn() }))
 
-const RESULT_STORAGE_KEY = 'nexus-test-signin'
+const RESULT_STORAGE_KEY = 'syntara-test-signin'
 
 describe('useTestSignIn', () => {
   beforeEach(() => {
@@ -44,7 +44,7 @@ describe('useTestSignIn', () => {
       'width=600,height=700'
     )
     expect(result.current.isListening).toBe(true)
-    expect(localStorage.getItem('nexus-test-signin-nonce')).toBe('test-nonce-123')
+    expect(localStorage.getItem('syntara-test-signin-nonce')).toBe('test-nonce-123')
   })
 
   it('polls localStorage and calls onResult when result appears', async () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useTestSignIn.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useTestSignIn.ts
@@ -3,8 +3,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { OIDC_AUTHORIZE_PATH } from '../../../../client'
 import { generateUUID } from '../../../../utils/generateUUID'
 
-export const NONCE_STORAGE_KEY = 'nexus-test-signin-nonce'
-export const RESULT_STORAGE_KEY = 'nexus-test-signin'
+export const NONCE_STORAGE_KEY = 'syntara-test-signin-nonce'
+export const RESULT_STORAGE_KEY = 'syntara-test-signin'
 
 type UseTestSignInOptions = {
   providerId?: string

--- a/frontend/packages/syntara-ui/src/routes/builder/components/BuilderDialogs.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/BuilderDialogs.test.tsx
@@ -291,7 +291,7 @@ describe('BuilderDialogs', () => {
     expect(screen.queryByText('Set mock output data for Manual Trigger')).not.toBeInTheDocument()
 
     // Verify the preference was stored
-    expect(store['nexus-run-workflow-confirm-dismissed']).toBe('true')
+    expect(store['syntara-run-workflow-confirm-dismissed']).toBe('true')
 
     vi.unstubAllGlobals()
   })

--- a/frontend/packages/syntara-ui/src/routes/builder/components/BuilderDialogs.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/BuilderDialogs.tsx
@@ -19,7 +19,7 @@ import type { RunStepDialogData, RunStepExecutionCreatedOptions } from './RunSte
 import { RunStepDialog } from './RunStepDialog'
 import { RunWorkflowModal } from './RunWorkflowModal'
 
-const RUN_CONFIRM_DISMISSED_KEY = 'nexus-run-workflow-confirm-dismissed'
+const RUN_CONFIRM_DISMISSED_KEY = 'syntara-run-workflow-confirm-dismissed'
 
 function getRunConfirmDismissed(): boolean {
   try {

--- a/frontend/packages/syntara-ui/src/routes/builder/components/ExpandableCodeEditor.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/ExpandableCodeEditor.test.tsx
@@ -201,7 +201,7 @@ describe('ExpandableCodeEditor', () => {
     const dropTarget = screen.getByTestId('inline-code-editor')
     const dataTransfer = {
       getData: (format: string) => {
-        if (format === 'application/json') return '{"type":"nexus/input-field"}'
+        if (format === 'application/json') return '{"type":"syntara/input-field"}'
         if (format === 'text/plain') return '${node.field}'
         return ''
       },

--- a/frontend/packages/syntara-ui/src/routes/builder/components/file-upload/FileUpload.module.css
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/file-upload/FileUpload.module.css
@@ -1,3 +1,3 @@
 .disabled {
-  opacity: var(--nexus-disabled-opacity);
+  opacity: var(--syntara-disabled-opacity);
 }

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/computeButtonEdgesUpdate.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/computeButtonEdgesUpdate.ts
@@ -101,7 +101,7 @@ function buildButtonHandleKeySets(existingButtonEdges: EdgeType[]): ButtonHandle
 }
 
 /** Tracks which `onAddNodeFromEdge` the edge's click handler was built with (in-memory only). */
-const BUTTON_EDGE_BOUND_ON_ADD = '__nexusButtonEdgeBoundOnAdd' as const
+const BUTTON_EDGE_BOUND_ON_ADD = '__syntaraButtonEdgeBoundOnAdd' as const
 
 function collectKeptButtonEdges(
   existingButtonEdges: EdgeType[],

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/ActionNodeForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/ActionNodeForm.test.tsx
@@ -289,7 +289,7 @@ describe('ActionNodeForm', () => {
     fireEvent.drop(parametersField, {
       dataTransfer: {
         getData: (type: string) => {
-          if (type === 'application/json') return '{"type":"nexus/input-field"}'
+          if (type === 'application/json') return '{"type":"syntara/input-field"}'
           if (type === 'text/plain') return '${trigger.tier}'
           return ''
         },

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/ConnectionsSection.module.css
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/ConnectionsSection.module.css
@@ -8,5 +8,5 @@
 }
 
 .dimmed {
-  opacity: var(--nexus-disabled-opacity);
+  opacity: var(--syntara-disabled-opacity);
 }

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/fields/DroppableField.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/fields/DroppableField.test.tsx
@@ -28,7 +28,7 @@ describe('DroppableField', () => {
     fireEvent.drop(input, {
       dataTransfer: {
         getData: (type: string) => {
-          if (type === 'application/json') return '{"type":"nexus/input-field"}'
+          if (type === 'application/json') return '{"type":"syntara/input-field"}'
           if (type === 'text/plain') return '${node1.output}'
           return ''
         },
@@ -89,7 +89,7 @@ describe('DroppableField', () => {
     fireEvent.drop(input, {
       dataTransfer: {
         getData: (type: string) => {
-          if (type === 'application/json') return '{"type":"nexus/input-field"}'
+          if (type === 'application/json') return '{"type":"syntara/input-field"}'
           if (type === 'text/plain') return '${node1.output}'
           return ''
         },

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/hooks/useResizablePanels.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/hooks/useResizablePanels.test.ts
@@ -42,25 +42,25 @@ describe('useResizablePanels', () => {
 
   describe('localStorage restoration', () => {
     it('restores saved widths from localStorage', () => {
-      localStorage.setItem('nexus-panel-sizes-wf-1-node-1', JSON.stringify([25, 50, 25]))
+      localStorage.setItem('syntara-panel-sizes-wf-1-node-1', JSON.stringify([25, 50, 25]))
       const { result } = renderHook(() => useResizablePanels({ panelCount: 3, workflowId: 'wf-1', nodeId: 'node-1' }))
       expect(result.current.widths).toEqual([25, 50, 25])
     })
 
     it('falls back to defaults when saved panel count does not match', () => {
-      localStorage.setItem('nexus-panel-sizes-wf-1-node-1', JSON.stringify([50, 50]))
+      localStorage.setItem('syntara-panel-sizes-wf-1-node-1', JSON.stringify([50, 50]))
       const { result } = renderHook(() => useResizablePanels({ panelCount: 3, workflowId: 'wf-1', nodeId: 'node-1' }))
       expect(result.current.widths).toEqual([33.3, 33.3, 33.4])
     })
 
     it('falls back to defaults when localStorage contains invalid JSON', () => {
-      localStorage.setItem('nexus-panel-sizes-wf-1-node-1', 'not-json')
+      localStorage.setItem('syntara-panel-sizes-wf-1-node-1', 'not-json')
       const { result } = renderHook(() => useResizablePanels({ panelCount: 3, workflowId: 'wf-1', nodeId: 'node-1' }))
       expect(result.current.widths).toEqual([33.3, 33.3, 33.4])
     })
 
     it('falls back to defaults when workflowId is undefined', () => {
-      localStorage.setItem('nexus-panel-sizes-wf-1-node-1', JSON.stringify([25, 50, 25]))
+      localStorage.setItem('syntara-panel-sizes-wf-1-node-1', JSON.stringify([25, 50, 25]))
       const { result } = renderHook(() =>
         useResizablePanels({ panelCount: 3, workflowId: undefined, nodeId: 'node-1' })
       )
@@ -68,13 +68,13 @@ describe('useResizablePanels', () => {
     })
 
     it('falls back to defaults when nodeId is undefined', () => {
-      localStorage.setItem('nexus-panel-sizes-wf-1-node-1', JSON.stringify([25, 50, 25]))
+      localStorage.setItem('syntara-panel-sizes-wf-1-node-1', JSON.stringify([25, 50, 25]))
       const { result } = renderHook(() => useResizablePanels({ panelCount: 3, workflowId: 'wf-1', nodeId: undefined }))
       expect(result.current.widths).toEqual([33.3, 33.3, 33.4])
     })
 
     it('falls back to defaults when saved widths contain values below minimum', () => {
-      localStorage.setItem('nexus-panel-sizes-wf-1-node-1', JSON.stringify([10, 45, 45]))
+      localStorage.setItem('syntara-panel-sizes-wf-1-node-1', JSON.stringify([10, 45, 45]))
       const { result } = renderHook(() => useResizablePanels({ panelCount: 3, workflowId: 'wf-1', nodeId: 'node-1' }))
       expect(result.current.widths).toEqual([33.3, 33.3, 33.4])
     })
@@ -126,7 +126,7 @@ describe('useResizablePanels', () => {
         result.current.handleResizeEnd()
       })
 
-      const stored = localStorage.getItem('nexus-panel-sizes-wf-1-node-1')
+      const stored = localStorage.getItem('syntara-panel-sizes-wf-1-node-1')
       expect(stored).not.toBeNull()
       expect(JSON.parse(stored!)).toEqual([33.3, 33.3, 33.4])
     })
@@ -156,7 +156,7 @@ describe('useResizablePanels', () => {
 
   describe('panel count changes', () => {
     it('resets to defaults when panelCount changes from 3 to 2', () => {
-      localStorage.setItem('nexus-panel-sizes-wf-1-node-1', JSON.stringify([25, 50, 25]))
+      localStorage.setItem('syntara-panel-sizes-wf-1-node-1', JSON.stringify([25, 50, 25]))
       const { result, rerender } = renderHook(
         ({ panelCount }: { panelCount: 2 | 3 }) =>
           useResizablePanels({ panelCount, workflowId: 'wf-1', nodeId: 'node-1' }),

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/hooks/useResizablePanels.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/hooks/useResizablePanels.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef, useState } from 'react'
 const DEFAULTS_3 = [33.3, 33.3, 33.4]
 const DEFAULTS_2 = [33.3, 100 - 33.3]
 const MIN_WIDTH = 15
-const STORAGE_PREFIX = 'nexus-panel-sizes-'
+const STORAGE_PREFIX = 'syntara-panel-sizes-'
 
 function getStorageKey(workflowId: string, nodeId: string): string {
   return `${STORAGE_PREFIX}${workflowId}-${nodeId}`

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/utils/dragTypes.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/utils/dragTypes.ts
@@ -1,5 +1,5 @@
-export const DRAG_TYPE_FIELD = 'nexus/input-field'
-export const DRAG_TYPE_CONTEXT = 'nexus/context-variable'
+export const DRAG_TYPE_FIELD = 'syntara/input-field'
+export const DRAG_TYPE_CONTEXT = 'syntara/context-variable'
 
 export const DROP_TARGET_OUTLINE: React.CSSProperties = {
   outline: '2px solid var(--pf-t--global--color--brand--default)',

--- a/frontend/packages/syntara-ui/src/stores/useProjectStore.ts
+++ b/frontend/packages/syntara-ui/src/stores/useProjectStore.ts
@@ -37,6 +37,6 @@ export const useProjectStore = create<ProjectState>()(
           return { favoriteProjectIds: [...s.favoriteProjectIds, projectId] }
         }),
     }),
-    { name: 'nexus-selected-project', version: 1 }
+    { name: 'syntara-selected-project', version: 1 }
   )
 )


### PR DESCRIPTION
## Summary

Mechanical rename of all `nexus` references in frontend source, tests, and CSS to `syntara`. No behavioral changes.

- **CSS variables**: `--nexus-form-max-width`, `--nexus-nav-logo-size`, `--nexus-disabled-opacity` → `--syntara-*`
- **localStorage keys**: `nexus-selected-project`, `nexus-panel-sizes-*`, `nexus-test-signin*` → `syntara-*`
- **Code identifiers**: `nexusGroupId` → `mappedGroupId`, `NexusGroup` → `MappedGroup`, drag types `nexus/*` → `syntara/*`

**Depends on:** #61 (`rename/nexus-group-id-backend`) — the `mappedGroupId` frontend rename assumes the backend field rename has landed.

### Part of a 3-PR split

1. Backend — PR #192
2. **This PR** — frontend
3. CI + repo root — coming next

## Test plan

- [ ] Merge #61 first, then rebase this PR
- [ ] `npm run check` (lint + typecheck)
- [ ] `npm test` (unit tests)
- [ ] Verify identity provider group mapping flow in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)