### PR TITLE
fix: LLM Duration Metrics

### DIFF
--- a/backend/src/syntara/agent_orchestrator/agents/generic_agent.py
+++ b/backend/src/syntara/agent_orchestrator/agents/generic_agent.py
@@ -30,7 +30,7 @@ from syntara.audit.dispatcher import AuditEventDispatcher
 from syntara.core.config.base import get_settings
 from syntara.core.utils.retry import retry_with_backoff
 from syntara.metrics.dependencies import get_metrics_recorder
-from syntara.metrics.instrumentation import record_llm_call
+from syntara.metrics.instrumentation import extract_llm_duration_ms, record_llm_call
 
 if TYPE_CHECKING:
     from langchain.messages import AnyMessage
@@ -202,6 +202,7 @@ class GenericAgent(BaseAgent):
             lambda: llm_with_tools.ainvoke(messages),
             model=getattr(self.llm, "model_name", None),
         )
+        self._accumulate_llm_duration(state, result_message)
 
         # Tool-call-only responses (empty text but tool_calls present) are valid;
         # check BEFORE mutating state so retry_with_backoff replays the original messages.
@@ -292,6 +293,7 @@ class GenericAgent(BaseAgent):
                 model=getattr(self.llm, "model_name", None),
             )
             parsed_output, raw_message = self._unpack_structured_response(structured_response)
+            self._accumulate_llm_duration(state, raw_message)
         except Exception as e:  # noqa: BLE001
             # Emit ERROR event before fallback
             AuditEventDispatcher.dispatch(
@@ -414,6 +416,7 @@ class GenericAgent(BaseAgent):
                 model=getattr(self.llm, "model_name", None),
             )
             parsed_output, raw_message = self._unpack_structured_response(structured_response)
+            self._accumulate_llm_duration(state, raw_message)
 
             # Count provider tokens for the extraction call even when parsing fails —
             # the LLM was billed regardless of whether parsed_output is usable.
@@ -481,6 +484,14 @@ class GenericAgent(BaseAgent):
             raw = response.get("raw")
             return response.get("parsed"), raw if isinstance(raw, AIMessage) else None
         return response, None
+
+    @staticmethod
+    def _accumulate_llm_duration(state: AgentState, response: object | None) -> None:
+        """Add measured LLM call duration from *response* onto AgentState."""
+        duration_ms = extract_llm_duration_ms(response)
+        if duration_ms is None:
+            return
+        state["llm_duration_ms"] = (state.get("llm_duration_ms") or 0.0) + duration_ms
 
     @staticmethod
     def _build_token_usage_entry(result_message: AIMessage) -> dict[str, Any] | None:

--- a/backend/src/syntara/agent_orchestrator/models/agent_state.py
+++ b/backend/src/syntara/agent_orchestrator/models/agent_state.py
@@ -81,6 +81,9 @@ class AgentState(TypedDict):
     routing_duration_ms: NotRequired[float | None]
     """Time spent in the routing decision, in milliseconds"""
 
+    llm_duration_ms: NotRequired[float | None]
+    """Accumulated wall-clock time of LLM provider calls, in milliseconds"""
+
 
 class AgentStateFactory:
     """Factory for creating AgentState instances."""

--- a/backend/src/syntara/agent_orchestrator/services/orchestration_service.py
+++ b/backend/src/syntara/agent_orchestrator/services/orchestration_service.py
@@ -54,7 +54,7 @@ from syntara.audit.emitter import AuditActorContext
 from syntara.audit.models.audit_event import EventCategory, EventSeverity
 from syntara.core.cache.stream import StreamClient
 from syntara.metrics.dependencies import get_metrics_recorder
-from syntara.metrics.instrumentation import LLMStreamTracker
+from syntara.metrics.instrumentation import LLM_DURATION_METADATA_KEY, LLMStreamTracker
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -864,6 +864,9 @@ class OrchestrationService:
                 if routing_ms is not None:
                     result.setdefault("response_metadata", {})["routing_duration_ms"] = routing_ms
                     result["response_metadata"]["routed_to_agent"] = final_state.get("current_agent", "unknown")
+                llm_ms = final_state.get("llm_duration_ms")
+                if llm_ms is not None:
+                    result.setdefault("response_metadata", {})[LLM_DURATION_METADATA_KEY] = llm_ms
                 return result
 
         # Fallback: Build placeholder response if no final state available

--- a/backend/src/syntara/metrics/completion_poller.py
+++ b/backend/src/syntara/metrics/completion_poller.py
@@ -36,6 +36,7 @@ from syntara.core.database.session import AsyncSessionLocal
 from syntara.core.workers.periodic import PeriodicWorker
 from syntara.metrics.dependencies import get_metrics_recorder
 from syntara.metrics.emission import emit_completion_metrics, emitted_invocations
+from syntara.metrics.instrumentation import LLM_DURATION_METADATA_KEY
 from syntara.metrics.types import MetricType
 from syntara.workflows.models.execution import TERMINAL_EXECUTION_STATUSES, Execution
 
@@ -87,12 +88,13 @@ def _emit_agent_duration(
     if invocation.started_at and invocation.completed_at:
         duration_ms = (invocation.completed_at - invocation.started_at).total_seconds() * 1000
         status = "success" if invocation.status == InvocationStatus.COMPLETED else invocation.status.value
-        recorder.record(
-            MetricType.AGENT_INVOCATION_DURATION,
-            duration_ms,
-            unit="ms",
-            labels={"invocation_id": str(invocation.id), "status": status},
-        )
+        if duration_ms > 0:
+            recorder.record(
+                MetricType.AGENT_INVOCATION_DURATION,
+                duration_ms,
+                unit="ms",
+                labels={"invocation_id": str(invocation.id), "status": status},
+            )
         recorder.record(
             MetricType.AGENT_STATUS,
             value=1,
@@ -116,16 +118,16 @@ def _emit_invocation_agent_metrics(
 ) -> bool:
     """Emit agent and LLM metrics for a completed invocation.
 
-    Reads ``routing_duration_ms`` and invocation timing from the
-    persisted result metadata and records AGENT_ROUTING_DURATION,
-    AGENT_INVOCATION_DURATION, and AGENT_STATUS.
+    Reads ``routing_duration_ms``, ``llm_duration_ms``, and invocation
+    timing from the persisted result metadata and records
+    AGENT_ROUTING_DURATION, AGENT_INVOCATION_DURATION, and AGENT_STATUS.
 
     When a *token_record* is provided, also bridges LLM metrics
     (LLM_TOKENS_INPUT, LLM_TOKENS_OUTPUT, LLM_DURATION, LLM_STATUS)
-    from the persisted ``TokenUsageRecord`` into the API server's
-    in-memory store.  The Temporal worker records these metrics in its
-    own process memory; this poller makes them visible to the internal
-    metrics API.
+    from the persisted ``TokenUsageRecord`` and result metadata into the
+    API server's in-memory store.  The Temporal worker records these
+    metrics in its own process memory; this poller makes them visible to
+    the internal metrics API.
 
     Returns True if metrics were emitted, False if skipped.
     """
@@ -141,8 +143,18 @@ def _emit_invocation_agent_metrics(
     emitted_any = _emit_routing_duration(inv_id, meta, recorder)
     emitted_any = _emit_agent_duration(invocation, recorder) or emitted_any
 
-    if token_record is not None:
-        emitted_any = _emit_llm_metrics(invocation, token_record, recorder) or emitted_any
+    llm_ms = meta.get(LLM_DURATION_METADATA_KEY) if isinstance(meta, dict) else None
+    llm_ms_val = float(llm_ms) if isinstance(llm_ms, (int, float)) else None
+    if token_record is not None or llm_ms_val is not None:
+        emitted_any = (
+            _emit_llm_metrics(
+                invocation,
+                token_record,
+                recorder,
+                llm_duration_ms=llm_ms_val,
+            )
+            or emitted_any
+        )
 
     if emitted_any:
         emitted_invocations.add(invocation.id)
@@ -152,25 +164,33 @@ def _emit_invocation_agent_metrics(
 
 def _emit_llm_metrics(
     invocation: Invocation,
-    token_record: TokenUsageRecord,
+    token_record: TokenUsageRecord | None,
     recorder: MetricsRecorder,
+    *,
+    llm_duration_ms: float | None = None,
 ) -> bool:
     """Bridge LLM token and duration metrics from the database.
 
-    The Temporal worker records these via ``record_llm_call`` in its own
-    process memory.  This function re-emits them from persisted data so
-    they appear in the API server's internal metrics store.
+    Prefers persisted ``response_metadata.llm_duration_ms`` (real provider
+    call time from the worker).  Falls back to invocation wall-clock when
+    that field is absent (older backends).  Always labels with
+    ``invocation_id`` so Suite 11 can pair total vs LLM per invocation.
     """
-    prompt_tokens = token_record.prompt_tokens or 0
-    completion_tokens = token_record.completion_tokens or 0
+    prompt_tokens = (token_record.prompt_tokens or 0) if token_record is not None else 0
+    completion_tokens = (token_record.completion_tokens or 0) if token_record is not None else 0
 
-    if prompt_tokens == 0 and completion_tokens == 0:
+    if prompt_tokens == 0 and completion_tokens == 0 and llm_duration_ms is None:
         return False
 
     model = invocation.model_name or "unknown"
     provider = model.split("/", 1)[0] if "/" in model else "unknown"
     status = "success" if invocation.status == InvocationStatus.COMPLETED else invocation.status.value
-    llm_labels = {"model": model, "provider": provider, "status": status}
+    llm_labels = {
+        "model": model,
+        "provider": provider,
+        "status": status,
+        "invocation_id": str(invocation.id),
+    }
 
     if prompt_tokens > 0:
         recorder.record(
@@ -188,10 +208,14 @@ def _emit_llm_metrics(
             labels=llm_labels,
         )
 
-    # LLM_DURATION approximated from invocation wall-clock time
-    if invocation.started_at and invocation.completed_at:
+    if llm_duration_ms is not None and float(llm_duration_ms) > 0:
+        recorder.record(MetricType.LLM_DURATION, float(llm_duration_ms), unit="ms", labels=llm_labels)
+    elif invocation.started_at and invocation.completed_at:
+        # Backward-compatible fallback for deployments that do not yet
+        # persist real LLM call duration in response_metadata.
         duration_ms = (invocation.completed_at - invocation.started_at).total_seconds() * 1000
-        recorder.record(MetricType.LLM_DURATION, duration_ms, unit="ms", labels=llm_labels)
+        if duration_ms > 0:
+            recorder.record(MetricType.LLM_DURATION, duration_ms, unit="ms", labels=llm_labels)
 
     recorder.record(MetricType.LLM_STATUS, 1.0, labels=llm_labels)
     recorder.increment("llm_calls")

--- a/backend/src/syntara/metrics/instrumentation.py
+++ b/backend/src/syntara/metrics/instrumentation.py
@@ -49,6 +49,11 @@ if TYPE_CHECKING:
 
 logger = structlog.stdlib.get_logger(__name__)
 
+# Stashed on LangChain response_metadata and persisted on invocation
+# result.response_metadata so the API server's completion poller can bridge
+# real LLM duration (worker and API have separate MetricsRecorders).
+LLM_DURATION_METADATA_KEY = "llm_duration_ms"
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -119,6 +124,43 @@ def _resolve_model_provider(
         resolved_provider = resolved_model.split("/", 1)[0]
 
     return resolved_model, resolved_provider
+
+
+def _attach_llm_duration(response: Any, duration_ms: float) -> None:  # noqa: ANN401
+    """Persist measured LLM call duration onto the response when possible."""
+    if response is None:
+        return
+    # with_structured_output(..., include_raw=True) returns {"raw": AIMessage, ...}
+    if isinstance(response, dict) and "raw" in response:
+        _attach_llm_duration(response.get("raw"), duration_ms)
+        return
+    if not hasattr(response, "response_metadata"):
+        return
+    meta = getattr(response, "response_metadata", None)
+    if meta is None:
+        try:
+            response.response_metadata = {LLM_DURATION_METADATA_KEY: duration_ms}
+        except (AttributeError, TypeError):
+            return
+    elif isinstance(meta, dict):
+        meta[LLM_DURATION_METADATA_KEY] = duration_ms
+
+
+def extract_llm_duration_ms(response: Any) -> float | None:  # noqa: ANN401
+    """Read ``llm_duration_ms`` from a LangChain response, if present."""
+    if response is None:
+        return None
+    if isinstance(response, dict) and "raw" in response:
+        return extract_llm_duration_ms(response.get("raw"))
+    if not hasattr(response, "response_metadata"):
+        return None
+    meta = getattr(response, "response_metadata", None)
+    if not isinstance(meta, dict):
+        return None
+    value = meta.get(LLM_DURATION_METADATA_KEY)
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
 
 
 def _record_llm_metrics(
@@ -230,6 +272,12 @@ async def record_llm_call[T](
             provider=resp_provider,
             status=status,
         )
+
+        # Attachment is best-effort and must not block the core metrics flush.
+        try:
+            _attach_llm_duration(result, duration_ms)
+        except Exception:  # noqa: BLE001
+            logger.debug("Failed to attach LLM duration to response", exc_info=True)
 
         try:
             _record_llm_metrics(recorder, collected)

--- a/backend/tests/unit/metrics/test_completion_poller.py
+++ b/backend/tests/unit/metrics/test_completion_poller.py
@@ -211,7 +211,24 @@ class TestEmitLlmMetrics:
         assert len(outputs) == 1
         assert outputs[0].value == pytest.approx(80.0)
 
-    def test_emits_duration_when_timestamps_present(self, recorder: MetricsRecorder) -> None:
+    def test_prefers_persisted_llm_duration_ms(self, recorder: MetricsRecorder) -> None:
+        now = datetime.now(UTC)
+        inv = _make_invocation(
+            status=InvocationStatus.COMPLETED,
+            started_at=now - timedelta(seconds=3),
+            completed_at=now,
+        )
+        inv.model_name = "anthropic/claude-3"
+        token_rec = _make_token_record()
+
+        _emit_llm_metrics(inv, token_rec, recorder, llm_duration_ms=450.0)
+
+        durations = list(recorder.query(metric_types={MetricType.LLM_DURATION}))
+        assert len(durations) == 1
+        assert durations[0].value == pytest.approx(450.0)
+        assert durations[0].labels.get("invocation_id") == str(inv.id)
+
+    def test_falls_back_to_wall_clock_when_llm_duration_missing(self, recorder: MetricsRecorder) -> None:
         now = datetime.now(UTC)
         inv = _make_invocation(
             status=InvocationStatus.COMPLETED,
@@ -226,6 +243,7 @@ class TestEmitLlmMetrics:
         durations = list(recorder.query(metric_types={MetricType.LLM_DURATION}))
         assert len(durations) == 1
         assert durations[0].value == pytest.approx(3000.0)
+        assert durations[0].labels.get("invocation_id") == str(inv.id)
 
     def test_skips_duration_without_started_at(self, recorder: MetricsRecorder) -> None:
         inv = _make_invocation(status=InvocationStatus.COMPLETED)

--- a/backend/tests/unit/metrics/test_instrumentation.py
+++ b/backend/tests/unit/metrics/test_instrumentation.py
@@ -9,11 +9,13 @@ import pytest
 from prometheus_client import CollectorRegistry
 
 from syntara.metrics.instrumentation import (
+    LLM_DURATION_METADATA_KEY,
     LLMCallMetrics,
     LLMStreamTracker,
     _extract_token_usage,
     _record_llm_metrics,
     _resolve_model_provider,
+    extract_llm_duration_ms,
     record_llm_call,
 )
 from syntara.metrics.recorder import MetricsRecorder
@@ -240,6 +242,55 @@ class TestRecordLLMCall:
         result = await record_llm_call(recorder, _async_response, model="m")
         assert isinstance(result, _FakeAIMessage)
         assert result.content == "Hello from LLM"
+
+    @pytest.mark.asyncio
+    async def test_attaches_duration_to_response_metadata(self, recorder: MetricsRecorder) -> None:
+        """Measured duration is stashed on response_metadata for poller bridging."""
+        result = await record_llm_call(
+            recorder,
+            lambda: _async_response(input_tokens=10, output_tokens=5),
+            model="m",
+        )
+        assert isinstance(result.response_metadata, dict)
+        assert LLM_DURATION_METADATA_KEY in result.response_metadata
+        assert result.response_metadata[LLM_DURATION_METADATA_KEY] > 0
+        assert extract_llm_duration_ms(result) == pytest.approx(result.response_metadata[LLM_DURATION_METADATA_KEY])
+
+    @pytest.mark.asyncio
+    async def test_records_metrics_when_attach_fails(
+        self, recorder: MetricsRecorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Attachment failure must not prevent the core metrics flush."""
+
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            msg = "attach failed"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(
+            "syntara.metrics.instrumentation._attach_llm_duration",
+            _boom,
+        )
+        result = await record_llm_call(
+            recorder,
+            lambda: _async_response(input_tokens=10, output_tokens=5),
+            model="m",
+        )
+        assert isinstance(result, _FakeAIMessage)
+        durations = list(recorder.query(metric_types={MetricType.LLM_DURATION}))
+        assert len(durations) == 1
+        assert durations[0].value > 0
+
+    @pytest.mark.asyncio
+    async def test_attaches_duration_to_structured_raw_message(self, recorder: MetricsRecorder) -> None:
+        """include_raw structured responses get duration on the raw AIMessage."""
+
+        async def _structured() -> dict[str, Any]:
+            return {"parsed": {"answer": 1}, "raw": _make_response()}
+
+        result = await record_llm_call(recorder, _structured, model="m")
+        assert isinstance(result, dict)
+        assert extract_llm_duration_ms(result) is not None
+        assert extract_llm_duration_ms(result.get("raw")) == extract_llm_duration_ms(result)
 
     @pytest.mark.asyncio
     async def test_records_error_and_reraises(self, recorder: MetricsRecorder) -> None:


### PR DESCRIPTION
## Description

Persist real LLM provider call duration (llm_duration_ms) from the worker onto LangChain response metadata and accumulate it on AgentState.
Propagate that value through orchestration into invocation response_metadata so the API completion poller can bridge true LLM_DURATION (instead of approximating from wall-clock).
Prefer persisted llm_duration_ms when emitting metrics; fall back to invocation wall-clock for older data; label LLM metrics with invocation_id.
Skip zero-duration agent/LLM duration records; keep metrics flush even if duration attachment fails.

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)