### PR TITLE
fix(AAP-85119): Fix flaky approvals tests

### DIFF
--- a/frontend/packages/syntara-ui/e2e/utils/api.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api.ts
@@ -5,7 +5,7 @@
  * and clean up resources via the API — faster and more reliable than
  * UI-based setup, especially for fixtures.
  */
-import { type Page } from '@playwright/test'
+import { expect, type Page } from '@playwright/test'
 
 import { appBaseUrl } from '../fixtures'
 
@@ -596,4 +596,23 @@ export async function deleteServiceAccountViaApi(app: Page, serviceAccountId: st
   } catch {
     // Best-effort cleanup
   }
+}
+
+/**
+ * Poll an execution's status via the API until it matches one of the expected values.
+ * Retries every 1s until timeout (default 90s). Used to wait for Temporal state
+ * transitions (e.g. "running", "paused", terminal statuses) without relying on UI updates.
+ */
+export async function pollExecutionStatus(
+  app: Page,
+  executionId: string,
+  expectedStatuses: string[],
+  options?: { token?: string; timeout?: number }
+): Promise<void> {
+  const token = options?.token ?? (await getAuthToken(app)) ?? undefined
+  await expect(async () => {
+    const resp = await apiRequest(app, 'get', `/executions/${executionId}`, { token })
+    const exec = (await resp.json()) as { status: string }
+    expect(expectedStatuses).toContain(exec.status)
+  }).toPass({ timeout: options?.timeout ?? 90_000, intervals: [1_000] })
 }

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
@@ -4,7 +4,7 @@ import { test, expect, toAppUrl } from '../fixtures'
 import { waitForApprovalPanel } from '../helpers/approvals'
 import { addManualTrigger } from '../helpers/v2-nodes'
 import { addNodePanel, waitForUIReady, buildUniqueName, closeNodeEditorPanel } from '../helpers/workflows'
-import { apiRequest } from '../utils/api'
+import { apiRequest, pollExecutionStatus } from '../utils/api'
 
 /** Select a direct (non-category) button in the add-node panel. */
 async function selectDirectNodeType(page: Page, label: string | RegExp) {
@@ -27,7 +27,7 @@ async function selectDirectNodeType(page: Page, label: string | RegExp) {
  * run them, and clean up afterward.
  */
 test.describe('Multi-Approval Navigation', () => {
-  test.skip('navigate between multiple pending approvals using Previous/Next buttons', async ({ app }) => {
+  test('navigate between multiple pending approvals using Previous/Next buttons', async ({ app }) => {
     const workflowName = buildUniqueName('Multi-Approval Workflow')
     let workflowId: string | undefined
 
@@ -132,13 +132,14 @@ test.describe('Multi-Approval Navigation', () => {
         .catch(() => false)
       test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
 
-      // Step 3: Wait for execution to reach "paused" status (all 3 parallel approvals pending)
-      const reachedPaused = await app
-        .getByText('Paused')
-        .waitFor({ state: 'visible', timeout: 30_000 })
+      // Step 3: Poll API for "paused" status (all 3 parallel approvals pending)
+      const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
+      test.skip(!executionId, 'Could not extract execution ID from URL')
+
+      const reachedPaused = await pollExecutionStatus(app, executionId!, ['paused'])
         .then(() => true)
         .catch(() => false)
-      test.skip(!reachedPaused, 'Execution stayed Pending — Temporal worker may not be running')
+      test.skip(!reachedPaused, 'Execution did not reach paused state — Temporal worker may not be running')
 
       // Navigate to approvals page to see all pending approvals
       await app.goto(toAppUrl('/approvals'))
@@ -209,7 +210,7 @@ test.describe('Multi-Approval Navigation', () => {
     }
   })
 
-  test.skip('verify approval counter shows correct position when multiple approvals exist', async ({ app }) => {
+  test('verify approval counter shows correct position when multiple approvals exist', async ({ app }) => {
     const workflowName = buildUniqueName('Counter Test Workflow')
     let workflowId: string | undefined
 
@@ -282,12 +283,13 @@ test.describe('Multi-Approval Navigation', () => {
         .catch(() => false)
       test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
 
-      const reachedPaused = await app
-        .getByText('Paused')
-        .waitFor({ state: 'visible', timeout: 30_000 })
+      const execId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
+      test.skip(!execId, 'Could not extract execution ID from URL')
+
+      const reachedPaused = await pollExecutionStatus(app, execId!, ['paused'])
         .then(() => true)
         .catch(() => false)
-      test.skip(!reachedPaused, 'Execution stayed Pending — Temporal worker may not be running')
+      test.skip(!reachedPaused, 'Execution did not reach paused state — Temporal worker may not be running')
 
       // Navigate to approvals page
       await app.goto(toAppUrl('/approvals'))

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
@@ -27,7 +27,8 @@ async function selectDirectNodeType(page: Page, label: string | RegExp) {
  * run them, and clean up afterward.
  */
 test.describe('Multi-Approval Navigation', () => {
-  test('navigate between multiple pending approvals using Previous/Next buttons', async ({ app }) => {
+  // API polling fix applied but Run button stays aria-disabled after saving parallel-branch workflows — separate root cause to investigate
+  test.skip('navigate between multiple pending approvals using Previous/Next buttons', async ({ app }) => {
     const workflowName = buildUniqueName('Multi-Approval Workflow')
     let workflowId: string | undefined
 
@@ -210,7 +211,8 @@ test.describe('Multi-Approval Navigation', () => {
     }
   })
 
-  test('verify approval counter shows correct position when multiple approvals exist', async ({ app }) => {
+  // API polling fix applied but Run button stays aria-disabled after saving parallel-branch workflows — separate root cause to investigate
+  test.skip('verify approval counter shows correct position when multiple approvals exist', async ({ app }) => {
     const workflowName = buildUniqueName('Counter Test Workflow')
     let workflowId: string | undefined
 

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-pending-badge.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-pending-badge.spec.ts
@@ -3,6 +3,7 @@ import type { Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
 import { addApprovalNodeWithBranch } from '../helpers/v2-nodes'
 import { buildUniqueName, createBasicWorkflowViaApi, openWorkflowInBuilder, deleteWorkflow } from '../helpers/workflows'
+import { pollExecutionStatus } from '../utils/api'
 
 /**
  * E2E Tests: Approval Pending Badge Display
@@ -51,13 +52,11 @@ async function createPendingApproval(
   const executionId = app.url().match(/executions\/([^/?]+)/)?.[1]
   if (!executionId) throw new Error('Failed to extract execution ID')
 
-  // Wait for execution to reach approval and pause
-  const reachedApproval = await app
-    .getByText('Paused')
-    .waitFor({ state: 'visible', timeout: 30_000 })
+  // Poll API for "paused" status instead of relying on UI updates
+  const reachedApproval = await pollExecutionStatus(app, executionId, ['paused'])
     .then(() => true)
     .catch(() => false)
-  test.skip(!reachedApproval, 'Execution stayed Pending — Temporal worker may not be running')
+  test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
 
   return { workflowId, executionId, workflowName }
 }

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -155,7 +155,8 @@ test.describe('Approval Side Panel — deep-link', () => {
 })
 
 test.describe('Approval Side Panel — self-contained', () => {
-  test('UI-28: execution shows Paused status and Waiting for approval indicator', async ({ app }) => {
+  // API polling fix applied but test times out during workflow build/run setup — separate root cause to investigate
+  test.skip('UI-28: execution shows Paused status and Waiting for approval indicator', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-approval-panel')
     const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Pre-approval step')
     await openWorkflowInBuilder(app, workflowName, id)
@@ -197,7 +198,8 @@ test.describe('Approval Side Panel — self-contained', () => {
     }
   })
 
-  test('UI-30: rejecting an approval terminates workflow execution', async ({ app }) => {
+  // API polling fix applied but test times out during workflow build/run setup — separate root cause to investigate
+  test.skip('UI-30: rejecting an approval terminates workflow execution', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-reject')
     const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Pre-rejection step')
     await openWorkflowInBuilder(app, workflowName, id)

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -17,7 +17,7 @@
 import { test, expect, toAppUrl } from '../fixtures'
 import { addApprovalNodeWithBranch } from '../helpers/v2-nodes'
 import { buildUniqueName, createBasicWorkflowViaApi, openWorkflowInBuilder } from '../helpers/workflows'
-import { apiRequest } from '../utils/api'
+import { apiRequest, pollExecutionStatus } from '../utils/api'
 
 const MOCK_APPROVAL_ID = '550e8400-e29b-41d4-a716-446655440050'
 const MOCK_EXECUTION_ID = 'exec-approval'
@@ -155,7 +155,7 @@ test.describe('Approval Side Panel — deep-link', () => {
 })
 
 test.describe('Approval Side Panel — self-contained', () => {
-  test.skip('UI-28: execution shows Paused status and Waiting for approval indicator', async ({ app }) => {
+  test('UI-28: execution shows Paused status and Waiting for approval indicator', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-approval-panel')
     const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Pre-approval step')
     await openWorkflowInBuilder(app, workflowName, id)
@@ -180,14 +180,14 @@ test.describe('Approval Side Panel — self-contained', () => {
       await expect(app.getByRole('heading', { level: 1 })).toBeVisible()
       await expect(app.getByRole('button', { name: 'Back to editor' })).toBeVisible()
 
-      // UI-28: Verify pending approval display
-      // Skip if the execution stays Pending — Temporal worker is not running
-      const reachedApproval = await app
-        .getByText('Paused')
-        .waitFor({ state: 'visible', timeout: 30_000 })
+      // Poll API for "paused" status instead of relying on UI updates
+      const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
+      test.skip(!executionId, 'Could not extract execution ID from URL')
+
+      const reachedApproval = await pollExecutionStatus(app, executionId!, ['paused'])
         .then(() => true)
         .catch(() => false)
-      test.skip(!reachedApproval, 'Execution stayed Pending — Temporal worker may not be running')
+      test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
       await expect(app.getByText('Waiting for approval')).toBeVisible({ timeout: 30_000 })
       await expect(app.getByRole('button', { name: 'Review approval' })).toBeVisible({ timeout: 30_000 })
     } finally {
@@ -197,7 +197,7 @@ test.describe('Approval Side Panel — self-contained', () => {
     }
   })
 
-  test.skip('UI-30: rejecting an approval terminates workflow execution', async ({ app }) => {
+  test('UI-30: rejecting an approval terminates workflow execution', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-reject')
     const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Pre-rejection step')
     await openWorkflowInBuilder(app, workflowName, id)
@@ -219,14 +219,14 @@ test.describe('Approval Side Panel — self-contained', () => {
         .catch(() => false)
       test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
 
-      // Wait for execution to pause at the approval node
-      // Skip if Temporal worker is not running (execution stays Pending)
-      const reachedApproval = await app
-        .getByText('Paused')
-        .waitFor({ state: 'visible', timeout: 30_000 })
+      // Poll API for "paused" status instead of relying on UI updates
+      const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
+      test.skip(!executionId, 'Could not extract execution ID from URL')
+
+      const reachedApproval = await pollExecutionStatus(app, executionId!, ['paused'])
         .then(() => true)
         .catch(() => false)
-      test.skip(!reachedApproval, 'Execution stayed Pending — Temporal worker may not be running')
+      test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
       await expect(app.getByText('Waiting for approval')).toBeVisible({ timeout: 30_000 })
 
       // Open approval panel

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-workflow-e2e.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-workflow-e2e.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '../fixtures'
 import { navigateToApprovalAndOpen } from '../helpers/approvals'
 import { addApprovalNodeWithBranch } from '../helpers/v2-nodes'
 import { buildUniqueName, createBasicWorkflowViaApi, openWorkflowInBuilder } from '../helpers/workflows'
-import { apiRequest } from '../utils/api'
+import { apiRequest, pollExecutionStatus } from '../utils/api'
 
 /**
  * Helper: Create a workflow with an approval node and run it to create a pending approval.
@@ -35,12 +35,13 @@ async function createPendingApproval(app: Page): Promise<{ workflowId: string; a
     .catch(() => false)
   test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
 
-  const reachedApproval = await app
-    .getByText('Paused')
-    .waitFor({ state: 'visible', timeout: 30_000 })
+  const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
+  test.skip(!executionId, 'Could not extract execution ID from URL')
+
+  const reachedApproval = await pollExecutionStatus(app, executionId!, ['paused'])
     .then(() => true)
     .catch(() => false)
-  test.skip(!reachedApproval, 'Execution stayed Pending — Temporal worker may not be running')
+  test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
 
   return { workflowId, approvalName }
 }

--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -12,7 +12,7 @@ import { test, expect, toAppUrl } from '../fixtures'
 import { APP_TITLE } from '../helpers/appTitle'
 import { addApprovalNodeWithBranch } from '../helpers/v2-nodes'
 import { buildUniqueName, createBasicWorkflowViaApi, openWorkflowInBuilder } from '../helpers/workflows'
-import { apiRequest } from '../utils/api'
+import { apiRequest, pollExecutionStatus } from '../utils/api'
 
 /**
  * Helper: Create a workflow with an approval node and run it to create a pending approval.
@@ -48,13 +48,14 @@ async function createPendingApproval(
     .catch(() => false)
   test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
 
-  // Wait for execution to pause at the approval node (requires Temporal)
-  const reachedApproval = await app
-    .getByText('Paused')
-    .waitFor({ state: 'visible', timeout: 30_000 })
+  // Extract execution ID from URL and poll API for "paused" status
+  const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
+  test.skip(!executionId, 'Could not extract execution ID from URL')
+
+  const reachedApproval = await pollExecutionStatus(app, executionId!, ['paused'])
     .then(() => true)
     .catch(() => false)
-  test.skip(!reachedApproval, 'Execution stayed Pending — Temporal worker may not be running')
+  test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
 
   return { workflowId, approvalName }
 }
@@ -490,13 +491,14 @@ test('UI-29: self-contained approve flow via approvals queue', async ({ app }) =
       .catch(() => false)
     test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
 
-    // Wait for execution to pause at the approval node (requires Temporal)
-    const reachedApproval = await app
-      .getByText('Paused')
-      .waitFor({ state: 'visible', timeout: 30_000 })
+    // Extract execution ID and poll API for "paused" status
+    const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
+    test.skip(!executionId, 'Could not extract execution ID from URL')
+
+    const reachedApproval = await pollExecutionStatus(app, executionId!, ['paused'])
       .then(() => true)
       .catch(() => false)
-    test.skip(!reachedApproval, 'Execution stayed Pending — Temporal worker may not be running')
+    test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
 
     // Navigate to the approvals queue and find our approval
     await app.goto(toAppUrl('/approvals'))

--- a/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
@@ -14,23 +14,16 @@
 
 import { test, expect, toAppUrl, type Page } from '../fixtures'
 import { buildUniqueName } from '../helpers/workflows'
-import { apiRequest, createWorkflowViaApi, deleteWorkflowViaApi, ensureProject, getAuthToken } from '../utils/api'
+import {
+  apiRequest,
+  createWorkflowViaApi,
+  deleteWorkflowViaApi,
+  ensureProject,
+  getAuthToken,
+  pollExecutionStatus,
+} from '../utils/api'
 
 const TERMINAL_STATUSES = ['completed', 'failed', 'cancelled']
-
-async function pollExecutionStatus(
-  page: Page,
-  executionId: string,
-  token: string,
-  expectedStatuses: string[],
-  timeout = 90_000
-): Promise<void> {
-  await expect(async () => {
-    const resp = await apiRequest(page, 'get', `/executions/${executionId}`, { token })
-    const exec = (await resp.json()) as { status: string }
-    expect(expectedStatuses).toContain(exec.status)
-  }).toPass({ timeout, intervals: [1_000] })
-}
 
 let sleepWorkflowId: string | null = null
 let runningExecutionId: string | null = null
@@ -68,7 +61,7 @@ test.beforeAll(async ({ browser }) => {
     if (runResp.ok()) {
       const body = (await runResp.json()) as { id: string }
       runningExecutionId = body.id
-      await pollExecutionStatus(page, runningExecutionId, token, ['running'], 60_000)
+      await pollExecutionStatus(page, runningExecutionId, ['running'], { token, timeout: 60_000 })
     }
 
     const echoName = buildUniqueName('e2e-cancel-echo')
@@ -94,7 +87,7 @@ test.beforeAll(async ({ browser }) => {
     if (echoRunResp.ok()) {
       const body = (await echoRunResp.json()) as { id: string }
       completedExecutionId = body.id
-      await pollExecutionStatus(page, completedExecutionId, token, TERMINAL_STATUSES)
+      await pollExecutionStatus(page, completedExecutionId, TERMINAL_STATUSES, { token })
     }
   } finally {
     await page.close()


### PR DESCRIPTION
## Description
Addresses flaky approval E2E tests by replacing UI-based `getByText('Paused').waitFor()` calls with API polling via a shared `pollExecutionStatus` utility. The UI waits were timing out under CI latency because Temporal state transitions weren't reflected in the UI within the wait window. API polling is more reliable because it checks the backend directly, independent of UI render timing.

Also extracts `pollExecutionStatus` from `cancel-execution.spec.ts` into `e2e/utils/api.ts` so the same pattern can be reused across all approval test files.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Changes Made
- **`e2e/utils/api.ts`**: Added shared `pollExecutionStatus` function — polls execution status via API every 1s with a 90s default timeout
- **`e2e/workflows/cancel-execution.spec.ts`**: Removed local `pollExecutionStatus` definition, now imports from shared utility
- **`e2e/workflows/approvals.spec.ts`**: Replaced `getByText('Paused').waitFor()` with `pollExecutionStatus` in `createPendingApproval` helper and the UI-29 batch test
- **`e2e/workflows/approval-workflow-e2e.spec.ts`**: Same UI wait → API polling replacement in `createPendingApproval`
- **`e2e/workflows/approval-pending-badge.spec.ts`**: Same UI wait → API polling replacement in `createPendingApproval`
- **`e2e/workflows/approval-side-panel.spec.ts`**: Applied API polling to self-contained UI-28/UI-30 tests; re-skipped — these have a separate root cause (test timeout during workflow build/run setup)
- **`e2e/workflows/approval-multi-navigation.spec.ts`**: Applied API polling; re-skipped — these have a separate root cause (Run button stays `aria-disabled` for parallel-branch workflows)
## Out of Scope
- Fixing the root cause of `approval-multi-navigation.spec.ts` failures (Run button disabled for parallel-branch workflows)
- Fixing the root cause of `approval-side-panel.spec.ts` UI-28/UI-30 timeouts (workflow build/run setup timing)
- These are documented with comments on the skipped tests for follow-up

## Related Issues
Partially fixes AAP-85119

## How to Test
1. Review CI results — E2E tests pass with 0 failures
2. Verify `approvals.spec.ts`, `approval-workflow-e2e.spec.ts`, and `approval-pending-badge.spec.ts` tests pass (these were the primary flaky tests)
3. Verify `cancel-execution.spec.ts` still passes after refactoring to shared utility

## Frontend Checklist
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)

## General Checklist
- [x] Code follows the project's coding conventions
- [x] No secrets or credentials are included in this PR
