### PR TITLE
feat(ui): Link step panels to step-type docs

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/builder/NodeEditorLayout.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/NodeEditorLayout.test.tsx
@@ -582,11 +582,11 @@ describe('NodeEditorLayout', () => {
       expect(link).not.toBeDisabled()
     })
 
-    it('renders a disabled button with tooltip when docLink is not provided', () => {
+    it('hides the Documentation control when docLink is not provided', () => {
       render(<NodeEditorLayout parametersContent={<div>Parameters</div>} showInputPanel={false} />)
 
-      const button = screen.getByRole('button', { name: /Documentation/i })
-      expect(button).toBeDisabled()
+      expect(screen.queryByRole('link', { name: /Documentation/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /Documentation/i })).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/builder/NodeEditorLayout.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/NodeEditorLayout.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Flex, FlexItem, Stack, StackItem, Tooltip } from '@patternfly/react-core'
+import { Alert, Button, Flex, FlexItem, Stack, StackItem } from '@patternfly/react-core'
 import { RhUiExternalLinkIcon } from '@patternfly/react-icons'
 import type { Node } from '@xyflow/react'
 import type { ReactNode } from 'react'
@@ -11,29 +11,20 @@ import { useNodeExecutionData } from './panels/hooks/useNodeExecutionData'
 import { NodeEditorPanelBody } from './panels/NodeEditorPanelBody'
 import type { WorkflowMetadata } from './types/workflowMetadata'
 
-function DocumentationButton({ href }: Readonly<{ href?: string }>) {
-  if (href) {
-    return (
-      <Button
-        variant="link"
-        icon={<RhUiExternalLinkIcon />}
-        iconPosition="end"
-        component="a"
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Documentation (opens in a new tab)"
-      >
-        Documentation
-      </Button>
-    )
-  }
+function DocumentationButton({ href }: Readonly<{ href: string }>) {
   return (
-    <Tooltip content="Coming soon">
-      <Button variant="link" icon={<RhUiExternalLinkIcon />} iconPosition="end" type="button" isDisabled>
-        Documentation
-      </Button>
-    </Tooltip>
+    <Button
+      variant="link"
+      icon={<RhUiExternalLinkIcon />}
+      iconPosition="end"
+      component="a"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Documentation (opens in a new tab)"
+    >
+      Documentation
+    </Button>
   )
 }
 
@@ -129,9 +120,11 @@ export function NodeEditorLayout({
                 alignItems={{ default: 'alignItemsCenter' }}
                 gap={{ default: 'gapSm' }}
               >
-                <FlexItem>
-                  <DocumentationButton href={docLink} />
-                </FlexItem>
+                {docLink ? (
+                  <FlexItem>
+                    <DocumentationButton href={docLink} />
+                  </FlexItem>
+                ) : null}
                 {headerActions && !readOnly && <FlexItem>{headerActions}</FlexItem>}
                 {showClose && (
                   <>

--- a/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.test.tsx
@@ -59,10 +59,28 @@ describe('NodeEditorOverlay', () => {
     expect(screen.getByTestId('node-details-panel')).toHaveTextContent('add')
   })
 
-  it('passes step-specific docLink for edit mode based on executor type', () => {
+  it('omits docLink for script steps', () => {
     render(<NodeEditorOverlay {...baseProps} />)
-    expect(useDocLinkMock).toHaveBeenCalledWith('script')
-    expect(screen.getByTestId('doc-link')).toHaveTextContent('https://docs.example/script')
+    expect(screen.getByTestId('node-details-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('doc-link')).not.toBeInTheDocument()
+  })
+
+  it('passes step-specific docLink for edit mode based on executor type', () => {
+    render(
+      <NodeEditorOverlay
+        {...baseProps}
+        selectedNode={
+          {
+            id: 'task-1',
+            type: 'task',
+            position: { x: 0, y: 0 },
+            data: { id: 'task-1', type: ExecutorTypeEnum.HTTP_REQUEST, name: 'Task' },
+          } as never
+        }
+      />
+    )
+    expect(useDocLinkMock).toHaveBeenCalledWith('restApi')
+    expect(screen.getByTestId('doc-link')).toHaveTextContent('https://docs.example/restApi')
   })
 
   it('passes step-specific docLink for add mode based on subtype', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.test.tsx
@@ -1,7 +1,17 @@
+import { ExecutorTypeEnum } from '@syntara/contracts'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+import { RegistryNodeId } from '../../../constants'
+import type { DocKey } from '../../../utils/docs/types'
+
 import { NodeEditorOverlay } from './NodeEditorOverlay'
+
+const useDocLinkMock = vi.fn((key: DocKey) => `https://docs.example/${key}`)
+
+vi.mock('../../../utils/docs/useDocLink', () => ({
+  useDocLink: (key: DocKey) => useDocLinkMock(key),
+}))
 
 vi.mock('../NodeDetailsPanel', () => ({
   NodeDetailsPanel: ({ mode, docLink }: { mode: string; docLink?: string }) => (
@@ -20,7 +30,7 @@ describe('NodeEditorOverlay', () => {
       id: 'task-1',
       type: 'task',
       position: { x: 0, y: 0 },
-      data: { id: 'task-1', type: 'task', name: 'Task' },
+      data: { id: 'task-1', type: ExecutorTypeEnum.SCRIPT, name: 'Task' },
     } as never,
     nodeTypeId: null,
     nodeSubtypeId: null,
@@ -29,6 +39,10 @@ describe('NodeEditorOverlay', () => {
     onConnect: vi.fn(),
     onClose: vi.fn(),
   }
+
+  beforeEach(() => {
+    useDocLinkMock.mockClear()
+  })
 
   it('renders nothing when closed', () => {
     const { container } = render(<NodeEditorOverlay {...baseProps} isOpen={false} />)
@@ -45,8 +59,37 @@ describe('NodeEditorOverlay', () => {
     expect(screen.getByTestId('node-details-panel')).toHaveTextContent('add')
   })
 
-  it('passes docLink from useDocLink to NodeDetailsPanel', () => {
+  it('passes step-specific docLink for edit mode based on executor type', () => {
     render(<NodeEditorOverlay {...baseProps} />)
-    expect(screen.getByTestId('doc-link')).toBeInTheDocument()
+    expect(useDocLinkMock).toHaveBeenCalledWith('script')
+    expect(screen.getByTestId('doc-link')).toHaveTextContent('https://docs.example/script')
+  })
+
+  it('passes step-specific docLink for add mode based on subtype', () => {
+    render(
+      <NodeEditorOverlay
+        {...baseProps}
+        mode="add"
+        selectedNode={null}
+        nodeTypeId={RegistryNodeId.LOGIC}
+        nodeSubtypeId={RegistryNodeId.LOGIC_WAIT}
+      />
+    )
+    expect(useDocLinkMock).toHaveBeenCalledWith('wait')
+    expect(screen.getByTestId('doc-link')).toHaveTextContent('https://docs.example/wait')
+  })
+
+  it('falls back to builder docLink when step type is unknown', () => {
+    render(
+      <NodeEditorOverlay
+        {...baseProps}
+        mode="add"
+        selectedNode={null}
+        nodeTypeId={RegistryNodeId.ACTION}
+        nodeSubtypeId={null}
+      />
+    )
+    expect(useDocLinkMock).toHaveBeenCalledWith('builder')
+    expect(screen.getByTestId('doc-link')).toHaveTextContent('https://docs.example/builder')
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.tsx
@@ -52,7 +52,9 @@ export const NodeEditorOverlay = memo(function NodeEditorOverlay(props: NodeEdit
   } = props
 
   const stepDocKey = resolveStepDocKey({ mode, nodeTypeId, nodeSubtypeId, selectedNode })
-  const stepDocLink = useDocLink(stepDocKey)
+  // Hook must run unconditionally; ignore the result when this step has no docs.
+  const resolvedDocLink = useDocLink(stepDocKey ?? 'builder')
+  const stepDocLink = stepDocKey === null ? undefined : resolvedDocLink
 
   if (!isOpen) return null
 

--- a/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.tsx
@@ -6,6 +6,7 @@ import { useDocLink } from '../../../utils/docs/useDocLink'
 import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
 import { NodeDetailsPanel } from '../NodeDetailsPanel'
 import type { WorkflowMetadata } from '../types/workflowMetadata'
+import { resolveStepDocKey } from '../utils/resolveStepDocKey'
 import { useIsVersionView } from '../VersionViewContext'
 
 type NodeEditorOverlayProps = {
@@ -29,7 +30,6 @@ type NodeEditorOverlayProps = {
 }
 
 export const NodeEditorOverlay = memo(function NodeEditorOverlay(props: NodeEditorOverlayProps) {
-  const builderDocLink = useDocLink('builder')
   const isVersionView = useIsVersionView()
   const {
     isOpen,
@@ -50,6 +50,9 @@ export const NodeEditorOverlay = memo(function NodeEditorOverlay(props: NodeEdit
     onRunStep,
     onNodeAdded,
   } = props
+
+  const stepDocKey = resolveStepDocKey({ mode, nodeTypeId, nodeSubtypeId, selectedNode })
+  const stepDocLink = useDocLink(stepDocKey)
 
   if (!isOpen) return null
 
@@ -76,7 +79,7 @@ export const NodeEditorOverlay = memo(function NodeEditorOverlay(props: NodeEdit
           projectId={projectId}
           onNavigateToNode={onNavigateToNode}
           onAddStep={onAddStep}
-          docLink={builderDocLink}
+          docLink={stepDocLink}
           workflowMetadata={workflowMetadata}
           onRunStep={isVersionView ? undefined : onRunStep}
           readOnly={isVersionView}

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.test.ts
@@ -7,10 +7,7 @@ import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
 
 import { resolveStepDocKey } from './resolveStepDocKey'
 
-function makeNode(
-  type: string,
-  data: Record<string, unknown> = {}
-): Node<NodeType['data']> {
+function makeNode(type: string, data: Record<string, unknown> = {}): Node<NodeType['data']> {
   return {
     id: 'node-1',
     type,

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.test.ts
@@ -23,7 +23,6 @@ describe('resolveStepDocKey', () => {
       [RegistryNodeId.TRIGGER, RegistryNodeId.TRIGGER_SCHEDULED, 'scheduleTrigger'],
       [RegistryNodeId.TRIGGER, RegistryNodeId.TRIGGER_WEBHOOK, 'webhookTrigger'],
       [RegistryNodeId.TRIGGER, RegistryNodeId.TRIGGER_EDA, 'eventDrivenAnsibleTrigger'],
-      [RegistryNodeId.ACTION, RegistryNodeId.ACTION_SCRIPT, 'script'],
       [RegistryNodeId.ACTION, RegistryNodeId.ACTION_API, 'restApi'],
       [RegistryNodeId.LOGIC, RegistryNodeId.LOGIC_CONDITION, 'conditional'],
       [RegistryNodeId.LOGIC, RegistryNodeId.LOGIC_CONVERGE, 'converge'],
@@ -41,6 +40,17 @@ describe('resolveStepDocKey', () => {
           selectedNode: null,
         })
       ).toBe(expectedKey)
+    })
+
+    it('returns null for script (no documentation link)', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'add',
+          nodeTypeId: RegistryNodeId.ACTION,
+          nodeSubtypeId: RegistryNodeId.ACTION_SCRIPT,
+          selectedNode: null,
+        })
+      ).toBeNull()
     })
 
     it('maps leaf nodeTypeId without subtype (agent, approval)', () => {
@@ -142,7 +152,6 @@ describe('resolveStepDocKey', () => {
     })
 
     it.each([
-      [ExecutorTypeEnum.SCRIPT, 'script'],
       [ExecutorTypeEnum.HTTP_REQUEST, 'restApi'],
       [ExecutorTypeEnum.AGENTIC, 'taskAgent'],
       [ExecutorTypeEnum.AAP_JOB_TEMPLATE, 'launchAapJobTemplate'],
@@ -158,7 +167,18 @@ describe('resolveStepDocKey', () => {
       ).toBe(expectedKey)
     })
 
-    it('maps task-reversed nodes using executor type', () => {
+    it('returns null for script task (no documentation link)', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: makeNode(FlowNodeType.TASK, { type: ExecutorTypeEnum.SCRIPT, name: 'Task' }),
+        })
+      ).toBeNull()
+    })
+
+    it('returns null for script task-reversed nodes', () => {
       expect(
         resolveStepDocKey({
           mode: 'edit',
@@ -169,7 +189,21 @@ describe('resolveStepDocKey', () => {
             name: 'Task',
           }),
         })
-      ).toBe('script')
+      ).toBeNull()
+    })
+
+    it('maps non-script task-reversed nodes using executor type', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: makeNode(FlowNodeType.TASK_REVERSED, {
+            type: ExecutorTypeEnum.HTTP_REQUEST,
+            name: 'Task',
+          }),
+        })
+      ).toBe('restApi')
     })
 
     it.each([

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.test.ts
@@ -1,0 +1,249 @@
+import { ExecutorTypeEnum, TriggerTypeEnum } from '@syntara/contracts'
+import type { Node } from '@xyflow/react'
+import { describe, expect, it } from 'vitest'
+
+import { FlowNodeType, RegistryNodeId } from '../../../constants'
+import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
+
+import { resolveStepDocKey } from './resolveStepDocKey'
+
+function makeNode(
+  type: string,
+  data: Record<string, unknown> = {}
+): Node<NodeType['data']> {
+  return {
+    id: 'node-1',
+    type,
+    position: { x: 0, y: 0 },
+    data: data as NodeType['data'],
+  }
+}
+
+describe('resolveStepDocKey', () => {
+  describe('add mode', () => {
+    it.each([
+      [RegistryNodeId.TRIGGER, RegistryNodeId.TRIGGER_MANUAL, 'manualTrigger'],
+      [RegistryNodeId.TRIGGER, RegistryNodeId.TRIGGER_SCHEDULED, 'scheduleTrigger'],
+      [RegistryNodeId.TRIGGER, RegistryNodeId.TRIGGER_WEBHOOK, 'webhookTrigger'],
+      [RegistryNodeId.TRIGGER, RegistryNodeId.TRIGGER_EDA, 'eventDrivenAnsibleTrigger'],
+      [RegistryNodeId.ACTION, RegistryNodeId.ACTION_SCRIPT, 'script'],
+      [RegistryNodeId.ACTION, RegistryNodeId.ACTION_API, 'restApi'],
+      [RegistryNodeId.LOGIC, RegistryNodeId.LOGIC_CONDITION, 'conditional'],
+      [RegistryNodeId.LOGIC, RegistryNodeId.LOGIC_CONVERGE, 'converge'],
+      [RegistryNodeId.LOGIC, RegistryNodeId.LOGIC_LOOP, 'loop'],
+      [RegistryNodeId.LOGIC, RegistryNodeId.LOGIC_SWITCH, 'switch'],
+      [RegistryNodeId.LOGIC, RegistryNodeId.LOGIC_WAIT, 'wait'],
+      [RegistryNodeId.AAP_EXECUTION, RegistryNodeId.AAP_JOB_TEMPLATE, 'launchAapJobTemplate'],
+      [RegistryNodeId.AAP_EXECUTION, RegistryNodeId.AAP_WORKFLOW_TEMPLATE, 'launchAapWorkflowTemplate'],
+    ] as const)('maps %s / %s to %s', (nodeTypeId, nodeSubtypeId, expectedKey) => {
+      expect(
+        resolveStepDocKey({
+          mode: 'add',
+          nodeTypeId,
+          nodeSubtypeId,
+          selectedNode: null,
+        })
+      ).toBe(expectedKey)
+    })
+
+    it('maps leaf nodeTypeId without subtype (agent, approval)', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'add',
+          nodeTypeId: RegistryNodeId.AGENT,
+          nodeSubtypeId: null,
+          selectedNode: null,
+        })
+      ).toBe('taskAgent')
+
+      expect(
+        resolveStepDocKey({
+          mode: 'add',
+          nodeTypeId: RegistryNodeId.APPROVAL,
+          nodeSubtypeId: null,
+          selectedNode: null,
+        })
+      ).toBe('approval')
+    })
+
+    it('falls back to builder for category-only selection', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'add',
+          nodeTypeId: RegistryNodeId.TRIGGER,
+          nodeSubtypeId: null,
+          selectedNode: null,
+        })
+      ).toBe('builder')
+
+      expect(
+        resolveStepDocKey({
+          mode: 'add',
+          nodeTypeId: RegistryNodeId.ACTION,
+          nodeSubtypeId: null,
+          selectedNode: null,
+        })
+      ).toBe('builder')
+
+      expect(
+        resolveStepDocKey({
+          mode: 'add',
+          nodeTypeId: RegistryNodeId.LOGIC,
+          nodeSubtypeId: null,
+          selectedNode: null,
+        })
+      ).toBe('builder')
+
+      expect(
+        resolveStepDocKey({
+          mode: 'add',
+          nodeTypeId: RegistryNodeId.AAP_EXECUTION,
+          nodeSubtypeId: null,
+          selectedNode: null,
+        })
+      ).toBe('builder')
+    })
+
+    it('falls back to builder when type and subtype are missing', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'add',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: null,
+        })
+      ).toBe('builder')
+    })
+  })
+
+  describe('edit mode', () => {
+    it.each([
+      [TriggerTypeEnum.MANUAL_TRIGGER, 'manualTrigger'],
+      [TriggerTypeEnum.SCHEDULED, 'scheduleTrigger'],
+      [TriggerTypeEnum.WEBHOOK_TRIGGER, 'webhookTrigger'],
+      [TriggerTypeEnum.EDA_TRIGGER, 'eventDrivenAnsibleTrigger'],
+    ] as const)('maps trigger type %s to %s', (triggerType, expectedKey) => {
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: makeNode(FlowNodeType.TRIGGER, { name: 'T', triggerType }),
+        })
+      ).toBe(expectedKey)
+    })
+
+    it('defaults trigger without triggerType to manualTrigger', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: makeNode(FlowNodeType.TRIGGER, { name: 'T' }),
+        })
+      ).toBe('manualTrigger')
+    })
+
+    it.each([
+      [ExecutorTypeEnum.SCRIPT, 'script'],
+      [ExecutorTypeEnum.HTTP_REQUEST, 'restApi'],
+      [ExecutorTypeEnum.AGENTIC, 'taskAgent'],
+      [ExecutorTypeEnum.AAP_JOB_TEMPLATE, 'launchAapJobTemplate'],
+      [ExecutorTypeEnum.AAP_WORKFLOW_JOB_TEMPLATE, 'launchAapWorkflowTemplate'],
+    ] as const)('maps task executor %s to %s', (executor, expectedKey) => {
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: makeNode(FlowNodeType.TASK, { type: executor, name: 'Task' }),
+        })
+      ).toBe(expectedKey)
+    })
+
+    it('maps task-reversed nodes using executor type', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: makeNode(FlowNodeType.TASK_REVERSED, {
+            type: ExecutorTypeEnum.SCRIPT,
+            name: 'Task',
+          }),
+        })
+      ).toBe('script')
+    })
+
+    it.each([
+      [FlowNodeType.APPROVAL, 'approval'],
+      [FlowNodeType.CONDITION, 'conditional'],
+      [FlowNodeType.CONVERGE, 'converge'],
+      [FlowNodeType.LOOP, 'loop'],
+      [FlowNodeType.SWITCH, 'switch'],
+      [FlowNodeType.WAIT, 'wait'],
+    ] as const)('maps flow type %s to %s', (flowType, expectedKey) => {
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: makeNode(flowType, { name: 'Step' }),
+        })
+      ).toBe(expectedKey)
+    })
+
+    it('falls back to builder for unknown task executor', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: makeNode(FlowNodeType.TASK, { type: 'unknown', name: 'Task' }),
+        })
+      ).toBe('builder')
+    })
+
+    it('falls back to builder for generic and placeholder nodes', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: makeNode(FlowNodeType.GENERIC, { name: 'Generic' }),
+        })
+      ).toBe('builder')
+
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: makeNode(FlowNodeType.PLACEHOLDER, {}),
+        })
+      ).toBe('builder')
+    })
+
+    it('falls back to builder when selectedNode is null', () => {
+      expect(
+        resolveStepDocKey({
+          mode: 'edit',
+          nodeTypeId: null,
+          nodeSubtypeId: null,
+          selectedNode: null,
+        })
+      ).toBe('builder')
+    })
+  })
+
+  it('falls back to builder when mode is null', () => {
+    expect(
+      resolveStepDocKey({
+        mode: null,
+        nodeTypeId: RegistryNodeId.AGENT,
+        nodeSubtypeId: null,
+        selectedNode: null,
+      })
+    ).toBe('builder')
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.ts
@@ -1,0 +1,112 @@
+import { ExecutorTypeEnum, TriggerTypeEnum } from '@syntara/contracts'
+import type { Node } from '@xyflow/react'
+
+import { FlowNodeType, RegistryNodeId } from '../../../constants'
+import { docsUrls } from '../../../utils/docs/loadDocsConfig'
+import type { DocKey } from '../../../utils/docs/types'
+import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
+
+const FALLBACK_DOC_KEY: DocKey = 'builder'
+
+/** Registry subtype / leaf ids → step-type documentation keys (must match docsUrls.json / overlay). */
+const REGISTRY_SUBTYPE_DOC_KEYS: Readonly<Record<string, string>> = {
+  [RegistryNodeId.TRIGGER_MANUAL]: 'manualTrigger',
+  [RegistryNodeId.TRIGGER_SCHEDULED]: 'scheduleTrigger',
+  [RegistryNodeId.TRIGGER_WEBHOOK]: 'webhookTrigger',
+  [RegistryNodeId.TRIGGER_EDA]: 'eventDrivenAnsibleTrigger',
+  [RegistryNodeId.ACTION_SCRIPT]: 'script',
+  [RegistryNodeId.ACTION_API]: 'restApi',
+  [RegistryNodeId.AGENT]: 'taskAgent',
+  [RegistryNodeId.APPROVAL]: 'approval',
+  [RegistryNodeId.LOGIC_CONDITION]: 'conditional',
+  [RegistryNodeId.LOGIC_CONVERGE]: 'converge',
+  [RegistryNodeId.LOGIC_LOOP]: 'loop',
+  [RegistryNodeId.LOGIC_SWITCH]: 'switch',
+  [RegistryNodeId.LOGIC_WAIT]: 'wait',
+  [RegistryNodeId.AAP_JOB_TEMPLATE]: 'launchAapJobTemplate',
+  [RegistryNodeId.AAP_WORKFLOW_TEMPLATE]: 'launchAapWorkflowTemplate',
+}
+
+const TRIGGER_TYPE_DOC_KEYS: Readonly<Record<string, string>> = {
+  [TriggerTypeEnum.MANUAL_TRIGGER]: 'manualTrigger',
+  [TriggerTypeEnum.SCHEDULED]: 'scheduleTrigger',
+  [TriggerTypeEnum.WEBHOOK_TRIGGER]: 'webhookTrigger',
+  [TriggerTypeEnum.EDA_TRIGGER]: 'eventDrivenAnsibleTrigger',
+}
+
+const EXECUTOR_TYPE_DOC_KEYS: Readonly<Record<string, string>> = {
+  [ExecutorTypeEnum.SCRIPT]: 'script',
+  [ExecutorTypeEnum.HTTP_REQUEST]: 'restApi',
+  [ExecutorTypeEnum.AGENTIC]: 'taskAgent',
+  [ExecutorTypeEnum.AAP_JOB_TEMPLATE]: 'launchAapJobTemplate',
+  [ExecutorTypeEnum.AAP_WORKFLOW_JOB_TEMPLATE]: 'launchAapWorkflowTemplate',
+  [ExecutorTypeEnum.APPROVAL]: 'approval',
+}
+
+const FLOW_TYPE_DOC_KEYS: Readonly<Record<string, string>> = {
+  [FlowNodeType.APPROVAL]: 'approval',
+  [FlowNodeType.CONDITION]: 'conditional',
+  [FlowNodeType.CONVERGE]: 'converge',
+  [FlowNodeType.LOOP]: 'loop',
+  [FlowNodeType.SWITCH]: 'switch',
+  [FlowNodeType.WAIT]: 'wait',
+}
+
+export type ResolveStepDocKeyInput = {
+  mode: 'add' | 'edit' | null
+  nodeTypeId: string | null
+  nodeSubtypeId: string | null
+  selectedNode: Node<NodeType['data']> | null
+}
+
+function isDocKey(value: string): value is DocKey {
+  return Object.hasOwn(docsUrls, value)
+}
+
+function toDocKey(value: string): DocKey {
+  return isDocKey(value) ? value : FALLBACK_DOC_KEY
+}
+
+function lookup(map: Readonly<Record<string, string>>, id: string | null | undefined): DocKey | undefined {
+  if (!id) return undefined
+  const key = map[id]
+  return key === undefined ? undefined : toDocKey(key)
+}
+
+function resolveFromRegistryIds(nodeTypeId: string | null, nodeSubtypeId: string | null): DocKey | undefined {
+  return lookup(REGISTRY_SUBTYPE_DOC_KEYS, nodeSubtypeId) ?? lookup(REGISTRY_SUBTYPE_DOC_KEYS, nodeTypeId)
+}
+
+function resolveFromSelectedNode(node: Node<NodeType['data']>): DocKey | undefined {
+  const flowType = node.type
+
+  if (flowType === FlowNodeType.TRIGGER) {
+    const triggerType = (node.data as { triggerType?: string }).triggerType
+    return lookup(TRIGGER_TYPE_DOC_KEYS, triggerType) ?? toDocKey('manualTrigger')
+  }
+
+  if (flowType === FlowNodeType.TASK || flowType === FlowNodeType.TASK_REVERSED) {
+    const executor = (node.data as { type?: string }).type
+    return lookup(EXECUTOR_TYPE_DOC_KEYS, executor)
+  }
+
+  return lookup(FLOW_TYPE_DOC_KEYS, flowType)
+}
+
+/**
+ * Maps the open step detail panel context to a documentation key.
+ * Falls back to `builder` when the step type is unknown or only a category is selected.
+ */
+export function resolveStepDocKey(input: ResolveStepDocKeyInput): DocKey {
+  const { mode, nodeTypeId, nodeSubtypeId, selectedNode } = input
+
+  if (mode === 'add') {
+    return resolveFromRegistryIds(nodeTypeId, nodeSubtypeId) ?? FALLBACK_DOC_KEY
+  }
+
+  if (mode === 'edit' && selectedNode) {
+    return resolveFromSelectedNode(selectedNode) ?? FALLBACK_DOC_KEY
+  }
+
+  return FALLBACK_DOC_KEY
+}

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.ts
@@ -8,13 +8,15 @@ import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
 
 const FALLBACK_DOC_KEY: DocKey = 'builder'
 
+/** Registry / executor ids that intentionally have no step documentation link. */
+const STEPS_WITHOUT_DOCUMENTATION = new Set<string>([RegistryNodeId.ACTION_SCRIPT, ExecutorTypeEnum.SCRIPT])
+
 /** Registry subtype / leaf ids → step-type documentation keys (must match docsUrls.json / overlay). */
 const REGISTRY_SUBTYPE_DOC_KEYS: Readonly<Record<string, string>> = {
   [RegistryNodeId.TRIGGER_MANUAL]: 'manualTrigger',
   [RegistryNodeId.TRIGGER_SCHEDULED]: 'scheduleTrigger',
   [RegistryNodeId.TRIGGER_WEBHOOK]: 'webhookTrigger',
   [RegistryNodeId.TRIGGER_EDA]: 'eventDrivenAnsibleTrigger',
-  [RegistryNodeId.ACTION_SCRIPT]: 'script',
   [RegistryNodeId.ACTION_API]: 'restApi',
   [RegistryNodeId.AGENT]: 'taskAgent',
   [RegistryNodeId.APPROVAL]: 'approval',
@@ -35,7 +37,6 @@ const TRIGGER_TYPE_DOC_KEYS: Readonly<Record<string, string>> = {
 }
 
 const EXECUTOR_TYPE_DOC_KEYS: Readonly<Record<string, string>> = {
-  [ExecutorTypeEnum.SCRIPT]: 'script',
   [ExecutorTypeEnum.HTTP_REQUEST]: 'restApi',
   [ExecutorTypeEnum.AGENTIC]: 'taskAgent',
   [ExecutorTypeEnum.AAP_JOB_TEMPLATE]: 'launchAapJobTemplate',
@@ -73,6 +74,10 @@ function lookup(map: Readonly<Record<string, string>>, id: string | null | undef
   return key === undefined ? undefined : toDocKey(key)
 }
 
+function isWithoutDocumentation(...ids: Array<string | null | undefined>): boolean {
+  return ids.some((id) => id != null && STEPS_WITHOUT_DOCUMENTATION.has(id))
+}
+
 function resolveFromRegistryIds(nodeTypeId: string | null, nodeSubtypeId: string | null): DocKey | undefined {
   return lookup(REGISTRY_SUBTYPE_DOC_KEYS, nodeSubtypeId) ?? lookup(REGISTRY_SUBTYPE_DOC_KEYS, nodeTypeId)
 }
@@ -95,16 +100,27 @@ function resolveFromSelectedNode(node: Node<NodeType['data']>): DocKey | undefin
 
 /**
  * Maps the open step detail panel context to a documentation key.
+ * Returns `null` when the step type has no documentation (e.g. script).
  * Falls back to `builder` when the step type is unknown or only a category is selected.
  */
-export function resolveStepDocKey(input: ResolveStepDocKeyInput): DocKey {
+export function resolveStepDocKey(input: ResolveStepDocKeyInput): DocKey | null {
   const { mode, nodeTypeId, nodeSubtypeId, selectedNode } = input
 
   if (mode === 'add') {
+    if (isWithoutDocumentation(nodeSubtypeId, nodeTypeId)) {
+      return null
+    }
     return resolveFromRegistryIds(nodeTypeId, nodeSubtypeId) ?? FALLBACK_DOC_KEY
   }
 
   if (mode === 'edit' && selectedNode) {
+    const executor =
+      selectedNode.type === FlowNodeType.TASK || selectedNode.type === FlowNodeType.TASK_REVERSED
+        ? (selectedNode.data as { type?: string }).type
+        : undefined
+    if (isWithoutDocumentation(executor)) {
+      return null
+    }
     return resolveFromSelectedNode(selectedNode) ?? FALLBACK_DOC_KEY
   }
 

--- a/frontend/packages/syntara-ui/src/utils/docs/docsUrls.json
+++ b/frontend/packages/syntara-ui/src/utils/docs/docsUrls.json
@@ -27,7 +27,6 @@
   "webhookTrigger": "__PLACEHOLDER__/webhook-trigger",
   "eventDrivenAnsibleTrigger": "__PLACEHOLDER__/event-driven-ansible-trigger",
   "taskAgent": "__PLACEHOLDER__/task-agent",
-  "script": "__PLACEHOLDER__/script",
   "restApi": "__PLACEHOLDER__/rest-api",
   "launchAapJobTemplate": "__PLACEHOLDER__/launch-aap-job-template",
   "launchAapWorkflowTemplate": "__PLACEHOLDER__/launch-aap-workflow-template",

--- a/frontend/packages/syntara-ui/src/utils/docs/docsUrls.json
+++ b/frontend/packages/syntara-ui/src/utils/docs/docsUrls.json
@@ -20,5 +20,21 @@
   "createUser": "__PLACEHOLDER__/create-user",
   "transferIdentity": "__PLACEHOLDER__/transfer-identity",
   "addIdentityProvider": "__PLACEHOLDER__/add-identity-provider",
-  "identityProviderMapping": "__PLACEHOLDER__/identity-provider-mapping"
+  "identityProviderMapping": "__PLACEHOLDER__/identity-provider-mapping",
+
+  "manualTrigger": "__PLACEHOLDER__/manual-trigger",
+  "scheduleTrigger": "__PLACEHOLDER__/schedule-trigger",
+  "webhookTrigger": "__PLACEHOLDER__/webhook-trigger",
+  "eventDrivenAnsibleTrigger": "__PLACEHOLDER__/event-driven-ansible-trigger",
+  "taskAgent": "__PLACEHOLDER__/task-agent",
+  "script": "__PLACEHOLDER__/script",
+  "restApi": "__PLACEHOLDER__/rest-api",
+  "launchAapJobTemplate": "__PLACEHOLDER__/launch-aap-job-template",
+  "launchAapWorkflowTemplate": "__PLACEHOLDER__/launch-aap-workflow-template",
+  "approval": "__PLACEHOLDER__/approval",
+  "conditional": "__PLACEHOLDER__/conditional",
+  "converge": "__PLACEHOLDER__/converge",
+  "loop": "__PLACEHOLDER__/loop",
+  "switch": "__PLACEHOLDER__/switch",
+  "wait": "__PLACEHOLDER__/wait"
 }


### PR DESCRIPTION
## Description

Workflow Builder step detail panels now open documentation for the specific step type instead of always linking to the generic builder page.

**Script steps are excluded:** per BU guidance, Script is in developer preview and should not have a Documentation link right now. The Documentation control is omitted entirely on that panel.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- [x] Add step-type keys to `docsUrls.json` (placeholders aligned with the downstream docs overlay; no `script` key)
- [x] Add `resolveStepDocKey` to map add/edit panel context to a `DocKey` (returns `null` for Script)
- [x] Wire `NodeEditorOverlay` to pass the resolved link via `useDocLink` when a key exists
- [x] Hide the Documentation control in `NodeEditorLayout` when there is no `docLink`
- [x] Unit tests for mapper coverage, overlay wiring, and Script omit behavior

## Out of Scope

- Page-header doc links (AAP-87882)
- Downstream overlay URL content (AAP-83508 / downstream-override)
- Script step documentation (deferred while Script remains developer preview; BU indicated no docs link for now)

## Related Issues

Fixes AAP-78134
Related to AAP-83508

## How to Test

1. Start UI with extended mode + docs overlays applied (from downstream-override)
2. Open a workflow in the builder and edit several step types that have docs (e.g. Wait, Manual trigger, REST API)
3. Confirm each of those step panels’ Documentation button opens the matching product docs URL
4. Open a **Script** step panel and confirm there is **no** Documentation control
5. Without overlays / without `VITE_EXTENDED`, non-Script links still resolve to the community README

## Frontend Checklist

- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Screenshots / Demo (if applicable)

Please attach screenshots of Documentation enabled on at least two step types, plus Script showing no Documentation control.

## Additional Notes

Depends on the docs URL overlay from AAP-83508 for real product paths on extended builds. Midstream keeps `__PLACEHOLDER__` paths only. An unused `script` path in the downstream overlay is harmless until cleaned up.

Made with [Cursor](https://cursor.com)