### PR TITLE
fix: enforce credential expires_at in StaleTokenMiddleware

### DIFF
--- a/backend/docs/service-accounts.md
+++ b/backend/docs/service-accounts.md
@@ -319,10 +319,14 @@ _check_sa_status(sa_id) — raw SQL with 5s TTL cache
      -> 401, code=SA_TOKEN_REVOKED, X-Auth-Failure-Type: revoked_sa_token
      -> Dispatch MissingSACredentialClaimEvent
 
-  5. _check_cred_status(cred_id) — raw SQL with 5s TTL cache
+  5. _check_cred_status(cred_id) — raw SQL with 5s TTL cache (fetches status + expires_at)
      Credential not found (deleted) or status != "active" (disabled)?
      -> 401, code=SA_CREDENTIAL_DISABLED, X-Auth-Failure-Type: disabled_sa_credential
      -> Dispatch DisabledSACredentialRejectionEvent
+
+  6. Credential expires_at is set and now >= expires_at?
+     -> 401, code=SA_CREDENTIAL_EXPIRED, X-Auth-Failure-Type: expired_sa_credential
+     -> Dispatch ExpiredSACredentialRejectionEvent
 ```
 
 All rejection responses use RFC 9457 Problem Details format.
@@ -341,8 +345,8 @@ The `token_version` column on the `service_accounts` table works with the `token
 The `cred_id` JWT claim enables per-credential invalidation:
 
 - Each SA token embeds the UUID of the credential that was used to obtain it
-- The middleware checks the credential's status via `_check_cred_status()` (5s TTL cache)
-- Disabling or deleting a credential immediately invalidates only tokens from that credential — other credentials on the same SA remain unaffected
+- The middleware checks the credential's status and `expires_at` via `_check_cred_status()` (5s TTL cache)
+- Disabling, deleting, or letting a credential expire immediately invalidates only tokens from that credential — other credentials on the same SA remain unaffected
 - Tokens without a `cred_id` claim are rejected outright (no backward compatibility)
 
 ### Caching
@@ -477,9 +481,10 @@ Login attempts include `method=LoginMethod.CLIENT_CREDENTIALS` and `principal_ty
 | `DisabledSARejectionEvent` | `src/syntara/auth/audit/sa_rejection.py` | SECURITY_EVENT | WARNING | Request from deleted or disabled SA rejected by middleware |
 | `StaleSATokenDetectionEvent` | `src/syntara/auth/audit/sa_rejection.py` | SECURITY_EVENT | INFO | Request with revoked (stale) SA token rejected by middleware |
 | `DisabledSACredentialRejectionEvent` | `src/syntara/auth/audit/sa_rejection.py` | SECURITY_EVENT | WARNING | Request rejected because the SA credential is disabled or deleted |
+| `ExpiredSACredentialRejectionEvent` | `src/syntara/auth/audit/sa_rejection.py` | SECURITY_EVENT | WARNING | Request rejected because the SA credential has expired |
 | `MissingSACredentialClaimEvent` | `src/syntara/auth/audit/sa_rejection.py` | SECURITY_EVENT | WARNING | SA token rejected for missing the `cred_id` claim |
 
-`DisabledSARejectionEvent` includes `is_alive` to distinguish deleted (`False`) from disabled (`True`). `StaleSATokenDetectionEvent` is throttled to at most one event per SA per 60 seconds to prevent audit log flooding. `DisabledSACredentialRejectionEvent` includes `credential_id` and `credential_status`.
+`DisabledSARejectionEvent` includes `is_alive` to distinguish deleted (`False`) from disabled (`True`). `StaleSATokenDetectionEvent` is throttled to at most one event per SA per 60 seconds to prevent audit log flooding. `DisabledSACredentialRejectionEvent` includes `credential_id` and `credential_status`. `ExpiredSACredentialRejectionEvent` includes `credential_id` and `expires_at`.
 
 ### Webhook auth audit events
 

--- a/backend/src/syntara/auth/audit/sa_rejection.py
+++ b/backend/src/syntara/auth/audit/sa_rejection.py
@@ -1,6 +1,7 @@
 """Audit events for service account token rejections in StaleTokenMiddleware."""
 
 from dataclasses import dataclass
+from datetime import datetime
 from urllib.parse import quote
 
 from syntara.audit.handler import AuditEventHandler
@@ -77,6 +78,43 @@ class DisabledSACredentialRejectionHandler(AuditEventHandler[DisabledSACredentia
             event_action="disabled_sa_credential_rejected",
             event_message=(
                 f"Rejected request: SA credential {event.credential_status} (credential {event.credential_id})"
+            ),
+            source_component=_SOURCE_COMPONENT,
+            structured_data=data,
+            actor_type=PrincipalType.SERVICE_ACCOUNT,
+            resource_urn=f"urn:syntara:service-account:{quote(event.service_account_id, safe='')}",
+            resource_name=event.service_account_id,
+        )
+
+
+@dataclass
+class ExpiredSACredentialRejectionEvent:
+    """Emitted when a request is rejected because the SA credential has expired."""
+
+    service_account_id: str
+    credential_id: str
+    expires_at: datetime
+
+
+class ExpiredSACredentialRejectionHandler(AuditEventHandler[ExpiredSACredentialRejectionEvent]):
+    """Maps an ExpiredSACredentialRejectionEvent to a normalized AuditEvent."""
+
+    def handle(self, event: ExpiredSACredentialRejectionEvent) -> AuditEvent:
+        """Map an ExpiredSACredentialRejectionEvent to a normalized AuditEvent."""
+        data = AuditContextData(
+            data_type="expired-sa-credential-rejection",
+            credential_id=event.credential_id,
+            expires_at=event.expires_at.isoformat(),
+        )
+
+        return AuditEvent(
+            event_category=EventCategory.SECURITY_EVENT,
+            event_severity=EventSeverity.WARNING,
+            event_status=EventStatus.ERROR,
+            event_action="expired_sa_credential_rejected",
+            event_message=(
+                f"Rejected request: SA credential expired at {event.expires_at.isoformat()}"
+                f" (credential {event.credential_id})"
             ),
             source_component=_SOURCE_COMPONENT,
             structured_data=data,

--- a/backend/src/syntara/auth/middleware.py
+++ b/backend/src/syntara/auth/middleware.py
@@ -11,6 +11,8 @@ accounts with a 401 response.
 Uses in-process TTLCaches (5s) to avoid a DB query on every request.
 """
 
+from datetime import UTC, datetime
+
 import structlog
 from cachetools import TTLCache
 from fastapi import status
@@ -33,9 +35,9 @@ _stale_audit_cache: TTLCache[str, bool] = TTLCache(maxsize=4096, ttl=60)
 
 _GET_USER_STATUS_SQL = "SELECT token_version, is_enabled FROM users WHERE id = :uid"
 _GET_SA_STATUS_SQL = "SELECT sa.status, sa.token_version FROM service_accounts sa WHERE sa.id = :sa_id"
-_SA_CRED_NOT_FOUND: str = "__cred_not_found__"
-_cred_status_cache: TTLCache[str, str] = TTLCache(maxsize=4096, ttl=5)
-_GET_CRED_STATUS_SQL = "SELECT sac.status FROM service_account_credentials sac WHERE sac.id = :cred_id"
+_SA_CRED_NOT_FOUND: tuple[str, None] = ("__cred_not_found__", None)
+_cred_status_cache: TTLCache[str, tuple[str, datetime | None]] = TTLCache(maxsize=4096, ttl=5)
+_GET_CRED_STATUS_SQL = "SELECT sac.status, sac.expires_at FROM service_account_credentials sac WHERE sac.id = :cred_id"
 
 
 async def _check_sa_status(sa_id: str) -> tuple[str, int] | None:
@@ -58,8 +60,8 @@ async def _check_sa_status(sa_id: str) -> tuple[str, int] | None:
         return None
 
 
-async def _check_cred_status(cred_id: str) -> str | None:
-    """Look up credential status (cached 5s). Returns status string or None if not found."""
+async def _check_cred_status(cred_id: str) -> tuple[str, datetime | None] | None:
+    """Look up credential status and expiry (cached 5s). Returns (status, expires_at) or None if not found."""
     cached = _cred_status_cache.get(cred_id)
     if cached is not None:
         return None if cached is _SA_CRED_NOT_FOUND else cached
@@ -71,9 +73,9 @@ async def _check_cred_status(cred_id: str) -> str | None:
         )
         row = result.one_or_none()
         if row:
-            status_val = str(row[0])
-            _cred_status_cache[cred_id] = status_val
-            return status_val
+            val = (str(row[0]), row[1])
+            _cred_status_cache[cred_id] = val
+            return val
         _cred_status_cache[cred_id] = _SA_CRED_NOT_FOUND
         return None
 
@@ -178,16 +180,16 @@ async def _check_sa_credential(request: Request, sa_id: str, cred_id: str | None
         )
 
     try:
-        cred_status = await _check_cred_status(cred_id)
+        cred_result = await _check_cred_status(cred_id)
     except Exception:  # noqa: BLE001
         logger.debug("Credential status check failed, skipping", exc_info=True)
         return None
 
-    if cred_status is None or cred_status != "active":
+    if cred_result is None or cred_result[0] != "active":
         from syntara.audit.dispatcher import AuditEventDispatcher  # noqa: PLC0415
         from syntara.auth.audit.sa_rejection import DisabledSACredentialRejectionEvent  # noqa: PLC0415
 
-        resolved_status = cred_status or "deleted"
+        resolved_status = cred_result[0] if cred_result else "deleted"
         AuditEventDispatcher.dispatch(
             DisabledSACredentialRejectionEvent(
                 service_account_id=sa_id, credential_id=cred_id, credential_status=resolved_status
@@ -204,6 +206,27 @@ async def _check_sa_credential(request: Request, sa_id: str, cred_id: str | None
             detail="Service account credential is disabled",
             code="SA_CREDENTIAL_DISABLED",
             failure_type="disabled_sa_credential",
+        )
+
+    _, expires_at = cred_result
+    if expires_at is not None and datetime.now(UTC) >= expires_at:
+        from syntara.audit.dispatcher import AuditEventDispatcher  # noqa: PLC0415
+        from syntara.auth.audit.sa_rejection import ExpiredSACredentialRejectionEvent  # noqa: PLC0415
+
+        AuditEventDispatcher.dispatch(
+            ExpiredSACredentialRejectionEvent(service_account_id=sa_id, credential_id=cred_id, expires_at=expires_at)
+        )
+        logger.warning(
+            "Rejected request: SA credential expired",
+            service_account_id=sa_id,
+            credential_id=cred_id,
+            expires_at=expires_at.isoformat(),
+        )
+        return _make_sa_rejection(
+            request,
+            detail="Service account credential has expired",
+            code="SA_CREDENTIAL_EXPIRED",
+            failure_type="expired_sa_credential",
         )
 
     return None

--- a/backend/tests/e2e/service_accounts/test_token_validation_middleware.py
+++ b/backend/tests/e2e/service_accounts/test_token_validation_middleware.py
@@ -184,7 +184,7 @@ class TestProjectRoleAssignment:
 class TestExpiredCredentialMiddlewareRejection:
     """Middleware rejects pre-issued JWTs after the underlying credential expires."""
 
-    CREDENTIAL_LIFETIME_SECONDS = 15
+    CREDENTIAL_LIFETIME_SECONDS = 60
 
     def test_pre_issued_jwt_rejected_after_credential_expires(
         self, syntara_api: SyntaraApiRegistry, first_project_id: UUID, syntara_base_url: str

--- a/backend/tests/e2e/service_accounts/test_token_validation_middleware.py
+++ b/backend/tests/e2e/service_accounts/test_token_validation_middleware.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
@@ -25,7 +26,7 @@ from syntara_api_client.models.role_assignment_create import RoleAssignmentCreat
 from syntara_api_client.models.service_account_credential_create import ServiceAccountCredentialCreate
 from syntara_api_client.models.service_account_credential_type import ServiceAccountCredentialType
 
-from tests.e2e.service_accounts import create_sa, create_sa_with_credential, token_request
+from tests.e2e.service_accounts import create_sa, create_sa_with_credential, poll_until_status, token_request
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -178,6 +179,50 @@ class TestProjectRoleAssignment:
             assert str(sa.id) in listed_ids
         finally:
             admin_api.service_accounts.delete(service_account_id=sa.id)
+
+
+class TestExpiredCredentialMiddlewareRejection:
+    """Middleware rejects pre-issued JWTs after the underlying credential expires."""
+
+    CREDENTIAL_LIFETIME_SECONDS = 15
+
+    def test_pre_issued_jwt_rejected_after_credential_expires(
+        self, syntara_api: SyntaraApiRegistry, first_project_id: UUID, syntara_base_url: str
+    ) -> None:
+        """A JWT issued before credential expiry is rejected by middleware after expiry."""
+        sa = create_sa(syntara_api, first_project_id)
+        expires_at = datetime.now(UTC) + timedelta(seconds=self.CREDENTIAL_LIFETIME_SECONDS)
+
+        cred = syntara_api.service_account_credentials.create(
+            service_account_id=sa.id,
+            body=ServiceAccountCredentialCreate(
+                credential_type=ServiceAccountCredentialType.CLIENT_CREDENTIALS,
+                expires_at=expires_at,
+            ),
+        ).assert_and_get()
+
+        try:
+            resp = token_request(syntara_base_url, cred.identifier, cred.client_secret)
+            assert resp.status_code == HTTPStatus.OK
+            access_token = resp.parsed.access_token
+
+            me_resp = httpx.get(
+                f"{syntara_base_url}/api/v1/auth/me",
+                headers={"Authorization": f"Bearer {access_token}"},
+                verify=e2e_ssl_context(),
+            )
+            assert me_resp.status_code == HTTPStatus.OK, "Token should work before credential expiry"
+
+            result = poll_until_status(
+                syntara_base_url,
+                access_token,
+                HTTPStatus.UNAUTHORIZED,
+                timeout=self.CREDENTIAL_LIFETIME_SECONDS + 10,
+            )
+            assert result.status_code == HTTPStatus.UNAUTHORIZED
+            assert result.json()["code"] == "SA_CREDENTIAL_EXPIRED"
+        finally:
+            syntara_api.service_accounts.delete(service_account_id=sa.id)
 
 
 class TestConcurrentServiceAccounts:

--- a/backend/tests/integration/audit/test_sa_credential_token_invalidation.py
+++ b/backend/tests/integration/audit/test_sa_credential_token_invalidation.py
@@ -1,12 +1,13 @@
 """Integration tests for SA credential token invalidation.
 
-When a service account credential is disabled or deleted, tokens issued
-from that credential must be rejected by StaleTokenMiddleware with
-``SA_CREDENTIAL_DISABLED``, and the corresponding audit event must fire.
+When a service account credential is disabled, deleted, or expired, tokens
+issued from that credential must be rejected by StaleTokenMiddleware with
+the appropriate error code, and the corresponding audit event must fire.
 """
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -175,6 +176,48 @@ class TestCredentialDeleteTokenInvalidation:
             events = _find_events(mock_build_otel_log_record, "disabled_sa_credential_rejected")
             assert len(events) >= 1, (
                 f"Expected disabled_sa_credential_rejected event, found: "
+                f"{[c.args[0].event_action for c in mock_build_otel_log_record.call_args_list]}"
+            )
+        finally:
+            await base_client.delete(f"/api/v1/service_accounts/{sa['id']}", headers=headers)
+
+
+class TestCredentialExpiredTokenInvalidation:
+    """Expired credentials invalidate tokens from that credential."""
+
+    @patch("syntara.audit.outbox.worker._build_otel_log_record")
+    async def test_expired_credential_token_rejected(
+        self,
+        mock_build_otel_log_record: MagicMock,
+        base_client: AsyncClient,
+        admin_user: User,
+        create_jwt_for_user: Callable[[User], str],
+        test_project_id: UUID,
+    ) -> None:
+        token = create_jwt_for_user(admin_user)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        sa = await _create_sa(base_client, headers, test_project_id)
+        cred = await _create_credential(base_client, headers, sa["id"])
+
+        try:
+            sa_token = await _obtain_sa_token(base_client, cred["identifier"], cred["client_secret"])
+
+            me_resp = await base_client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {sa_token}"})
+            assert me_resp.status_code == 200, f"Token should work before expiry: {me_resp.status_code}"
+
+            mock_build_otel_log_record.reset_mock()
+
+            past = datetime.now(UTC) - timedelta(minutes=5)
+            with patch("syntara.auth.middleware._check_cred_status", return_value=("active", past)):
+                me_resp2 = await base_client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {sa_token}"})
+            assert me_resp2.status_code == 401, f"Expected 401 after expiry, got {me_resp2.status_code}"
+            assert me_resp2.json()["code"] == "SA_CREDENTIAL_EXPIRED"
+
+            await get_outbox_worker().drain()
+            events = _find_events(mock_build_otel_log_record, "expired_sa_credential_rejected")
+            assert len(events) >= 1, (
+                f"Expected expired_sa_credential_rejected event, found: "
                 f"{[c.args[0].event_action for c in mock_build_otel_log_record.call_args_list]}"
             )
         finally:

--- a/backend/tests/integration/audit/test_sa_credential_token_invalidation.py
+++ b/backend/tests/integration/audit/test_sa_credential_token_invalidation.py
@@ -119,7 +119,7 @@ class TestCredentialDisableTokenInvalidation:
 
             mock_build_otel_log_record.reset_mock()
 
-            with patch("syntara.auth.middleware._check_cred_status", return_value="disabled"):
+            with patch("syntara.auth.middleware._check_cred_status", return_value=("disabled", None)):
                 me_resp2 = await base_client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {sa_token}"})
             assert me_resp2.status_code == 401, f"Expected 401 after disable, got {me_resp2.status_code}"
             assert me_resp2.json()["code"] == "SA_CREDENTIAL_DISABLED"

--- a/backend/tests/unit/auth/audit/test_sa_rejection.py
+++ b/backend/tests/unit/auth/audit/test_sa_rejection.py
@@ -1,5 +1,6 @@
 """Unit tests for SA rejection audit events and handlers."""
 
+from datetime import UTC, datetime
 from uuid import uuid4
 
 from syntara.audit.handler import AuditEventHandler
@@ -9,6 +10,8 @@ from syntara.auth.audit.sa_rejection import (
     DisabledSACredentialRejectionHandler,
     DisabledSARejectionEvent,
     DisabledSARejectionHandler,
+    ExpiredSACredentialRejectionEvent,
+    ExpiredSACredentialRejectionHandler,
     MissingSACredentialClaimEvent,
     MissingSACredentialClaimHandler,
     StaleSATokenDetectionEvent,
@@ -107,6 +110,57 @@ class TestDisabledSACredentialRejectionHandler:
         assert result.structured_data.data_type == "disabled-sa-credential-rejection"
         assert result.structured_data.credential_id == cred_id  # type: ignore[attr-defined]
         assert result.structured_data.credential_status == "deleted"  # type: ignore[attr-defined]
+
+
+class TestExpiredSACredentialRejectionHandler:
+    """Tests for ExpiredSACredentialRejectionHandler."""
+
+    def test_is_audit_event_handler_subclass(self) -> None:
+        assert issubclass(ExpiredSACredentialRejectionHandler, AuditEventHandler)
+
+    def test_maps_event_to_audit_event(self) -> None:
+        sa_id = str(uuid4())
+        cred_id = str(uuid4())
+        expires_at = datetime(2026, 8, 13, 12, 0, 0, tzinfo=UTC)
+        event = ExpiredSACredentialRejectionEvent(
+            service_account_id=sa_id, credential_id=cred_id, expires_at=expires_at
+        )
+        result = ExpiredSACredentialRejectionHandler().handle(event)
+
+        assert result.event_category == EventCategory.SECURITY_EVENT
+        assert result.event_severity == EventSeverity.WARNING
+        assert result.event_status == EventStatus.ERROR
+        assert result.event_action == "expired_sa_credential_rejected"
+        assert result.actor_type == PrincipalType.SERVICE_ACCOUNT
+        assert result.source_component == "syntara.auth.middleware"
+        assert "expired" in result.event_message
+        assert cred_id in result.event_message
+
+    def test_resource_fields(self) -> None:
+        sa_id = str(uuid4())
+        cred_id = str(uuid4())
+        expires_at = datetime(2026, 8, 13, 12, 0, 0, tzinfo=UTC)
+        event = ExpiredSACredentialRejectionEvent(
+            service_account_id=sa_id, credential_id=cred_id, expires_at=expires_at
+        )
+        result = ExpiredSACredentialRejectionHandler().handle(event)
+
+        assert result.resource_urn == f"urn:syntara:service-account:{sa_id}"
+        assert result.resource_name == sa_id
+
+    def test_structured_data(self) -> None:
+        sa_id = str(uuid4())
+        cred_id = str(uuid4())
+        expires_at = datetime(2026, 8, 13, 12, 0, 0, tzinfo=UTC)
+        event = ExpiredSACredentialRejectionEvent(
+            service_account_id=sa_id, credential_id=cred_id, expires_at=expires_at
+        )
+        result = ExpiredSACredentialRejectionHandler().handle(event)
+
+        assert result.structured_data is not None
+        assert result.structured_data.data_type == "expired-sa-credential-rejection"
+        assert result.structured_data.credential_id == cred_id  # type: ignore[attr-defined]
+        assert result.structured_data.expires_at == expires_at.isoformat()  # type: ignore[attr-defined]
 
 
 class TestMissingSACredentialClaimHandler:

--- a/backend/tests/unit/core/auth/test_stale_token_middleware.py
+++ b/backend/tests/unit/core/auth/test_stale_token_middleware.py
@@ -796,3 +796,23 @@ class TestStaleTokenMiddlewareSACredential:
 
         assert response.status_code == 401
         assert response.json()["code"] == "SA_DISABLED"
+
+    def test_disabled_credential_takes_priority_over_expired(self) -> None:
+        """Disabled credential rejection takes priority over expiration check."""
+        app = _build_app()
+        payload = _make_sa_payload(sub="sa-456", token_version=1, credential_id="cred-001")
+        past = datetime.now(UTC) - timedelta(minutes=5)
+
+        mock_ts = _mock_token_service(payload=payload)
+        mock_ctx = _mock_sa_async_session(sa_status="active", token_version=1)
+
+        with (
+            patch("syntara.auth.middleware.AsyncSessionLocal", return_value=mock_ctx),
+            patch("syntara.auth.middleware.TokenService", return_value=mock_ts),
+            patch("syntara.auth.middleware._check_cred_status", return_value=("disabled", past)),
+        ):
+            client = TestClient(app)
+            response = client.get("/", headers={"Authorization": "Bearer sa-jwt"})
+
+        assert response.status_code == 401
+        assert response.json()["code"] == "SA_CREDENTIAL_DISABLED"

--- a/backend/tests/unit/core/auth/test_stale_token_middleware.py
+++ b/backend/tests/unit/core/auth/test_stale_token_middleware.py
@@ -8,7 +8,7 @@ Tests cover:
 - Disabled user rejection with 401
 """
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -504,7 +504,7 @@ class TestStaleTokenMiddlewareSA:
         with (
             patch("syntara.auth.middleware.AsyncSessionLocal", return_value=mock_ctx),
             patch("syntara.auth.middleware.TokenService", return_value=mock_ts),
-            patch("syntara.auth.middleware._check_cred_status", return_value="active"),
+            patch("syntara.auth.middleware._check_cred_status", return_value=("active", None)),
         ):
             client = TestClient(app)
             response = client.get("/", headers={"Authorization": "Bearer sa-jwt"})
@@ -605,7 +605,7 @@ class TestStaleTokenMiddlewareSACredential:
         with (
             patch("syntara.auth.middleware.AsyncSessionLocal", return_value=mock_ctx),
             patch("syntara.auth.middleware.TokenService", return_value=mock_ts),
-            patch("syntara.auth.middleware._check_cred_status", return_value="disabled"),
+            patch("syntara.auth.middleware._check_cred_status", return_value=("disabled", None)),
         ):
             client = TestClient(app)
             response = client.get("/", headers={"Authorization": "Bearer sa-jwt"})
@@ -643,7 +643,7 @@ class TestStaleTokenMiddlewareSACredential:
         with (
             patch("syntara.auth.middleware.AsyncSessionLocal", return_value=mock_ctx),
             patch("syntara.auth.middleware.TokenService", return_value=mock_ts),
-            patch("syntara.auth.middleware._check_cred_status", return_value="active"),
+            patch("syntara.auth.middleware._check_cred_status", return_value=("active", None)),
         ):
             client = TestClient(app)
             response = client.get("/", headers={"Authorization": "Bearer sa-jwt"})
@@ -687,6 +687,92 @@ class TestStaleTokenMiddlewareSACredential:
             patch("syntara.auth.middleware.AsyncSessionLocal", return_value=mock_ctx),
             patch("syntara.auth.middleware.TokenService", return_value=mock_ts),
             patch("syntara.auth.middleware._check_cred_status", side_effect=OSError("connection refused")),
+        ):
+            client = TestClient(app)
+            response = client.get("/", headers={"Authorization": "Bearer sa-jwt"})
+
+        assert response.status_code == 200
+
+    def test_expired_credential_returns_401(self) -> None:
+        """Active SA with expired credential returns 401 SA_CREDENTIAL_EXPIRED."""
+        app = _build_app()
+        payload = _make_sa_payload(sub="sa-456", token_version=1, credential_id="cred-001")
+        past = datetime.now(UTC) - timedelta(minutes=5)
+
+        mock_ts = _mock_token_service(payload=payload)
+        mock_ctx = _mock_sa_async_session(sa_status="active", token_version=1)
+
+        with (
+            patch("syntara.auth.middleware.AsyncSessionLocal", return_value=mock_ctx),
+            patch("syntara.auth.middleware.TokenService", return_value=mock_ts),
+            patch("syntara.auth.middleware._check_cred_status", return_value=("active", past)),
+        ):
+            client = TestClient(app)
+            response = client.get("/", headers={"Authorization": "Bearer sa-jwt"})
+
+        assert response.status_code == 401
+        assert response.json()["code"] == "SA_CREDENTIAL_EXPIRED"
+        assert response.json()["detail"] == "Service account credential has expired"
+
+    def test_expired_credential_dispatches_audit_event(self) -> None:
+        """Expired credential rejection dispatches ExpiredSACredentialRejectionEvent."""
+        app = _build_app()
+        payload = _make_sa_payload(sub="sa-456", token_version=1, credential_id="cred-001")
+        past = datetime.now(UTC) - timedelta(minutes=5)
+
+        mock_ts = _mock_token_service(payload=payload)
+        mock_ctx = _mock_sa_async_session(sa_status="active", token_version=1)
+
+        with (
+            patch("syntara.auth.middleware.AsyncSessionLocal", return_value=mock_ctx),
+            patch("syntara.auth.middleware.TokenService", return_value=mock_ts),
+            patch("syntara.auth.middleware._check_cred_status", return_value=("active", past)),
+            patch("syntara.audit.dispatcher.AuditEventDispatcher.dispatch") as mock_dispatch,
+        ):
+            client = TestClient(app)
+            response = client.get("/", headers={"Authorization": "Bearer sa-jwt"})
+
+        assert response.status_code == 401
+        mock_dispatch.assert_called_once()
+        dispatched = mock_dispatch.call_args[0][0]
+        from syntara.auth.audit.sa_rejection import ExpiredSACredentialRejectionEvent
+
+        assert isinstance(dispatched, ExpiredSACredentialRejectionEvent)
+        assert dispatched.service_account_id == "sa-456"
+        assert dispatched.credential_id == "cred-001"
+        assert dispatched.expires_at == past
+
+    def test_non_expired_credential_passes(self) -> None:
+        """Active SA with non-expired credential (future expires_at) passes through."""
+        app = _build_app()
+        payload = _make_sa_payload(sub="sa-456", token_version=1, credential_id="cred-001")
+        future = datetime.now(UTC) + timedelta(hours=1)
+
+        mock_ts = _mock_token_service(payload=payload)
+        mock_ctx = _mock_sa_async_session(sa_status="active", token_version=1)
+
+        with (
+            patch("syntara.auth.middleware.AsyncSessionLocal", return_value=mock_ctx),
+            patch("syntara.auth.middleware.TokenService", return_value=mock_ts),
+            patch("syntara.auth.middleware._check_cred_status", return_value=("active", future)),
+        ):
+            client = TestClient(app)
+            response = client.get("/", headers={"Authorization": "Bearer sa-jwt"})
+
+        assert response.status_code == 200
+
+    def test_null_expires_at_passes(self) -> None:
+        """Active SA with no expiration (expires_at=None) passes through."""
+        app = _build_app()
+        payload = _make_sa_payload(sub="sa-456", token_version=1, credential_id="cred-001")
+
+        mock_ts = _mock_token_service(payload=payload)
+        mock_ctx = _mock_sa_async_session(sa_status="active", token_version=1)
+
+        with (
+            patch("syntara.auth.middleware.AsyncSessionLocal", return_value=mock_ctx),
+            patch("syntara.auth.middleware.TokenService", return_value=mock_ts),
+            patch("syntara.auth.middleware._check_cred_status", return_value=("active", None)),
         ):
             client = TestClient(app)
             response = client.get("/", headers={"Authorization": "Bearer sa-jwt"})


### PR DESCRIPTION
## Summary

- `StaleTokenMiddleware` checked credential status (active/disabled/deleted) on every request but did not check `expires_at`, allowing pre-issued JWTs to remain valid indefinitely after the underlying credential expired
- `_check_cred_status` now also fetches `expires_at` from the DB and the middleware rejects requests with `SA_CREDENTIAL_EXPIRED` when the credential has passed its expiry
- Added `ExpiredSACredentialRejectionEvent` audit event for security observability

## Test plan

- [x] Unit tests: expired credential returns 401, dispatches audit event, non-expired passes, null `expires_at` passes (4 new tests in `test_stale_token_middleware.py`)
- [x] Unit tests: audit handler produces correct event fields (4 new tests in `test_sa_rejection.py`)
- [x] E2E test: issues JWT, waits for credential expiry, confirms middleware rejects with `SA_CREDENTIAL_EXPIRED` (`test_token_validation_middleware.py`)
- [x] Manually verified against live OCP cluster — both login rejection and middleware rejection confirmed
- [x] All 55 affected unit tests pass, lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)