### PR TITLE
fix: bump API info.version to 1.0.0 for GA release

### DIFF
--- a/backend/src/api_client/pyproject.toml
+++ b/backend/src/api_client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntara-api-client"
-version = "0.1.0"
+version = "1.0.0"
 description = "A client library for accessing Syntara API"
 license = "Apache-2.0"
 authors = []

--- a/backend/src/cli/orchestrator_cli/openapi.yaml
+++ b/backend/src/cli/orchestrator_cli/openapi.yaml
@@ -11,7 +11,7 @@
 openapi: 3.1.0
 info:
   title: Syntara API
-  version: 0.1.0
+  version: 1.0.0
   description: A distributed multi-agent workflow orchestration system
 servers:
   - url: /api/v1

--- a/backend/src/syntara/api/constants.py
+++ b/backend/src/syntara/api/constants.py
@@ -7,7 +7,7 @@ For configurable values, use get_settings() from syntara.core.config.base.
 # API configuration
 
 API_V1_PATH_PREFIX = "/api/v1"
-API_V1_VERSION = "0.1.0"
+API_V1_VERSION = "1.0.0"
 
 # Full path to the OIDC callback endpoint, used by the auth router and
 # referenced by the AAP setup service when registering redirect URIs.

--- a/backend/src/syntara/schemas/openapi.yaml
+++ b/backend/src/syntara/schemas/openapi.yaml
@@ -11,7 +11,7 @@
 openapi: 3.1.0
 info:
   title: Syntara API
-  version: 0.1.0
+  version: 1.0.0
   description: A distributed multi-agent workflow orchestration system
 servers:
   - url: /api/v1

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3703,7 +3703,7 @@ dev = [
 
 [[package]]
 name = "syntara-api-client"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "src/api_client" }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Description

Bump API_V1_VERSION constant from 0.1.0 to 1.0.0 in api/constants.py and regenerate the bundled OpenAPI spec, CLI spec copy, and Python API client to signal GA stability and semver-governed backward compatibility.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [ ] List the specific changes made
- [ ] Include any new dependencies or configuration changes

## Out of Scope

<!-- What this PR intentionally does NOT include, to set reviewer expectations -->

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## How to Test

<!-- Manual testing directions, for example:
1. Log in as an admin
2. Go to the `/workflows` route
3. Click on a thing
4. Validate that something changed
-->

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [ ] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [ ] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->
