### PR TITLE
fix(e2e ui): fix aao ui devel pull request e2e test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/aap-node-wiring.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/aap-node-wiring.spec.ts
@@ -12,9 +12,6 @@ import { deleteIntegrationViaApi } from './seeds/resources'
 import { apiRequest, deleteCredentialViaApi, ensureProject } from './utils/api'
 
 const isRealBackend = isSkipWebServerForPlaywrightTests()
-// Real backend rejects an unresolvable base_url as an SSRF risk; use the compose-allowlisted
-// mcp-server host (override via SYNTARA_E2E_INTEGRATION_HOST). Mock mode keeps a readable placeholder.
-const ssrfSafeIntegrationHost = process.env.SYNTARA_E2E_INTEGRATION_HOST ?? 'https://mcp-server'
 
 async function createAAPIntegration(
   app: import('@playwright/test').Page,
@@ -45,7 +42,7 @@ async function createAAPIntegration(
       integration_type: 'ansible_automation_platform',
       configuration: {
         integration_type: 'ansible_automation_platform',
-        base_url: isRealBackend ? ssrfSafeIntegrationHost : `https://${name}.example.com`,
+        base_url: `https://example.com`,
       },
       management_credential_id: cred.id,
       scope: 'global',

--- a/frontend/packages/syntara-ui/e2e/credential-delete-integration-warning.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-delete-integration-warning.spec.ts
@@ -6,14 +6,8 @@
  */
 import { test, expect, toAppUrl } from './fixtures'
 import { buildUniqueName } from './helpers/workflows'
-import { isSkipWebServerForPlaywrightTests } from './playwrightWebServerEnv'
 import { deleteIntegrationViaApi } from './seeds/resources'
 import { apiRequest, createCredentialViaApi, deleteCredentialViaApi, ensureProject, getAuthToken } from './utils/api'
-
-// Real backend rejects an unresolvable base_url as an SSRF risk; use the compose-allowlisted
-// mcp-server host (override via SYNTARA_E2E_INTEGRATION_HOST). Mock mode keeps a readable placeholder.
-const isRealBackend = isSkipWebServerForPlaywrightTests()
-const ssrfSafeIntegrationHost = process.env.SYNTARA_E2E_INTEGRATION_HOST ?? 'https://mcp-server'
 
 test.describe('Credential Delete — Integration Impact Warning', () => {
   test('delete credential dialog warns about affected integrations', async ({ app }) => {
@@ -39,7 +33,7 @@ test.describe('Credential Delete — Integration Impact Warning', () => {
           integration_type: 'mcp_server',
           configuration: {
             integration_type: 'mcp_server',
-            base_url: isRealBackend ? ssrfSafeIntegrationHost : `https://${integrationName}.example.com`,
+            base_url: `https://example.com`,
           },
           management_credential_id: credentialId,
           scope: 'global',
@@ -112,7 +106,7 @@ test.describe('Credential Delete — Integration Impact Warning', () => {
           integration_type: 'mcp_server',
           configuration: {
             integration_type: 'mcp_server',
-            base_url: isRealBackend ? ssrfSafeIntegrationHost : `https://${integrationName}.example.com`,
+            base_url: `https://example.com`,
           },
           management_credential_id: credentialId,
           scope: 'global',

--- a/frontend/packages/syntara-ui/e2e/integration-connection-test.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/integration-connection-test.spec.ts
@@ -170,7 +170,7 @@ test.describe('Integration Wizard @pr-check', () => {
   })
 
   test('connection test with unreachable endpoint returns connection error', async ({ app }) => {
-    test.skip(!isRealBackend, 'Requires real backend — mock API discover always returns success')
+    test.skip(!isRealBackend || !mcpServerUrl, 'Requires real backend with SYNTARA_E2E_MCP_SERVER_URL set')
     const name = buildUniqueName('e2e-wizard-t9a')
     const credName = buildUniqueName('e2e-wizard-t9a-cred')
     let credentialId: string | undefined
@@ -186,7 +186,7 @@ test.describe('Integration Wizard @pr-check', () => {
       await app.getByRole('option', { name: 'LLM Provider' }).click()
 
       await app.getByRole('textbox', { name: 'Name' }).fill(name)
-      await app.getByRole('textbox', { name: 'API URL' }).fill('https://example.com:9999')
+      await app.getByRole('textbox', { name: 'API URL' }).fill('https://mcp-server:9999')
 
       await app.getByRole('button', { name: 'Next' }).click()
 

--- a/frontend/packages/syntara-ui/e2e/integration-connection-test.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/integration-connection-test.spec.ts
@@ -177,11 +177,8 @@ test.describe('Integration Wizard @pr-check', () => {
 
     try {
       credentialId = await createLlmCredential(app, credName)
-      // Step 1 — LLM Provider with base_url pointing to a closed port on the allowlisted,
-      // in-network mcp-server host (mirrors the backend e2e). The host is allowlisted so it passes
-      // write-time SSRF validation, while nothing listens on :9999 — TCP RST is immediate so the
-      // backend classifies this as connection_error, not timeout. A loopback address (127.0.0.1)
-      // cannot be used: it is not allowlisted and would be rejected as an SSRF risk before connect.
+      // Step 1 — LLM Provider with Red Hat AI hint, base_url pointing to a port with nothing
+      // listening. TCP RST is immediate so the backend classifies this as connection_error, not timeout.
       await app.goto(toAppUrl('/configuration/integrations/configure'))
       await expect(app.getByRole('heading', { name: 'Integration details', level: 2 })).toBeVisible()
 
@@ -189,7 +186,7 @@ test.describe('Integration Wizard @pr-check', () => {
       await app.getByRole('option', { name: 'LLM Provider' }).click()
 
       await app.getByRole('textbox', { name: 'Name' }).fill(name)
-      await app.getByRole('textbox', { name: 'API URL' }).fill('https://mcp-server:9999')
+      await app.getByRole('textbox', { name: 'API URL' }).fill('https://example.com:9999')
 
       await app.getByRole('button', { name: 'Next' }).click()
 

--- a/frontend/packages/syntara-ui/e2e/integration-models.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/integration-models.spec.ts
@@ -19,14 +19,8 @@ import { type Page } from '@playwright/test'
 
 import { test, expect, toAppUrl } from './fixtures'
 import { buildUniqueName, clickAddConnectedStep, startWorkflowWithTrigger } from './helpers/workflows'
-import { isSkipWebServerForPlaywrightTests } from './playwrightWebServerEnv'
 import { deleteIntegrationViaApi, type SeededIntegration } from './seeds/resources'
 import { apiRequest, deleteCredentialViaApi, ensureProject } from './utils/api'
-
-// Real backend rejects an unresolvable base_url as an SSRF risk; use the compose-allowlisted
-// mcp-server host (override via SYNTARA_E2E_INTEGRATION_HOST). Mock mode keeps a readable placeholder.
-const isRealBackend = isSkipWebServerForPlaywrightTests()
-const ssrfSafeIntegrationHost = process.env.SYNTARA_E2E_INTEGRATION_HOST ?? 'https://mcp-server'
 
 async function ensureLlmCredentialId(app: Page): Promise<string> {
   const project = await ensureProject(app)
@@ -64,7 +58,7 @@ async function createLLMIntegration(app: Page, name: string): Promise<LLMIntegra
       configuration: {
         integration_type: 'llm_provider',
         provider_hint: 'custom',
-        base_url: isRealBackend ? ssrfSafeIntegrationHost : `https://${name}.example.com/v1`,
+        base_url: `https://example.com/v1`,
       },
       management_credential_id: credentialId,
       scope: 'global',

--- a/frontend/packages/syntara-ui/e2e/integration-wizard.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/integration-wizard.spec.ts
@@ -288,12 +288,6 @@ test.describe('HTTP URL Rejection and Allow HTTP Override', () => {
 })
 
 test('discovery failure shows error state, retry after correction succeeds', async ({ app }) => {
-  // Mock-only: after the injected discover failure is cleared, the "retry" step expects a real
-  // discover to succeed, which requires a reachable, live LLM endpoint. The real-backend E2E
-  // environment has none (and an unresolvable placeholder host is rejected by SSRF validation),
-  // so this UX flow cannot be exercised there.
-  test.skip(isRealBackend, 'Retry requires a live LLM endpoint not available on the real backend')
-
   const integrationName = buildUniqueName('e2e-wizard-retry')
   const credName = buildUniqueName('e2e-wizard-retry-cred')
   let credential: SeededCredential | null = null
@@ -314,7 +308,7 @@ test('discovery failure shows error state, retry after correction succeeds', asy
     await app.getByRole('button', { name: 'Red Hat AI' }).click()
     await app.getByRole('option', { name: 'Custom' }).click()
     await app.getByRole('textbox', { name: 'Name' }).fill(integrationName)
-    await app.getByRole('textbox', { name: 'API URL' }).fill('https://llm-test.example.com/v1')
+    await app.getByRole('textbox', { name: 'API URL' }).fill('https://example.com/v1')
     await app.getByRole('button', { name: 'Next' }).click()
 
     await expect(app.getByRole('heading', { level: 2, name: 'Connection credential' })).toBeVisible()

--- a/frontend/packages/syntara-ui/e2e/seeds/resources.ts
+++ b/frontend/packages/syntara-ui/e2e/seeds/resources.ts
@@ -10,22 +10,7 @@
  */
 import { type Page } from '@playwright/test'
 
-import { isSkipWebServerForPlaywrightTests } from '../playwrightWebServerEnv'
 import { apiRequest, createCredentialViaApi, deleteCredentialViaApi, ensureProject, getAuthToken } from '../utils/api'
-
-const isRealBackend = isSkipWebServerForPlaywrightTests()
-
-/**
- * Real-backend base_url for seeded integrations.
- *
- * The real backend rejects an integration base_url whose hostname is neither in
- * APP_INTEGRATION_URL_ALLOWED_HOSTS nor resolvable to a public address, so random
- * `<name>.example.com` subdomains return NXDOMAIN and fail closed with a 422 at creation time.
- * Defaults to the compose-allowlisted, in-network `mcp-server` service (the podman-compose
- * default, resolvable without external DNS); override via SYNTARA_E2E_INTEGRATION_HOST. Mock mode
- * does not validate, so callers keep a descriptive `<name>.example.com` placeholder there.
- */
-const SSRF_SAFE_INTEGRATION_HOST = process.env.SYNTARA_E2E_INTEGRATION_HOST ?? 'https://mcp-server'
 
 export type SeededIntegration = {
   id: string
@@ -50,7 +35,7 @@ export async function createIntegrationViaApi(
       integration_type: 'mcp_server',
       configuration: {
         integration_type: 'mcp_server',
-        base_url: isRealBackend ? SSRF_SAFE_INTEGRATION_HOST : `https://${options.name}.example.com/api`,
+        base_url: `https://example.com`,
       },
       scope: 'global',
     }


### PR DESCRIPTION
## Description

Updates the AO frontend e2e tests to accomodate SSRF validation on integration base_url. Fix the failing introduced in PR https://github.com/syntara-orchestration/syntara/pull/157 (APP_INTEGRATION_URL_ALLOWED_HOSTS): SSRF validation rejects in-cluster hostnames

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

Updates the frontend e2e tests to accomodate SSRF validation on integration base_url.

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors

## General Checklist

- [x] Code follows the project's coding conventions
- [x] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR