### PR TITLE
feat(ui): AAP-87882 add documentation links to page headers

### DIFF
--- a/frontend/packages/syntara-ui/src/components/layout/NxPageHeader.tsx
+++ b/frontend/packages/syntara-ui/src/components/layout/NxPageHeader.tsx
@@ -53,7 +53,7 @@ export type NxPageHeaderProps = Readonly<{
   titleProps?: Readonly<Pick<TitleProps, 'size' | 'className'>>
 }>
 
-function DocLinkButton({ href }: Readonly<{ href: string }>) {
+export function DocLinkButton({ href }: Readonly<{ href: string }>) {
   return (
     <Tooltip content="View documentation">
       <Button

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/Authentication.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/Authentication.test.tsx
@@ -7,8 +7,15 @@ import { axe } from 'vitest-axe'
 import { adminClient, identityProvidersClient } from '../../../client'
 import { useCanI } from '../../../hooks/useCanI'
 import { AlertProvider } from '../../../providers/alerts'
+import type { DocKey } from '../../../utils/docs/types'
 
 import Authentication from './Authentication'
+
+const useDocLinkMock = vi.fn((key: DocKey) => `https://docs.example/${key}`)
+
+vi.mock('../../../utils/docs/useDocLink', () => ({
+  useDocLink: (key: DocKey) => useDocLinkMock(key),
+}))
 
 vi.mock('../../../client', () => ({
   identityProvidersClient: {
@@ -70,6 +77,7 @@ function setupEmptyProviders() {
 
 describe('Authentication', () => {
   beforeEach(() => {
+    useDocLinkMock.mockClear()
     vi.mocked(useCanI).mockReturnValue({ allowed: true, isChecking: false, isError: false })
   })
 
@@ -160,12 +168,13 @@ describe('Authentication', () => {
   })
 
   describe('documentation link', () => {
-    it('passes authentication doc link to header', () => {
+    it('passes identityProviders doc link to header', () => {
       setupEmptyProviders()
       render(<Authentication />, { wrapper })
 
+      expect(useDocLinkMock).toHaveBeenCalledWith('identityProviders')
       const docLink = screen.getByRole('link', { name: /documentation/i })
-      expect(docLink).toBeInTheDocument()
+      expect(docLink).toHaveAttribute('href', 'https://docs.example/identityProviders')
     })
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/Authentication.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/Authentication.tsx
@@ -12,7 +12,7 @@ import { IdentityProvidersTab } from './IdentityProvidersTab'
 
 export default function Authentication() {
   const { allowed: canRead, isChecking } = useCanI('read', 'identity-provider')
-  const authenticationDocLink = useDocLink('authentication')
+  const identityProvidersDocLink = useDocLink('identityProviders')
 
   if (isChecking) {
     return (
@@ -45,7 +45,7 @@ export default function Authentication() {
       <NxPageTitle segments={['Identity Providers']} />
       <NxPageHeader
         title="Identity Providers"
-        docLink={authenticationDocLink}
+        docLink={identityProvidersDocLink}
         breadcrumbs={breadcrumbsIdentityProvidersPage()}
       />
       <NxPageBody>

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingFormEditor.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingFormEditor.test.tsx
@@ -7,12 +7,19 @@ import { axe } from 'vitest-axe'
 
 import { identityProvidersClient, usersClient } from '../../../../client'
 import { AlertProvider } from '../../../../providers/alerts'
+import type { DocKey } from '../../../../utils/docs/types'
 import { useAllGroups } from '../../../access/useAllGroups'
 
 import { GroupMappingFormEditor } from './GroupMappingFormEditor'
 import type { UseGroupMappingFormMetadataResult } from './useGroupMappingForm'
 
 const VALID_PROVIDER_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
+const useDocLinkMock = vi.fn((key: DocKey) => `https://docs.example/${key}`)
+
+vi.mock('../../../../utils/docs/useDocLink', () => ({
+  useDocLink: (key: DocKey) => useDocLinkMock(key),
+}))
 
 vi.mock('../../../../client', () => ({
   identityProvidersClient: {
@@ -88,6 +95,7 @@ function buildMetadata(overrides: Partial<UseGroupMappingFormMetadataResult> = {
 
 describe('GroupMappingFormEditor', () => {
   beforeEach(() => {
+    useDocLinkMock.mockClear()
     vi.mocked(useAllGroups).mockReturnValue({
       groups: [],
       isLoading: false,
@@ -106,6 +114,19 @@ describe('GroupMappingFormEditor', () => {
       mutate: vi.fn(),
       isPending: false,
     } as never)
+  })
+
+  it('uses identityProviderMapping documentation key', async () => {
+    render(<GroupMappingFormEditor metadata={buildMetadata()} openTestSignInRef={createRef()} />, { wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1, name: 'Add group mapping' })).toBeInTheDocument()
+    })
+    expect(useDocLinkMock).toHaveBeenCalledWith('identityProviderMapping')
+    expect(screen.getByRole('link', { name: /documentation/i })).toHaveAttribute(
+      'href',
+      'https://docs.example/identityProviderMapping'
+    )
   })
 
   it('disables Save mapping while the patch mutation is pending', async () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingFormEditor.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingFormEditor.tsx
@@ -6,6 +6,7 @@ import { FormProvider } from 'react-hook-form'
 import { NxPage, NxPageBody } from '../../../../components/layout/NxPage'
 import { NxPageHeader } from '../../../../components/layout/NxPageHeader'
 import { NxPanel } from '../../../../components/layout/NxPanel'
+import { useDocLink } from '../../../../utils/docs/useDocLink'
 
 import { GroupMappingEditPanel } from './GroupMappingEditPanel'
 import { useGroupMappingEditForm, type UseGroupMappingFormMetadataResult } from './useGroupMappingForm'
@@ -24,6 +25,7 @@ function GroupMappingFormEditorContent({
   GroupMappingFormEditorProps & { providerId: string; config: NonNullable<UseGroupMappingFormMetadataResult['config']> }
 >) {
   const { defaultExpression, groupMappingConfig, idpType, pageTitle, breadcrumbs } = metadata
+  const mappingDocLink = useDocLink('identityProviderMapping')
 
   const editForm = useGroupMappingEditForm({
     providerId,
@@ -40,7 +42,7 @@ function GroupMappingFormEditorContent({
   return (
     <FormProvider {...editForm.form}>
       <NxPage>
-        <NxPageHeader title={pageTitle} breadcrumbs={breadcrumbs} />
+        <NxPageHeader title={pageTitle} breadcrumbs={breadcrumbs} docLink={mappingDocLink} />
         <NxPageBody>
           <NxPanel
             isFullHeight

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.test.tsx
@@ -8,6 +8,7 @@ import { axe } from 'vitest-axe'
 import { identityProvidersClient } from '../../../../client'
 import { AlertProvider } from '../../../../providers/alerts'
 import { routerTestState } from '../../../../test/setup'
+import type { DocKey } from '../../../../utils/docs/types'
 
 import { IdentityProviderForm } from './IdentityProviderForm'
 
@@ -19,6 +20,12 @@ type MutationCallbacks = {
 function getMutationCallbacks(mockFn: ReturnType<typeof vi.fn>): MutationCallbacks {
   return (mockFn.mock.calls[0]?.[1] ?? {}) as MutationCallbacks
 }
+
+const useDocLinkMock = vi.fn((key: DocKey) => `https://docs.example/${key}`)
+
+vi.mock('../../../../utils/docs/useDocLink', () => ({
+  useDocLink: (key: DocKey) => useDocLinkMock(key),
+}))
 
 vi.mock('../../../../client', () => ({
   authMiddleware: { onRequest: vi.fn() },
@@ -97,6 +104,17 @@ describe('IdentityProviderForm', () => {
 
       await user.click(screen.getByRole('button', { name: 'Claim mapping' }))
       expect(screen.getByRole('button', { name: 'Add provider' })).toBeInTheDocument()
+    })
+
+    it('uses addIdentityProvider documentation key', () => {
+      setupMocks()
+      render(<IdentityProviderForm mode="add" />, { wrapper })
+
+      expect(useDocLinkMock).toHaveBeenCalledWith('addIdentityProvider')
+      expect(screen.getByRole('link', { name: /documentation/i })).toHaveAttribute(
+        'href',
+        'https://docs.example/addIdentityProvider'
+      )
     })
 
     it('renders test connection button', () => {
@@ -193,6 +211,17 @@ describe('IdentityProviderForm', () => {
 
       await user.click(screen.getByRole('button', { name: 'Claim mapping' }))
       expect(screen.getByRole('button', { name: 'Save provider' })).toBeInTheDocument()
+    })
+
+    it('uses identityProviders documentation key', () => {
+      setupEditMocks()
+      render(<IdentityProviderForm mode="edit" />, { wrapper })
+
+      expect(useDocLinkMock).toHaveBeenCalledWith('identityProviders')
+      expect(screen.getByRole('link', { name: /documentation/i })).toHaveAttribute(
+        'href',
+        'https://docs.example/identityProviders'
+      )
     })
 
     it('populates form with provider data', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.tsx
@@ -278,8 +278,8 @@ function ProviderNotFound({ onBack, onRetry }: Readonly<{ onBack: () => void; on
  */
 export function IdentityProviderForm({ mode }: Readonly<IdentityProviderFormProps>) {
   const navigate = useNavigate()
-  const identityProvidersDocLink = useDocLink('identityProviders')
   const isEdit = mode === 'edit'
+  const identityProvidersDocLink = useDocLink(isEdit ? 'identityProviders' : 'addIdentityProvider')
   const pageTitle = isEdit ? 'Edit OIDC provider' : 'Add OIDC provider'
   const submitLabel = isEdit ? 'Save provider' : 'Add provider'
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/TransferIdentityWizard.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/TransferIdentityWizard.test.tsx
@@ -9,8 +9,15 @@ import { axe } from 'vitest-axe'
 import { usersClient } from '../../../client'
 import { AlertProvider } from '../../../providers/alerts'
 import { routerTestState } from '../../../test/setup'
+import type { DocKey } from '../../../utils/docs/types'
 
 import { TransferIdentityWizard } from './TransferIdentityWizard'
+
+const useDocLinkMock = vi.fn((key: DocKey) => `https://docs.example/${key}`)
+
+vi.mock('../../../utils/docs/useDocLink', () => ({
+  useDocLink: (key: DocKey) => useDocLinkMock(key),
+}))
 
 vi.mock('../../../client', () => ({
   authMiddleware: { onRequest: vi.fn() },
@@ -172,6 +179,7 @@ function setupMocks({
 
 describe('TransferIdentityWizard', () => {
   beforeEach(() => {
+    useDocLinkMock.mockClear()
     queryClient.clear()
     vi.mocked(useParams).mockReturnValue({ userId: 'target-user' })
     setupAccessClientMock()
@@ -182,6 +190,16 @@ describe('TransferIdentityWizard', () => {
     render(<TransferIdentityWizard />, { wrapper })
 
     expect(screen.getByRole('heading', { name: /Transfer identity to targetuser/i })).toBeInTheDocument()
+  })
+
+  it('renders documentation link in the page header', () => {
+    render(<TransferIdentityWizard />, { wrapper })
+
+    expect(useDocLinkMock).toHaveBeenCalledWith('transferIdentity')
+    expect(screen.getByRole('link', { name: /View documentation/i })).toHaveAttribute(
+      'href',
+      'https://docs.example/transferIdentity'
+    )
   })
 
   it('renders the description text with username', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/TransferIdentityWizard.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/TransferIdentityWizard.tsx
@@ -5,6 +5,8 @@ import {
   Button,
   Content,
   ContentVariants,
+  Flex,
+  FlexItem,
   Stack,
   StackItem,
   Title,
@@ -21,7 +23,7 @@ import { AppRoute } from '../../../app/AppRoute'
 import { breadcrumbsUserDetailEarlyShell } from '../../../app/breadcrumbBuilders'
 import { usersClient } from '../../../client'
 import { NxPage, NxPageBody } from '../../../components/layout/NxPage'
-import { NxPageHeader } from '../../../components/layout/NxPageHeader'
+import { DocLinkButton, NxPageHeader } from '../../../components/layout/NxPageHeader'
 import { NxPanel } from '../../../components/layout/NxPanel'
 import { NxLink } from '../../../components/NxLink'
 import { NxPageTitle } from '../../../components/NxPageTitle'
@@ -30,6 +32,7 @@ import { useQueryState } from '../../../components/states/useQueryState'
 import { useMutationErrorHandler } from '../../../hooks/useMutationErrorHandler'
 import { useAlerts } from '../../../providers/alerts'
 import { detachPromise } from '../../../utils/detachPromise'
+import { useDocLink } from '../../../utils/docs/useDocLink'
 import { isValidUUID } from '../../../utils/generateUUID'
 import { accessClient } from '../../access/accessClient'
 import { DetailPageShell } from '../DetailPageShell'
@@ -112,6 +115,7 @@ export function TransferIdentityWizard() {
   const { userId }: { userId: string } = useParams({ strict: false })
   const safeUserId = userId ?? ''
   const isValidId = !!userId && isValidUUID(userId)
+  const transferIdentityDocLink = useDocLink('transferIdentity')
 
   const { showSuccess } = useAlerts()
   const handleMutationError = useMutationErrorHandler()
@@ -228,7 +232,14 @@ export function TransferIdentityWizard() {
         titleSlot={
           <Stack>
             <StackItem>
-              <Title headingLevel="h1">Transfer identity to {targetUsername}</Title>
+              <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapMd' }}>
+                <FlexItem>
+                  <Title headingLevel="h1">Transfer identity to {targetUsername}</Title>
+                </FlexItem>
+                <FlexItem>
+                  <DocLinkButton href={transferIdentityDocLink} />
+                </FlexItem>
+              </Flex>
             </StackItem>
             <StackItem>
               <Content component={ContentVariants.p} className={styles.descriptionText}>

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.test.tsx
@@ -8,10 +8,17 @@ import { axe } from 'vitest-axe'
 import { authClient } from '../../../client'
 import { AlertProvider } from '../../../providers/alerts'
 import { routerTestState } from '../../../test/setup'
+import type { DocKey } from '../../../utils/docs/types'
 import { accessClient } from '../../access/accessClient'
 import { COMPLIANT_TEST_PASSWORD } from '../passwordComplexity.testFixtures'
 
 import { UserForm } from './UserForm'
+
+const useDocLinkMock = vi.fn((key: DocKey) => `https://docs.example/${key}`)
+
+vi.mock('../../../utils/docs/useDocLink', () => ({
+  useDocLink: (key: DocKey) => useDocLinkMock(key),
+}))
 
 vi.mock('../../../client', () => ({
   authClient: {
@@ -150,6 +157,17 @@ describe('UserForm', () => {
 
       expect(screen.getByRole('heading', { name: 'Create User' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Create user' })).toBeInTheDocument()
+    })
+
+    it('uses createUser documentation key', () => {
+      setupCreateMocks()
+      render(<UserForm mode="create" />, { wrapper })
+
+      expect(useDocLinkMock).toHaveBeenCalledWith('createUser')
+      expect(screen.getByRole('link', { name: /documentation/i })).toHaveAttribute(
+        'href',
+        'https://docs.example/createUser'
+      )
     })
 
     it('renders a Cancel button that navigates back to users list', async () => {
@@ -323,6 +341,14 @@ describe('UserForm', () => {
 
       expect(screen.getByRole('heading', { name: 'Edit User' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    })
+
+    it('uses users documentation key', () => {
+      setupEditMocks()
+      render(<UserForm mode="edit" />, { wrapper })
+
+      expect(useDocLinkMock).toHaveBeenCalledWith('users')
+      expect(screen.getByRole('link', { name: /documentation/i })).toHaveAttribute('href', 'https://docs.example/users')
     })
 
     it('does not render the groups field', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.tsx
@@ -171,8 +171,8 @@ function UserFormEditBusyPage({ pageTitle, children }: Readonly<{ pageTitle: str
 
 export function UserForm({ mode }: Readonly<UserFormProps>) {
   const navigate = useNavigate()
-  const usersDocLink = useDocLink('users')
   const isEdit = mode === 'edit'
+  const usersDocLink = useDocLink(isEdit ? 'users' : 'createUser')
   const pageTitle = isEdit ? 'Edit User' : 'Create User'
   const submitLabel = isEdit ? 'Save' : 'Create user'
 

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationForm.test.tsx
@@ -9,8 +9,15 @@ import { axe } from 'vitest-axe'
 import { tanstackRouter } from '../../../../app/tanstackRouter'
 import { integrationsClient } from '../../../../client'
 import { AlertProvider } from '../../../../providers/alerts'
+import type { DocKey } from '../../../../utils/docs/types'
 
 import { IntegrationForm } from './IntegrationForm'
+
+const useDocLinkMock = vi.fn((key: DocKey) => `https://docs.example/${key}`)
+
+vi.mock('../../../../utils/docs/useDocLink', () => ({
+  useDocLink: (key: DocKey) => useDocLinkMock(key),
+}))
 
 vi.mock('../useProjectAssignmentSync', () => ({
   useProjectAssignmentSync: () => ({
@@ -102,6 +109,16 @@ function mockMutations(discoverMutate?: Mock, createMutate?: Mock) {
 describe('IntegrationForm', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('uses configureIntegration documentation key', () => {
+    render(<IntegrationForm />, { wrapper })
+
+    expect(useDocLinkMock).toHaveBeenCalledWith('configureIntegration')
+    expect(screen.getByRole('link', { name: /documentation/i })).toHaveAttribute(
+      'href',
+      'https://docs.example/configureIntegration'
+    )
   })
 
   it('renders the wizard with three steps in navigation', () => {

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationForm.tsx
@@ -246,7 +246,7 @@ function useDiscoverConnection(getValues: () => IntegrationFormData) {
 }
 
 export function IntegrationForm() {
-  const docLink = useDocLink('integrations')
+  const docLink = useDocLink('configureIntegration')
   // zodResolver with discriminated unions produces a resolver type that react-hook-form
   // cannot reconcile — the TFieldValues generic diverges. This is a known @hookform/resolvers
   // limitation. The cast is safe because the schema defines the actual validation.

--- a/frontend/packages/syntara-ui/src/utils/docs/docsUrls.json
+++ b/frontend/packages/syntara-ui/src/utils/docs/docsUrls.json
@@ -15,5 +15,10 @@
   "accessControl": "__PLACEHOLDER__/access-control",
   "authentication": "__PLACEHOLDER__/authentication",
   "identityProviders": "__PLACEHOLDER__/identity-providers",
-  "serviceAccounts": "__PLACEHOLDER__/service-accounts"
+  "serviceAccounts": "__PLACEHOLDER__/service-accounts",
+  "configureIntegration": "__PLACEHOLDER__/configure-integration",
+  "createUser": "__PLACEHOLDER__/create-user",
+  "transferIdentity": "__PLACEHOLDER__/transfer-identity",
+  "addIdentityProvider": "__PLACEHOLDER__/add-identity-provider",
+  "identityProviderMapping": "__PLACEHOLDER__/identity-provider-mapping"
 }


### PR DESCRIPTION
## Description

Wire page-header documentation icons to the correct product doc keys (AAP-87882), aligned with the downstream-override docs URL overlay.

**Added document link icon to transfer identity page header**

<img width="1512" height="824" alt="Screenshot 2026-08-14 at 1 24 38 PM" src="https://github.com/user-attachments/assets/a54952a1-3a38-4dd7-a4be-61d1ab117315" />


## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- [x] Add page-specific keys to `docsUrls.json`: `configureIntegration`, `createUser`, `transferIdentity`, `addIdentityProvider`, `identityProviderMapping`
- [x] Point Identity Providers list at `identityProviders`
- [x] Use mode-aware keys on Create User / Add OIDC provider forms
- [x] Use `configureIntegration` on the configure-integration form
- [x] Wire group mapping editor and Transfer Identity docs icons
- [x] Unit tests asserting the correct `useDocLink` keys

## Out of Scope

- Step-panel / builder node-type doc links (AAP-78134 — separate PR)
- Downstream overlay path updates (already in automation-nexus/downstream-override)

## Related Issues

Fixes AAP-87882
Related to AAP-83508 / downstream-override docs overlay

## How to Test

1. Run an extended/downstream local UI build (`apply-downstream-brand` + `VITE_EXTENDED=true`)
2. Open page headers for Integrations configure, Create User, Add IdP, Group mapping, Identity Providers list, Transfer Identity
3. Confirm each info icon opens the matching product docs path (not the community README)

## Frontend Checklist

- [x] I have added tests (unit) for new functionality
- [x] Accessibility has been considered (docs control keeps existing aria-label / opens in new tab)
- [ ] Screenshots or screen recordings are attached for UI changes

## Additional Notes

May conflict with AAP-78134 on `docsUrls.json` when both merge — only additive key differences; resolve by keeping both key sets.

Made with [Cursor](https://cursor.com)