### PR TITLE
feat(AAP-85272): enforce OpenAPI version bump for breaking API changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,8 @@
 
 # Repository governance
 /.github/CODEOWNERS @syntara-orchestration/syntara-leads
+# Privileged in-place breaking-change override — who may apply the label.
+/.github/workflows/breaking-change-label-guard.yml @syntara-orchestration/syntara-leads @syntara-orchestration/syntara-ci-stability
 /.github/AI_AGENT_POLICY.md @syntara-orchestration/syntara-leads
 /GOVERNANCE.md @syntara-orchestration/syntara-leads
 /LICENSE @syntara-orchestration/syntara-leads

--- a/.github/workflows/breaking-change-label-guard.yml
+++ b/.github/workflows/breaking-change-label-guard.yml
@@ -22,9 +22,13 @@ on:
   #
   # opened/synchronize/reopened are included so this workflow reports a check
   # result on every PR (the job's `if:` skips them, and GitHub treats a skipped
-  # required check as satisfied). That lets it be made a **required** status
-  # check, closing the TOCTOU window where the OpenAPI gate could pass on a
-  # label this guard is concurrently removing.
+  # required check as satisfied). This lets it be made a **required** status
+  # check. That required-check configuration is what closes the TOCTOU window
+  # where the OpenAPI gate could pass on a label this guard is concurrently
+  # removing. It is a manual branch-protection setting on `devel` (see the
+  # repo-admin action items on the PR) and cannot be verified from this workflow
+  # file; until it is in place, the guard still removes an unauthorized label,
+  # but asynchronously (best effort) rather than blocking the merge.
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 

--- a/.github/workflows/breaking-change-label-guard.yml
+++ b/.github/workflows/breaking-change-label-guard.yml
@@ -11,15 +11,22 @@
 #
 # Team membership requires an `read:org` scoped token. Provision the
 # `SYNTARA_LEADS_READ_TOKEN` secret (a fine-grained PAT or GitHub App token with
-# organization "Members: read"). Without it the guard fails closed: it cannot
-# confirm membership, so it removes the label and asks for a re-apply by a lead.
+# organization "Members: read"). If it is missing, the guard fails fast with a
+# clear configuration error (a preflight step) rather than silently falling back
+# to a token that cannot read team membership.
 name: Breaking Change Label Guard
 
 on:
   # pull_request_target so the token has write access to manage labels/comments,
   # including on fork PRs. No fork code is checked out or executed here.
+  #
+  # opened/synchronize/reopened are included so this workflow reports a check
+  # result on every PR (the job's `if:` skips them, and GitHub treats a skipped
+  # required check as satisfied). That lets it be made a **required** status
+  # check, closing the TOCTOU window where the OpenAPI gate could pass on a
+  # label this guard is concurrently removing.
   pull_request_target:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: breaking-change-label-guard-${{ github.event.pull_request.number }}
@@ -35,12 +42,22 @@ jobs:
     if: github.event.label.name == 'breaking-change-approved'
     runs-on: ubuntu-latest
     steps:
+      - name: Ensure org-read token is configured
+        env:
+          SYNTARA_LEADS_READ_TOKEN: ${{ secrets.SYNTARA_LEADS_READ_TOKEN }}
+        run: |
+          if [ -z "$SYNTARA_LEADS_READ_TOKEN" ]; then
+            echo "::error::SYNTARA_LEADS_READ_TOKEN secret is not configured. The Breaking Change Label Guard cannot verify syntara-leads membership without a read:org token. Provision the secret (a fine-grained PAT or GitHub App token with organization 'Members: read'), then re-apply the label." >&2
+            exit 1
+          fi
+
       - name: Verify actor is a member of syntara-leads
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
-          # Prefer a read:org token; fall back to GITHUB_TOKEN (which cannot read
-          # team membership and will therefore fail closed).
-          github-token: ${{ secrets.SYNTARA_LEADS_READ_TOKEN || secrets.GITHUB_TOKEN }}
+          # Requires a read:org token; the preflight step above fails the job if
+          # it is not configured, so there is no fallback to GITHUB_TOKEN (which
+          # cannot read team membership).
+          github-token: ${{ secrets.SYNTARA_LEADS_READ_TOKEN }}
           script: |
             const org = context.repo.owner;
             const repo = context.repo.repo;
@@ -89,7 +106,7 @@ jobs:
               `privileged \`${label}\` label has been removed.\n\n` +
               `Per the AO REST API Versioning and Deprecation Policy, this label sanctions an ` +
               `**in-place breaking change** only for a CVE / critical security vulnerability with ` +
-              `no non-breaking remediation, applied to all supported versions, after escalation to ` +
+              `no non-breaking remediation, after escalation to ` +
               `engineering and BU leadership (Senior Director or above). Only members of ` +
               `\`${org}/${team}\` may apply it.\n\n` +
               `If this override is warranted, ask a member of **${team}** to review and re-apply the label.`;

--- a/.github/workflows/breaking-change-label-guard.yml
+++ b/.github/workflows/breaking-change-label-guard.yml
@@ -1,0 +1,106 @@
+---
+# Restrict who may apply the privileged `breaking-change-approved` label.
+#
+# GitHub has no native per-label permission, so this guard enforces it: when the
+# label is added, it verifies the actor who added it is a member of the
+# `syntara-leads` team. If not, it fails the check, removes the label, and posts
+# a PR comment explaining why. This is the enforcement point for the AO REST API
+# Versioning and Deprecation Policy — the label sanctions an in-place breaking
+# change only for a CVE/critical security vulnerability with no non-breaking
+# remediation, after escalation to engineering and BU leadership.
+#
+# Team membership requires an `read:org` scoped token. Provision the
+# `SYNTARA_LEADS_READ_TOKEN` secret (a fine-grained PAT or GitHub App token with
+# organization "Members: read"). Without it the guard fails closed: it cannot
+# confirm membership, so it removes the label and asks for a re-apply by a lead.
+name: Breaking Change Label Guard
+
+on:
+  # pull_request_target so the token has write access to manage labels/comments,
+  # including on fork PRs. No fork code is checked out or executed here.
+  pull_request_target:
+    types: [labeled]
+
+concurrency:
+  group: breaking-change-label-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  verify-label-authority:
+    # Only act when the privileged label is the one that was added.
+    if: github.event.label.name == 'breaking-change-approved'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify actor is a member of syntara-leads
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        with:
+          # Prefer a read:org token; fall back to GITHUB_TOKEN (which cannot read
+          # team membership and will therefore fail closed).
+          github-token: ${{ secrets.SYNTARA_LEADS_READ_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const org = context.repo.owner;
+            const repo = context.repo.repo;
+            const team = 'syntara-leads';
+            const label = 'breaking-change-approved';
+            const prNumber = context.payload.pull_request.number;
+            const actor = context.payload.sender.login;
+
+            let isMember = false;
+            try {
+              const res = await github.rest.teams.getMembershipForUserInOrg({
+                org,
+                team_slug: team,
+                username: actor,
+              });
+              isMember = res.data.state === 'active';
+            } catch (err) {
+              // 404 => not a member (or the token cannot read org membership).
+              core.warning(
+                `Could not confirm '${actor}' is an active member of '${org}/${team}': ` +
+                `${err.status || ''} ${err.message}`
+              );
+              isMember = false;
+            }
+
+            if (isMember) {
+              core.info(`'${actor}' is an active member of '${org}/${team}'. Label authorized.`);
+              return;
+            }
+
+            // Unauthorized: remove the label, comment, and fail the check.
+            try {
+              await github.rest.issues.removeLabel({
+                owner: org,
+                repo,
+                issue_number: prNumber,
+                name: label,
+              });
+            } catch (err) {
+              core.warning(`Failed to remove label '${label}': ${err.status || ''} ${err.message}`);
+            }
+
+            const body =
+              `### 🚫 \`${label}\` label removed\n\n` +
+              `@${actor} is not an authorized member of the **${team}** team, so the ` +
+              `privileged \`${label}\` label has been removed.\n\n` +
+              `Per the AO REST API Versioning and Deprecation Policy, this label sanctions an ` +
+              `**in-place breaking change** only for a CVE / critical security vulnerability with ` +
+              `no non-breaking remediation, applied to all supported versions, after escalation to ` +
+              `engineering and BU leadership (Senior Director or above). Only members of ` +
+              `\`${org}/${team}\` may apply it.\n\n` +
+              `If this override is warranted, ask a member of **${team}** to review and re-apply the label.`;
+
+            await github.rest.issues.createComment({
+              owner: org,
+              repo,
+              issue_number: prNumber,
+              body,
+            });
+
+            core.setFailed(
+              `'${actor}' is not authorized to apply the '${label}' label; it has been removed.`
+            );

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -303,6 +303,7 @@ jobs:
         working-directory: backend
         env:
           OPENAPI_PR_BODY: ${{ github.event.pull_request.body }}
+          OPENAPI_PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
 
   verify-test-structure:
     name: (Backend) Verify Test Structure

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -302,7 +302,7 @@ jobs:
         run: make check-openapi-breaking-pre-commit
         working-directory: backend
         env:
-          OPENAPI_PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
+          OPENAPI_PR_LABELS: ${{ github.event_name == 'pull_request' && toJSON(github.event.pull_request.labels.*.name) || '' }}
 
   verify-test-structure:
     name: (Backend) Verify Test Structure

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -302,7 +302,6 @@ jobs:
         run: make check-openapi-breaking-pre-commit
         working-directory: backend
         env:
-          OPENAPI_PR_BODY: ${{ github.event.pull_request.body }}
           OPENAPI_PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
 
   verify-test-structure:

--- a/.github/workflows/openapi-breaking-changes.yml
+++ b/.github/workflows/openapi-breaking-changes.yml
@@ -61,8 +61,8 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
-            const labels = context.payload.pull_request.labels.map(l => l.name).join(',');
-            core.setOutput('labels', labels);
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            core.setOutput('labels', JSON.stringify(labels));
 
       - name: Set up Python
         if: steps.detect.outputs.changed == 'true'
@@ -84,8 +84,10 @@ jobs:
             --head HEAD \
             --output breaking-results.json \
             --fallback-spec-path backend/src/syntara/schemas/openapi.yaml \
-            --pr-labels "${{ steps.labels.outputs.labels }}"
+            --pr-labels "$OPENAPI_PR_LABELS"
         working-directory: backend
+        env:
+          OPENAPI_PR_LABELS: ${{ steps.labels.outputs.labels }}
 
       - name: Show breaking-change results on failure
         if: failure() && steps.detect.outputs.changed == 'true'
@@ -97,7 +99,7 @@ jobs:
         working-directory: backend
 
       - name: Check contract regeneration
-        if: always() && steps.detect.outputs.changed == 'true'
+        if: ${{ !cancelled() && steps.detect.outputs.changed == 'true' }}
         run: |
           PR_BODY=$(cat "$GITHUB_WORKSPACE/pr-body.txt")
           ./scripts/openapi/check-contract-regeneration.py \

--- a/.github/workflows/openapi-breaking-changes.yml
+++ b/.github/workflows/openapi-breaking-changes.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: ${{ !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || github.event.label.name == 'cve-breaking-change-approved' }}
+    if: ${{ !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || github.event.label.name == 'breaking-change-approved' }}
     permissions:
       contents: read
     steps:
@@ -79,13 +79,11 @@ jobs:
         if: steps.detect.outputs.changed == 'true'
         id: breaking
         run: |
-          PR_BODY=$(cat "$GITHUB_WORKSPACE/pr-body.txt")
           ./scripts/openapi/check-breaking-changes.py \
             --base origin/${{ github.base_ref }} \
             --head HEAD \
             --output breaking-results.json \
             --fallback-spec-path backend/src/syntara/schemas/openapi.yaml \
-            --pr-body "$PR_BODY" \
             --pr-labels "${{ steps.labels.outputs.labels }}"
         working-directory: backend
 

--- a/.github/workflows/openapi-breaking-changes.yml
+++ b/.github/workflows/openapi-breaking-changes.yml
@@ -87,6 +87,15 @@ jobs:
             --pr-labels "${{ steps.labels.outputs.labels }}"
         working-directory: backend
 
+      - name: Show breaking-change results on failure
+        if: failure() && steps.detect.outputs.changed == 'true'
+        run: |
+          if [ -f breaking-results.json ]; then
+            echo "OpenAPI breaking-change gate failed. Results (spec_path, base_version, head_version, version_bumped, breaking_changes):"
+            cat breaking-results.json
+          fi
+        working-directory: backend
+
       - name: Check contract regeneration
         if: always() && steps.detect.outputs.changed == 'true'
         run: |

--- a/.github/workflows/openapi-breaking-changes.yml
+++ b/.github/workflows/openapi-breaking-changes.yml
@@ -9,6 +9,7 @@ name: OpenAPI Breaking Changes
 on:
   pull_request:
     branches: [devel, early-access]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - 'backend/**'
       - 'frontend/packages/syntara-contracts/src/**'
@@ -21,6 +22,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: ${{ !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) || github.event.label.name == 'cve-breaking-change-approved' }}
     permissions:
       contents: read
     steps:
@@ -53,6 +55,15 @@ jobs:
             const fs = require('fs');
             fs.writeFileSync('pr-body.txt', context.payload.pull_request.body || '');
 
+      - name: Extract PR labels
+        if: steps.detect.outputs.changed == 'true'
+        id: labels
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name).join(',');
+            core.setOutput('labels', labels);
+
       - name: Set up Python
         if: steps.detect.outputs.changed == 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -67,7 +78,6 @@ jobs:
       - name: Check for breaking changes
         if: steps.detect.outputs.changed == 'true'
         id: breaking
-        continue-on-error: true
         run: |
           PR_BODY=$(cat "$GITHUB_WORKSPACE/pr-body.txt")
           ./scripts/openapi/check-breaking-changes.py \
@@ -75,11 +85,12 @@ jobs:
             --head HEAD \
             --output breaking-results.json \
             --fallback-spec-path backend/src/syntara/schemas/openapi.yaml \
-            --pr-body "$PR_BODY"
+            --pr-body "$PR_BODY" \
+            --pr-labels "${{ steps.labels.outputs.labels }}"
         working-directory: backend
 
       - name: Check contract regeneration
-        if: steps.detect.outputs.changed == 'true'
+        if: always() && steps.detect.outputs.changed == 'true'
         run: |
           PR_BODY=$(cat "$GITHUB_WORKSPACE/pr-body.txt")
           ./scripts/openapi/check-contract-regeneration.py \

--- a/backend/CONTRIBUTING.md
+++ b/backend/CONTRIBUTING.md
@@ -177,13 +177,12 @@ CI posts an informational warning if the spec changed but contracts were not reg
 
 The pre-commit hook (enforced in CI) compares your spec against `devel` to detect breaking changes (removed fields, type changes, deleted endpoints).
 
-**If breaking changes are detected**, you must acknowledge them in the PR description:
+**If breaking changes are detected**, they are blocked on the current major API version. Two resolution paths exist:
 
-- Add to PR description: `breaking-change-ack: <detailed justification>`
-- Minimum 20 characters explaining why necessary, migration path, and how the frontend is updated
-- Example: `breaking-change-ack: Removing deprecated created_by_id field in favor of created_by object. Regenerated contracts and updated UI references in this PR. Migration guide added to API docs.`
+1. **Route to a new major version** — bump `info.version` to the next major (e.g., 1.0.0 → 2.0.0) and add `breaking-change-ack: <detailed justification>` (≥ 20 characters) to the PR description. The new version must be served from a separate URL path.
+2. **CVE escape hatch** — for CVE fixes that cannot avoid a breaking change, request the `cve-breaking-change-approved` label from engineering leadership (Senior Director or above). This label is restricted in GitHub; a PR-body annotation is not enough.
 
-**This check blocks merge** until breaking changes are acknowledged. See [OpenAPI Breaking Changes](docs/openapi-breaking-changes.md) for details.
+A `breaking-change-ack` alone (without a major version bump) is **not sufficient**. Additive non-breaking changes that bump `info.version` must use a minor bump (not patch). See [OpenAPI Spec Management](docs/standards/openapi-spec-management.md) for the full policy.
 
 ### Submitting a Pull Request
 

--- a/backend/CONTRIBUTING.md
+++ b/backend/CONTRIBUTING.md
@@ -177,7 +177,7 @@ CI posts an informational warning if the spec changed but contracts were not reg
 
 The pre-commit hook (enforced in CI) compares your spec against `devel` to detect breaking changes (removed fields, type changes, deleted endpoints).
 
-**Every meaningful OpenAPI spec change must bump `info.version`.** Comparison is canonical, so serialization-only diffs (whitespace, key order, quotes) do not require a bump. The bump segment is enforced: use a **minor** bump for additive changes (new endpoint, field, or enum value) and a **patch** bump for spec-only edits (description, example, annotation). A missing bump or a wrong-segment bump is blocked.
+**Every meaningful OpenAPI spec change must update `info.version`.** Comparison is canonical, so serialization-only diffs (whitespace, key order, quotes) do not require a version change. The version increment is enforced: increment the **minor** version for additive changes (new endpoint, field, or enum value) and the **patch** version for spec-only edits (description, example, annotation). A missing version change or an incorrect version increment is blocked.
 
 **If breaking changes are detected**, they are blocked in place — full stop. A new major version is a new spec served from a separate URL path (e.g., `/api/v2/`), so it does not register as a breaking change to the current spec. A PR-body annotation is not enough.
 
@@ -187,14 +187,13 @@ See [OpenAPI Spec Management](docs/standards/openapi-spec-management.md) for gat
 
 This is the handbook for the AO REST API Versioning and Deprecation Policy as enforced in Syntara.
 
-1. **Do not break the current version in place.** Ship a non-breaking change, or introduce a new major version as a new spec at a new URL path (for example `/api/v2/`). Each spec is compared only against its own prior state.
-2. **Bump `info.version` on every meaningful spec change.** Canonical (semantic) comparison means serialization-only diffs do not require a bump. Use **minor** for additive changes (new endpoint, field, or enum value) and **patch** for spec-only edits (description, example, annotation).
+1. **Do not break the current version in place.** Ship a non-breaking change, or if strictly necessary or otherwise deemed appropriate, introduce a new major version as a new spec at a new URL path (for example `/api/v2/`). Each spec is compared only against its own prior state.
+2. **Update `info.version` on every meaningful spec change.** Canonical (semantic) comparison means serialization-only diffs do not require a version change. Increment the **minor** version for additive changes (new endpoint, field, or enum value) and the **patch** version for spec-only edits (description, example, annotation).
 3. **CVE / critical security escape hatch.** An in-place breaking change is allowed only when all of the following are true:
    - there is no non-breaking remediation
-   - the change is applied to all supported versions
    - engineering and BU leadership (Senior Director or above) have approved
    - a member of `syntara-leads` applies the `breaking-change-approved` label
-   - `info.version` is bumped by a **minor** segment (never major — a new major version is a new spec at a new path)
+   - `info.version` is incremented by a **minor** version (never major — a new major version is a new spec at a new path)
 4. **Label restriction.** GitHub has no native per-label permission. The Breaking Change Label Guard workflow (`.github/workflows/breaking-change-label-guard.yml`) verifies the actor who added the label is in `syntara-leads`. If not, it fails the check, removes the label, and comments on the PR. Provision `SYNTARA_LEADS_READ_TOKEN` (org Members: read); without it the guard fails closed.
 
 ### Submitting a Pull Request

--- a/backend/CONTRIBUTING.md
+++ b/backend/CONTRIBUTING.md
@@ -177,12 +177,11 @@ CI posts an informational warning if the spec changed but contracts were not reg
 
 The pre-commit hook (enforced in CI) compares your spec against `devel` to detect breaking changes (removed fields, type changes, deleted endpoints).
 
-**If breaking changes are detected**, they are blocked on the current major API version. Two resolution paths exist:
+**Every OpenAPI spec change must bump `info.version`** (major/minor/patch). The bump is how you signal your interpretation of the change to reviewers and how API consumers become aware of spec updates. A spec change with no version bump is blocked.
 
-1. **Route to a new major version** — bump `info.version` to the next major (e.g., 1.0.0 → 2.0.0) and add `breaking-change-ack: <detailed justification>` (≥ 20 characters) to the PR description. The new version must be served from a separate URL path.
-2. **CVE escape hatch** — for CVE fixes that cannot avoid a breaking change, request the `cve-breaking-change-approved` label from engineering leadership (Senior Director or above). This label is restricted in GitHub; a PR-body annotation is not enough.
+**If breaking changes are detected**, they are blocked in place — full stop. A new major version is a new spec served from a separate URL path (e.g., `/api/v2/`), so it does not register as a breaking change to the current spec. The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label, restricted to engineering leadership. A PR-body annotation is not enough.
 
-A `breaking-change-ack` alone (without a major version bump) is **not sufficient**. Additive non-breaking changes that bump `info.version` must use a minor bump (not patch). See [OpenAPI Spec Management](docs/standards/openapi-spec-management.md) for the full policy.
+See [OpenAPI Spec Management](docs/standards/openapi-spec-management.md) for the full policy.
 
 ### Submitting a Pull Request
 

--- a/backend/CONTRIBUTING.md
+++ b/backend/CONTRIBUTING.md
@@ -177,11 +177,25 @@ CI posts an informational warning if the spec changed but contracts were not reg
 
 The pre-commit hook (enforced in CI) compares your spec against `devel` to detect breaking changes (removed fields, type changes, deleted endpoints).
 
-**Every OpenAPI spec change must bump `info.version`** (major/minor/patch). The bump is how you signal your interpretation of the change to reviewers and how API consumers become aware of spec updates. A spec change with no version bump is blocked.
+**Every meaningful OpenAPI spec change must bump `info.version`.** Comparison is canonical, so serialization-only diffs (whitespace, key order, quotes) do not require a bump. The bump segment is enforced: use a **minor** bump for additive changes (new endpoint, field, or enum value) and a **patch** bump for spec-only edits (description, example, annotation). A missing bump or a wrong-segment bump is blocked.
 
-**If breaking changes are detected**, they are blocked in place — full stop. A new major version is a new spec served from a separate URL path (e.g., `/api/v2/`), so it does not register as a breaking change to the current spec. The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label, restricted to engineering leadership. A PR-body annotation is not enough.
+**If breaking changes are detected**, they are blocked in place — full stop. A new major version is a new spec served from a separate URL path (e.g., `/api/v2/`), so it does not register as a breaking change to the current spec. A PR-body annotation is not enough.
 
-See [OpenAPI Spec Management](docs/standards/openapi-spec-management.md) for the full policy.
+See [OpenAPI Spec Management](docs/standards/openapi-spec-management.md) for gate codes and repo configuration.
+
+#### Breaking-change override process
+
+This is the handbook for the AO REST API Versioning and Deprecation Policy as enforced in Syntara.
+
+1. **Do not break the current version in place.** Ship a non-breaking change, or introduce a new major version as a new spec at a new URL path (for example `/api/v2/`). Each spec is compared only against its own prior state.
+2. **Bump `info.version` on every meaningful spec change.** Canonical (semantic) comparison means serialization-only diffs do not require a bump. Use **minor** for additive changes (new endpoint, field, or enum value) and **patch** for spec-only edits (description, example, annotation).
+3. **CVE / critical security escape hatch.** An in-place breaking change is allowed only when all of the following are true:
+   - there is no non-breaking remediation
+   - the change is applied to all supported versions
+   - engineering and BU leadership (Senior Director or above) have approved
+   - a member of `syntara-leads` applies the `breaking-change-approved` label
+   - `info.version` is bumped by a **minor** segment (never major — a new major version is a new spec at a new path)
+4. **Label restriction.** GitHub has no native per-label permission. The Breaking Change Label Guard workflow (`.github/workflows/breaking-change-label-guard.yml`) verifies the actor who added the label is in `syntara-leads`. If not, it fails the check, removes the label, and comments on the PR. Provision `SYNTARA_LEADS_READ_TOKEN` (org Members: read); without it the guard fails closed.
 
 ### Submitting a Pull Request
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -801,27 +801,38 @@ check-openapi-breaking: ## Check OpenAPI spec for breaking changes against devel
 		./scripts/openapi/install-oasdiff.sh; \
 	fi
 	@PR_LABELS_TEXT="$${PR_LABELS:-$${OPENAPI_PR_LABELS:-}}"; \
-	CMD="./scripts/openapi/check-breaking-changes.py \
-		--base $(OPENAPI_BASE_REF) \
-		--head HEAD \
-		--format text \
-		--fallback-spec-path backend/src/syntara/schemas/openapi.yaml"; \
 	if [ -n "$$PR_LABELS_TEXT" ]; then \
-		CMD="$$CMD --pr-labels \"$$PR_LABELS_TEXT\""; \
-	fi; \
-	eval $$CMD
+		./scripts/openapi/check-breaking-changes.py \
+			--base $(OPENAPI_BASE_REF) \
+			--head HEAD \
+			--format text \
+			--fallback-spec-path backend/src/syntara/schemas/openapi.yaml \
+			--pr-labels "$$PR_LABELS_TEXT"; \
+	else \
+		./scripts/openapi/check-breaking-changes.py \
+			--base $(OPENAPI_BASE_REF) \
+			--head HEAD \
+			--format text \
+			--fallback-spec-path backend/src/syntara/schemas/openapi.yaml; \
+	fi
 	@echo "Checking public OpenAPI spec for breaking changes..."
 	@PR_LABELS_TEXT="$${PR_LABELS:-$${OPENAPI_PR_LABELS:-}}"; \
-	CMD="./scripts/openapi/check-breaking-changes.py \
-		--base $(OPENAPI_BASE_REF) \
-		--head HEAD \
-		--format text \
-		--spec-path backend/src/syntara/schemas/openapi-public.yaml \
-		--fallback-spec-path backend/src/syntara/schemas/openapi-public.yaml"; \
 	if [ -n "$$PR_LABELS_TEXT" ]; then \
-		CMD="$$CMD --pr-labels \"$$PR_LABELS_TEXT\""; \
-	fi; \
-	eval $$CMD
+		./scripts/openapi/check-breaking-changes.py \
+			--base $(OPENAPI_BASE_REF) \
+			--head HEAD \
+			--format text \
+			--spec-path backend/src/syntara/schemas/openapi-public.yaml \
+			--fallback-spec-path backend/src/syntara/schemas/openapi-public.yaml \
+			--pr-labels "$$PR_LABELS_TEXT"; \
+	else \
+		./scripts/openapi/check-breaking-changes.py \
+			--base $(OPENAPI_BASE_REF) \
+			--head HEAD \
+			--format text \
+			--spec-path backend/src/syntara/schemas/openapi-public.yaml \
+			--fallback-spec-path backend/src/syntara/schemas/openapi-public.yaml; \
+	fi
 	@echo "OpenAPI breaking changes check complete"
 
 .PHONY: check-openapi-breaking-pre-commit

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -800,16 +800,12 @@ check-openapi-breaking: ## Check OpenAPI spec for breaking changes against devel
 		echo "Installing oasdiff..."; \
 		./scripts/openapi/install-oasdiff.sh; \
 	fi
-	@PR_BODY_TEXT="$${PR_BODY:-$${OPENAPI_PR_BODY:-}}"; \
-	PR_LABELS_TEXT="$${PR_LABELS:-$${OPENAPI_PR_LABELS:-}}"; \
+	@PR_LABELS_TEXT="$${PR_LABELS:-$${OPENAPI_PR_LABELS:-}}"; \
 	CMD="./scripts/openapi/check-breaking-changes.py \
 		--base $(OPENAPI_BASE_REF) \
 		--head HEAD \
 		--format text \
 		--fallback-spec-path backend/src/syntara/schemas/openapi.yaml"; \
-	if [ -n "$$PR_BODY_TEXT" ]; then \
-		CMD="$$CMD --pr-body \"$$PR_BODY_TEXT\""; \
-	fi; \
 	if [ -n "$$PR_LABELS_TEXT" ]; then \
 		CMD="$$CMD --pr-labels \"$$PR_LABELS_TEXT\""; \
 	fi; \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -811,17 +811,13 @@ check-openapi-breaking: ## Check OpenAPI spec for breaking changes against devel
 	fi; \
 	eval $$CMD
 	@echo "Checking public OpenAPI spec for breaking changes..."
-	@PR_BODY_TEXT="$${PR_BODY:-$${OPENAPI_PR_BODY:-}}"; \
-	PR_LABELS_TEXT="$${PR_LABELS:-$${OPENAPI_PR_LABELS:-}}"; \
+	@PR_LABELS_TEXT="$${PR_LABELS:-$${OPENAPI_PR_LABELS:-}}"; \
 	CMD="./scripts/openapi/check-breaking-changes.py \
 		--base $(OPENAPI_BASE_REF) \
 		--head HEAD \
 		--format text \
 		--spec-path backend/src/syntara/schemas/openapi-public.yaml \
 		--fallback-spec-path backend/src/syntara/schemas/openapi-public.yaml"; \
-	if [ -n "$$PR_BODY_TEXT" ]; then \
-		CMD="$$CMD --pr-body \"$$PR_BODY_TEXT\""; \
-	fi; \
 	if [ -n "$$PR_LABELS_TEXT" ]; then \
 		CMD="$$CMD --pr-labels \"$$PR_LABELS_TEXT\""; \
 	fi; \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -801,38 +801,35 @@ check-openapi-breaking: ## Check OpenAPI spec for breaking changes against devel
 		./scripts/openapi/install-oasdiff.sh; \
 	fi
 	@PR_BODY_TEXT="$${PR_BODY:-$${OPENAPI_PR_BODY:-}}"; \
+	PR_LABELS_TEXT="$${PR_LABELS:-$${OPENAPI_PR_LABELS:-}}"; \
+	CMD="./scripts/openapi/check-breaking-changes.py \
+		--base $(OPENAPI_BASE_REF) \
+		--head HEAD \
+		--format text \
+		--fallback-spec-path backend/src/syntara/schemas/openapi.yaml"; \
 	if [ -n "$$PR_BODY_TEXT" ]; then \
-		./scripts/openapi/check-breaking-changes.py \
-			--base $(OPENAPI_BASE_REF) \
-			--head HEAD \
-			--format text \
-			--fallback-spec-path backend/src/syntara/schemas/openapi.yaml \
-			--pr-body "$$PR_BODY_TEXT"; \
-	else \
-		./scripts/openapi/check-breaking-changes.py \
-			--base $(OPENAPI_BASE_REF) \
-			--head HEAD \
-			--format text \
-			--fallback-spec-path backend/src/syntara/schemas/openapi.yaml; \
-	fi
+		CMD="$$CMD --pr-body \"$$PR_BODY_TEXT\""; \
+	fi; \
+	if [ -n "$$PR_LABELS_TEXT" ]; then \
+		CMD="$$CMD --pr-labels \"$$PR_LABELS_TEXT\""; \
+	fi; \
+	eval $$CMD
 	@echo "Checking public OpenAPI spec for breaking changes..."
 	@PR_BODY_TEXT="$${PR_BODY:-$${OPENAPI_PR_BODY:-}}"; \
+	PR_LABELS_TEXT="$${PR_LABELS:-$${OPENAPI_PR_LABELS:-}}"; \
+	CMD="./scripts/openapi/check-breaking-changes.py \
+		--base $(OPENAPI_BASE_REF) \
+		--head HEAD \
+		--format text \
+		--spec-path backend/src/syntara/schemas/openapi-public.yaml \
+		--fallback-spec-path backend/src/syntara/schemas/openapi-public.yaml"; \
 	if [ -n "$$PR_BODY_TEXT" ]; then \
-		./scripts/openapi/check-breaking-changes.py \
-			--base $(OPENAPI_BASE_REF) \
-			--head HEAD \
-			--format text \
-			--spec-path backend/src/syntara/schemas/openapi-public.yaml \
-			--fallback-spec-path backend/src/syntara/schemas/openapi-public.yaml \
-			--pr-body "$$PR_BODY_TEXT"; \
-	else \
-		./scripts/openapi/check-breaking-changes.py \
-			--base $(OPENAPI_BASE_REF) \
-			--head HEAD \
-			--format text \
-			--spec-path backend/src/syntara/schemas/openapi-public.yaml \
-			--fallback-spec-path backend/src/syntara/schemas/openapi-public.yaml; \
-	fi
+		CMD="$$CMD --pr-body \"$$PR_BODY_TEXT\""; \
+	fi; \
+	if [ -n "$$PR_LABELS_TEXT" ]; then \
+		CMD="$$CMD --pr-labels \"$$PR_LABELS_TEXT\""; \
+	fi; \
+	eval $$CMD
 	@echo "OpenAPI breaking changes check complete"
 
 .PHONY: check-openapi-breaking-pre-commit
@@ -843,7 +840,7 @@ check-openapi-breaking-pre-commit: ## Pre-commit: breaking changes when openapi.
 	elif git rev-parse --verify origin/$(OPENAPI_BASE_REF) >/dev/null 2>&1; then \
 		BASE_REF="origin/$(OPENAPI_BASE_REF)"; \
 	fi; \
-	if [ -n "$$BASE_REF" ] && git diff --quiet "$$BASE_REF" -- $(OPENAPI_SPEC) 2>/dev/null; then \
+	if [ -n "$$BASE_REF" ] && git diff --quiet "$$BASE_REF" -- $(OPENAPI_SPEC) $(OPENAPI_PUBLIC_SPEC) 2>/dev/null; then \
 		echo "OpenAPI spec unchanged vs $$BASE_REF, skipping breaking changes check"; \
 		exit 0; \
 	fi; \

--- a/backend/docs/standards/openapi-spec-management.md
+++ b/backend/docs/standards/openapi-spec-management.md
@@ -67,23 +67,23 @@ These hooks run automatically on commit (and in CI via the `pre-commit` job):
 | `backend-api-spec-drift` | Runs when backend `.py` files change; invokes `make api-spec-drift` to compare the committed spec to the live FastAPI schema; **blocking** |
 | `backend-check-openapi-breaking` | Runs when `openapi.yaml` changes; compares against `devel` and blocks on breaking changes |
 
-### Mandatory version bump
+### OpenAPI info.version updates
 
-**Every meaningful OpenAPI spec change must bump `info.version`.** The bump is how the engineer signals their interpretation of the change to reviewers and how API consumers become aware of spec updates. A meaningful spec change with no `info.version` bump is **blocked** (`gate_code: version_bump_required`).
+**Every meaningful OpenAPI spec change must update `info.version`.** The version change communicates the nature of the API change to API consumers as well as PR reviewers. A meaningful spec change that leaves `info.version` unchanged is **blocked** (`gate_code: version_bump_required`).
 
-Comparison is **canonical** (semantic): the two specs are parsed and compared as data structures. Serialization-only diffs — whitespace, indentation, line endings, key order, quote style — are **not** a meaningful change and do **not** require a bump.
+Comparison is **canonical** (semantic): the two specs are parsed and compared as data structures. Serialization-only diffs — whitespace, indentation, line endings, key order, quote style — are **not** considered meaningful changes and do **not** require a version update.
 
-### Correct bump segment (enforced)
+### Required version increment check (enforced)
 
-CI validates that the bump segment matches the change type, not just that `info.version` changed. A bump of the wrong segment is **blocked** (`gate_code: wrong_bump_segment`) with an error naming the expected segment.
+CI validates that the `info.version` increment is appropriate for the type of specification change. A change using the wrong version increment is **blocked** (`gate_code: incorrect_version_increment`) with an error naming the expected increment.
 
-| Change type | Detected via | Required segment |
+| Change type | Detected via | Required version change |
 |-------------|--------------|------------------|
-| Additive — new endpoint, field, or enum value | oasdiff reports a structural change entry | **minor** |
-| Spec-only — description, example, or annotation edit | canonical diff with no oasdiff structural entry | **patch** |
-| Approved in-place breaking change | oasdiff reports a breaking change + `breaking-change-approved` label | **minor** (never major — a new major version is a new spec at a new URL path) |
+| Additive — new endpoint, field, or enum value | oasdiff reports a structural change entry | Increment the **minor** version |
+| Spec-only — description, example, or annotation edit | canonical diff with no oasdiff structural entry | Increment the **patch** version |
+| Approved in-place breaking change | oasdiff reports a breaking change + `breaking-change-approved` label | Increment the **minor** version (never major — a new major version is a new spec at a new URL path) |
 
-Note: oasdiff does not report pure description/summary/example edits, so those are detected only by the canonical comparison and classified as `patch`.
+Note: oasdiff does not report pure description/summary/example edits, so those are detected only by the canonical comparison and classified as a **patch** change.
 
 ### Dynamic-map / `additionalProperties` content
 
@@ -93,21 +93,28 @@ Changes to dynamic-map fields (`additionalProperties` schemas such as `labels`, 
 
 The gate compares each spec only against its own prior state on the base ref. A new major version introduced as a **new spec at a new URL path** (e.g. `/api/v2/`) has no baseline on the base ref, so the check is skipped for it — it does not register as a breaking change to the current spec.
 
+### Detection scope and limitations
+
+Breaking-change detection is delegated entirely to `oasdiff breaking`; there is no secondary classification layer, so coverage equals oasdiff's own ruleset. Two limits follow from this and a green check must **not** be read as full policy compliance:
+
+- **Coverage equals oasdiff.** Categories in the AO REST API Versioning and Deprecation Policy that oasdiff does not model will not be flagged. Audit oasdiff's ruleset against the policy periodically.
+- **Semantic-only changes are undetectable by any schema differ.** A change where the shape is unchanged but the behavior differs for the same request/response (a "semantic change with no type change") cannot be detected by comparing schemas. Our policy classifies that class as breaking; catching it always requires human review. This gate is not a backstop for it.
+
 ### Breaking Change Policy
 
 Breaking changes are **always blocked in place** — full stop. Per the AO REST API Versioning and Deprecation Policy, breaking changes never apply in place: v1 and v2 are separate specs served from different URL paths.
 
-The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label. The label is sanctioned **only** for a CVE / critical security vulnerability with no non-breaking remediation, applied to all supported versions, after escalation to engineering and BU leadership (Senior Director or above). An approved breaking change must still bump `info.version` by a **minor** segment.
+The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label. The label is sanctioned **only** for a CVE / critical security vulnerability with no non-breaking remediation, after escalation to engineering and BU leadership (Senior Director or above). An approved breaking change must still increment `info.version` by a **minor** version.
 
 | Change type | Gate |
 |-------------|------|
 | No meaningful spec change (incl. serialization-only) | Allowed (`ok`) |
-| Additive change, minor bump | Allowed (`ok`) |
-| Spec-only change, patch bump | Allowed (`ok`) |
-| Meaningful change, no version bump | Blocked (`version_bump_required`) |
-| Meaningful change, wrong bump segment | Blocked (`wrong_bump_segment`) |
+| Additive change, minor increment | Allowed (`ok`) |
+| Spec-only change, patch increment | Allowed (`ok`) |
+| Meaningful change, no version change | Blocked (`version_bump_required`) |
+| Meaningful change, wrong version increment | Blocked (`incorrect_version_increment`) |
 | Breaking change, no approval label | Blocked (`breaking_blocked`) |
-| Breaking change, `breaking-change-approved` label + minor bump | Allowed (`breaking_approved`) |
+| Breaking change, `breaking-change-approved` label + minor increment | Allowed (`breaking_approved`) |
 
 ### Privileged approval label (enforcement)
 

--- a/backend/docs/standards/openapi-spec-management.md
+++ b/backend/docs/standards/openapi-spec-management.md
@@ -122,7 +122,7 @@ CI accepts the override when the PR has the `breaking-change-approved` label, bu
 
 1. Create the label named exactly `breaking-change-approved`.
 2. When the label is added, the guard verifies the actor who added it is an active member of the `syntara-leads` team. If not, it **fails the check, removes the label, and posts a PR comment** explaining why.
-3. Team-membership lookups require an `read:org`-scoped token. Provision the `SYNTARA_LEADS_READ_TOKEN` secret (a fine-grained PAT or GitHub App token with organization **Members: read**). Without it the guard **fails closed** — it cannot confirm membership, so it removes the label and asks a lead to re-apply.
+3. Team-membership lookups require a `read:org`-scoped token. Provision the `SYNTARA_LEADS_READ_TOKEN` secret (a fine-grained PAT or GitHub App token with organization **Members: read**). If it is missing, the guard **fails closed by failing the workflow run itself** (a configuration error); it does not remove the label or post a comment in that case, so making it a required status check (see #5) is what actually blocks the merge.
 4. After a lead applies the label to a failed PR, the OpenAPI Breaking Changes workflow re-runs on `labeled` / `unlabeled`. Re-run **(Backend) Check OpenAPI Breaking Changes** if that required check still shows the pre-label failure.
 5. Make **Breaking Change Label Guard** a required status check so an unauthorized label cannot merge during the window before the OpenAPI job re-runs.
 

--- a/backend/docs/standards/openapi-spec-management.md
+++ b/backend/docs/standards/openapi-spec-management.md
@@ -67,40 +67,35 @@ These hooks run automatically on commit (and in CI via the `pre-commit` job):
 | `backend-api-spec-drift` | Runs when backend `.py` files change; invokes `make api-spec-drift` to compare the committed spec to the live FastAPI schema; **blocking** |
 | `backend-check-openapi-breaking` | Runs when `openapi.yaml` changes; compares against `devel` and blocks on breaking changes |
 
+### Mandatory version bump
+
+**Every OpenAPI spec change must bump `info.version`** (major, minor, or patch). The bump is how the engineer signals their interpretation of the change to reviewers and how API consumers become aware of spec updates. A spec change with no `info.version` bump is **blocked** (`gate_code: version_bump_required`). The gate treats any difference in the spec file as a change (not only diffs that oasdiff reports), so description and metadata edits still require a bump.
+
+CI does not enforce a specific bump *type* for non-breaking changes — choosing minor vs. patch is the engineer's signal and the reviewer's judgment call. Use a **minor** bump for additive changes (new endpoints/fields) and a **patch** bump for fixes and metadata-only edits.
+
 ### Breaking Change Policy
 
-Breaking changes on the current major API version are **always blocked**. Per the AO REST API Versioning and Deprecation Policy, breaking changes never apply in place — v1 and v2 are separate specs served from different URL paths.
+Breaking changes are **always blocked in place** — full stop. Per the AO REST API Versioning and Deprecation Policy, breaking changes never apply in place: v1 and v2 are separate specs served from different URL paths. A genuinely new major version is a new spec at a new path, so it does not register as a breaking change to the current spec.
 
-Two override paths exist:
+The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label (a formal override restricted to engineering leadership). An approved breaking change must still bump `info.version`.
 
-1. **New major version** — bump `info.version` to the next major (e.g., 1.0.0 → 2.0.0) and add `breaking-change-ack: <justification>` (≥ 20 characters) to the PR description. The new major version must be served from a separate URL path.
-2. **CVE escape hatch** — for CVE fixes that cannot avoid a breaking change, request the `cve-breaking-change-approved` GitHub label from engineering leadership (Senior Director or above). This label is protected and restricted to authorized personnel.
+| Change type | Gate |
+|-------------|------|
+| No spec change | Allowed |
+| Non-breaking change, with version bump | Allowed |
+| Non-breaking change, no version bump | Blocked (`version_bump_required`) |
+| Breaking change, no approval label | Blocked (`breaking_blocked`) |
+| Breaking change, with `breaking-change-approved` label + version bump | Allowed (`breaking_approved`) |
 
-A `breaking-change-ack` annotation alone (without a major version bump) is **not sufficient** to bypass the breaking change gate.
+### Privileged approval label (repo configuration)
 
-### Non-breaking version bumps
+CI accepts the override when the PR has the label `breaking-change-approved`. That check is not a substitute for restricting *who can apply* the label. Repo admins must create this label and restrict it so only authorized personnel (engineering leadership) can add it:
 
-Non-breaking PRs always pass when `info.version` is unchanged. Voluntary **minor** and **patch** bumps are allowed. If a bump *is* present, it must match the change type:
-
-| Change type | Required bump if version is changed | Unchanged version |
-|-------------|-------------------------------------|-------------------|
-| Additive (new endpoints, properties, parameters, enum values) | **minor** (patch is blocked) | Allowed |
-| Other non-breaking (descriptions, examples, metadata) | **patch** or **minor** | Allowed |
-| Breaking | **major** + `breaking-change-ack`, or CVE label | Blocked |
-
-A **major** bump without a breaking change is blocked — major increments are reserved for a new API version.
-
-### Privileged CVE label (repo configuration)
-
-CI accepts the hatch when the PR has the label `cve-breaking-change-approved`. That check is not a substitute for restricting *who can apply* the label. Repo admins must create this label and restrict it so only engineering / BU leadership (Senior Director or above) can add it:
-
-1. Create the label named exactly `cve-breaking-change-approved`.
+1. Create the label named exactly `breaking-change-approved`.
 2. On GitHub Enterprise Cloud, configure it as a [restricted label](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) (or equivalent org role) so typical contributors cannot apply it.
 3. After the label is applied to a failed PR, the OpenAPI Breaking Changes workflow re-runs on `labeled` / `unlabeled`. Re-run **(Backend) Check OpenAPI Breaking Changes** if that required check still shows the pre-label failure.
 
-Python cannot enforce Senior Director approval by itself; the protected label is the enforcement point.
-
-For non-breaking changes that pass the bump rules, version information (`base_version`, `head_version`, `version_bump_type`) is included in the output.
+Python cannot enforce leadership approval by itself; the restricted label is the enforcement point.
 
 ## CI Checks
 

--- a/backend/docs/standards/openapi-spec-management.md
+++ b/backend/docs/standards/openapi-spec-management.md
@@ -69,33 +69,57 @@ These hooks run automatically on commit (and in CI via the `pre-commit` job):
 
 ### Mandatory version bump
 
-**Every OpenAPI spec change must bump `info.version`** (major, minor, or patch). The bump is how the engineer signals their interpretation of the change to reviewers and how API consumers become aware of spec updates. A spec change with no `info.version` bump is **blocked** (`gate_code: version_bump_required`). The gate treats any difference in the spec file as a change (not only diffs that oasdiff reports), so description and metadata edits still require a bump.
+**Every meaningful OpenAPI spec change must bump `info.version`.** The bump is how the engineer signals their interpretation of the change to reviewers and how API consumers become aware of spec updates. A meaningful spec change with no `info.version` bump is **blocked** (`gate_code: version_bump_required`).
 
-CI does not enforce a specific bump *type* for non-breaking changes — choosing minor vs. patch is the engineer's signal and the reviewer's judgment call. Use a **minor** bump for additive changes (new endpoints/fields) and a **patch** bump for fixes and metadata-only edits.
+Comparison is **canonical** (semantic): the two specs are parsed and compared as data structures. Serialization-only diffs — whitespace, indentation, line endings, key order, quote style — are **not** a meaningful change and do **not** require a bump.
+
+### Correct bump segment (enforced)
+
+CI validates that the bump segment matches the change type, not just that `info.version` changed. A bump of the wrong segment is **blocked** (`gate_code: wrong_bump_segment`) with an error naming the expected segment.
+
+| Change type | Detected via | Required segment |
+|-------------|--------------|------------------|
+| Additive — new endpoint, field, or enum value | oasdiff reports a structural change entry | **minor** |
+| Spec-only — description, example, or annotation edit | canonical diff with no oasdiff structural entry | **patch** |
+| Approved in-place breaking change | oasdiff reports a breaking change + `breaking-change-approved` label | **minor** (never major — a new major version is a new spec at a new URL path) |
+
+Note: oasdiff does not report pure description/summary/example edits, so those are detected only by the canonical comparison and classified as `patch`.
+
+### Dynamic-map / `additionalProperties` content
+
+Changes to dynamic-map fields (`additionalProperties` schemas such as `labels`, `context_data`, `input_data`, `output_data`, `result`) are **not** treated as breaking — oasdiff reports them as non-breaking. Such a change is still a spec change and requires a `patch` bump.
+
+### New major version at a new path
+
+The gate compares each spec only against its own prior state on the base ref. A new major version introduced as a **new spec at a new URL path** (e.g. `/api/v2/`) has no baseline on the base ref, so the check is skipped for it — it does not register as a breaking change to the current spec.
 
 ### Breaking Change Policy
 
-Breaking changes are **always blocked in place** — full stop. Per the AO REST API Versioning and Deprecation Policy, breaking changes never apply in place: v1 and v2 are separate specs served from different URL paths. A genuinely new major version is a new spec at a new path, so it does not register as a breaking change to the current spec.
+Breaking changes are **always blocked in place** — full stop. Per the AO REST API Versioning and Deprecation Policy, breaking changes never apply in place: v1 and v2 are separate specs served from different URL paths.
 
-The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label (a formal override restricted to engineering leadership). An approved breaking change must still bump `info.version`.
+The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label. The label is sanctioned **only** for a CVE / critical security vulnerability with no non-breaking remediation, applied to all supported versions, after escalation to engineering and BU leadership (Senior Director or above). An approved breaking change must still bump `info.version` by a **minor** segment.
 
 | Change type | Gate |
 |-------------|------|
-| No spec change | Allowed |
-| Non-breaking change, with version bump | Allowed |
-| Non-breaking change, no version bump | Blocked (`version_bump_required`) |
+| No meaningful spec change (incl. serialization-only) | Allowed (`ok`) |
+| Additive change, minor bump | Allowed (`ok`) |
+| Spec-only change, patch bump | Allowed (`ok`) |
+| Meaningful change, no version bump | Blocked (`version_bump_required`) |
+| Meaningful change, wrong bump segment | Blocked (`wrong_bump_segment`) |
 | Breaking change, no approval label | Blocked (`breaking_blocked`) |
-| Breaking change, with `breaking-change-approved` label + version bump | Allowed (`breaking_approved`) |
+| Breaking change, `breaking-change-approved` label + minor bump | Allowed (`breaking_approved`) |
 
-### Privileged approval label (repo configuration)
+### Privileged approval label (enforcement)
 
-CI accepts the override when the PR has the label `breaking-change-approved`. That check is not a substitute for restricting *who can apply* the label. Repo admins must create this label and restrict it so only authorized personnel (engineering leadership) can add it:
+CI accepts the override when the PR has the `breaking-change-approved` label, but who may **apply** it is enforced by the **Breaking Change Label Guard** workflow (`.github/workflows/breaking-change-label-guard.yml`):
 
 1. Create the label named exactly `breaking-change-approved`.
-2. On GitHub Enterprise Cloud, configure it as a [restricted label](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) (or equivalent org role) so typical contributors cannot apply it.
-3. After the label is applied to a failed PR, the OpenAPI Breaking Changes workflow re-runs on `labeled` / `unlabeled`. Re-run **(Backend) Check OpenAPI Breaking Changes** if that required check still shows the pre-label failure.
+2. When the label is added, the guard verifies the actor who added it is an active member of the `syntara-leads` team. If not, it **fails the check, removes the label, and posts a PR comment** explaining why.
+3. Team-membership lookups require an `read:org`-scoped token. Provision the `SYNTARA_LEADS_READ_TOKEN` secret (a fine-grained PAT or GitHub App token with organization **Members: read**). Without it the guard **fails closed** — it cannot confirm membership, so it removes the label and asks a lead to re-apply.
+4. After a lead applies the label to a failed PR, the OpenAPI Breaking Changes workflow re-runs on `labeled` / `unlabeled`. Re-run **(Backend) Check OpenAPI Breaking Changes** if that required check still shows the pre-label failure.
+5. Make **Breaking Change Label Guard** a required status check so an unauthorized label cannot merge during the window before the OpenAPI job re-runs.
 
-Python cannot enforce leadership approval by itself; the restricted label is the enforcement point.
+GitHub has no native per-label permission; the label guard is the enforcement point. The contributor handbook for this process is in [CONTRIBUTING.md](../../CONTRIBUTING.md#breaking-change-override-process).
 
 ## CI Checks
 

--- a/backend/docs/standards/openapi-spec-management.md
+++ b/backend/docs/standards/openapi-spec-management.md
@@ -65,9 +65,42 @@ These hooks run automatically on commit (and in CI via the `pre-commit` job):
 |------|-----------|
 | `backend-api-spec-bundle` | Runs when backend YAML/Python changes; regenerates the bundled spec before commit |
 | `backend-api-spec-drift` | Runs when backend `.py` files change; invokes `make api-spec-drift` to compare the committed spec to the live FastAPI schema; **blocking** |
-| `backend-check-openapi-breaking` | Runs when `openapi.yaml` changes; compares against `devel` and blocks on unacknowledged breaking changes |
+| `backend-check-openapi-breaking` | Runs when `openapi.yaml` changes; compares against `devel` and blocks on breaking changes |
 
-In CI, `OPENAPI_PR_BODY` is set from the pull request description so `breaking-change-ack:` acknowledgments are honored. Locally, add the acknowledgment to your PR description before CI runs.
+### Breaking Change Policy
+
+Breaking changes on the current major API version are **always blocked**. Per the AO REST API Versioning and Deprecation Policy, breaking changes never apply in place — v1 and v2 are separate specs served from different URL paths.
+
+Two override paths exist:
+
+1. **New major version** — bump `info.version` to the next major (e.g., 1.0.0 → 2.0.0) and add `breaking-change-ack: <justification>` (≥ 20 characters) to the PR description. The new major version must be served from a separate URL path.
+2. **CVE escape hatch** — for CVE fixes that cannot avoid a breaking change, request the `cve-breaking-change-approved` GitHub label from engineering leadership (Senior Director or above). This label is protected and restricted to authorized personnel.
+
+A `breaking-change-ack` annotation alone (without a major version bump) is **not sufficient** to bypass the breaking change gate.
+
+### Non-breaking version bumps
+
+Non-breaking PRs always pass when `info.version` is unchanged. Voluntary **minor** and **patch** bumps are allowed. If a bump *is* present, it must match the change type:
+
+| Change type | Required bump if version is changed | Unchanged version |
+|-------------|-------------------------------------|-------------------|
+| Additive (new endpoints, properties, parameters, enum values) | **minor** (patch is blocked) | Allowed |
+| Other non-breaking (descriptions, examples, metadata) | **patch** or **minor** | Allowed |
+| Breaking | **major** + `breaking-change-ack`, or CVE label | Blocked |
+
+A **major** bump without a breaking change is blocked — major increments are reserved for a new API version.
+
+### Privileged CVE label (repo configuration)
+
+CI accepts the hatch when the PR has the label `cve-breaking-change-approved`. That check is not a substitute for restricting *who can apply* the label. Repo admins must create this label and restrict it so only engineering / BU leadership (Senior Director or above) can add it:
+
+1. Create the label named exactly `cve-breaking-change-approved`.
+2. On GitHub Enterprise Cloud, configure it as a [restricted label](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) (or equivalent org role) so typical contributors cannot apply it.
+3. After the label is applied to a failed PR, the OpenAPI Breaking Changes workflow re-runs on `labeled` / `unlabeled`. Re-run **(Backend) Check OpenAPI Breaking Changes** if that required check still shows the pre-label failure.
+
+Python cannot enforce Senior Director approval by itself; the protected label is the enforcement point.
+
+For non-breaking changes that pass the bump rules, version information (`base_version`, `head_version`, `version_bump_type`) is included in the output.
 
 ## CI Checks
 

--- a/backend/docs/standards/ui-api-parity.md
+++ b/backend/docs/standards/ui-api-parity.md
@@ -106,9 +106,9 @@ Use when a spec change has no impact on generated types — for example, updatin
 
 Breaking changes are **always blocked in place** — full stop. A new major version is a new spec served from a separate URL path (e.g., `/api/v2/`), so it does not register as a breaking change to the current spec.
 
-The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label, requested from engineering leadership. The label must be restricted in GitHub so typical contributors cannot apply it. An approved breaking change must still bump `info.version`.
+The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label, sanctioned only for a CVE / critical vulnerability with no non-breaking remediation, after escalation to engineering leadership. Who may apply it is enforced by the **Breaking Change Label Guard** workflow (restricted to the `syntara-leads` team). An approved breaking change must still bump `info.version` by a **minor** segment.
 
-**Every spec change must bump `info.version`** (major/minor/patch). A spec change with no bump is blocked. CI does not enforce a specific bump type — it is the engineer's signal to reviewers and consumers.
+**Every meaningful spec change must bump `info.version`.** Comparison is canonical, so serialization-only diffs (whitespace, key order, quotes) do not require a bump. The bump segment is enforced: **minor** for additive changes (new endpoint, field, or enum value), **patch** for spec-only edits (description, example, annotation). A missing or wrong-segment bump is blocked.
 
 **Severity:** Blocking via the pre-commit hook `backend-check-openapi-breaking` and the `openapi-breaking-changes` CI job.
 

--- a/backend/docs/standards/ui-api-parity.md
+++ b/backend/docs/standards/ui-api-parity.md
@@ -102,13 +102,9 @@ Use when a spec change has no impact on generated types — for example, updatin
 
 **Severity:** Informational (does not block merge). CI still posts a notice acknowledging the exception.
 
-### Breaking changes
+### Breaking changes and versioning
 
-Breaking changes are **always blocked in place** — full stop. A new major version is a new spec served from a separate URL path (e.g., `/api/v2/`), so it does not register as a breaking change to the current spec.
-
-The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label, sanctioned only for a CVE / critical vulnerability with no non-breaking remediation, after escalation to engineering leadership. Who may apply it is enforced by the **Breaking Change Label Guard** workflow (restricted to the `syntara-leads` team). An approved breaking change must still bump `info.version` by a **minor** segment.
-
-**Every meaningful spec change must bump `info.version`.** Comparison is canonical, so serialization-only diffs (whitespace, key order, quotes) do not require a bump. The bump segment is enforced: **minor** for additive changes (new endpoint, field, or enum value), **patch** for spec-only edits (description, example, annotation). A missing or wrong-segment bump is blocked.
+Breaking changes and the `info.version` increment gate are governed by [OpenAPI Spec Management](openapi-spec-management.md#breaking-change-policy) — that is the single source of truth for the gate codes, the version-increment rules, and the `breaking-change-approved` override. In short: breaking changes are blocked in place, and every meaningful spec change must increment `info.version` by the correct segment.
 
 **Severity:** Blocking via the pre-commit hook `backend-check-openapi-breaking` and the `openapi-breaking-changes` CI job.
 
@@ -144,7 +140,7 @@ The scheduled workflow auto-closes drift issues when the drift is resolved.
 | Use typed API clients only | ESLint `syntara/no-raw-http-calls` | `eslint-disable-next-line` with justification |
 | Regenerate contracts when spec changes | CI warning + weekly drift check | `no-contract-regen: <justification>` in PR description |
 | Breaking changes blocked in place | Pre-commit + `openapi-breaking-changes` CI job | `breaking-change-approved` label (privileged), or route to a new major version at a new path |
-| Every spec change bumps `info.version` | Pre-commit + `openapi-breaking-changes` CI job | N/A — a bump is always required |
+| Every spec change updates `info.version` | Pre-commit + `openapi-breaking-changes` CI job | N/A — a version update is always required |
 | WebSocket is read-only streaming | Convention (see [WebSocket Standards](websocket.md)) | N/A — REST is the complete CRUD interface |
 | Backend + frontend changes in one PR | CI warning if contracts stale | `no-contract-regen: <justification>` for spec-only changes |
 

--- a/backend/docs/standards/ui-api-parity.md
+++ b/backend/docs/standards/ui-api-parity.md
@@ -104,23 +104,13 @@ Use when a spec change has no impact on generated types — for example, updatin
 
 ### Breaking changes
 
-Breaking changes on the current major API version are **always blocked**. Two override paths exist:
+Breaking changes are **always blocked in place** — full stop. A new major version is a new spec served from a separate URL path (e.g., `/api/v2/`), so it does not register as a breaking change to the current spec.
 
-1. **New major version** — bump `info.version` to the next major (e.g., 1.0.0 → 2.0.0) and add to the PR description:
-   ```
-   breaking-change-ack: <justification>
-   ```
-   Minimum 20 characters. The new major version must be served from a separate URL path.
+The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label, requested from engineering leadership. The label must be restricted in GitHub so typical contributors cannot apply it. An approved breaking change must still bump `info.version`.
 
-2. **CVE escape hatch** — request the `cve-breaking-change-approved` protected GitHub label from engineering leadership (Senior Director or above). The label must be restricted in GitHub so typical contributors cannot apply it.
-
-A `breaking-change-ack` alone (without a major version bump) is **not sufficient** to bypass the gate.
-
-Non-breaking PRs pass with no version bump. If `info.version` is bumped, additive changes require a minor bump (not patch); a major bump without breaking changes is blocked.
+**Every spec change must bump `info.version`** (major/minor/patch). A spec change with no bump is blocked. CI does not enforce a specific bump type — it is the engineer's signal to reviewers and consumers.
 
 **Severity:** Blocking via the pre-commit hook `backend-check-openapi-breaking` and the `openapi-breaking-changes` CI job.
-
-Both markers are case-insensitive and checked by scripts in `backend/scripts/openapi/`.
 
 ## WebSocket Scope
 
@@ -153,7 +143,8 @@ The scheduled workflow auto-closes drift issues when the drift is resolved.
 |------|-------------|-----------|
 | Use typed API clients only | ESLint `syntara/no-raw-http-calls` | `eslint-disable-next-line` with justification |
 | Regenerate contracts when spec changes | CI warning + weekly drift check | `no-contract-regen: <justification>` in PR description |
-| Breaking changes blocked on current major | Pre-commit + `openapi-breaking-changes` CI job | Major version bump + ack, or `cve-breaking-change-approved` label |
+| Breaking changes blocked in place | Pre-commit + `openapi-breaking-changes` CI job | `breaking-change-approved` label (privileged), or route to a new major version at a new path |
+| Every spec change bumps `info.version` | Pre-commit + `openapi-breaking-changes` CI job | N/A — a bump is always required |
 | WebSocket is read-only streaming | Convention (see [WebSocket Standards](websocket.md)) | N/A — REST is the complete CRUD interface |
 | Backend + frontend changes in one PR | CI warning if contracts stale | `no-contract-regen: <justification>` for spec-only changes |
 

--- a/backend/docs/standards/ui-api-parity.md
+++ b/backend/docs/standards/ui-api-parity.md
@@ -80,9 +80,9 @@ In the monorepo, backend spec changes and frontend contract updates land in **on
 
 | Check | When | Severity |
 |-------|------|----------|
-| Pre-commit `backend-check-openapi-breaking` | `openapi.yaml` changed | **Blocking** — requires `breaking-change-ack:` in the PR description when oasdiff detects breaking changes |
+| Pre-commit `backend-check-openapi-breaking` | `openapi.yaml` changed | **Blocking** — breaking changes on the current major version are always blocked; see override paths below |
 | `check-contract-regeneration.py` | PR touches `backend/src/syntara/schemas/openapi.yaml` (via `ci-backend.yml`) | **Informational** — posts a PR comment if contracts were not regenerated; does not fail the job |
-| `openapi-breaking-changes` CI job | Same trigger | **Informational** — posts breaking-change analysis; the step uses `continue-on-error` |
+| `openapi-breaking-changes` CI job | Same trigger | **Blocking** — fails on unresolved breaking changes; posts breaking-change analysis as a PR comment |
 
 The contract regeneration job runs only when the PR changes `backend/**` (see `ci-backend.yml` path filters).
 
@@ -102,15 +102,23 @@ Use when a spec change has no impact on generated types — for example, updatin
 
 **Severity:** Informational (does not block merge). CI still posts a notice acknowledging the exception.
 
-### Acknowledging breaking changes
+### Breaking changes
 
-```
-breaking-change-ack: <justification>
-```
+Breaking changes on the current major API version are **always blocked**. Two override paths exist:
 
-Required when oasdiff detects breaking changes (removed endpoints, changed types, removed fields). Minimum 20 characters explaining why the change is necessary, the migration path, and how the frontend was updated.
+1. **New major version** — bump `info.version` to the next major (e.g., 1.0.0 → 2.0.0) and add to the PR description:
+   ```
+   breaking-change-ack: <justification>
+   ```
+   Minimum 20 characters. The new major version must be served from a separate URL path.
 
-**Severity:** Blocking via the pre-commit hook `backend-check-openapi-breaking` (enforced in CI). CI reads the PR description through `OPENAPI_PR_BODY`.
+2. **CVE escape hatch** — request the `cve-breaking-change-approved` protected GitHub label from engineering leadership (Senior Director or above). The label must be restricted in GitHub so typical contributors cannot apply it.
+
+A `breaking-change-ack` alone (without a major version bump) is **not sufficient** to bypass the gate.
+
+Non-breaking PRs pass with no version bump. If `info.version` is bumped, additive changes require a minor bump (not patch); a major bump without breaking changes is blocked.
+
+**Severity:** Blocking via the pre-commit hook `backend-check-openapi-breaking` and the `openapi-breaking-changes` CI job.
 
 Both markers are case-insensitive and checked by scripts in `backend/scripts/openapi/`.
 
@@ -145,7 +153,7 @@ The scheduled workflow auto-closes drift issues when the drift is resolved.
 |------|-------------|-----------|
 | Use typed API clients only | ESLint `syntara/no-raw-http-calls` | `eslint-disable-next-line` with justification |
 | Regenerate contracts when spec changes | CI warning + weekly drift check | `no-contract-regen: <justification>` in PR description |
-| Acknowledge breaking API changes | Pre-commit `backend-check-openapi-breaking` | `breaking-change-ack: <justification>` in PR description |
+| Breaking changes blocked on current major | Pre-commit + `openapi-breaking-changes` CI job | Major version bump + ack, or `cve-breaking-change-approved` label |
 | WebSocket is read-only streaming | Convention (see [WebSocket Standards](websocket.md)) | N/A — REST is the complete CRUD interface |
 | Backend + frontend changes in one PR | CI warning if contracts stale | `no-contract-regen: <justification>` for spec-only changes |
 

--- a/backend/scripts/openapi/README.md
+++ b/backend/scripts/openapi/README.md
@@ -24,11 +24,9 @@ Installs the `oasdiff` tool with checksum verification to prevent supply chain a
 #### `check-breaking-changes.py`
 Checks for breaking changes in OpenAPI spec using `oasdiff`. Automatically resolves the spec path relative to the git root, so it works from any subdirectory (e.g., `backend/` in the monorepo).
 
-Breaking changes on the current major version are always blocked. Two override paths exist:
-1. **Major version bump + ack** — bump `info.version` by a major increment and add `breaking-change-ack: <justification>` to the PR body
-2. **CVE escape hatch** — apply the `cve-breaking-change-approved` protected label (requires Senior Director+ approval)
-
-For non-breaking changes, a version bump is optional. If present, additive changes require a **minor** bump (patch is blocked); other non-breaking changes may use patch or minor. A major bump without a breaking change is blocked.
+The gate enforces two rules:
+1. **Every spec change must bump `info.version`** (major/minor/patch). A spec change with no bump is blocked. CI does not enforce a specific bump type — it is the engineer's signal to reviewers and consumers.
+2. **Breaking changes are blocked in place** — full stop. The only override is the privileged `breaking-change-approved` label (restricted to engineering leadership). A new major version is a new spec at a new path and does not register as a breaking change here. An approved breaking change must still bump `info.version`.
 
 ```bash
 # Compare current branch against devel
@@ -37,18 +35,17 @@ For non-breaking changes, a version bump is optional. If present, additive chang
 # Compare specific spec files
 ./check-breaking-changes.py --base-spec old.yaml --head-spec new.yaml
 
-# Include PR body and labels for override checks
+# Include PR labels for the breaking-change approval override
 ./check-breaking-changes.py --base devel --head HEAD \
-  --pr-body "breaking-change-ack: Routing to v2 for field rename" \
-  --pr-labels "cve-breaking-change-approved,bug"
+  --pr-labels "breaking-change-approved,bug"
 
 # Output as text instead of JSON
 ./check-breaking-changes.py --base devel --head HEAD --format text
 ```
 
 **Exit Codes:**
-- `0` - No breaking changes (or valid override: major bump + ack, or CVE label)
-- `1` - Breaking changes without a valid override, or incorrect `info.version` bump type
+- `0` - Allowed: no changes, non-breaking change with a version bump, or approved breaking change with a version bump
+- `1` - Blocked: breaking change without approval, or any spec change with no version bump
 - `2` - Error running oasdiff or processing specs
 
 **Output (JSON):**
@@ -57,17 +54,14 @@ For non-breaking changes, a version bump is optional. If present, additive chang
   "has_breaking_changes": bool,
   "breaking_changes": "oasdiff output...",
   "all_changes": "full changelog...",
-  "acknowledged": bool,
-  "justification": "justification text",
-  "ack_insufficient": bool,
+  "has_changes": bool,
   "version_bumped": bool,
   "base_version": "1.0.0",
   "head_version": "1.0.0",
   "version_bump_type": "major" | "minor" | "patch" | null,
-  "cve_approved": bool,
+  "breaking_approved": bool,
   "spec_path": "backend/src/syntara/schemas/openapi.yaml",
-  "change_kind": "none" | "additive" | "other",
-  "gate_code": "ok" | "cve_override" | "major_ack" | "breaking_blocked" | "ack_without_major" | "ack_insufficient" | "incorrect_bump"
+  "gate_code": "ok" | "breaking_approved" | "breaking_blocked" | "version_bump_required"
 }
 ```
 
@@ -203,33 +197,25 @@ make check-openapi-contracts
 ### 4. Test Full Workflow Locally
 
 ```bash
-# 1. Check for breaking changes (will block if breaking changes exist)
+# 1. Check for breaking changes (blocks on breaking changes or a missing version bump)
 ./scripts/openapi/check-breaking-changes.py \
   --base devel \
   --head HEAD \
   --output /tmp/breaking-results.json
 
-# 2. If breaking changes are intentional (new major version):
-PR_BODY="breaking-change-ack: Routing field rename to v2 API"
+# 2. If a breaking change is unavoidable (requires the privileged label in CI):
 ./scripts/openapi/check-breaking-changes.py \
   --base devel \
   --head HEAD \
-  --pr-body "$PR_BODY" \
+  --pr-labels "breaking-change-approved" \
   --output /tmp/breaking-results.json
 
-# 3. If breaking changes are a CVE fix (requires protected label in CI):
-./scripts/openapi/check-breaking-changes.py \
-  --base devel \
-  --head HEAD \
-  --pr-labels "cve-breaking-change-approved" \
-  --output /tmp/breaking-results.json
-
-# 4. Check contract regeneration
+# 3. Check contract regeneration
 ./scripts/openapi/check-contract-regeneration.py \
   --changed-files-from devel \
   --output /tmp/contract-regeneration-results.json
 
-# 5. View results
+# 4. View results
 cat /tmp/breaking-results.json | jq
 cat /tmp/contract-regeneration-results.json | jq
 ```
@@ -269,8 +255,7 @@ These scripts are used by the monorepo CI workflow (`.github/workflows/ci-backen
 
 The CI `pre-commit` job:
 1. Fetches `devel` for OpenAPI baseline comparison
-2. Passes `OPENAPI_PR_BODY` from the pull request for breaking-change acknowledgment
-3. Passes `OPENAPI_PR_LABELS` so the CVE escape hatch can succeed on the required backend check
+2. Passes `OPENAPI_PR_LABELS` so the `breaking-change-approved` override can succeed on the required backend check
 
 The `openapi-breaking-changes` job:
 1. Detects changes to `backend/src/syntara/schemas/openapi.yaml`

--- a/backend/scripts/openapi/README.md
+++ b/backend/scripts/openapi/README.md
@@ -24,9 +24,10 @@ Installs the `oasdiff` tool with checksum verification to prevent supply chain a
 #### `check-breaking-changes.py`
 Checks for breaking changes in OpenAPI spec using `oasdiff`. Automatically resolves the spec path relative to the git root, so it works from any subdirectory (e.g., `backend/` in the monorepo).
 
-The gate enforces two rules:
-1. **Every spec change must bump `info.version`** (major/minor/patch). A spec change with no bump is blocked. CI does not enforce a specific bump type — it is the engineer's signal to reviewers and consumers.
-2. **Breaking changes are blocked in place** — full stop. The only override is the privileged `breaking-change-approved` label (restricted to engineering leadership). A new major version is a new spec at a new path and does not register as a breaking change here. An approved breaking change must still bump `info.version`.
+The gate enforces these rules:
+1. **Every meaningful spec change must bump `info.version`.** Comparison is canonical (semantic), so serialization-only diffs (whitespace, key order, quote style) do not require a bump. A meaningful change with no bump is blocked (`version_bump_required`).
+2. **The bump segment must match the change type**: `minor` for additive changes (new endpoint, field, or enum value), `patch` for spec-only edits (description, example, annotation). A wrong-segment bump is blocked (`wrong_bump_segment`).
+3. **Breaking changes are blocked in place** — full stop (`breaking_blocked`). The only override is the privileged `breaking-change-approved` label (restricted to the `syntara-leads` team via the Breaking Change Label Guard workflow). A new major version is a new spec at a new path and does not register as a breaking change here. An approved breaking change must still bump `info.version` by a `minor` segment.
 
 ```bash
 # Compare current branch against devel
@@ -44,9 +45,11 @@ The gate enforces two rules:
 ```
 
 **Exit Codes:**
-- `0` - Allowed: no changes, non-breaking change with a version bump, or approved breaking change with a version bump
-- `1` - Blocked: breaking change without approval, or any spec change with no version bump
+- `0` - Allowed: no meaningful change, non-breaking change with the correct-segment bump, or approved breaking change with a minor bump
+- `1` - Blocked: breaking change without approval, a meaningful change with no version bump, or a wrong-segment bump
 - `2` - Error running oasdiff or processing specs
+
+When the gate blocks and `--format json` is used, a human-readable summary (spec path, versions, `version_bumped`, breaking changes) is also written to stderr so CI logs stay actionable.
 
 **Output (JSON):**
 ```json
@@ -59,9 +62,10 @@ The gate enforces two rules:
   "base_version": "1.0.0",
   "head_version": "1.0.0",
   "version_bump_type": "major" | "minor" | "patch" | null,
+  "expected_bump_type": "minor" | "patch" | null,
   "breaking_approved": bool,
   "spec_path": "backend/src/syntara/schemas/openapi.yaml",
-  "gate_code": "ok" | "breaking_approved" | "breaking_blocked" | "version_bump_required"
+  "gate_code": "ok" | "breaking_approved" | "breaking_blocked" | "version_bump_required" | "wrong_bump_segment"
 }
 ```
 
@@ -260,7 +264,10 @@ The CI `pre-commit` job:
 The `openapi-breaking-changes` job:
 1. Detects changes to `backend/src/syntara/schemas/openapi.yaml`
 2. Runs `check-breaking-changes.py` and posts results via `post-breaking-changes-comment.py`
-3. Runs `check-contract-regeneration.py` to verify contracts are regenerated and posts results via `post-contract-regeneration-comment.py`
+3. On failure, prints `breaking-results.json` (spec path, versions, `version_bumped`, breaking changes) to the job log
+4. Runs `check-contract-regeneration.py` to verify contracts are regenerated and posts results via `post-contract-regeneration-comment.py`
+
+The **Breaking Change Label Guard** workflow (`.github/workflows/breaking-change-label-guard.yml`) fires when `breaking-change-approved` is added. Unauthorized actors have the label removed, the check fails, and a PR comment explains why.
 
 ## Security Features
 

--- a/backend/scripts/openapi/README.md
+++ b/backend/scripts/openapi/README.md
@@ -25,9 +25,9 @@ Installs the `oasdiff` tool with checksum verification to prevent supply chain a
 Checks for breaking changes in OpenAPI spec using `oasdiff`. Automatically resolves the spec path relative to the git root, so it works from any subdirectory (e.g., `backend/` in the monorepo).
 
 The gate enforces these rules:
-1. **Every meaningful spec change must bump `info.version`.** Comparison is canonical (semantic), so serialization-only diffs (whitespace, key order, quote style) do not require a bump. A meaningful change with no bump is blocked (`version_bump_required`).
-2. **The bump segment must match the change type**: `minor` for additive changes (new endpoint, field, or enum value), `patch` for spec-only edits (description, example, annotation). A wrong-segment bump is blocked (`wrong_bump_segment`).
-3. **Breaking changes are blocked in place** — full stop (`breaking_blocked`). The only override is the privileged `breaking-change-approved` label (restricted to the `syntara-leads` team via the Breaking Change Label Guard workflow). A new major version is a new spec at a new path and does not register as a breaking change here. An approved breaking change must still bump `info.version` by a `minor` segment.
+1. **Every meaningful spec change must update `info.version`.** Comparison is canonical (semantic), so serialization-only diffs (whitespace, key order, quote style) do not require a version change. A meaningful change that leaves `info.version` unchanged is blocked (`version_bump_required`).
+2. **The version increment must match the change type**: increment the `minor` version for additive changes (new endpoint, field, or enum value), the `patch` version for spec-only edits (description, example, annotation). An incorrect version increment is blocked (`incorrect_version_increment`).
+3. **Breaking changes are blocked in place** — full stop (`breaking_blocked`). The only override is the privileged `breaking-change-approved` label (restricted to the `syntara-leads` team via the Breaking Change Label Guard workflow). A new major version is a new spec at a new path and does not register as a breaking change here. An approved breaking change must still increment `info.version` by a `minor` version.
 
 ```bash
 # Compare current branch against devel
@@ -36,17 +36,17 @@ The gate enforces these rules:
 # Compare specific spec files
 ./check-breaking-changes.py --base-spec old.yaml --head-spec new.yaml
 
-# Include PR labels for the breaking-change approval override
+# Include PR labels (JSON-encoded array) for the breaking-change approval override
 ./check-breaking-changes.py --base devel --head HEAD \
-  --pr-labels "breaking-change-approved,bug"
+  --pr-labels '["breaking-change-approved", "bug"]'
 
 # Output as text instead of JSON
 ./check-breaking-changes.py --base devel --head HEAD --format text
 ```
 
 **Exit Codes:**
-- `0` - Allowed: no meaningful change, non-breaking change with the correct-segment bump, or approved breaking change with a minor bump
-- `1` - Blocked: breaking change without approval, a meaningful change with no version bump, or a wrong-segment bump
+- `0` - Allowed: no meaningful change, non-breaking change with the correct version increment, or approved breaking change with a minor increment
+- `1` - Blocked: breaking change without approval, a meaningful change with no version change, or an incorrect version increment
 - `2` - Error running oasdiff or processing specs
 
 When the gate blocks and `--format json` is used, a human-readable summary (spec path, versions, `version_bumped`, breaking changes) is also written to stderr so CI logs stay actionable.
@@ -65,7 +65,7 @@ When the gate blocks and `--format json` is used, a human-readable summary (spec
   "expected_bump_type": "minor" | "patch" | null,
   "breaking_approved": bool,
   "spec_path": "backend/src/syntara/schemas/openapi.yaml",
-  "gate_code": "ok" | "breaking_approved" | "breaking_blocked" | "version_bump_required" | "wrong_bump_segment"
+  "gate_code": "ok" | "breaking_approved" | "breaking_blocked" | "version_bump_required" | "incorrect_version_increment"
 }
 ```
 
@@ -201,7 +201,7 @@ make check-openapi-contracts
 ### 4. Test Full Workflow Locally
 
 ```bash
-# 1. Check for breaking changes (blocks on breaking changes or a missing version bump)
+# 1. Check for breaking changes (blocks on breaking changes or a missing version update)
 ./scripts/openapi/check-breaking-changes.py \
   --base devel \
   --head HEAD \

--- a/backend/scripts/openapi/README.md
+++ b/backend/scripts/openapi/README.md
@@ -24,6 +24,12 @@ Installs the `oasdiff` tool with checksum verification to prevent supply chain a
 #### `check-breaking-changes.py`
 Checks for breaking changes in OpenAPI spec using `oasdiff`. Automatically resolves the spec path relative to the git root, so it works from any subdirectory (e.g., `backend/` in the monorepo).
 
+Breaking changes on the current major version are always blocked. Two override paths exist:
+1. **Major version bump + ack** — bump `info.version` by a major increment and add `breaking-change-ack: <justification>` to the PR body
+2. **CVE escape hatch** — apply the `cve-breaking-change-approved` protected label (requires Senior Director+ approval)
+
+For non-breaking changes, a version bump is optional. If present, additive changes require a **minor** bump (patch is blocked); other non-breaking changes may use patch or minor. A major bump without a breaking change is blocked.
+
 ```bash
 # Compare current branch against devel
 ./check-breaking-changes.py --base devel --head HEAD
@@ -31,16 +37,18 @@ Checks for breaking changes in OpenAPI spec using `oasdiff`. Automatically resol
 # Compare specific spec files
 ./check-breaking-changes.py --base-spec old.yaml --head-spec new.yaml
 
-# Include PR body for acknowledgment check
-./check-breaking-changes.py --base devel --head HEAD --pr-body "$(cat pr_description.txt)"
+# Include PR body and labels for override checks
+./check-breaking-changes.py --base devel --head HEAD \
+  --pr-body "breaking-change-ack: Routing to v2 for field rename" \
+  --pr-labels "cve-breaking-change-approved,bug"
 
 # Output as text instead of JSON
 ./check-breaking-changes.py --base devel --head HEAD --format text
 ```
 
 **Exit Codes:**
-- `0` - No breaking changes OR breaking changes acknowledged
-- `1` - Breaking changes detected and not acknowledged
+- `0` - No breaking changes (or valid override: major bump + ack, or CVE label)
+- `1` - Breaking changes without a valid override, or incorrect `info.version` bump type
 - `2` - Error running oasdiff or processing specs
 
 **Output (JSON):**
@@ -51,7 +59,15 @@ Checks for breaking changes in OpenAPI spec using `oasdiff`. Automatically resol
   "all_changes": "full changelog...",
   "acknowledged": bool,
   "justification": "justification text",
-  "ack_insufficient": bool
+  "ack_insufficient": bool,
+  "version_bumped": bool,
+  "base_version": "1.0.0",
+  "head_version": "1.0.0",
+  "version_bump_type": "major" | "minor" | "patch" | null,
+  "cve_approved": bool,
+  "spec_path": "backend/src/syntara/schemas/openapi.yaml",
+  "change_kind": "none" | "additive" | "other",
+  "gate_code": "ok" | "cve_override" | "major_ack" | "breaking_blocked" | "ack_without_major" | "ack_insufficient" | "incorrect_bump"
 }
 ```
 
@@ -187,22 +203,33 @@ make check-openapi-contracts
 ### 4. Test Full Workflow Locally
 
 ```bash
-# 1. Check for breaking changes with PR body
-PR_BODY="breaking-change-ack: This change is necessary for the new feature"
+# 1. Check for breaking changes (will block if breaking changes exist)
+./scripts/openapi/check-breaking-changes.py \
+  --base devel \
+  --head HEAD \
+  --output /tmp/breaking-results.json
 
+# 2. If breaking changes are intentional (new major version):
+PR_BODY="breaking-change-ack: Routing field rename to v2 API"
 ./scripts/openapi/check-breaking-changes.py \
   --base devel \
   --head HEAD \
   --pr-body "$PR_BODY" \
   --output /tmp/breaking-results.json
 
-# 2. Check contract regeneration
+# 3. If breaking changes are a CVE fix (requires protected label in CI):
+./scripts/openapi/check-breaking-changes.py \
+  --base devel \
+  --head HEAD \
+  --pr-labels "cve-breaking-change-approved" \
+  --output /tmp/breaking-results.json
+
+# 4. Check contract regeneration
 ./scripts/openapi/check-contract-regeneration.py \
   --changed-files-from devel \
-  --pr-body "$PR_BODY" \
   --output /tmp/contract-regeneration-results.json
 
-# 3. View results
+# 5. View results
 cat /tmp/breaking-results.json | jq
 cat /tmp/contract-regeneration-results.json | jq
 ```
@@ -243,6 +270,7 @@ These scripts are used by the monorepo CI workflow (`.github/workflows/ci-backen
 The CI `pre-commit` job:
 1. Fetches `devel` for OpenAPI baseline comparison
 2. Passes `OPENAPI_PR_BODY` from the pull request for breaking-change acknowledgment
+3. Passes `OPENAPI_PR_LABELS` so the CVE escape hatch can succeed on the required backend check
 
 The `openapi-breaking-changes` job:
 1. Detects changes to `backend/src/syntara/schemas/openapi.yaml`

--- a/backend/scripts/openapi/README.md
+++ b/backend/scripts/openapi/README.md
@@ -211,7 +211,7 @@ make check-openapi-contracts
 ./scripts/openapi/check-breaking-changes.py \
   --base devel \
   --head HEAD \
-  --pr-labels "breaking-change-approved" \
+  --pr-labels '["breaking-change-approved"]' \
   --output /tmp/breaking-results.json
 
 # 3. Check contract regeneration

--- a/backend/scripts/openapi/check-breaking-changes.py
+++ b/backend/scripts/openapi/check-breaking-changes.py
@@ -4,10 +4,15 @@
 This script compares two OpenAPI specs and detects breaking changes,
 returning structured JSON output for consumption by CI or local tooling.
 
+Breaking changes on the current major version are always blocked.
+Two override paths exist:
+  1. Major version bump + breaking-change-ack in PR body (new API version)
+  2. CVE escape hatch via a protected GitHub label (emergency override)
+
 Usage:
     ./check-breaking-changes.py --base devel --head HEAD
     ./check-breaking-changes.py --base-spec baseline.yaml --head-spec current.yaml
-    ./check-breaking-changes.py --pr-body "$(cat pr_description.txt)"
+    ./check-breaking-changes.py --pr-body "breaking-change-ack: <justification>" --pr-labels "cve-breaking-change-approved"
 
 Returns:
     JSON with structure:
@@ -17,25 +22,67 @@ Returns:
         "all_changes": str,
         "acknowledged": bool,
         "justification": str,
-        "ack_insufficient": bool
+        "ack_insufficient": bool,
+        "version_bumped": bool,
+        "base_version": str,
+        "head_version": str,
+        "version_bump_type": str | null,
+        "cve_approved": bool,
+        "spec_path": str,
+        "change_kind": "none" | "additive" | "other",
+        "gate_code": str
     }
 
 Exit codes:
-    0 - No breaking changes OR breaking changes acknowledged
-    1 - Breaking changes detected and not acknowledged
+    0 - No breaking changes, or breaking changes with valid override
+    1 - Breaking changes or incorrect version bump without valid override
     2 - Error running oasdiff or processing specs
 """
+
+from __future__ import annotations
 
 import argparse
 import json
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional, Tuple
 
 
 DEFAULT_SPEC_PATH = "backend/src/syntara/schemas/openapi.yaml"
+CVE_ESCAPE_LABEL = "cve-breaking-change-approved"
+
+# oasdiff changelog IDs that indicate additive (non-breaking) API surface.
+_ADDITIVE_CHANGE_IDS = (
+    "endpoint-added",
+    "request-property-added",
+    "response-property-added",
+    "request-parameter-added",
+    "request-body-added",
+    "response-added",
+    "response-media-type-added",
+    "request-media-type-added",
+    "request-property-enum-value-added",
+    "response-property-enum-value-added",
+)
+_ADDITIVE_CHANGE_TEXT = re.compile(
+    r"\badded the (?:path|endpoint|operations?|optional |required )|"
+    r"\b(?:endpoint|path) added\b|"
+    r"\badded .+ (?:request|response) propert|"
+    r"\badded the .+ parameter\b|"
+    r"\badded .+ enum value",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Result of applying the OpenAPI versioning gate."""
+
+    allowed: bool
+    code: str
+    message: str
 
 
 def run_command(cmd: list[str], capture_output: bool = True) -> subprocess.CompletedProcess:
@@ -53,7 +100,7 @@ def run_command(cmd: list[str], capture_output: bool = True) -> subprocess.Compl
         sys.exit(2)
 
 
-def get_spec_from_git(ref: str, spec_path: str) -> Optional[str]:
+def get_spec_from_git(ref: str, spec_path: str) -> str | None:
     """Get OpenAPI spec content from a git reference.
 
     Returns None if the path does not exist on the given ref (e.g. file was
@@ -70,7 +117,51 @@ def get_spec_from_git(ref: str, spec_path: str) -> Optional[str]:
     return result.stdout
 
 
-def check_breaking_changes(base_spec: str, head_spec: str) -> Tuple[bool, str]:
+def extract_info_version(content: str) -> str | None:
+    """Extract info.version from OpenAPI spec YAML content."""
+    in_info = False
+    for line in content.split("\n"):
+        if line.startswith("info:"):
+            in_info = True
+            continue
+        if in_info:
+            if line and not line[0].isspace():
+                break
+            stripped = line.strip()
+            if stripped.startswith("version:"):
+                return stripped.split(":", 1)[1].strip().strip("\"'")
+    return None
+
+
+def parse_semver(version: str) -> tuple[int, int, int] | None:
+    """Parse a semver string into (major, minor, patch). Returns None on failure."""
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    if not match:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def get_version_bump_type(base_version: str, head_version: str) -> str | None:
+    """Determine the version bump type between base and head.
+
+    Returns "major", "minor", "patch", or None (no bump / unparseable).
+    """
+    base = parse_semver(base_version)
+    head = parse_semver(head_version)
+    if base is None or head is None:
+        return None
+    if head[0] > base[0]:
+        return "major"
+    if head == base:
+        return None
+    if head[1] > base[1] and head[0] == base[0]:
+        return "minor"
+    if head[2] > base[2] and head[0] == base[0] and head[1] == base[1]:
+        return "patch"
+    return None
+
+
+def check_breaking_changes(base_spec: str, head_spec: str) -> tuple[bool, str]:
     """Run oasdiff breaking changes check.
 
     Args:
@@ -130,7 +221,7 @@ def get_all_changes(base_spec: str, head_spec: str) -> str:
     return (result.stdout + result.stderr).strip()
 
 
-def check_acknowledgment(pr_body: str) -> Dict[str, any]:
+def check_acknowledgment(pr_body: str) -> dict:
     """Check if breaking changes are acknowledged in PR body.
 
     Args:
@@ -174,6 +265,108 @@ def check_acknowledgment(pr_body: str) -> Dict[str, any]:
     }
 
 
+def check_cve_label(pr_labels: str) -> bool:
+    """Check if the CVE escape hatch label is present on the PR.
+
+    Args:
+        pr_labels: Comma-separated list of PR label names
+
+    Returns:
+        True if the CVE escape label is present
+    """
+    if not pr_labels:
+        return False
+    labels = [label.strip().lower() for label in pr_labels.split(",")]
+    return CVE_ESCAPE_LABEL.lower() in labels
+
+
+def classify_non_breaking_changes(all_changes: str) -> str:
+    """Classify non-breaking changelog output as none, additive, or other.
+
+    Additive means new endpoints, properties, parameters, or enum values.
+    ``other`` covers documentation, description, and similar non-surface changes.
+    """
+    text = (all_changes or "").strip()
+    if not text or re.match(r"^no changes\b", text, re.IGNORECASE):
+        return "none"
+    lowered = text.lower()
+    if any(change_id in lowered for change_id in _ADDITIVE_CHANGE_IDS):
+        return "additive"
+    if _ADDITIVE_CHANGE_TEXT.search(text):
+        return "additive"
+    return "other"
+
+
+def evaluate_gate(
+    *,
+    has_breaking: bool,
+    version_bump_type: str | None,
+    acknowledged: bool,
+    ack_insufficient: bool,
+    justification: str,
+    cve_approved: bool,
+    change_kind: str,
+) -> GateDecision:
+    """Apply the OpenAPI versioning gate. Returns whether the PR is allowed."""
+    allowed = True
+    code = "ok"
+    message = "No breaking changes detected"
+
+    if has_breaking:
+        if cve_approved:
+            allowed = True
+            code = "cve_override"
+            message = "ALLOWED: CVE escape hatch label present"
+        elif version_bump_type == "major" and acknowledged:
+            allowed = True
+            code = "major_ack"
+            message = f"ALLOWED: Major version bump with acknowledgment: {justification}"
+        elif acknowledged:
+            allowed = False
+            code = "ack_without_major"
+            message = (
+                "BLOCKED: Breaking changes require a major version bump. "
+                "An acknowledgment alone is not sufficient."
+            )
+        elif ack_insufficient:
+            allowed = False
+            code = "ack_insufficient"
+            message = f"BLOCKED: Insufficient acknowledgment: {justification}"
+        else:
+            allowed = False
+            code = "breaking_blocked"
+            message = (
+                "BLOCKED: Breaking changes on the current major version are not allowed. "
+                "Options:\n"
+                "  1. Bump info.version to the next major version and add "
+                "'breaking-change-ack: <justification>' to the PR body\n"
+                "  2. For CVE fixes only: request the 'cve-breaking-change-approved' label "
+                "from engineering leadership (Senior Director or above)"
+            )
+    elif version_bump_type == "major":
+        allowed = False
+        code = "incorrect_bump"
+        message = (
+            "BLOCKED: Major version bumps are reserved for breaking changes. "
+            "Use a minor bump for additive features or a patch bump for fixes, "
+            "or omit the bump."
+        )
+    elif change_kind == "additive" and version_bump_type == "patch":
+        allowed = False
+        code = "incorrect_bump"
+        message = (
+            "BLOCKED: Additive API changes require a minor version bump, not patch. "
+            "Bump info.version minor (for example 1.0.0 -> 1.1.0), or omit the bump."
+        )
+
+    return GateDecision(allowed=allowed, code=code, message=message)
+
+
+def read_spec_content(spec_path: str) -> str:
+    """Read spec content from a file path."""
+    return Path(spec_path).read_text()
+
+
 def main():
     parser = argparse.ArgumentParser(description="Check OpenAPI spec for breaking changes")
 
@@ -215,6 +408,13 @@ def main():
         default="",
     )
 
+    # PR labels for CVE escape hatch
+    parser.add_argument(
+        "--pr-labels",
+        help="Comma-separated list of PR label names",
+        default="",
+    )
+
     # Output options
     parser.add_argument(
         "--output",
@@ -230,19 +430,24 @@ def main():
 
     args = parser.parse_args()
 
+    # Track spec content for version extraction
+    base_spec_content = None
+    head_spec_content = None
+
     # Determine base spec source
     if args.base_spec:
         base_spec_path = args.base_spec
+        base_spec_content = read_spec_content(base_spec_path)
     elif args.base:
-        spec_content = get_spec_from_git(args.base, args.spec_path)
-        if spec_content is None and args.fallback_spec_path:
+        base_spec_content = get_spec_from_git(args.base, args.spec_path)
+        if base_spec_content is None and args.fallback_spec_path:
             print(
                 f"Spec not found at '{args.spec_path}' on '{args.base}'; "
                 f"trying fallback '{args.fallback_spec_path}'",
                 file=sys.stderr,
             )
-            spec_content = get_spec_from_git(args.base, args.fallback_spec_path)
-        if spec_content is None:
+            base_spec_content = get_spec_from_git(args.base, args.fallback_spec_path)
+        if base_spec_content is None:
             print(
                 f"Spec path not found on base ref '{args.base}' (file is new or renamed). "
                 f"Skipping breaking changes check.",
@@ -252,7 +457,7 @@ def main():
         import tempfile
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write(spec_content)
+            f.write(base_spec_content)
             base_spec_path = f.name
     else:
         print("ERROR: Must specify --base or --base-spec", file=sys.stderr)
@@ -262,14 +467,21 @@ def main():
     # Determine head spec source
     if args.head:
         # Get spec from git reference - write to temp file
-        spec_content = get_spec_from_git(args.head, args.spec_path)
+        head_spec_content = get_spec_from_git(args.head, args.spec_path)
         import tempfile
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write(spec_content)
+            f.write(head_spec_content)
             head_spec_path = f.name
     else:
         head_spec_path = args.head_spec
+        head_spec_content = read_spec_content(head_spec_path)
+
+    # Extract versions
+    base_version = extract_info_version(base_spec_content) if base_spec_content else ""
+    head_version = extract_info_version(head_spec_content) if head_spec_content else ""
+    version_bump_type = get_version_bump_type(base_version, head_version) if base_version and head_version else None
+    version_bumped = version_bump_type is not None
 
     # Check for breaking changes
     has_breaking, breaking_output = check_breaking_changes(base_spec_path, head_spec_path)
@@ -277,8 +489,19 @@ def main():
     # Get all changes
     all_changes = get_all_changes(base_spec_path, head_spec_path)
 
-    # Check acknowledgment
+    # Check acknowledgment and CVE label
     ack_result = check_acknowledgment(args.pr_body)
+    cve_approved = check_cve_label(args.pr_labels)
+    change_kind = classify_non_breaking_changes(all_changes) if not has_breaking else "none"
+    decision = evaluate_gate(
+        has_breaking=has_breaking,
+        version_bump_type=version_bump_type,
+        acknowledged=ack_result["acknowledged"],
+        ack_insufficient=ack_result["ack_insufficient"],
+        justification=ack_result["justification"],
+        cve_approved=cve_approved,
+        change_kind=change_kind,
+    )
 
     # Build result
     result = {
@@ -286,34 +509,30 @@ def main():
         "breaking_changes": breaking_output,
         "all_changes": all_changes,
         **ack_result,
+        "version_bumped": version_bumped,
+        "base_version": base_version or "",
+        "head_version": head_version or "",
+        "version_bump_type": version_bump_type,
+        "cve_approved": cve_approved,
+        "spec_path": args.spec_path,
+        "change_kind": change_kind,
+        "gate_code": decision.code,
     }
 
     # Output
     if args.format == "json":
         output_text = json.dumps(result, indent=2)
     else:
-        # Text format
-        lines = []
-        if has_breaking:
-            lines.append("BREAKING CHANGES DETECTED")
-            lines.append("=" * 50)
-            lines.append(breaking_output)
-            lines.append("")
-            if ack_result["acknowledged"]:
-                lines.append(f"Acknowledged: {ack_result['justification']}")
-            elif ack_result["ack_insufficient"]:
-                lines.append(f"Insufficient acknowledgment: {ack_result['justification']}")
-            else:
-                lines.append("NOT ACKNOWLEDGED - Add 'breaking-change-ack: <justification>' to PR")
-        else:
-            lines.append("No breaking changes detected")
-
-        if all_changes and all_changes != breaking_output:
-            lines.append("")
-            lines.append("All changes:")
-            lines.append("-" * 50)
-            lines.append(all_changes)
-
+        lines = _format_text_output(
+            has_breaking=has_breaking,
+            breaking_output=breaking_output,
+            all_changes=all_changes,
+            decision=decision,
+            base_version=base_version,
+            head_version=head_version,
+            version_bump_type=version_bump_type,
+            spec_path=args.spec_path,
+        )
         output_text = "\n".join(lines)
 
     # Write output
@@ -322,11 +541,45 @@ def main():
     else:
         print(output_text)
 
-    # Exit with appropriate code
-    if has_breaking and not ack_result["acknowledged"]:
-        sys.exit(1)
-    else:
-        sys.exit(0)
+    sys.exit(0 if decision.allowed else 1)
+
+
+def _format_text_output(
+    *,
+    has_breaking: bool,
+    breaking_output: str,
+    all_changes: str,
+    decision: GateDecision,
+    base_version: str,
+    head_version: str,
+    version_bump_type: str | None,
+    spec_path: str,
+) -> list[str]:
+    """Format results as human-readable text lines."""
+    lines = []
+
+    # Version info header — always include spec path and versions for CI errors
+    lines.append(f"Spec: {spec_path}")
+    lines.append(f"Version: {base_version or 'unknown'} -> {head_version or 'unknown'}")
+    if version_bump_type:
+        lines.append(f"Bump type: {version_bump_type}")
+    lines.append("")
+
+    if has_breaking:
+        lines.append("BREAKING CHANGES DETECTED")
+        lines.append("=" * 50)
+        lines.append(breaking_output)
+        lines.append("")
+
+    lines.append(decision.message)
+
+    if all_changes and all_changes != breaking_output:
+        lines.append("")
+        lines.append("All changes:")
+        lines.append("-" * 50)
+        lines.append(all_changes)
+
+    return lines
 
 
 if __name__ == "__main__":

--- a/backend/scripts/openapi/check-breaking-changes.py
+++ b/backend/scripts/openapi/check-breaking-changes.py
@@ -25,7 +25,7 @@ Policy):
      so it would not register as a breaking change here.
 
 Dynamic-map / ``additionalProperties`` content (labels, context_data,
-input_data, output_data, result) is not treated as breaking — oasdiff reports
+input_data, output_data, result) is not treated as breaking; oasdiff reports
 such changes as non-breaking.
 
 Usage:
@@ -181,7 +181,12 @@ def check_breaking_changes(base_spec: str, head_spec: str) -> tuple[bool, str]:
         print("Run: ./scripts/openapi/install-oasdiff.sh", file=sys.stderr)
         sys.exit(2)
 
-    # Run oasdiff breaking changes check
+    # Run oasdiff breaking changes check. Without --fail-on, oasdiff exits 0 even
+    # when it finds breaking changes, so we must request a failing exit code.
+    # With --fail-on ERR the exit code is:
+    #   0   -> no ERR-level breaking changes
+    #   1   -> at least one ERR-level breaking change
+    #   >1  -> oasdiff error (e.g. spec failed to load), not a breaking change
     result = run_command(
         [
             "oasdiff",
@@ -190,14 +195,24 @@ def check_breaking_changes(base_spec: str, head_spec: str) -> tuple[bool, str]:
             head_spec,
             "--format",
             "text",
+            "--fail-on",
+            "ERR",
         ]
     )
+    output = (result.stdout + result.stderr).strip()
 
-    # oasdiff returns non-zero if breaking changes found
-    has_breaking = result.returncode != 0
-    output = result.stdout + result.stderr
+    # Distinguish "breaking changes found" (exit 1) from a tool error (exit >1).
+    # Treating any non-zero code as breaking would both misreport oasdiff errors
+    # as breaking changes and (before --fail-on was added) miss real ones.
+    if result.returncode not in (0, 1):
+        print(
+            f"ERROR: oasdiff failed (exit {result.returncode}) while checking for breaking changes:\n{output}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
-    return has_breaking, output.strip()
+    has_breaking = result.returncode == 1
+    return has_breaking, output
 
 
 def get_all_changes(base_spec: str, head_spec: str) -> str:
@@ -229,7 +244,7 @@ def get_changelog_entries(base_spec: str, head_spec: str) -> list[dict[str, Any]
 
     Each entry describes a *structural* change (added endpoint, field, enum
     value, etc.). oasdiff does NOT report spec-only edits (description, summary,
-    example, annotation) here — those are detected via canonical comparison
+    example, annotation) here; those are detected via canonical comparison
     instead. Returns an empty list when there are no structural changes or the
     JSON cannot be parsed.
     """
@@ -253,7 +268,7 @@ def check_approval_label(pr_labels_json: str) -> bool:
     contains a comma cannot be split into two and forge the approval label. The
     match is case-sensitive to stay consistent with the exact-case ``if:``
     conditions in ``breaking-change-label-guard.yml`` and
-    ``openapi-breaking-changes.yml`` — a case-variant label that never triggers
+    ``openapi-breaking-changes.yml``; a case-variant label that never triggers
     those guards must not be accepted here either.
 
     Args:
@@ -400,7 +415,7 @@ def evaluate_gate(
                     "spec-only edits (description, example, annotation) require a patch bump. "
                     if not has_breaking
                     else "An approved in-place breaking change requires a minor bump, not a major "
-                    "one — a new major version is a new spec at a new URL path. "
+                    "one; a new major version is a new spec at a new URL path. "
                 )
                 + f"Set info.version to a '{expected_bump_type}' increment."
             ),
@@ -657,7 +672,7 @@ def _format_text_output(
     """Format results as human-readable text lines."""
     lines = []
 
-    # Version info header — always include spec path, versions, and bump state
+    # Version info header: always include spec path, versions, and bump state
     lines.append(f"Spec: {spec_path}")
     lines.append(f"Version: {base_version or 'unknown'} -> {head_version or 'unknown'}")
     lines.append(f"version_bumped: {str(version_bumped).lower()}")

--- a/backend/scripts/openapi/check-breaking-changes.py
+++ b/backend/scripts/openapi/check-breaking-changes.py
@@ -294,8 +294,11 @@ def check_approval_label(pr_labels_json: str) -> bool:
         return False
     try:
         labels = json.loads(pr_labels_json)
-    except json.JSONDecodeError:
-        return False
+    except json.JSONDecodeError as exc:
+        # Fail loudly: a malformed value almost always means a caller reverted
+        # to the old comma-joined format. Silently returning False would hide
+        # that as a confusing "not approved" false-negative.
+        raise SystemExit(f"--pr-labels must be JSON-encoded, got: {pr_labels_json!r}") from exc
     return isinstance(labels, list) and BREAKING_CHANGE_APPROVED_LABEL in labels
 
 

--- a/backend/scripts/openapi/check-breaking-changes.py
+++ b/backend/scripts/openapi/check-breaking-changes.py
@@ -106,9 +106,22 @@ def run_command(cmd: list[str], capture_output: bool = True) -> subprocess.Compl
 def get_spec_from_git(ref: str, spec_path: str) -> str | None:
     """Get OpenAPI spec content from a git reference.
 
-    Returns None if the path does not exist on the given ref (e.g. file was
-    renamed or added in this branch). Exits with code 2 on other git errors.
+    Returns None only when the ref resolves but the path does not exist on it
+    (e.g. the file was renamed or added in this branch). Exits with code 2 if
+    the ref itself cannot be resolved (e.g. a typo, or the branch was not
+    fetched in CI), so a bad ref cannot be silently treated as "new spec,
+    nothing to check". Also exits with code 2 on other git errors.
     """
+    ref_exists = run_command(
+        ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"]
+    )
+    if ref_exists.returncode != 0:
+        print(
+            f"ERROR: Git ref '{ref}' could not be resolved. "
+            f"Ensure it exists and is fetched (e.g. 'git fetch origin {ref}').",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     exists = run_command(["git", "cat-file", "-e", f"{ref}:{spec_path}"])
     if exists.returncode != 0:
         return None

--- a/backend/scripts/openapi/check-breaking-changes.py
+++ b/backend/scripts/openapi/check-breaking-changes.py
@@ -4,15 +4,21 @@
 This script compares two OpenAPI specs and detects breaking changes,
 returning structured JSON output for consumption by CI or local tooling.
 
-Breaking changes on the current major version are always blocked.
-Two override paths exist:
-  1. Major version bump + breaking-change-ack in PR body (new API version)
-  2. CVE escape hatch via a protected GitHub label (emergency override)
+The gate enforces two rules:
+
+  1. Every OpenAPI spec change MUST bump ``info.version`` (major/minor/patch).
+     The bump is how the engineer signals their interpretation of the change to
+     reviewers and how API consumers become aware of spec updates.
+  2. Breaking changes are never allowed in place. A breaking change is only
+     permitted when the privileged ``breaking-change-approved`` label is present
+     (a formal override restricted to engineering leadership). Otherwise it is
+     blocked, full stop. A genuinely new major version is a new spec served from
+     a separate URL path, so it would not register as a breaking change here.
 
 Usage:
     ./check-breaking-changes.py --base devel --head HEAD
     ./check-breaking-changes.py --base-spec baseline.yaml --head-spec current.yaml
-    ./check-breaking-changes.py --pr-body "breaking-change-ack: <justification>" --pr-labels "cve-breaking-change-approved"
+    ./check-breaking-changes.py --base devel --head HEAD --pr-labels "breaking-change-approved"
 
 Returns:
     JSON with structure:
@@ -20,22 +26,21 @@ Returns:
         "has_breaking_changes": bool,
         "breaking_changes": str,
         "all_changes": str,
-        "acknowledged": bool,
-        "justification": str,
-        "ack_insufficient": bool,
+        "has_changes": bool,
         "version_bumped": bool,
         "base_version": str,
         "head_version": str,
         "version_bump_type": str | null,
-        "cve_approved": bool,
+        "breaking_approved": bool,
         "spec_path": str,
-        "change_kind": "none" | "additive" | "other",
         "gate_code": str
     }
 
 Exit codes:
-    0 - No breaking changes, or breaking changes with valid override
-    1 - Breaking changes or incorrect version bump without valid override
+    0 - Change is allowed (no changes, non-breaking change with a version bump,
+        or an approved breaking change with a version bump)
+    1 - Change is blocked (breaking without approval, or any spec change with no
+        version bump)
     2 - Error running oasdiff or processing specs
 """
 
@@ -51,29 +56,9 @@ from pathlib import Path
 
 
 DEFAULT_SPEC_PATH = "backend/src/syntara/schemas/openapi.yaml"
-CVE_ESCAPE_LABEL = "cve-breaking-change-approved"
-
-# oasdiff changelog IDs that indicate additive (non-breaking) API surface.
-_ADDITIVE_CHANGE_IDS = (
-    "endpoint-added",
-    "request-property-added",
-    "response-property-added",
-    "request-parameter-added",
-    "request-body-added",
-    "response-added",
-    "response-media-type-added",
-    "request-media-type-added",
-    "request-property-enum-value-added",
-    "response-property-enum-value-added",
-)
-_ADDITIVE_CHANGE_TEXT = re.compile(
-    r"\badded the (?:path|endpoint|operations?|optional |required )|"
-    r"\b(?:endpoint|path) added\b|"
-    r"\badded .+ (?:request|response) propert|"
-    r"\badded the .+ parameter\b|"
-    r"\badded .+ enum value",
-    re.IGNORECASE,
-)
+# Privileged override label for breaking changes. Restricted to engineering
+# leadership at the repo level; CI only checks for its presence.
+BREAKING_CHANGE_APPROVED_LABEL = "breaking-change-approved"
 
 
 @dataclass(frozen=True)
@@ -144,7 +129,7 @@ def parse_semver(version: str) -> tuple[int, int, int] | None:
 def get_version_bump_type(base_version: str, head_version: str) -> str | None:
     """Determine the version bump type between base and head.
 
-    Returns "major", "minor", "patch", or None (no bump / unparseable).
+    Returns "major", "minor", "patch", or None (no bump / downgrade / unparseable).
     """
     base = parse_semver(base_version)
     head = parse_semver(head_version)
@@ -221,145 +206,105 @@ def get_all_changes(base_spec: str, head_spec: str) -> str:
     return (result.stdout + result.stderr).strip()
 
 
-def check_acknowledgment(pr_body: str) -> dict:
-    """Check if breaking changes are acknowledged in PR body.
-
-    Args:
-        pr_body: PR description text
-
-    Returns:
-        Dict with keys: acknowledged, justification, ack_insufficient
-    """
-    if not pr_body:
-        return {
-            "acknowledged": False,
-            "justification": "",
-            "ack_insufficient": False,
-        }
-
-    # Pattern: breaking-change-ack: <justification>
-    ack_pattern = re.compile(r"breaking-change-ack\s*:\s*(.+)", re.IGNORECASE)
-    match = ack_pattern.search(pr_body)
-
-    if not match:
-        return {
-            "acknowledged": False,
-            "justification": "",
-            "ack_insufficient": False,
-        }
-
-    justification = match.group(1).strip()
-
-    # Validate justification is substantial (minimum 20 chars)
-    if len(justification) < 20:
-        return {
-            "acknowledged": False,
-            "justification": justification,
-            "ack_insufficient": True,
-        }
-
-    return {
-        "acknowledged": True,
-        "justification": justification,
-        "ack_insufficient": False,
-    }
-
-
-def check_cve_label(pr_labels: str) -> bool:
-    """Check if the CVE escape hatch label is present on the PR.
+def check_approval_label(pr_labels: str) -> bool:
+    """Check if the breaking-change approval label is present on the PR.
 
     Args:
         pr_labels: Comma-separated list of PR label names
 
     Returns:
-        True if the CVE escape label is present
+        True if the ``breaking-change-approved`` label is present
     """
     if not pr_labels:
         return False
     labels = [label.strip().lower() for label in pr_labels.split(",")]
-    return CVE_ESCAPE_LABEL.lower() in labels
+    return BREAKING_CHANGE_APPROVED_LABEL.lower() in labels
 
 
-def classify_non_breaking_changes(all_changes: str) -> str:
-    """Classify non-breaking changelog output as none, additive, or other.
+def spec_has_changes(
+    base_content: str,
+    head_content: str,
+    *,
+    has_breaking: bool,
+    all_changes: str,
+) -> bool:
+    """True if the spec changed, including edits oasdiff does not report.
 
-    Additive means new endpoints, properties, parameters, or enum values.
-    ``other`` covers documentation, description, and similar non-surface changes.
+    File content is the source of truth so whitespace, description, and other
+    metadata edits still require an info.version bump. Changelog/breaking
+    output is a fallback when the files cannot be compared.
     """
+    if has_breaking:
+        return True
+    if (base_content or "") != (head_content or ""):
+        return True
     text = (all_changes or "").strip()
-    if not text or re.match(r"^no changes\b", text, re.IGNORECASE):
-        return "none"
-    lowered = text.lower()
-    if any(change_id in lowered for change_id in _ADDITIVE_CHANGE_IDS):
-        return "additive"
-    if _ADDITIVE_CHANGE_TEXT.search(text):
-        return "additive"
-    return "other"
+    return bool(text) and not re.match(r"^no changes\b", text, re.IGNORECASE)
 
 
 def evaluate_gate(
     *,
     has_breaking: bool,
-    version_bump_type: str | None,
-    acknowledged: bool,
-    ack_insufficient: bool,
-    justification: str,
-    cve_approved: bool,
-    change_kind: str,
+    has_changes: bool,
+    version_bumped: bool,
+    breaking_approved: bool,
 ) -> GateDecision:
-    """Apply the OpenAPI versioning gate. Returns whether the PR is allowed."""
-    allowed = True
-    code = "ok"
-    message = "No breaking changes detected"
+    """Apply the OpenAPI versioning gate. Returns whether the PR is allowed.
+
+    Rules:
+      * No spec changes -> allowed.
+      * Breaking changes without the approval label -> blocked, full stop.
+      * Any spec change without an info.version bump -> blocked.
+      * Approved breaking change (with bump) or non-breaking change (with bump)
+        -> allowed.
+    """
+    if not has_breaking and not has_changes:
+        return GateDecision(
+            allowed=True,
+            code="ok",
+            message="No OpenAPI spec changes detected",
+        )
+
+    if has_breaking and not breaking_approved:
+        return GateDecision(
+            allowed=False,
+            code="breaking_blocked",
+            message=(
+                "BLOCKED: This PR introduces breaking changes to the current API version. "
+                "Breaking changes are never allowed in place.\n"
+                "  - A new major version must be a new spec served from a separate URL path "
+                "(it would not register as a breaking change here).\n"
+                f"  - For an approved emergency override, request the '{BREAKING_CHANGE_APPROVED_LABEL}' "
+                "label from engineering leadership."
+            ),
+        )
+
+    if not version_bumped:
+        return GateDecision(
+            allowed=False,
+            code="version_bump_required",
+            message=(
+                "BLOCKED: The OpenAPI spec changed but info.version was not bumped. "
+                "Every spec change must bump info.version (major/minor/patch) to signal "
+                "the change to reviewers and API consumers."
+            ),
+        )
 
     if has_breaking:
-        if cve_approved:
-            allowed = True
-            code = "cve_override"
-            message = "ALLOWED: CVE escape hatch label present"
-        elif version_bump_type == "major" and acknowledged:
-            allowed = True
-            code = "major_ack"
-            message = f"ALLOWED: Major version bump with acknowledgment: {justification}"
-        elif acknowledged:
-            allowed = False
-            code = "ack_without_major"
-            message = (
-                "BLOCKED: Breaking changes require a major version bump. "
-                "An acknowledgment alone is not sufficient."
-            )
-        elif ack_insufficient:
-            allowed = False
-            code = "ack_insufficient"
-            message = f"BLOCKED: Insufficient acknowledgment: {justification}"
-        else:
-            allowed = False
-            code = "breaking_blocked"
-            message = (
-                "BLOCKED: Breaking changes on the current major version are not allowed. "
-                "Options:\n"
-                "  1. Bump info.version to the next major version and add "
-                "'breaking-change-ack: <justification>' to the PR body\n"
-                "  2. For CVE fixes only: request the 'cve-breaking-change-approved' label "
-                "from engineering leadership (Senior Director or above)"
-            )
-    elif version_bump_type == "major":
-        allowed = False
-        code = "incorrect_bump"
-        message = (
-            "BLOCKED: Major version bumps are reserved for breaking changes. "
-            "Use a minor bump for additive features or a patch bump for fixes, "
-            "or omit the bump."
-        )
-    elif change_kind == "additive" and version_bump_type == "patch":
-        allowed = False
-        code = "incorrect_bump"
-        message = (
-            "BLOCKED: Additive API changes require a minor version bump, not patch. "
-            "Bump info.version minor (for example 1.0.0 -> 1.1.0), or omit the bump."
+        return GateDecision(
+            allowed=True,
+            code="breaking_approved",
+            message=(
+                f"ALLOWED: Breaking change permitted via the '{BREAKING_CHANGE_APPROVED_LABEL}' "
+                "label (privileged override)."
+            ),
         )
 
-    return GateDecision(allowed=allowed, code=code, message=message)
+    return GateDecision(
+        allowed=True,
+        code="ok",
+        message="Non-breaking spec change with a version bump",
+    )
 
 
 def read_spec_content(spec_path: str) -> str:
@@ -401,14 +346,7 @@ def main():
         default=None,
     )
 
-    # PR body for acknowledgment check
-    parser.add_argument(
-        "--pr-body",
-        help="PR description text to check for acknowledgment",
-        default="",
-    )
-
-    # PR labels for CVE escape hatch
+    # PR labels for the breaking-change approval override
     parser.add_argument(
         "--pr-labels",
         help="Comma-separated list of PR label names",
@@ -442,8 +380,7 @@ def main():
         base_spec_content = get_spec_from_git(args.base, args.spec_path)
         if base_spec_content is None and args.fallback_spec_path:
             print(
-                f"Spec not found at '{args.spec_path}' on '{args.base}'; "
-                f"trying fallback '{args.fallback_spec_path}'",
+                f"Spec not found at '{args.spec_path}' on '{args.base}'; trying fallback '{args.fallback_spec_path}'",
                 file=sys.stderr,
             )
             base_spec_content = get_spec_from_git(args.base, args.fallback_spec_path)
@@ -489,18 +426,21 @@ def main():
     # Get all changes
     all_changes = get_all_changes(base_spec_path, head_spec_path)
 
-    # Check acknowledgment and CVE label
-    ack_result = check_acknowledgment(args.pr_body)
-    cve_approved = check_cve_label(args.pr_labels)
-    change_kind = classify_non_breaking_changes(all_changes) if not has_breaking else "none"
+    has_changes = spec_has_changes(
+        base_spec_content or "",
+        head_spec_content or "",
+        has_breaking=has_breaking,
+        all_changes=all_changes,
+    )
+
+    # Check the breaking-change approval label
+    breaking_approved = check_approval_label(args.pr_labels)
+
     decision = evaluate_gate(
         has_breaking=has_breaking,
-        version_bump_type=version_bump_type,
-        acknowledged=ack_result["acknowledged"],
-        ack_insufficient=ack_result["ack_insufficient"],
-        justification=ack_result["justification"],
-        cve_approved=cve_approved,
-        change_kind=change_kind,
+        has_changes=has_changes,
+        version_bumped=version_bumped,
+        breaking_approved=breaking_approved,
     )
 
     # Build result
@@ -508,14 +448,13 @@ def main():
         "has_breaking_changes": has_breaking,
         "breaking_changes": breaking_output,
         "all_changes": all_changes,
-        **ack_result,
+        "has_changes": has_changes,
         "version_bumped": version_bumped,
         "base_version": base_version or "",
         "head_version": head_version or "",
         "version_bump_type": version_bump_type,
-        "cve_approved": cve_approved,
+        "breaking_approved": breaking_approved,
         "spec_path": args.spec_path,
-        "change_kind": change_kind,
         "gate_code": decision.code,
     }
 

--- a/backend/scripts/openapi/check-breaking-changes.py
+++ b/backend/scripts/openapi/check-breaking-changes.py
@@ -4,16 +4,29 @@
 This script compares two OpenAPI specs and detects breaking changes,
 returning structured JSON output for consumption by CI or local tooling.
 
-The gate enforces two rules:
+The gate enforces these rules (per the AO REST API Versioning and Deprecation
+Policy):
 
-  1. Every OpenAPI spec change MUST bump ``info.version`` (major/minor/patch).
-     The bump is how the engineer signals their interpretation of the change to
-     reviewers and how API consumers become aware of spec updates.
-  2. Breaking changes are never allowed in place. A breaking change is only
+  1. Every *meaningful* OpenAPI spec change MUST bump ``info.version``.
+     Comparison is **canonical** (semantic): the two specs are parsed and
+     compared as data structures, so serialization-only diffs (whitespace,
+     indentation, line endings, key order, quote style) do not count as a change
+     and do not require a bump.
+  2. The bump segment MUST match the change type:
+       * ``minor`` for additive changes (new endpoint, field, or enum value),
+       * ``patch`` for spec-only edits (description, example, or annotation).
+     A bump of the wrong segment is blocked with an error naming the expected
+     segment.
+  3. Breaking changes are never allowed in place. A breaking change is only
      permitted when the privileged ``breaking-change-approved`` label is present
-     (a formal override restricted to engineering leadership). Otherwise it is
-     blocked, full stop. A genuinely new major version is a new spec served from
-     a separate URL path, so it would not register as a breaking change here.
+     (a formal override restricted to engineering leadership) AND ``info.version``
+     is bumped by a ``minor`` increment. Otherwise it is blocked, full stop. A
+     genuinely new major version is a new spec served from a separate URL path,
+     so it would not register as a breaking change here.
+
+Dynamic-map / ``additionalProperties`` content (labels, context_data,
+input_data, output_data, result) is not treated as breaking — oasdiff reports
+such changes as non-breaking.
 
 Usage:
     ./check-breaking-changes.py --base devel --head HEAD
@@ -31,16 +44,17 @@ Returns:
         "base_version": str,
         "head_version": str,
         "version_bump_type": str | null,
+        "expected_bump_type": str | null,
         "breaking_approved": bool,
         "spec_path": str,
         "gate_code": str
     }
 
 Exit codes:
-    0 - Change is allowed (no changes, non-breaking change with a version bump,
-        or an approved breaking change with a version bump)
-    1 - Change is blocked (breaking without approval, or any spec change with no
-        version bump)
+    0 - Change is allowed (no changes, non-breaking change bumped by the correct
+        segment, or an approved breaking change bumped by a minor segment)
+    1 - Change is blocked (breaking without approval, any meaningful spec change
+        with no version bump, or a wrong-segment bump)
     2 - Error running oasdiff or processing specs
 """
 
@@ -53,11 +67,15 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 
 DEFAULT_SPEC_PATH = "backend/src/syntara/schemas/openapi.yaml"
-# Privileged override label for breaking changes. Restricted to engineering
-# leadership at the repo level; CI only checks for its presence.
+# Privileged override label for breaking changes. Restricted to the
+# ``syntara-leads`` team via the Breaking Change Label Guard workflow; CI here
+# only checks for its presence.
 BREAKING_CHANGE_APPROVED_LABEL = "breaking-change-approved"
 
 
@@ -206,6 +224,26 @@ def get_all_changes(base_spec: str, head_spec: str) -> str:
     return (result.stdout + result.stderr).strip()
 
 
+def get_changelog_entries(base_spec: str, head_spec: str) -> list[dict[str, Any]]:
+    """Get structured changelog entries from oasdiff (JSON format).
+
+    Each entry describes a *structural* change (added endpoint, field, enum
+    value, etc.). oasdiff does NOT report spec-only edits (description, summary,
+    example, annotation) here — those are detected via canonical comparison
+    instead. Returns an empty list when there are no structural changes or the
+    JSON cannot be parsed.
+    """
+    result = run_command(["oasdiff", "changelog", base_spec, head_spec, "--format", "json"])
+    text = (result.stdout or "").strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
 def check_approval_label(pr_labels: str) -> bool:
     """Check if the breaking-change approval label is present on the PR.
 
@@ -221,32 +259,77 @@ def check_approval_label(pr_labels: str) -> bool:
     return BREAKING_CHANGE_APPROVED_LABEL.lower() in labels
 
 
-def spec_has_changes(
-    base_content: str,
-    head_content: str,
+def canonicalize_spec(content: str | None) -> tuple[bool, Any]:
+    """Parse spec content into a canonical (semantic) data structure.
+
+    ``info.version`` is stripped so that a version bump on its own is not counted
+    as a meaningful change. Returns ``(parsed_ok, data)``; ``parsed_ok`` is False
+    when the content is not valid YAML (the caller then falls back to a raw
+    string comparison).
+    """
+    if not content:
+        return True, None
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return False, None
+    if isinstance(data, dict) and isinstance(data.get("info"), dict):
+        data["info"] = {k: v for k, v in data["info"].items() if k != "version"}
+    return True, data
+
+
+def has_meaningful_change(
+    base_content: str | None,
+    head_content: str | None,
     *,
     has_breaking: bool,
-    all_changes: str,
 ) -> bool:
-    """True if the spec changed, including edits oasdiff does not report.
+    """True if the spec changed semantically (ignoring ``info.version``).
 
-    File content is the source of truth so whitespace, description, and other
-    metadata edits still require an info.version bump. Changelog/breaking
-    output is a fallback when the files cannot be compared.
+    Comparison is canonical: whitespace, indentation, line endings, key order,
+    and quote style do not count as changes. Breaking changes always count.
+    Falls back to a raw string comparison if either spec cannot be parsed.
     """
     if has_breaking:
         return True
-    if (base_content or "") != (head_content or ""):
-        return True
-    text = (all_changes or "").strip()
-    return bool(text) and not re.match(r"^no changes\b", text, re.IGNORECASE)
+    base_ok, base_data = canonicalize_spec(base_content)
+    head_ok, head_data = canonicalize_spec(head_content)
+    if base_ok and head_ok:
+        return base_data != head_data
+    return (base_content or "") != (head_content or "")
+
+
+def classify_expected_segment(
+    *,
+    has_breaking: bool,
+    has_changes: bool,
+    changelog_entries: list[dict[str, Any]],
+) -> str | None:
+    """Determine the version-bump segment a change is expected to use.
+
+    Rules (see module docstring):
+      * No meaningful change -> None (no bump required).
+      * Breaking change (approved in place) -> "minor" (never "major"; a new
+        major version is a new spec at a new URL path, outside this gate).
+      * Additive change (oasdiff reports structural entries) -> "minor".
+      * Spec-only edit (canonical diff with no structural entries, e.g. a
+        description/example/annotation change) -> "patch".
+    """
+    if not has_changes and not has_breaking:
+        return None
+    if has_breaking:
+        return "minor"
+    if changelog_entries:
+        return "minor"
+    return "patch"
 
 
 def evaluate_gate(
     *,
     has_breaking: bool,
     has_changes: bool,
-    version_bumped: bool,
+    version_bump_type: str | None,
+    expected_bump_type: str | None,
     breaking_approved: bool,
 ) -> GateDecision:
     """Apply the OpenAPI versioning gate. Returns whether the PR is allowed.
@@ -254,10 +337,13 @@ def evaluate_gate(
     Rules:
       * No spec changes -> allowed.
       * Breaking changes without the approval label -> blocked, full stop.
-      * Any spec change without an info.version bump -> blocked.
-      * Approved breaking change (with bump) or non-breaking change (with bump)
-        -> allowed.
+      * Any meaningful spec change without an info.version bump -> blocked.
+      * A bump using the wrong segment -> blocked (names the expected segment).
+      * Approved breaking change (minor bump) or non-breaking change (correct
+        segment) -> allowed.
     """
+    version_bumped = version_bump_type is not None
+
     if not has_breaking and not has_changes:
         return GateDecision(
             allowed=True,
@@ -275,7 +361,7 @@ def evaluate_gate(
                 "  - A new major version must be a new spec served from a separate URL path "
                 "(it would not register as a breaking change here).\n"
                 f"  - For an approved emergency override, request the '{BREAKING_CHANGE_APPROVED_LABEL}' "
-                "label from engineering leadership."
+                "label from engineering leadership (syntara-leads)."
             ),
         )
 
@@ -285,8 +371,26 @@ def evaluate_gate(
             code="version_bump_required",
             message=(
                 "BLOCKED: The OpenAPI spec changed but info.version was not bumped. "
-                "Every spec change must bump info.version (major/minor/patch) to signal "
-                "the change to reviewers and API consumers."
+                "Every meaningful spec change must bump info.version to signal the change "
+                f"to reviewers and API consumers (expected a '{expected_bump_type}' bump)."
+            ),
+        )
+
+    if expected_bump_type is not None and version_bump_type != expected_bump_type:
+        return GateDecision(
+            allowed=False,
+            code="wrong_bump_segment",
+            message=(
+                f"BLOCKED: info.version was bumped by a '{version_bump_type}' segment, but this "
+                f"change requires a '{expected_bump_type}' bump. "
+                + (
+                    "Additive changes (new endpoint, field, or enum value) require a minor bump; "
+                    "spec-only edits (description, example, annotation) require a patch bump. "
+                    if not has_breaking
+                    else "An approved in-place breaking change requires a minor bump, not a major "
+                    "one — a new major version is a new spec at a new URL path. "
+                )
+                + f"Set info.version to a '{expected_bump_type}' increment."
             ),
         )
 
@@ -296,14 +400,14 @@ def evaluate_gate(
             code="breaking_approved",
             message=(
                 f"ALLOWED: Breaking change permitted via the '{BREAKING_CHANGE_APPROVED_LABEL}' "
-                "label (privileged override)."
+                "label (privileged override) with a minor version bump."
             ),
         )
 
     return GateDecision(
         allowed=True,
         code="ok",
-        message="Non-breaking spec change with a version bump",
+        message=f"Non-breaking spec change with a correct '{version_bump_type}' version bump",
     )
 
 
@@ -385,6 +489,9 @@ def main():
             )
             base_spec_content = get_spec_from_git(args.base, args.fallback_spec_path)
         if base_spec_content is None:
+            # A spec that does not exist on the base ref is a *new* spec (e.g. a
+            # new major version introduced at a new URL path). It has no prior
+            # baseline to compare against, so the gate does not fire.
             print(
                 f"Spec path not found on base ref '{args.base}' (file is new or renamed). "
                 f"Skipping breaking changes check.",
@@ -423,14 +530,20 @@ def main():
     # Check for breaking changes
     has_breaking, breaking_output = check_breaking_changes(base_spec_path, head_spec_path)
 
-    # Get all changes
+    # Get all changes (human-readable) and structured entries (for classification)
     all_changes = get_all_changes(base_spec_path, head_spec_path)
+    changelog_entries = get_changelog_entries(base_spec_path, head_spec_path)
 
-    has_changes = spec_has_changes(
+    has_changes = has_meaningful_change(
         base_spec_content or "",
         head_spec_content or "",
         has_breaking=has_breaking,
-        all_changes=all_changes,
+    )
+
+    expected_bump_type = classify_expected_segment(
+        has_breaking=has_breaking,
+        has_changes=has_changes,
+        changelog_entries=changelog_entries,
     )
 
     # Check the breaking-change approval label
@@ -439,7 +552,8 @@ def main():
     decision = evaluate_gate(
         has_breaking=has_breaking,
         has_changes=has_changes,
-        version_bumped=version_bumped,
+        version_bump_type=version_bump_type,
+        expected_bump_type=expected_bump_type,
         breaking_approved=breaking_approved,
     )
 
@@ -453,6 +567,7 @@ def main():
         "base_version": base_version or "",
         "head_version": head_version or "",
         "version_bump_type": version_bump_type,
+        "expected_bump_type": expected_bump_type,
         "breaking_approved": breaking_approved,
         "spec_path": args.spec_path,
         "gate_code": decision.code,
@@ -469,7 +584,9 @@ def main():
             decision=decision,
             base_version=base_version,
             head_version=head_version,
+            version_bumped=version_bumped,
             version_bump_type=version_bump_type,
+            expected_bump_type=expected_bump_type,
             spec_path=args.spec_path,
         )
         output_text = "\n".join(lines)
@@ -479,6 +596,28 @@ def main():
         Path(args.output).write_text(output_text)
     else:
         print(output_text)
+
+    # JSON mode writes a machine-readable file (or stdout). Always also emit an
+    # actionable text error on stderr when the gate blocks, so CI job logs name
+    # the spec, versions, version_bumped, and breaking changes.
+    if not decision.allowed and args.format == "json":
+        print(
+            "\n".join(
+                _format_text_output(
+                    has_breaking=has_breaking,
+                    breaking_output=breaking_output,
+                    all_changes=all_changes,
+                    decision=decision,
+                    base_version=base_version,
+                    head_version=head_version,
+                    version_bumped=version_bumped,
+                    version_bump_type=version_bump_type,
+                    expected_bump_type=expected_bump_type,
+                    spec_path=args.spec_path,
+                )
+            ),
+            file=sys.stderr,
+        )
 
     sys.exit(0 if decision.allowed else 1)
 
@@ -491,17 +630,22 @@ def _format_text_output(
     decision: GateDecision,
     base_version: str,
     head_version: str,
+    version_bumped: bool,
     version_bump_type: str | None,
+    expected_bump_type: str | None,
     spec_path: str,
 ) -> list[str]:
     """Format results as human-readable text lines."""
     lines = []
 
-    # Version info header — always include spec path and versions for CI errors
+    # Version info header — always include spec path, versions, and bump state
     lines.append(f"Spec: {spec_path}")
     lines.append(f"Version: {base_version or 'unknown'} -> {head_version or 'unknown'}")
+    lines.append(f"version_bumped: {str(version_bumped).lower()}")
     if version_bump_type:
         lines.append(f"Bump type: {version_bump_type}")
+    if expected_bump_type:
+        lines.append(f"Expected bump: {expected_bump_type}")
     lines.append("")
 
     if has_breaking:

--- a/backend/scripts/openapi/check-breaking-changes.py
+++ b/backend/scripts/openapi/check-breaking-changes.py
@@ -31,7 +31,7 @@ such changes as non-breaking.
 Usage:
     ./check-breaking-changes.py --base devel --head HEAD
     ./check-breaking-changes.py --base-spec baseline.yaml --head-spec current.yaml
-    ./check-breaking-changes.py --base devel --head HEAD --pr-labels "breaking-change-approved"
+    ./check-breaking-changes.py --base devel --head HEAD --pr-labels '["breaking-change-approved"]'
 
 Returns:
     JSON with structure:
@@ -244,19 +244,31 @@ def get_changelog_entries(base_spec: str, head_spec: str) -> list[dict[str, Any]
     return parsed if isinstance(parsed, list) else []
 
 
-def check_approval_label(pr_labels: str) -> bool:
+def check_approval_label(pr_labels_json: str) -> bool:
     """Check if the breaking-change approval label is present on the PR.
 
+    The contract is a JSON-encoded array of the PR's label names (e.g.
+    ``["bug", "breaking-change-approved"]``), matched **exactly**. A JSON array
+    is used instead of a comma-joined string so that a label name that itself
+    contains a comma cannot be split into two and forge the approval label. The
+    match is case-sensitive to stay consistent with the exact-case ``if:``
+    conditions in ``breaking-change-label-guard.yml`` and
+    ``openapi-breaking-changes.yml`` — a case-variant label that never triggers
+    those guards must not be accepted here either.
+
     Args:
-        pr_labels: Comma-separated list of PR label names
+        pr_labels_json: JSON-encoded array of PR label names
 
     Returns:
         True if the ``breaking-change-approved`` label is present
     """
-    if not pr_labels:
+    if not pr_labels_json:
         return False
-    labels = [label.strip().lower() for label in pr_labels.split(",")]
-    return BREAKING_CHANGE_APPROVED_LABEL.lower() in labels
+    try:
+        labels = json.loads(pr_labels_json)
+    except json.JSONDecodeError:
+        return False
+    return isinstance(labels, list) and BREAKING_CHANGE_APPROVED_LABEL in labels
 
 
 def canonicalize_spec(content: str | None) -> tuple[bool, Any]:
@@ -379,7 +391,7 @@ def evaluate_gate(
     if expected_bump_type is not None and version_bump_type != expected_bump_type:
         return GateDecision(
             allowed=False,
-            code="wrong_bump_segment",
+            code="incorrect_version_increment",
             message=(
                 f"BLOCKED: info.version was bumped by a '{version_bump_type}' segment, but this "
                 f"change requires a '{expected_bump_type}' bump. "
@@ -453,7 +465,7 @@ def main():
     # PR labels for the breaking-change approval override
     parser.add_argument(
         "--pr-labels",
-        help="Comma-separated list of PR label names",
+        help='JSON-encoded array of PR label names, e.g. \'["bug", "breaking-change-approved"]\'',
         default="",
     )
 
@@ -512,6 +524,13 @@ def main():
     if args.head:
         # Get spec from git reference - write to temp file
         head_spec_content = get_spec_from_git(args.head, args.spec_path)
+        if head_spec_content is None:
+            print(
+                f"ERROR: Spec path '{args.spec_path}' not found on head ref '{args.head}'. "
+                f"If the spec was intentionally deleted, this is a breaking change.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
         import tempfile
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:

--- a/backend/scripts/openapi/post-breaking-changes-comment.py
+++ b/backend/scripts/openapi/post-breaking-changes-comment.py
@@ -103,7 +103,7 @@ def _version_bump_required_lines(
     return lines
 
 
-def _wrong_bump_segment_lines(
+def _incorrect_version_increment_lines(
     *,
     spec_path: str,
     base_version: str,
@@ -112,12 +112,12 @@ def _wrong_bump_segment_lines(
     version_bump_type: str | None,
     expected_bump_type: str | None,
 ) -> list[str]:
-    """Format the blocked wrong-bump-segment PR comment section."""
+    """Format the blocked incorrect-version-increment PR comment section."""
     lines = [
-        "### Wrong Version Bump Segment (Blocked)\n",
+        "### Incorrect Version Increment (Blocked)\n",
         (
-            f"This PR bumped `info.version` by a **{escape_markdown(version_bump_type or 'unknown')}** "
-            f"segment, but the change requires a **{escape_markdown(expected_bump_type or 'unknown')}** bump.\n"
+            f"This PR incremented `info.version` by a **{escape_markdown(version_bump_type or 'unknown')}** "
+            f"segment, but the change requires a **{escape_markdown(expected_bump_type or 'unknown')}** increment.\n"
         ),
     ]
     lines.extend(
@@ -232,9 +232,9 @@ def format_breaking_changes_comment(results: dict, repo_owner: str, repo_name: s
                 expected_bump_type=expected_bump_type,
             )
         )
-    elif gate_code == "wrong_bump_segment":
+    elif gate_code == "incorrect_version_increment":
         lines.extend(
-            _wrong_bump_segment_lines(
+            _incorrect_version_increment_lines(
                 spec_path=spec_path,
                 base_version=base_version,
                 head_version=head_version,

--- a/backend/scripts/openapi/post-breaking-changes-comment.py
+++ b/backend/scripts/openapi/post-breaking-changes-comment.py
@@ -33,20 +33,19 @@ def escape_markdown(text: str) -> str:
     )
 
 
-def _incorrect_bump_lines(
+def _version_bump_required_lines(
     *,
     spec_path: str,
     base_version: str,
     head_version: str,
-    version_bump_type: str | None,
-    change_kind: str,
 ) -> list[str]:
-    """Format the blocked incorrect-bump PR comment section."""
+    """Format the blocked missing-version-bump PR comment section."""
     lines = [
-        "### Incorrect Version Bump (Blocked)\n",
+        "### Version Bump Required (Blocked)\n",
         (
-            "This PR does **not** introduce breaking changes, but `info.version` "
-            "was bumped in a way that does not match the change type.\n"
+            "This PR changes the OpenAPI spec but does **not** bump `info.version`. "
+            "Every spec change must include an `info.version` bump so reviewers can see "
+            "your interpretation of the change and API consumers are aware of the update.\n"
         ),
     ]
     if spec_path:
@@ -54,27 +53,12 @@ def _incorrect_bump_lines(
     if base_version or head_version:
         lines.append(
             f"**Version:** {escape_markdown(base_version or 'unknown')} → "
-            f"{escape_markdown(head_version or 'unknown')}"
+            f"{escape_markdown(head_version or 'unknown')} (no bump)\n"
         )
-        if version_bump_type:
-            lines.append(f" ({escape_markdown(version_bump_type)} bump)")
-        lines.append("")
-    if change_kind:
-        lines.append(f"**Change kind:** {escape_markdown(change_kind)}\n")
-    if version_bump_type == "major":
-        lines.append(
-            "Major bumps are reserved for breaking changes. "
-            "Use a **minor** bump for additive features/new endpoints, "
-            "or a **patch** bump for fixes — or omit the bump.\n"
-        )
-    elif change_kind == "additive":
-        lines.append(
-            "Additive API changes require a **minor** version bump "
-            "(for example `1.0.0` → `1.1.0`). A patch bump is not sufficient. "
-            "You may also omit the bump.\n"
-        )
-    else:
-        lines.append("See the OpenAPI versioning policy for the required bump type.\n")
+    lines.append(
+        "Bump `info.version` (major/minor/patch) to reflect the change — "
+        "for example `1.0.0` → `1.1.0` for additive changes, or `1.0.1` for fixes.\n"
+    )
     return lines
 
 
@@ -92,55 +76,34 @@ def format_breaking_changes_comment(results: dict, repo_owner: str, repo_name: s
     has_breaking = results["has_breaking_changes"]
     breaking_changes = results["breaking_changes"]
     all_changes = results["all_changes"]
-    acknowledged = results["acknowledged"]
-    ack_insufficient = results["ack_insufficient"]
-    justification = results["justification"]
     base_version = results.get("base_version", "")
     head_version = results.get("head_version", "")
     version_bump_type = results.get("version_bump_type")
-    cve_approved = results.get("cve_approved", False)
+    breaking_approved = results.get("breaking_approved", False)
     spec_path = results.get("spec_path", "")
     gate_code = results.get("gate_code", "")
-    change_kind = results.get("change_kind", "")
 
     escaped_breaking = escape_markdown(breaking_changes)
     escaped_all = escape_markdown(all_changes)
-    escaped_justification = escape_markdown(justification)
 
     lines = [COMMENT_MARKER, ""]
 
     if has_breaking:
-        # Determine which override path (if any) was used
-        major_bump_ack = version_bump_type == "major" and acknowledged
-
-        if cve_approved:
-            lines.append("### Breaking Changes Detected (CVE Override)\n")
+        if breaking_approved:
+            lines.append("### Breaking Changes Detected (Approved Override)\n")
             lines.append(
-                "The `cve-breaking-change-approved` label is present. "
-                "This breaking change is permitted under the CVE escape hatch.\n"
+                "The `breaking-change-approved` label is present. "
+                "This breaking change is permitted via a privileged override.\n"
             )
             lines.append("**Reviewer:** Please verify:")
-            lines.append("1. This override was authorized by engineering leadership (Senior Director or above)")
-            lines.append("2. The breaking change is necessary to address a CVE")
+            lines.append("1. This override was authorized by engineering leadership")
+            lines.append("2. The breaking change is genuinely necessary")
             lines.append("3. Frontend contracts are regenerated in this PR (`make gen-contracts`)")
             lines.append("4. Migration path is documented for API consumers\n")
-        elif major_bump_ack:
-            lines.append("### Breaking Changes Detected (New Major Version)\n")
-            lines.append(
-                f"The API version has been bumped from **{escape_markdown(base_version)}** to "
-                f"**{escape_markdown(head_version)}** (major) with acknowledgment:\n"
-            )
-            lines.append(f"```\n{escaped_justification}\n```\n")
-            lines.append("**Reviewer:** Please verify:")
-            lines.append("1. The justification is valid and necessary")
-            lines.append("2. The new major version is served from a separate URL path (e.g., `/api/v2/`)")
-            lines.append("3. Frontend contracts are regenerated in this PR (`make gen-contracts`)")
-            lines.append("4. Migration path is clear for API consumers\n")
         else:
             lines.append("### Breaking Changes Detected (Blocked)\n")
             lines.append(
-                "This PR introduces **breaking changes** that are **not allowed** "
-                "on the current major API version.\n"
+                "This PR introduces **breaking changes** that are **not allowed** on the current API version.\n"
             )
 
             if spec_path:
@@ -149,29 +112,15 @@ def format_breaking_changes_comment(results: dict, repo_owner: str, repo_name: s
                 lines.append(f"**Current version:** {escape_markdown(base_version or 'unknown')}")
                 lines.append(f"**PR version:** {escape_markdown(head_version or 'unknown')}\n")
 
-            if acknowledged and version_bump_type != "major":
-                lines.append(
-                    "A `breaking-change-ack` is present, but breaking changes require "
-                    "a **major version bump** (not just an acknowledgment).\n"
-                )
-            elif ack_insufficient:
-                lines.append(
-                    f"**Insufficient acknowledgment:**\n```\n{escaped_justification}\n```\n"
-                    "Acknowledgments must be at least 20 characters.\n"
-                )
-
             lines.append("**To resolve, choose one of:**\n")
             lines.append(
-                "1. **Route to a new major version** — bump `info.version` to the next major "
-                "(e.g., 2.0.0) and add to your PR description:\n"
-                "   ```\n"
-                "   breaking-change-ack: <detailed justification>\n"
-                "   ```"
+                "1. **Route to a new major version** — a new major version is a new spec served "
+                "from a separate URL path (e.g., `/api/v2/`), so it is not a breaking change to "
+                "the current spec."
             )
             lines.append(
-                "2. **CVE escape hatch** — if this is a CVE fix that cannot avoid a breaking change, "
-                "request the `cve-breaking-change-approved` label from engineering leadership "
-                "(Senior Director or above)\n"
+                "2. **Approved override** — if this breaking change is unavoidable, request the "
+                "`breaking-change-approved` label from engineering leadership.\n"
             )
 
         lines.append("---\n")
@@ -184,7 +133,7 @@ def format_breaking_changes_comment(results: dict, repo_owner: str, repo_name: s
             lines.append(f"```\n{escaped_all}\n```")
             lines.append("</details>\n")
 
-        if not (cve_approved or major_bump_ack):
+        if not breaking_approved:
             lines.append("---\n")
             lines.append("### What This Means\n")
             lines.append(
@@ -195,14 +144,12 @@ def format_breaking_changes_comment(results: dict, repo_owner: str, repo_name: s
             lines.append("- Changed field types (e.g., string → number)")
             lines.append("- Changed required/optional status")
             lines.append("- Removed enum values\n")
-    elif gate_code == "incorrect_bump":
+    elif gate_code == "version_bump_required":
         lines.extend(
-            _incorrect_bump_lines(
+            _version_bump_required_lines(
                 spec_path=spec_path,
                 base_version=base_version,
                 head_version=head_version,
-                version_bump_type=version_bump_type,
-                change_kind=change_kind,
             )
         )
     else:

--- a/backend/scripts/openapi/post-breaking-changes-comment.py
+++ b/backend/scripts/openapi/post-breaking-changes-comment.py
@@ -33,31 +33,106 @@ def escape_markdown(text: str) -> str:
     )
 
 
+def _json_bool(*, value: bool) -> str:
+    """Return a JSON true/false string for *value*."""
+    return "true" if value else "false"
+
+
+def _coerce_version_bumped(results: dict) -> bool:
+    """Read version_bumped from results, falling back to version_bump_type."""
+    if results.get("version_bumped") is not None:
+        return bool(results["version_bumped"])
+    return results.get("version_bump_type") is not None
+
+
+def _gate_context_lines(
+    *,
+    spec_path: str,
+    base_version: str,
+    head_version: str,
+    version_bumped: bool,
+    version_line_suffix: str = "",
+) -> list[str]:
+    """Return spec, version, and version_bumped lines for blocked PR comments."""
+    lines: list[str] = []
+    if spec_path:
+        lines.append(f"**Spec:** `{escape_markdown(spec_path)}`")
+    if base_version or head_version:
+        lines.append(
+            f"**Version:** {escape_markdown(base_version or 'unknown')} → "
+            f"{escape_markdown(head_version or 'unknown')}{version_line_suffix}"
+        )
+    lines.append(f"**version_bumped:** `{_json_bool(value=version_bumped)}`")
+    lines.append("")
+    return lines
+
+
 def _version_bump_required_lines(
     *,
     spec_path: str,
     base_version: str,
     head_version: str,
+    version_bumped: bool,
+    expected_bump_type: str | None,
 ) -> list[str]:
     """Format the blocked missing-version-bump PR comment section."""
     lines = [
         "### Version Bump Required (Blocked)\n",
         (
             "This PR changes the OpenAPI spec but does **not** bump `info.version`. "
-            "Every spec change must include an `info.version` bump so reviewers can see "
+            "Every meaningful spec change must include an `info.version` bump so reviewers can see "
             "your interpretation of the change and API consumers are aware of the update.\n"
         ),
     ]
-    if spec_path:
-        lines.append(f"**Spec:** `{escape_markdown(spec_path)}`")
-    if base_version or head_version:
-        lines.append(
-            f"**Version:** {escape_markdown(base_version or 'unknown')} → "
-            f"{escape_markdown(head_version or 'unknown')} (no bump)\n"
+    lines.extend(
+        _gate_context_lines(
+            spec_path=spec_path,
+            base_version=base_version,
+            head_version=head_version,
+            version_bumped=version_bumped,
+            version_line_suffix=" (no bump)",
         )
+    )
+    if expected_bump_type:
+        lines.append(f"**Expected bump:** `{escape_markdown(expected_bump_type)}`\n")
     lines.append(
-        "Bump `info.version` (major/minor/patch) to reflect the change — "
-        "for example `1.0.0` → `1.1.0` for additive changes, or `1.0.1` for fixes.\n"
+        "Bump `info.version` to reflect the change — a **minor** bump for additive changes "
+        "(new endpoint, field, or enum value) or a **patch** bump for spec-only edits "
+        "(description, example, annotation).\n"
+    )
+    return lines
+
+
+def _wrong_bump_segment_lines(
+    *,
+    spec_path: str,
+    base_version: str,
+    head_version: str,
+    version_bumped: bool,
+    version_bump_type: str | None,
+    expected_bump_type: str | None,
+) -> list[str]:
+    """Format the blocked wrong-bump-segment PR comment section."""
+    lines = [
+        "### Wrong Version Bump Segment (Blocked)\n",
+        (
+            f"This PR bumped `info.version` by a **{escape_markdown(version_bump_type or 'unknown')}** "
+            f"segment, but the change requires a **{escape_markdown(expected_bump_type or 'unknown')}** bump.\n"
+        ),
+    ]
+    lines.extend(
+        _gate_context_lines(
+            spec_path=spec_path,
+            base_version=base_version,
+            head_version=head_version,
+            version_bumped=version_bumped,
+        )
+    )
+    lines.append(
+        "- **minor** for additive changes (new endpoint, field, or enum value)\n"
+        "- **patch** for spec-only edits (description, example, annotation)\n"
+        "- an approved in-place breaking change uses **minor** (not major — a new major "
+        "version is a new spec at a new URL path)\n"
     )
     return lines
 
@@ -79,6 +154,8 @@ def format_breaking_changes_comment(results: dict, repo_owner: str, repo_name: s
     base_version = results.get("base_version", "")
     head_version = results.get("head_version", "")
     version_bump_type = results.get("version_bump_type")
+    expected_bump_type = results.get("expected_bump_type")
+    version_bumped = _coerce_version_bumped(results)
     breaking_approved = results.get("breaking_approved", False)
     spec_path = results.get("spec_path", "")
     gate_code = results.get("gate_code", "")
@@ -110,7 +187,8 @@ def format_breaking_changes_comment(results: dict, repo_owner: str, repo_name: s
                 lines.append(f"**Spec:** `{escape_markdown(spec_path)}`")
             if base_version or head_version:
                 lines.append(f"**Current version:** {escape_markdown(base_version or 'unknown')}")
-                lines.append(f"**PR version:** {escape_markdown(head_version or 'unknown')}\n")
+                lines.append(f"**PR version:** {escape_markdown(head_version or 'unknown')}")
+            lines.append(f"**version_bumped:** `{_json_bool(value=version_bumped)}`\n")
 
             lines.append("**To resolve, choose one of:**\n")
             lines.append(
@@ -150,6 +228,19 @@ def format_breaking_changes_comment(results: dict, repo_owner: str, repo_name: s
                 spec_path=spec_path,
                 base_version=base_version,
                 head_version=head_version,
+                version_bumped=version_bumped,
+                expected_bump_type=expected_bump_type,
+            )
+        )
+    elif gate_code == "wrong_bump_segment":
+        lines.extend(
+            _wrong_bump_segment_lines(
+                spec_path=spec_path,
+                base_version=base_version,
+                head_version=head_version,
+                version_bumped=version_bumped,
+                version_bump_type=version_bump_type,
+                expected_bump_type=expected_bump_type,
             )
         )
     else:

--- a/backend/scripts/openapi/post-breaking-changes-comment.py
+++ b/backend/scripts/openapi/post-breaking-changes-comment.py
@@ -15,9 +15,10 @@ Environment variables:
 import argparse
 import json
 import subprocess
-import sys
 from pathlib import Path
-from typing import Dict
+
+
+COMMENT_MARKER = "<!-- syntara-openapi-breaking-changes -->"
 
 
 def escape_markdown(text: str) -> str:
@@ -32,7 +33,52 @@ def escape_markdown(text: str) -> str:
     )
 
 
-def format_breaking_changes_comment(results: Dict, repo_owner: str, repo_name: str) -> str:
+def _incorrect_bump_lines(
+    *,
+    spec_path: str,
+    base_version: str,
+    head_version: str,
+    version_bump_type: str | None,
+    change_kind: str,
+) -> list[str]:
+    """Format the blocked incorrect-bump PR comment section."""
+    lines = [
+        "### Incorrect Version Bump (Blocked)\n",
+        (
+            "This PR does **not** introduce breaking changes, but `info.version` "
+            "was bumped in a way that does not match the change type.\n"
+        ),
+    ]
+    if spec_path:
+        lines.append(f"**Spec:** `{escape_markdown(spec_path)}`")
+    if base_version or head_version:
+        lines.append(
+            f"**Version:** {escape_markdown(base_version or 'unknown')} → "
+            f"{escape_markdown(head_version or 'unknown')}"
+        )
+        if version_bump_type:
+            lines.append(f" ({escape_markdown(version_bump_type)} bump)")
+        lines.append("")
+    if change_kind:
+        lines.append(f"**Change kind:** {escape_markdown(change_kind)}\n")
+    if version_bump_type == "major":
+        lines.append(
+            "Major bumps are reserved for breaking changes. "
+            "Use a **minor** bump for additive features/new endpoints, "
+            "or a **patch** bump for fixes — or omit the bump.\n"
+        )
+    elif change_kind == "additive":
+        lines.append(
+            "Additive API changes require a **minor** version bump "
+            "(for example `1.0.0` → `1.1.0`). A patch bump is not sufficient. "
+            "You may also omit the bump.\n"
+        )
+    else:
+        lines.append("See the OpenAPI versioning policy for the required bump type.\n")
+    return lines
+
+
+def format_breaking_changes_comment(results: dict, repo_owner: str, repo_name: str) -> str:
     """Format breaking changes results as a GitHub comment.
 
     Args:
@@ -49,36 +95,84 @@ def format_breaking_changes_comment(results: Dict, repo_owner: str, repo_name: s
     acknowledged = results["acknowledged"]
     ack_insufficient = results["ack_insufficient"]
     justification = results["justification"]
+    base_version = results.get("base_version", "")
+    head_version = results.get("head_version", "")
+    version_bump_type = results.get("version_bump_type")
+    cve_approved = results.get("cve_approved", False)
+    spec_path = results.get("spec_path", "")
+    gate_code = results.get("gate_code", "")
+    change_kind = results.get("change_kind", "")
 
     escaped_breaking = escape_markdown(breaking_changes)
     escaped_all = escape_markdown(all_changes)
     escaped_justification = escape_markdown(justification)
 
-    lines = []
+    lines = [COMMENT_MARKER, ""]
 
     if has_breaking:
-        if acknowledged:
-            lines.append("### Breaking Changes Detected (Acknowledged)\n")
-            lines.append("The developer has acknowledged these breaking changes with justification:\n")
+        # Determine which override path (if any) was used
+        major_bump_ack = version_bump_type == "major" and acknowledged
+
+        if cve_approved:
+            lines.append("### Breaking Changes Detected (CVE Override)\n")
+            lines.append(
+                "The `cve-breaking-change-approved` label is present. "
+                "This breaking change is permitted under the CVE escape hatch.\n"
+            )
+            lines.append("**Reviewer:** Please verify:")
+            lines.append("1. This override was authorized by engineering leadership (Senior Director or above)")
+            lines.append("2. The breaking change is necessary to address a CVE")
+            lines.append("3. Frontend contracts are regenerated in this PR (`make gen-contracts`)")
+            lines.append("4. Migration path is documented for API consumers\n")
+        elif major_bump_ack:
+            lines.append("### Breaking Changes Detected (New Major Version)\n")
+            lines.append(
+                f"The API version has been bumped from **{escape_markdown(base_version)}** to "
+                f"**{escape_markdown(head_version)}** (major) with acknowledgment:\n"
+            )
             lines.append(f"```\n{escaped_justification}\n```\n")
             lines.append("**Reviewer:** Please verify:")
             lines.append("1. The justification is valid and necessary")
-            lines.append("2. Frontend contracts are regenerated in this PR (`make gen-contracts`)")
-            lines.append("3. Migration path is clear for API consumers\n")
-        elif ack_insufficient:
-            lines.append("### Breaking Changes Detected (Insufficient Acknowledgment)\n")
-            lines.append("Breaking changes require explicit acknowledgment with detailed justification.\n")
-            lines.append(f"**Your acknowledgment is too brief:**\n```\n{escaped_justification}\n```\n")
-            lines.append("Please update your PR description with a detailed explanation (minimum 20 characters).\n")
+            lines.append("2. The new major version is served from a separate URL path (e.g., `/api/v2/`)")
+            lines.append("3. Frontend contracts are regenerated in this PR (`make gen-contracts`)")
+            lines.append("4. Migration path is clear for API consumers\n")
         else:
-            lines.append("### Breaking Changes Detected (Not Acknowledged)\n")
-            lines.append("This PR introduces **breaking changes** that will affect existing API consumers.\n")
-            lines.append("**Action Required:** Add to your PR description:")
-            lines.append("```")
+            lines.append("### Breaking Changes Detected (Blocked)\n")
             lines.append(
-                "breaking-change-ack: <detailed justification explaining why this breaking change is necessary and how consumers should migrate>"
+                "This PR introduces **breaking changes** that are **not allowed** "
+                "on the current major API version.\n"
             )
-            lines.append("```\n")
+
+            if spec_path:
+                lines.append(f"**Spec:** `{escape_markdown(spec_path)}`")
+            if base_version or head_version:
+                lines.append(f"**Current version:** {escape_markdown(base_version or 'unknown')}")
+                lines.append(f"**PR version:** {escape_markdown(head_version or 'unknown')}\n")
+
+            if acknowledged and version_bump_type != "major":
+                lines.append(
+                    "A `breaking-change-ack` is present, but breaking changes require "
+                    "a **major version bump** (not just an acknowledgment).\n"
+                )
+            elif ack_insufficient:
+                lines.append(
+                    f"**Insufficient acknowledgment:**\n```\n{escaped_justification}\n```\n"
+                    "Acknowledgments must be at least 20 characters.\n"
+                )
+
+            lines.append("**To resolve, choose one of:**\n")
+            lines.append(
+                "1. **Route to a new major version** — bump `info.version` to the next major "
+                "(e.g., 2.0.0) and add to your PR description:\n"
+                "   ```\n"
+                "   breaking-change-ack: <detailed justification>\n"
+                "   ```"
+            )
+            lines.append(
+                "2. **CVE escape hatch** — if this is a CVE fix that cannot avoid a breaking change, "
+                "request the `cve-breaking-change-approved` label from engineering leadership "
+                "(Senior Director or above)\n"
+            )
 
         lines.append("---\n")
         lines.append("### Breaking Changes Detected\n")
@@ -90,29 +184,37 @@ def format_breaking_changes_comment(results: Dict, repo_owner: str, repo_name: s
             lines.append(f"```\n{escaped_all}\n```")
             lines.append("</details>\n")
 
-        lines.append("---\n")
-        lines.append("### What This Means\n")
-        lines.append(
-            "**Breaking changes** remove or modify existing API contracts in ways that break existing consumers:"
-        )
-        lines.append("- Removed endpoints or fields")
-        lines.append("- Changed field types (e.g., string → number)")
-        lines.append("- Changed required/optional status")
-        lines.append("- Removed enum values\n")
-
-        lines.append("**Before merging, you must:**\n")
-        lines.append("1. **Acknowledge the breaking change** in your PR description")
-        lines.append(
-            "2. **Regenerate frontend contracts** — run `make gen-contracts` and include the updated types in this PR"
-        )
-        lines.append("3. **Document the migration path** for API consumers\n")
-
-        lines.append(
-            f"See [docs/openapi-breaking-changes.md](https://github.com/{repo_owner}/{repo_name}/blob/devel/docs/openapi-breaking-changes.md) for details.\n"
+        if not (cve_approved or major_bump_ack):
+            lines.append("---\n")
+            lines.append("### What This Means\n")
+            lines.append(
+                "Per the **AO REST API Versioning and Deprecation Policy**, breaking changes "
+                "never apply in place — v1 and v2 are separate specs served from different URL paths."
+            )
+            lines.append("- Removed endpoints or fields")
+            lines.append("- Changed field types (e.g., string → number)")
+            lines.append("- Changed required/optional status")
+            lines.append("- Removed enum values\n")
+    elif gate_code == "incorrect_bump":
+        lines.extend(
+            _incorrect_bump_lines(
+                spec_path=spec_path,
+                base_version=base_version,
+                head_version=head_version,
+                version_bump_type=version_bump_type,
+                change_kind=change_kind,
+            )
         )
     else:
         lines.append("### No Breaking Changes Detected\n")
         lines.append("This PR modifies the OpenAPI spec but does **not** introduce breaking changes.\n")
+
+        if base_version and head_version:
+            lines.append(f"**Version:** {escape_markdown(base_version)} → {escape_markdown(head_version)}")
+            if version_bump_type:
+                lines.append(f" ({version_bump_type} bump)\n")
+            else:
+                lines.append("\n")
 
         if all_changes and all_changes.strip():
             lines.append("**Changes detected:**")
@@ -123,7 +225,8 @@ def format_breaking_changes_comment(results: Dict, repo_owner: str, repo_name: s
 
     lines.append("---")
     lines.append(
-        f"*Automated check from [`ci-backend.yml`](https://github.com/{repo_owner}/{repo_name}/blob/devel/.github/workflows/ci-backend.yml)*"
+        f"*Automated check from [`openapi-breaking-changes.yml`]"
+        f"(https://github.com/{repo_owner}/{repo_name}/blob/devel/.github/workflows/openapi-breaking-changes.yml)*"
     )
 
     return "\n".join(lines)
@@ -144,7 +247,7 @@ def post_or_update_comment(pr_number: str, comment_body: str, repo: str) -> None
         f"repos/{repo}/issues/{pr_number}/comments",
         "--paginate",
         "--jq",
-        '.[] | select(.body | contains("Breaking Changes Detected")) | .id',
+        '.[] | select(.body | contains("syntara-openapi-breaking-changes")) | .id',
     ]
 
     result = subprocess.run(list_cmd, capture_output=True, text=True)

--- a/backend/tests/unit/scripts/test_check_breaking_changes.py
+++ b/backend/tests/unit/scripts/test_check_breaking_changes.py
@@ -991,6 +991,52 @@ class TestCheckBreakingChangesExitCodes:
         assert "ERR" in captured["cmd"]
 
 
+class TestGetSpecFromGit:
+    """get_spec_from_git distinguishes a missing file from an unresolvable ref.
+
+    Regression guard: previously ``git cat-file -e {ref}:{path}`` returned
+    non-zero for both a missing file and a bad ref, so a typo'd or unfetched
+    base ref collapsed to None and the base-ref path skipped the gate ("new
+    spec, nothing to check"), a silent false negative. A bad ref must now exit
+    2; None means only "ref resolves, file absent".
+    """
+
+    def _patch_git(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        ref_ok: bool,
+        file_ok: bool,
+        content: str = "spec: content\n",
+    ) -> None:
+        def _fake_run(cmd: list[str], *, capture_output: bool = True) -> subprocess.CompletedProcess[str]:
+            if cmd[:3] == ["git", "rev-parse", "--verify"]:
+                return subprocess.CompletedProcess(cmd, 0 if ref_ok else 128, "", "")
+            if cmd[:2] == ["git", "cat-file"]:
+                return subprocess.CompletedProcess(cmd, 0 if file_ok else 1, "", "")
+            if cmd[:2] == ["git", "show"]:
+                return subprocess.CompletedProcess(cmd, 0, content, "")
+            pytest.fail(f"unexpected command: {cmd}")
+
+        monkeypatch.setattr(check_breaking, "run_command", _fake_run)
+
+    def test_returns_content_when_ref_and_file_exist(self, monkeypatch):
+        self._patch_git(monkeypatch, ref_ok=True, file_ok=True, content="spec: yes\n")
+        assert check_breaking.get_spec_from_git("origin/devel", "a.yaml") == "spec: yes\n"
+
+    def test_returns_none_when_ref_resolves_but_file_missing(self, monkeypatch):
+        self._patch_git(monkeypatch, ref_ok=True, file_ok=False)
+        assert check_breaking.get_spec_from_git("origin/devel", "a.yaml") is None
+
+    def test_unresolvable_ref_exits_two(self, monkeypatch):
+        # A bad or unfetched ref must fail loudly, not be treated as a missing
+        # file (which the base-ref path would silently skip).
+        self._patch_git(monkeypatch, ref_ok=False, file_ok=False)
+        with pytest.raises(SystemExit) as exc:
+            check_breaking.get_spec_from_git("origin/does-not-exist", "a.yaml")
+        assert exc.value.code == 2
+
+
 class TestFormatTextOutput:
     """Tests for _format_text_output()."""
 

--- a/backend/tests/unit/scripts/test_check_breaking_changes.py
+++ b/backend/tests/unit/scripts/test_check_breaking_changes.py
@@ -1,0 +1,737 @@
+"""Tests for backend/scripts/openapi/check-breaking-changes.py.
+
+Covers version helpers, acknowledgment, CVE labels, bump-type matching,
+and the full main() gate (oasdiff is mocked).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parents[3] / "scripts" / "openapi"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+check_breaking = importlib.import_module("check-breaking-changes")
+post_comment = importlib.import_module("post-breaking-changes-comment")
+
+REQUIRED_JSON_FIELDS = (
+    "has_breaking_changes",
+    "breaking_changes",
+    "all_changes",
+    "acknowledged",
+    "justification",
+    "ack_insufficient",
+    "version_bumped",
+    "base_version",
+    "head_version",
+    "version_bump_type",
+    "cve_approved",
+    "spec_path",
+    "change_kind",
+    "gate_code",
+)
+
+
+def _spec_yaml(version: str) -> str:
+    return textwrap.dedent(f"""\
+        openapi: "3.1.0"
+        info:
+          title: Syntara API
+          version: {version}
+        paths: {{}}
+    """)
+
+
+def _write_spec(path: Path, version: str) -> None:
+    path.write_text(_spec_yaml(version))
+
+
+def _run_main(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    base_version: str,
+    head_version: str,
+    has_breaking: bool,
+    changelog: str,
+    pr_body: str = "",
+    pr_labels: str = "",
+    extra_args: list[str] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Invoke main() with mocked oasdiff and return (exit_code, json_result)."""
+    base_spec = tmp_path / "base.yaml"
+    head_spec = tmp_path / "head.yaml"
+    output = tmp_path / "breaking-results.json"
+    _write_spec(base_spec, base_version)
+    _write_spec(head_spec, head_version)
+
+    monkeypatch.setattr(
+        check_breaking,
+        "check_breaking_changes",
+        lambda *_args, **_kwargs: (has_breaking, "removed GET /legacy" if has_breaking else ""),
+    )
+    monkeypatch.setattr(
+        check_breaking,
+        "get_all_changes",
+        lambda *_args, **_kwargs: changelog,
+    )
+
+    argv = [
+        "check-breaking-changes.py",
+        "--base-spec",
+        str(base_spec),
+        "--head-spec",
+        str(head_spec),
+        "--spec-path",
+        "backend/src/syntara/schemas/openapi.yaml",
+        "--output",
+        str(output),
+        "--pr-body",
+        pr_body,
+        "--pr-labels",
+        pr_labels,
+    ]
+    if extra_args:
+        argv.extend(extra_args)
+
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit) as exc:
+        check_breaking.main()
+
+    raw = output.read_text() if output.exists() else ""
+    is_text = extra_args is not None and "text" in extra_args
+    result: dict[str, Any] = {} if is_text or not raw else json.loads(raw)
+    return int(exc.value.code), result
+
+
+class TestExtractInfoVersion:
+    """Tests for extract_info_version()."""
+
+    def test_standard_yaml(self):
+        content = textwrap.dedent("""\
+            openapi: "3.1.0"
+            info:
+              title: Syntara API
+              version: 1.0.0
+            paths: {}
+        """)
+        assert check_breaking.extract_info_version(content) == "1.0.0"
+
+    def test_quoted_version(self):
+        content = textwrap.dedent("""\
+            openapi: "3.1.0"
+            info:
+              title: Syntara API
+              version: "2.1.0"
+            paths: {}
+        """)
+        assert check_breaking.extract_info_version(content) == "2.1.0"
+
+    def test_single_quoted_version(self):
+        content = textwrap.dedent("""\
+            openapi: "3.1.0"
+            info:
+              title: Test
+              version: '0.1.0'
+            paths: {}
+        """)
+        assert check_breaking.extract_info_version(content) == "0.1.0"
+
+    def test_version_with_prerelease(self):
+        content = textwrap.dedent("""\
+            openapi: "3.1.0"
+            info:
+              title: Test
+              version: 1.0.0-beta.1
+            paths: {}
+        """)
+        assert check_breaking.extract_info_version(content) == "1.0.0-beta.1"
+
+    def test_no_info_section(self):
+        content = textwrap.dedent("""\
+            openapi: "3.1.0"
+            paths: {}
+        """)
+        assert check_breaking.extract_info_version(content) is None
+
+    def test_no_version_in_info(self):
+        content = textwrap.dedent("""\
+            openapi: "3.1.0"
+            info:
+              title: Test
+            paths: {}
+        """)
+        assert check_breaking.extract_info_version(content) is None
+
+    def test_version_field_outside_info_ignored(self):
+        content = textwrap.dedent("""\
+            openapi: "3.1.0"
+            info:
+              title: Test
+              version: 1.0.0
+            components:
+              schemas:
+                Foo:
+                  version: 99.0.0
+        """)
+        assert check_breaking.extract_info_version(content) == "1.0.0"
+
+    def test_info_with_extra_fields_before_version(self):
+        content = textwrap.dedent("""\
+            openapi: "3.1.0"
+            info:
+              title: Syntara API
+              description: Some description
+              contact:
+                name: Support
+              version: 3.2.1
+            paths: {}
+        """)
+        assert check_breaking.extract_info_version(content) == "3.2.1"
+
+
+class TestParseSemver:
+    """Tests for parse_semver()."""
+
+    def test_basic(self):
+        assert check_breaking.parse_semver("1.0.0") == (1, 0, 0)
+
+    def test_with_prerelease(self):
+        assert check_breaking.parse_semver("1.0.0-beta.1") == (1, 0, 0)
+
+    def test_large_numbers(self):
+        assert check_breaking.parse_semver("12.34.56") == (12, 34, 56)
+
+    def test_invalid_format(self):
+        assert check_breaking.parse_semver("not-a-version") is None
+
+    def test_partial_version(self):
+        assert check_breaking.parse_semver("1.0") is None
+
+    def test_empty(self):
+        assert check_breaking.parse_semver("") is None
+
+
+class TestGetVersionBumpType:
+    """Tests for get_version_bump_type()."""
+
+    def test_major_bump(self):
+        assert check_breaking.get_version_bump_type("1.0.0", "2.0.0") == "major"
+
+    def test_minor_bump(self):
+        assert check_breaking.get_version_bump_type("1.0.0", "1.1.0") == "minor"
+
+    def test_patch_bump(self):
+        assert check_breaking.get_version_bump_type("1.0.0", "1.0.1") == "patch"
+
+    def test_no_bump(self):
+        assert check_breaking.get_version_bump_type("1.0.0", "1.0.0") is None
+
+    def test_major_with_minor_and_patch(self):
+        assert check_breaking.get_version_bump_type("1.2.3", "2.0.0") == "major"
+
+    def test_major_bump_resets_minor_patch(self):
+        assert check_breaking.get_version_bump_type("1.5.3", "2.1.0") == "major"
+
+    def test_minor_bump_with_patch_change(self):
+        assert check_breaking.get_version_bump_type("1.0.5", "1.1.0") == "minor"
+
+    def test_downgrade_returns_none(self):
+        assert check_breaking.get_version_bump_type("2.0.0", "1.0.0") is None
+
+    def test_minor_downgrade_returns_none(self):
+        assert check_breaking.get_version_bump_type("1.5.0", "1.4.0") is None
+
+    def test_unparseable_base(self):
+        assert check_breaking.get_version_bump_type("bad", "1.0.0") is None
+
+    def test_unparseable_head(self):
+        assert check_breaking.get_version_bump_type("1.0.0", "bad") is None
+
+    def test_prerelease_to_ga(self):
+        assert check_breaking.get_version_bump_type("0.1.0", "1.0.0") == "major"
+
+
+class TestCheckAcknowledgment:
+    """Tests for check_acknowledgment()."""
+
+    def test_no_pr_body(self):
+        result = check_breaking.check_acknowledgment("")
+        assert result["acknowledged"] is False
+        assert result["justification"] == ""
+        assert result["ack_insufficient"] is False
+
+    def test_no_ack_in_body(self):
+        result = check_breaking.check_acknowledgment("This is a normal PR description")
+        assert result["acknowledged"] is False
+
+    def test_valid_ack(self):
+        body = "Some text\nbreaking-change-ack: This change is necessary for the v2 field rename migration\nMore text"
+        result = check_breaking.check_acknowledgment(body)
+        assert result["acknowledged"] is True
+        assert "v2 field rename" in result["justification"]
+        assert result["ack_insufficient"] is False
+
+    def test_insufficient_ack(self):
+        body = "breaking-change-ack: too short"
+        result = check_breaking.check_acknowledgment(body)
+        assert result["acknowledged"] is False
+        assert result["ack_insufficient"] is True
+        assert result["justification"] == "too short"
+
+    def test_case_insensitive(self):
+        body = "Breaking-Change-Ack: This is a sufficiently long justification for the change"
+        result = check_breaking.check_acknowledgment(body)
+        assert result["acknowledged"] is True
+
+    def test_colon_with_spaces(self):
+        body = "breaking-change-ack :   This is a sufficiently long justification text here"
+        result = check_breaking.check_acknowledgment(body)
+        assert result["acknowledged"] is True
+
+    def test_exactly_20_chars(self):
+        body = "breaking-change-ack: 12345678901234567890"
+        result = check_breaking.check_acknowledgment(body)
+        assert result["acknowledged"] is True
+
+    def test_19_chars_insufficient(self):
+        body = "breaking-change-ack: 1234567890123456789"
+        result = check_breaking.check_acknowledgment(body)
+        assert result["acknowledged"] is False
+        assert result["ack_insufficient"] is True
+
+
+class TestCheckCveLabel:
+    """Tests for check_cve_label()."""
+
+    def test_empty_labels(self):
+        assert check_breaking.check_cve_label("") is False
+
+    def test_no_cve_label(self):
+        assert check_breaking.check_cve_label("bug,enhancement") is False
+
+    def test_cve_label_present(self):
+        assert check_breaking.check_cve_label("bug,cve-breaking-change-approved,enhancement") is True
+
+    def test_cve_label_only(self):
+        assert check_breaking.check_cve_label("cve-breaking-change-approved") is True
+
+    def test_case_insensitive(self):
+        assert check_breaking.check_cve_label("CVE-BREAKING-CHANGE-APPROVED") is True
+
+    def test_whitespace_handling(self):
+        assert check_breaking.check_cve_label("bug, cve-breaking-change-approved , fix") is True
+
+    def test_partial_match_rejected(self):
+        assert check_breaking.check_cve_label("not-cve-breaking-change-approved-extra") is False
+
+
+class TestClassifyNonBreakingChanges:
+    """Tests for classify_non_breaking_changes()."""
+
+    def test_empty_is_none(self):
+        assert check_breaking.classify_non_breaking_changes("") == "none"
+
+    def test_no_changes_text_is_none(self):
+        assert check_breaking.classify_non_breaking_changes("No changes") == "none"
+
+    def test_endpoint_added_id_is_additive(self):
+        changelog = "info\t[endpoint-added] at paths/widgets.yaml\n\tin API added GET /widgets"
+        assert check_breaking.classify_non_breaking_changes(changelog) == "additive"
+
+    def test_request_property_added_is_additive(self):
+        changelog = "info [request-property-added] added the optional request property 'nickname'"
+        assert check_breaking.classify_non_breaking_changes(changelog) == "additive"
+
+    def test_description_change_is_other(self):
+        changelog = "info [endpoint-description-changed] updated description of GET /widgets"
+        assert check_breaking.classify_non_breaking_changes(changelog) == "other"
+
+
+class TestEvaluateGate:
+    """Policy decision tests (single source of truth for the gate)."""
+
+    def _decide(
+        self,
+        *,
+        has_breaking: bool = False,
+        version_bump_type: str | None = None,
+        acknowledged: bool = False,
+        ack_insufficient: bool = False,
+        justification: str = "",
+        cve_approved: bool = False,
+        change_kind: str = "none",
+    ) -> check_breaking.GateDecision:
+        return check_breaking.evaluate_gate(
+            has_breaking=has_breaking,
+            version_bump_type=version_bump_type,
+            acknowledged=acknowledged,
+            ack_insufficient=ack_insufficient,
+            justification=justification,
+            cve_approved=cve_approved,
+            change_kind=change_kind,
+        )
+
+    def test_no_changes_allowed(self):
+        decision = self._decide()
+        assert decision.allowed is True
+        assert decision.code == "ok"
+
+    def test_breaking_blocked(self):
+        decision = self._decide(has_breaking=True)
+        assert decision.allowed is False
+        assert decision.code == "breaking_blocked"
+
+    def test_breaking_ack_without_major_blocked(self):
+        decision = self._decide(has_breaking=True, acknowledged=True, version_bump_type=None)
+        assert decision.allowed is False
+        assert decision.code == "ack_without_major"
+
+    def test_breaking_minor_bump_ack_blocked(self):
+        decision = self._decide(has_breaking=True, acknowledged=True, version_bump_type="minor")
+        assert decision.allowed is False
+        assert decision.code == "ack_without_major"
+
+    def test_breaking_major_bump_with_ack_allowed(self):
+        decision = self._decide(
+            has_breaking=True,
+            acknowledged=True,
+            version_bump_type="major",
+            justification="Routing the field rename to /api/v2/",
+        )
+        assert decision.allowed is True
+        assert decision.code == "major_ack"
+
+    def test_breaking_cve_escape_hatch_allowed(self):
+        decision = self._decide(has_breaking=True, cve_approved=True)
+        assert decision.allowed is True
+        assert decision.code == "cve_override"
+
+    def test_additive_minor_bump_allowed(self):
+        decision = self._decide(change_kind="additive", version_bump_type="minor")
+        assert decision.allowed is True
+
+    def test_additive_patch_bump_blocked(self):
+        decision = self._decide(change_kind="additive", version_bump_type="patch")
+        assert decision.allowed is False
+        assert decision.code == "incorrect_bump"
+
+    def test_additive_no_bump_allowed(self):
+        decision = self._decide(change_kind="additive", version_bump_type=None)
+        assert decision.allowed is True
+
+    def test_other_patch_bump_allowed(self):
+        decision = self._decide(change_kind="other", version_bump_type="patch")
+        assert decision.allowed is True
+
+    def test_major_bump_without_breaking_blocked(self):
+        decision = self._decide(change_kind="other", version_bump_type="major")
+        assert decision.allowed is False
+        assert decision.code == "incorrect_bump"
+
+
+class TestMainGate:
+    """End-to-end main() tests with mocked oasdiff."""
+
+    def test_breaking_change_blocked_even_with_ack(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.0.0",
+            has_breaking=True,
+            changelog="removed GET /legacy",
+            pr_body="breaking-change-ack: This is a sufficiently long justification text",
+        )
+        assert code == 1
+        assert result["has_breaking_changes"] is True
+        assert result["acknowledged"] is True
+        assert result["version_bumped"] is False
+        assert result["base_version"] == "1.0.0"
+        assert result["head_version"] == "1.0.0"
+        assert result["gate_code"] == "ack_without_major"
+        assert result["spec_path"] == "backend/src/syntara/schemas/openapi.yaml"
+        for field in REQUIRED_JSON_FIELDS:
+            assert field in result, f"Missing required field: {field}"
+
+    def test_breaking_change_with_cve_escape_hatch(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.0.0",
+            has_breaking=True,
+            changelog="removed GET /legacy",
+            pr_labels="cve-breaking-change-approved",
+        )
+        assert code == 0
+        assert result["cve_approved"] is True
+        assert result["gate_code"] == "cve_override"
+        assert result["version_bumped"] is False
+
+    def test_breaking_change_major_bump_and_ack(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="2.0.0",
+            has_breaking=True,
+            changelog="removed GET /legacy",
+            pr_body="breaking-change-ack: Routing the rename to a new /api/v2/ spec",
+        )
+        assert code == 0
+        assert result["version_bump_type"] == "major"
+        assert result["gate_code"] == "major_ack"
+
+    def test_non_breaking_correct_minor_bump(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.1.0",
+            has_breaking=False,
+            changelog="info [endpoint-added] in API added GET /widgets",
+        )
+        assert code == 0
+        assert result["change_kind"] == "additive"
+        assert result["version_bump_type"] == "minor"
+        assert result["version_bumped"] is True
+        assert result["gate_code"] == "ok"
+
+    def test_non_breaking_incorrect_patch_bump_for_additive(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.0.1",
+            has_breaking=False,
+            changelog="info [endpoint-added] in API added GET /widgets",
+        )
+        assert code == 1
+        assert result["change_kind"] == "additive"
+        assert result["version_bump_type"] == "patch"
+        assert result["gate_code"] == "incorrect_bump"
+        assert result["has_breaking_changes"] is False
+
+    def test_non_breaking_no_bump_allowed(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.0.0",
+            has_breaking=False,
+            changelog="info [endpoint-added] in API added GET /widgets",
+        )
+        assert code == 0
+        assert result["version_bumped"] is False
+        assert result["gate_code"] == "ok"
+
+    def test_no_changes(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.0.0",
+            has_breaking=False,
+            changelog="",
+        )
+        assert code == 0
+        assert result["has_breaking_changes"] is False
+        assert result["change_kind"] == "none"
+        assert result["version_bumped"] is False
+        assert result["base_version"] == "1.0.0"
+        assert result["head_version"] == "1.0.0"
+        assert result["gate_code"] == "ok"
+        for field in REQUIRED_JSON_FIELDS:
+            assert field in result, f"Missing required field: {field}"
+
+    def test_text_output_includes_spec_and_versions(self, monkeypatch, tmp_path):
+        code, _result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.0.0",
+            has_breaking=True,
+            changelog="removed GET /legacy",
+            extra_args=["--format", "text"],
+        )
+        assert code == 1
+        text = (tmp_path / "breaking-results.json").read_text()
+        assert "backend/src/syntara/schemas/openapi.yaml" in text
+        assert "1.0.0 -> 1.0.0" in text
+        assert "BREAKING CHANGES DETECTED" in text
+        assert "removed GET /legacy" in text
+
+
+class TestFormatTextOutput:
+    """Tests for _format_text_output()."""
+
+    def test_no_breaking_changes(self):
+        decision = check_breaking.GateDecision(allowed=True, code="ok", message="No breaking changes detected")
+        lines = check_breaking._format_text_output(
+            has_breaking=False,
+            breaking_output="",
+            all_changes="some changes",
+            decision=decision,
+            base_version="1.0.0",
+            head_version="1.0.1",
+            version_bump_type="patch",
+            spec_path="backend/src/syntara/schemas/openapi.yaml",
+        )
+        text = "\n".join(lines)
+        assert "No breaking changes detected" in text
+        assert "1.0.0 -> 1.0.1" in text
+        assert "backend/src/syntara/schemas/openapi.yaml" in text
+
+    def test_breaking_blocked(self):
+        decision = check_breaking.evaluate_gate(
+            has_breaking=True,
+            version_bump_type=None,
+            acknowledged=False,
+            ack_insufficient=False,
+            justification="",
+            cve_approved=False,
+            change_kind="none",
+        )
+        lines = check_breaking._format_text_output(
+            has_breaking=True,
+            breaking_output="endpoint removed",
+            all_changes="endpoint removed",
+            decision=decision,
+            base_version="1.0.0",
+            head_version="1.0.0",
+            version_bump_type=None,
+            spec_path="backend/src/syntara/schemas/openapi.yaml",
+        )
+        text = "\n".join(lines)
+        assert "BREAKING CHANGES DETECTED" in text
+        assert "BLOCKED" in text
+        assert "cve-breaking-change-approved" in text
+
+    def test_breaking_cve_approved(self):
+        decision = check_breaking.evaluate_gate(
+            has_breaking=True,
+            version_bump_type=None,
+            acknowledged=False,
+            ack_insufficient=False,
+            justification="",
+            cve_approved=True,
+            change_kind="none",
+        )
+        lines = check_breaking._format_text_output(
+            has_breaking=True,
+            breaking_output="field removed",
+            all_changes="field removed",
+            decision=decision,
+            base_version="1.0.0",
+            head_version="1.0.0",
+            version_bump_type=None,
+            spec_path="backend/src/syntara/schemas/openapi.yaml",
+        )
+        text = "\n".join(lines)
+        assert "ALLOWED: CVE escape hatch" in text
+
+    def test_breaking_major_bump_ack(self):
+        decision = check_breaking.evaluate_gate(
+            has_breaking=True,
+            version_bump_type="major",
+            acknowledged=True,
+            ack_insufficient=False,
+            justification="Routing to v2 for the field rename",
+            cve_approved=False,
+            change_kind="none",
+        )
+        lines = check_breaking._format_text_output(
+            has_breaking=True,
+            breaking_output="endpoint renamed",
+            all_changes="endpoint renamed",
+            decision=decision,
+            base_version="1.0.0",
+            head_version="2.0.0",
+            version_bump_type="major",
+            spec_path="backend/src/syntara/schemas/openapi.yaml",
+        )
+        text = "\n".join(lines)
+        assert "ALLOWED: Major version bump" in text
+
+    def test_incorrect_bump_message(self):
+        decision = check_breaking.evaluate_gate(
+            has_breaking=False,
+            version_bump_type="patch",
+            acknowledged=False,
+            ack_insufficient=False,
+            justification="",
+            cve_approved=False,
+            change_kind="additive",
+        )
+        lines = check_breaking._format_text_output(
+            has_breaking=False,
+            breaking_output="",
+            all_changes="info [endpoint-added]",
+            decision=decision,
+            base_version="1.0.0",
+            head_version="1.0.1",
+            version_bump_type="patch",
+            spec_path="backend/src/syntara/schemas/openapi.yaml",
+        )
+        text = "\n".join(lines)
+        assert "BLOCKED" in text
+        assert "minor version bump" in text
+
+
+class TestPostBreakingChangesComment:
+    """Tests for PR comment formatting of the new gate outcomes."""
+
+    def test_blocked_breaking_includes_spec_and_versions(self):
+        comment = post_comment.format_breaking_changes_comment(
+            {
+                "has_breaking_changes": True,
+                "breaking_changes": "removed GET /legacy",
+                "all_changes": "removed GET /legacy",
+                "acknowledged": False,
+                "ack_insufficient": False,
+                "justification": "",
+                "base_version": "1.0.0",
+                "head_version": "1.0.0",
+                "version_bump_type": None,
+                "cve_approved": False,
+                "spec_path": "backend/src/syntara/schemas/openapi.yaml",
+                "gate_code": "breaking_blocked",
+            },
+            "syntara-orchestration",
+            "syntara",
+        )
+        assert "backend/src/syntara/schemas/openapi.yaml" in comment
+        assert "1.0.0" in comment
+        assert "removed GET /legacy" in comment
+        assert "Blocked" in comment
+
+    def test_incorrect_bump_comment(self):
+        comment = post_comment.format_breaking_changes_comment(
+            {
+                "has_breaking_changes": False,
+                "breaking_changes": "",
+                "all_changes": "info [endpoint-added]",
+                "acknowledged": False,
+                "ack_insufficient": False,
+                "justification": "",
+                "base_version": "1.0.0",
+                "head_version": "1.0.1",
+                "version_bump_type": "patch",
+                "cve_approved": False,
+                "spec_path": "backend/src/syntara/schemas/openapi.yaml",
+                "gate_code": "incorrect_bump",
+                "change_kind": "additive",
+            },
+            "syntara-orchestration",
+            "syntara",
+        )
+        assert "Incorrect Version Bump" in comment
+        assert "minor" in comment.lower()

--- a/backend/tests/unit/scripts/test_check_breaking_changes.py
+++ b/backend/tests/unit/scripts/test_check_breaking_changes.py
@@ -308,8 +308,12 @@ class TestCheckApprovalLabel:
     def test_approval_label_only(self):
         assert check_breaking.check_approval_label('["breaking-change-approved"]') is True
 
-    def test_invalid_json_rejected(self):
-        assert check_breaking.check_approval_label("breaking-change-approved") is False
+    def test_invalid_json_fails_loudly(self):
+        # A bare (non-JSON) value almost always means a caller reverted to the
+        # old comma-joined format; fail loudly rather than silently "not
+        # approved", so the broken caller is caught immediately in CI.
+        with pytest.raises(SystemExit):
+            check_breaking.check_approval_label("breaking-change-approved")
 
     def test_non_list_json_rejected(self):
         assert check_breaking.check_approval_label('{"label": "breaking-change-approved"}') is False
@@ -989,6 +993,37 @@ class TestCheckBreakingChangesExitCodes:
         check_breaking.check_breaking_changes("a.yaml", "b.yaml")
         assert "--fail-on" in captured["cmd"]
         assert "ERR" in captured["cmd"]
+
+
+class TestGetChangelogEntries:
+    """get_changelog_entries handles empty/invalid/non-list oasdiff JSON.
+
+    The function's three defensive branches (empty stdout, unparseable JSON,
+    valid-but-non-list JSON) are otherwise only reached through the real-binary
+    integration tests, which skip when oasdiff is not installed.
+    """
+
+    def _patch_run(self, monkeypatch: pytest.MonkeyPatch, stdout: str) -> None:
+        def _fake_run(cmd: list[str], *, capture_output: bool = True) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(cmd, 0, stdout, "")
+
+        monkeypatch.setattr(check_breaking, "run_command", _fake_run)
+
+    def test_empty_output_returns_empty_list(self, monkeypatch):
+        self._patch_run(monkeypatch, "")
+        assert check_breaking.get_changelog_entries("a.yaml", "b.yaml") == []
+
+    def test_invalid_json_returns_empty_list(self, monkeypatch):
+        self._patch_run(monkeypatch, "{not valid json")
+        assert check_breaking.get_changelog_entries("a.yaml", "b.yaml") == []
+
+    def test_non_list_json_returns_empty_list(self, monkeypatch):
+        self._patch_run(monkeypatch, '{"changes": []}')
+        assert check_breaking.get_changelog_entries("a.yaml", "b.yaml") == []
+
+    def test_valid_list_json_is_returned(self, monkeypatch):
+        self._patch_run(monkeypatch, '[{"id": "endpoint-added"}]')
+        assert check_breaking.get_changelog_entries("a.yaml", "b.yaml") == [{"id": "endpoint-added"}]
 
 
 class TestGetSpecFromGit:

--- a/backend/tests/unit/scripts/test_check_breaking_changes.py
+++ b/backend/tests/unit/scripts/test_check_breaking_changes.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib
 import json
 import shutil
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -857,6 +858,16 @@ _INTEGRATION_ADDITIVE = textwrap.dedent("""\
               description: ok
 """)
 
+# Base with the /things endpoint removed, an ERR-level breaking change per
+# oasdiff. The minor bump (1.1.0) satisfies the approved-breaking version rule.
+_INTEGRATION_BREAKING = textwrap.dedent("""\
+    openapi: "3.1.0"
+    info:
+      title: Test API
+      version: 1.1.0
+    paths: {}
+""")
+
 
 @pytest.mark.skipif(shutil.which("oasdiff") is None, reason="oasdiff not installed")
 class TestOasdiffIntegration:
@@ -903,6 +914,81 @@ class TestOasdiffIntegration:
         # Patch bump for an additive change is the wrong segment.
         assert code == 1
         assert result["gate_code"] == "incorrect_version_increment"
+
+    def test_removed_endpoint_is_breaking_and_blocked(self, monkeypatch, tmp_path):
+        # Regression: oasdiff exits 0 even with breaking changes unless --fail-on
+        # is set, so this real-binary case must detect the removed endpoint.
+        code, result = self._run(monkeypatch, tmp_path, _INTEGRATION_BASE, _INTEGRATION_BREAKING)
+        assert result["has_breaking_changes"] is True
+        assert code == 1
+        assert result["gate_code"] == "breaking_blocked"
+
+    def test_removed_endpoint_allowed_with_approval_label(self, monkeypatch, tmp_path):
+        code, result = self._run(
+            monkeypatch,
+            tmp_path,
+            _INTEGRATION_BASE,
+            _INTEGRATION_BREAKING,
+            pr_labels='["breaking-change-approved"]',
+        )
+        assert result["has_breaking_changes"] is True
+        assert code == 0
+        assert result["gate_code"] == "breaking_approved"
+
+
+class TestCheckBreakingChangesExitCodes:
+    """check_breaking_changes maps oasdiff exit codes correctly.
+
+    Regression guard: previously any non-zero exit was treated as a breaking
+    change. That both misreported oasdiff errors (e.g. a spec that fails to
+    load, exit 102) as breaking changes and, because --fail-on was missing,
+    missed real breaking changes (oasdiff exits 0 with breaking changes unless
+    told otherwise).
+    """
+
+    def _patch_oasdiff(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        breaking_returncode: int,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> dict[str, list[str]]:
+        captured: dict[str, list[str]] = {}
+
+        def _fake_run(cmd: list[str], *, capture_output: bool = True) -> subprocess.CompletedProcess[str]:
+            if cmd[:2] == ["oasdiff", "--version"]:
+                return subprocess.CompletedProcess(cmd, 0, "oasdiff v1.18.5", "")
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, breaking_returncode, stdout, stderr)
+
+        monkeypatch.setattr(check_breaking, "run_command", _fake_run)
+        return captured
+
+    def test_exit_zero_is_not_breaking(self, monkeypatch):
+        self._patch_oasdiff(monkeypatch, 0, stdout="No changes")
+        has_breaking, _ = check_breaking.check_breaking_changes("a.yaml", "b.yaml")
+        assert has_breaking is False
+
+    def test_exit_one_is_breaking(self, monkeypatch):
+        self._patch_oasdiff(monkeypatch, 1, stdout="1 changes: 1 error")
+        has_breaking, output = check_breaking.check_breaking_changes("a.yaml", "b.yaml")
+        assert has_breaking is True
+        assert "1 error" in output
+
+    def test_tool_error_exit_code_exits_two(self, monkeypatch):
+        # oasdiff returns 102 when a spec fails to load: an error, not a
+        # breaking change. It must not be reported as breaking.
+        self._patch_oasdiff(monkeypatch, 102, stderr="failed to load spec")
+        with pytest.raises(SystemExit) as exc:
+            check_breaking.check_breaking_changes("a.yaml", "missing.yaml")
+        assert exc.value.code == 2
+
+    def test_fail_on_err_flag_is_passed(self, monkeypatch):
+        captured = self._patch_oasdiff(monkeypatch, 0)
+        check_breaking.check_breaking_changes("a.yaml", "b.yaml")
+        assert "--fail-on" in captured["cmd"]
+        assert "ERR" in captured["cmd"]
 
 
 class TestFormatTextOutput:

--- a/backend/tests/unit/scripts/test_check_breaking_changes.py
+++ b/backend/tests/unit/scripts/test_check_breaking_changes.py
@@ -1,7 +1,12 @@
 """Tests for backend/scripts/openapi/check-breaking-changes.py.
 
-Covers version helpers, acknowledgment, CVE labels, bump-type matching,
-and the full main() gate (oasdiff is mocked).
+Covers version helpers, the breaking-change approval label, spec-change
+detection, and the full main() gate (oasdiff is mocked).
+
+Gate policy under test:
+  * Every OpenAPI spec change must bump info.version (major/minor/patch).
+  * Breaking changes are blocked in place unless the privileged
+    ``breaking-change-approved`` label is present.
 """
 
 from __future__ import annotations
@@ -25,32 +30,24 @@ REQUIRED_JSON_FIELDS = (
     "has_breaking_changes",
     "breaking_changes",
     "all_changes",
-    "acknowledged",
-    "justification",
-    "ack_insufficient",
+    "has_changes",
     "version_bumped",
     "base_version",
     "head_version",
     "version_bump_type",
-    "cve_approved",
+    "breaking_approved",
     "spec_path",
-    "change_kind",
     "gate_code",
 )
 
 
-def _spec_yaml(version: str) -> str:
-    return textwrap.dedent(f"""\
-        openapi: "3.1.0"
-        info:
-          title: Syntara API
-          version: {version}
-        paths: {{}}
-    """)
+def _spec_yaml(version: str, *, description: str | None = None) -> str:
+    extra = f"  description: {description}\n" if description else ""
+    return f'openapi: "3.1.0"\ninfo:\n  title: Syntara API\n{extra}  version: {version}\npaths: {{}}\n'
 
 
-def _write_spec(path: Path, version: str) -> None:
-    path.write_text(_spec_yaml(version))
+def _write_spec(path: Path, version: str, *, description: str | None = None) -> None:
+    path.write_text(_spec_yaml(version, description=description))
 
 
 def _run_main(
@@ -61,16 +58,16 @@ def _run_main(
     head_version: str,
     has_breaking: bool,
     changelog: str,
-    pr_body: str = "",
     pr_labels: str = "",
     extra_args: list[str] | None = None,
+    head_description: str | None = None,
 ) -> tuple[int, dict[str, Any]]:
     """Invoke main() with mocked oasdiff and return (exit_code, json_result)."""
     base_spec = tmp_path / "base.yaml"
     head_spec = tmp_path / "head.yaml"
     output = tmp_path / "breaking-results.json"
     _write_spec(base_spec, base_version)
-    _write_spec(head_spec, head_version)
+    _write_spec(head_spec, head_version, description=head_description)
 
     monkeypatch.setattr(
         check_breaking,
@@ -93,8 +90,6 @@ def _run_main(
         "backend/src/syntara/schemas/openapi.yaml",
         "--output",
         str(output),
-        "--pr-body",
-        pr_body,
         "--pr-labels",
         pr_labels,
     ]
@@ -259,100 +254,56 @@ class TestGetVersionBumpType:
         assert check_breaking.get_version_bump_type("0.1.0", "1.0.0") == "major"
 
 
-class TestCheckAcknowledgment:
-    """Tests for check_acknowledgment()."""
-
-    def test_no_pr_body(self):
-        result = check_breaking.check_acknowledgment("")
-        assert result["acknowledged"] is False
-        assert result["justification"] == ""
-        assert result["ack_insufficient"] is False
-
-    def test_no_ack_in_body(self):
-        result = check_breaking.check_acknowledgment("This is a normal PR description")
-        assert result["acknowledged"] is False
-
-    def test_valid_ack(self):
-        body = "Some text\nbreaking-change-ack: This change is necessary for the v2 field rename migration\nMore text"
-        result = check_breaking.check_acknowledgment(body)
-        assert result["acknowledged"] is True
-        assert "v2 field rename" in result["justification"]
-        assert result["ack_insufficient"] is False
-
-    def test_insufficient_ack(self):
-        body = "breaking-change-ack: too short"
-        result = check_breaking.check_acknowledgment(body)
-        assert result["acknowledged"] is False
-        assert result["ack_insufficient"] is True
-        assert result["justification"] == "too short"
-
-    def test_case_insensitive(self):
-        body = "Breaking-Change-Ack: This is a sufficiently long justification for the change"
-        result = check_breaking.check_acknowledgment(body)
-        assert result["acknowledged"] is True
-
-    def test_colon_with_spaces(self):
-        body = "breaking-change-ack :   This is a sufficiently long justification text here"
-        result = check_breaking.check_acknowledgment(body)
-        assert result["acknowledged"] is True
-
-    def test_exactly_20_chars(self):
-        body = "breaking-change-ack: 12345678901234567890"
-        result = check_breaking.check_acknowledgment(body)
-        assert result["acknowledged"] is True
-
-    def test_19_chars_insufficient(self):
-        body = "breaking-change-ack: 1234567890123456789"
-        result = check_breaking.check_acknowledgment(body)
-        assert result["acknowledged"] is False
-        assert result["ack_insufficient"] is True
-
-
-class TestCheckCveLabel:
-    """Tests for check_cve_label()."""
+class TestCheckApprovalLabel:
+    """Tests for check_approval_label()."""
 
     def test_empty_labels(self):
-        assert check_breaking.check_cve_label("") is False
+        assert check_breaking.check_approval_label("") is False
 
-    def test_no_cve_label(self):
-        assert check_breaking.check_cve_label("bug,enhancement") is False
+    def test_no_approval_label(self):
+        assert check_breaking.check_approval_label("bug,enhancement") is False
 
-    def test_cve_label_present(self):
-        assert check_breaking.check_cve_label("bug,cve-breaking-change-approved,enhancement") is True
+    def test_approval_label_present(self):
+        assert check_breaking.check_approval_label("bug,breaking-change-approved,enhancement") is True
 
-    def test_cve_label_only(self):
-        assert check_breaking.check_cve_label("cve-breaking-change-approved") is True
+    def test_approval_label_only(self):
+        assert check_breaking.check_approval_label("breaking-change-approved") is True
 
     def test_case_insensitive(self):
-        assert check_breaking.check_cve_label("CVE-BREAKING-CHANGE-APPROVED") is True
+        assert check_breaking.check_approval_label("BREAKING-CHANGE-APPROVED") is True
 
     def test_whitespace_handling(self):
-        assert check_breaking.check_cve_label("bug, cve-breaking-change-approved , fix") is True
+        assert check_breaking.check_approval_label("bug, breaking-change-approved , fix") is True
 
     def test_partial_match_rejected(self):
-        assert check_breaking.check_cve_label("not-cve-breaking-change-approved-extra") is False
+        assert check_breaking.check_approval_label("not-breaking-change-approved-extra") is False
 
 
-class TestClassifyNonBreakingChanges:
-    """Tests for classify_non_breaking_changes()."""
+class TestSpecHasChanges:
+    """Tests for spec_has_changes()."""
 
-    def test_empty_is_none(self):
-        assert check_breaking.classify_non_breaking_changes("") == "none"
+    def test_identical_content_no_changelog(self):
+        spec = _spec_yaml("1.0.0")
+        assert check_breaking.spec_has_changes(spec, spec, has_breaking=False, all_changes="") is False
 
-    def test_no_changes_text_is_none(self):
-        assert check_breaking.classify_non_breaking_changes("No changes") == "none"
+    def test_identical_content_no_changes_text(self):
+        spec = _spec_yaml("1.0.0")
+        assert check_breaking.spec_has_changes(spec, spec, has_breaking=False, all_changes="No changes") is False
 
-    def test_endpoint_added_id_is_additive(self):
-        changelog = "info\t[endpoint-added] at paths/widgets.yaml\n\tin API added GET /widgets"
-        assert check_breaking.classify_non_breaking_changes(changelog) == "additive"
+    def test_content_diff_without_oasdiff_output(self):
+        base = _spec_yaml("1.0.0")
+        head = _spec_yaml("1.0.0", description="tweaked")
+        assert check_breaking.spec_has_changes(base, head, has_breaking=False, all_changes="") is True
 
-    def test_request_property_added_is_additive(self):
-        changelog = "info [request-property-added] added the optional request property 'nickname'"
-        assert check_breaking.classify_non_breaking_changes(changelog) == "additive"
+    def test_breaking_always_counts(self):
+        spec = _spec_yaml("1.0.0")
+        assert check_breaking.spec_has_changes(spec, spec, has_breaking=True, all_changes="") is True
 
-    def test_description_change_is_other(self):
-        changelog = "info [endpoint-description-changed] updated description of GET /widgets"
-        assert check_breaking.classify_non_breaking_changes(changelog) == "other"
+    def test_changelog_fallback_when_content_matches(self):
+        spec = _spec_yaml("1.0.0")
+        assert (
+            check_breaking.spec_has_changes(spec, spec, has_breaking=False, all_changes="info [endpoint-added]") is True
+        )
 
 
 class TestEvaluateGate:
@@ -362,21 +313,15 @@ class TestEvaluateGate:
         self,
         *,
         has_breaking: bool = False,
-        version_bump_type: str | None = None,
-        acknowledged: bool = False,
-        ack_insufficient: bool = False,
-        justification: str = "",
-        cve_approved: bool = False,
-        change_kind: str = "none",
-    ) -> Any:
+        has_changes: bool = False,
+        version_bumped: bool = False,
+        breaking_approved: bool = False,
+    ) -> Any:  # noqa: ANN401 - GateDecision comes from a dynamically imported (hyphenated) module
         return check_breaking.evaluate_gate(
             has_breaking=has_breaking,
-            version_bump_type=version_bump_type,
-            acknowledged=acknowledged,
-            ack_insufficient=ack_insufficient,
-            justification=justification,
-            cve_approved=cve_approved,
-            change_kind=change_kind,
+            has_changes=has_changes,
+            version_bumped=version_bumped,
+            breaking_approved=breaking_approved,
         )
 
     def test_no_changes_allowed(self):
@@ -384,99 +329,53 @@ class TestEvaluateGate:
         assert decision.allowed is True
         assert decision.code == "ok"
 
-    def test_breaking_blocked(self):
-        decision = self._decide(has_breaking=True)
+    def test_breaking_no_label_blocked(self):
+        decision = self._decide(has_breaking=True, has_changes=True, version_bumped=True)
         assert decision.allowed is False
         assert decision.code == "breaking_blocked"
 
-    def test_breaking_ack_without_major_blocked(self):
-        decision = self._decide(has_breaking=True, acknowledged=True, version_bump_type=None)
+    def test_breaking_no_label_blocked_even_without_bump(self):
+        # Breaking-without-approval is the dominant reason regardless of bump state.
+        decision = self._decide(has_breaking=True, has_changes=True, version_bumped=False)
         assert decision.allowed is False
-        assert decision.code == "ack_without_major"
+        assert decision.code == "breaking_blocked"
 
-    def test_breaking_minor_bump_ack_blocked(self):
-        decision = self._decide(has_breaking=True, acknowledged=True, version_bump_type="minor")
-        assert decision.allowed is False
-        assert decision.code == "ack_without_major"
-
-    def test_breaking_major_bump_with_ack_allowed(self):
+    def test_breaking_approved_with_bump_allowed(self):
         decision = self._decide(
             has_breaking=True,
-            acknowledged=True,
-            version_bump_type="major",
-            justification="Routing the field rename to /api/v2/",
+            has_changes=True,
+            version_bumped=True,
+            breaking_approved=True,
         )
         assert decision.allowed is True
-        assert decision.code == "major_ack"
+        assert decision.code == "breaking_approved"
 
-    def test_breaking_cve_escape_hatch_allowed(self):
-        decision = self._decide(has_breaking=True, cve_approved=True)
-        assert decision.allowed is True
-        assert decision.code == "cve_override"
-
-    def test_additive_minor_bump_allowed(self):
-        decision = self._decide(change_kind="additive", version_bump_type="minor")
-        assert decision.allowed is True
-
-    def test_additive_patch_bump_blocked(self):
-        decision = self._decide(change_kind="additive", version_bump_type="patch")
+    def test_breaking_approved_without_bump_blocked(self):
+        # Even an approved breaking change must bump info.version.
+        decision = self._decide(
+            has_breaking=True,
+            has_changes=True,
+            version_bumped=False,
+            breaking_approved=True,
+        )
         assert decision.allowed is False
-        assert decision.code == "incorrect_bump"
+        assert decision.code == "version_bump_required"
 
-    def test_additive_no_bump_allowed(self):
-        decision = self._decide(change_kind="additive", version_bump_type=None)
+    def test_non_breaking_with_bump_allowed(self):
+        decision = self._decide(has_changes=True, version_bumped=True)
         assert decision.allowed is True
+        assert decision.code == "ok"
 
-    def test_other_patch_bump_allowed(self):
-        decision = self._decide(change_kind="other", version_bump_type="patch")
-        assert decision.allowed is True
-
-    def test_major_bump_without_breaking_blocked(self):
-        decision = self._decide(change_kind="other", version_bump_type="major")
+    def test_non_breaking_without_bump_blocked(self):
+        decision = self._decide(has_changes=True, version_bumped=False)
         assert decision.allowed is False
-        assert decision.code == "incorrect_bump"
+        assert decision.code == "version_bump_required"
 
 
 class TestMainGate:
     """End-to-end main() tests with mocked oasdiff."""
 
-    def test_breaking_change_blocked_even_with_ack(self, monkeypatch, tmp_path):
-        code, result = _run_main(
-            monkeypatch,
-            tmp_path,
-            base_version="1.0.0",
-            head_version="1.0.0",
-            has_breaking=True,
-            changelog="removed GET /legacy",
-            pr_body="breaking-change-ack: This is a sufficiently long justification text",
-        )
-        assert code == 1
-        assert result["has_breaking_changes"] is True
-        assert result["acknowledged"] is True
-        assert result["version_bumped"] is False
-        assert result["base_version"] == "1.0.0"
-        assert result["head_version"] == "1.0.0"
-        assert result["gate_code"] == "ack_without_major"
-        assert result["spec_path"] == "backend/src/syntara/schemas/openapi.yaml"
-        for field in REQUIRED_JSON_FIELDS:
-            assert field in result, f"Missing required field: {field}"
-
-    def test_breaking_change_with_cve_escape_hatch(self, monkeypatch, tmp_path):
-        code, result = _run_main(
-            monkeypatch,
-            tmp_path,
-            base_version="1.0.0",
-            head_version="1.0.0",
-            has_breaking=True,
-            changelog="removed GET /legacy",
-            pr_labels="cve-breaking-change-approved",
-        )
-        assert code == 0
-        assert result["cve_approved"] is True
-        assert result["gate_code"] == "cve_override"
-        assert result["version_bumped"] is False
-
-    def test_breaking_change_major_bump_and_ack(self, monkeypatch, tmp_path):
+    def test_breaking_change_blocked_without_label(self, monkeypatch, tmp_path):
         code, result = _run_main(
             monkeypatch,
             tmp_path,
@@ -484,13 +383,46 @@ class TestMainGate:
             head_version="2.0.0",
             has_breaking=True,
             changelog="removed GET /legacy",
-            pr_body="breaking-change-ack: Routing the rename to a new /api/v2/ spec",
+        )
+        assert code == 1
+        assert result["has_breaking_changes"] is True
+        assert result["breaking_approved"] is False
+        assert result["gate_code"] == "breaking_blocked"
+        assert result["spec_path"] == "backend/src/syntara/schemas/openapi.yaml"
+        for field in REQUIRED_JSON_FIELDS:
+            assert field in result, f"Missing required field: {field}"
+
+    def test_breaking_change_with_approval_label(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.0.1",
+            has_breaking=True,
+            changelog="removed GET /legacy",
+            pr_labels="breaking-change-approved",
         )
         assert code == 0
-        assert result["version_bump_type"] == "major"
-        assert result["gate_code"] == "major_ack"
+        assert result["breaking_approved"] is True
+        assert result["version_bumped"] is True
+        assert result["gate_code"] == "breaking_approved"
 
-    def test_non_breaking_correct_minor_bump(self, monkeypatch, tmp_path):
+    def test_breaking_change_approved_but_no_bump_blocked(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.0.0",
+            has_breaking=True,
+            changelog="removed GET /legacy",
+            pr_labels="breaking-change-approved",
+        )
+        assert code == 1
+        assert result["breaking_approved"] is True
+        assert result["version_bumped"] is False
+        assert result["gate_code"] == "version_bump_required"
+
+    def test_non_breaking_minor_bump_allowed(self, monkeypatch, tmp_path):
         code, result = _run_main(
             monkeypatch,
             tmp_path,
@@ -498,14 +430,16 @@ class TestMainGate:
             head_version="1.1.0",
             has_breaking=False,
             changelog="info [endpoint-added] in API added GET /widgets",
+            head_description="new endpoint",
         )
         assert code == 0
-        assert result["change_kind"] == "additive"
+        assert result["has_changes"] is True
         assert result["version_bump_type"] == "minor"
         assert result["version_bumped"] is True
         assert result["gate_code"] == "ok"
 
-    def test_non_breaking_incorrect_patch_bump_for_additive(self, monkeypatch, tmp_path):
+    def test_non_breaking_patch_bump_allowed(self, monkeypatch, tmp_path):
+        # Bump *type* is not enforced — any bump satisfies the gate for non-breaking changes.
         code, result = _run_main(
             monkeypatch,
             tmp_path,
@@ -513,14 +447,14 @@ class TestMainGate:
             head_version="1.0.1",
             has_breaking=False,
             changelog="info [endpoint-added] in API added GET /widgets",
+            head_description="new endpoint",
         )
-        assert code == 1
-        assert result["change_kind"] == "additive"
+        assert code == 0
+        assert result["has_changes"] is True
         assert result["version_bump_type"] == "patch"
-        assert result["gate_code"] == "incorrect_bump"
-        assert result["has_breaking_changes"] is False
+        assert result["gate_code"] == "ok"
 
-    def test_non_breaking_no_bump_allowed(self, monkeypatch, tmp_path):
+    def test_non_breaking_no_bump_blocked(self, monkeypatch, tmp_path):
         code, result = _run_main(
             monkeypatch,
             tmp_path,
@@ -528,10 +462,26 @@ class TestMainGate:
             head_version="1.0.0",
             has_breaking=False,
             changelog="info [endpoint-added] in API added GET /widgets",
+            head_description="new endpoint",
         )
-        assert code == 0
+        assert code == 1
+        assert result["has_changes"] is True
         assert result["version_bumped"] is False
-        assert result["gate_code"] == "ok"
+        assert result["gate_code"] == "version_bump_required"
+
+    def test_oasdiff_silent_content_change_requires_bump(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.0.0",
+            has_breaking=False,
+            changelog="",
+            head_description="metadata only",
+        )
+        assert code == 1
+        assert result["has_changes"] is True
+        assert result["gate_code"] == "version_bump_required"
 
     def test_no_changes(self, monkeypatch, tmp_path):
         code, result = _run_main(
@@ -544,7 +494,7 @@ class TestMainGate:
         )
         assert code == 0
         assert result["has_breaking_changes"] is False
-        assert result["change_kind"] == "none"
+        assert result["has_changes"] is False
         assert result["version_bumped"] is False
         assert result["base_version"] == "1.0.0"
         assert result["head_version"] == "1.0.0"
@@ -573,8 +523,10 @@ class TestMainGate:
 class TestFormatTextOutput:
     """Tests for _format_text_output()."""
 
-    def test_no_breaking_changes(self):
-        decision = check_breaking.GateDecision(allowed=True, code="ok", message="No breaking changes detected")
+    def test_non_breaking_with_bump(self):
+        decision = check_breaking.GateDecision(
+            allowed=True, code="ok", message="Non-breaking spec change with a version bump"
+        )
         lines = check_breaking._format_text_output(
             has_breaking=False,
             breaking_output="",
@@ -586,19 +538,16 @@ class TestFormatTextOutput:
             spec_path="backend/src/syntara/schemas/openapi.yaml",
         )
         text = "\n".join(lines)
-        assert "No breaking changes detected" in text
+        assert "version bump" in text
         assert "1.0.0 -> 1.0.1" in text
         assert "backend/src/syntara/schemas/openapi.yaml" in text
 
     def test_breaking_blocked(self):
         decision = check_breaking.evaluate_gate(
             has_breaking=True,
-            version_bump_type=None,
-            acknowledged=False,
-            ack_insufficient=False,
-            justification="",
-            cve_approved=False,
-            change_kind="none",
+            has_changes=True,
+            version_bumped=True,
+            breaking_approved=False,
         )
         lines = check_breaking._format_text_output(
             has_breaking=True,
@@ -606,24 +555,21 @@ class TestFormatTextOutput:
             all_changes="endpoint removed",
             decision=decision,
             base_version="1.0.0",
-            head_version="1.0.0",
-            version_bump_type=None,
+            head_version="1.1.0",
+            version_bump_type="minor",
             spec_path="backend/src/syntara/schemas/openapi.yaml",
         )
         text = "\n".join(lines)
         assert "BREAKING CHANGES DETECTED" in text
         assert "BLOCKED" in text
-        assert "cve-breaking-change-approved" in text
+        assert "breaking-change-approved" in text
 
-    def test_breaking_cve_approved(self):
+    def test_breaking_approved(self):
         decision = check_breaking.evaluate_gate(
             has_breaking=True,
-            version_bump_type=None,
-            acknowledged=False,
-            ack_insufficient=False,
-            justification="",
-            cve_approved=True,
-            change_kind="none",
+            has_changes=True,
+            version_bumped=True,
+            breaking_approved=True,
         )
         lines = check_breaking._format_text_output(
             has_breaking=True,
@@ -631,45 +577,20 @@ class TestFormatTextOutput:
             all_changes="field removed",
             decision=decision,
             base_version="1.0.0",
-            head_version="1.0.0",
-            version_bump_type=None,
+            head_version="1.0.1",
+            version_bump_type="patch",
             spec_path="backend/src/syntara/schemas/openapi.yaml",
         )
         text = "\n".join(lines)
-        assert "ALLOWED: CVE escape hatch" in text
+        assert "ALLOWED" in text
+        assert "breaking-change-approved" in text
 
-    def test_breaking_major_bump_ack(self):
-        decision = check_breaking.evaluate_gate(
-            has_breaking=True,
-            version_bump_type="major",
-            acknowledged=True,
-            ack_insufficient=False,
-            justification="Routing to v2 for the field rename",
-            cve_approved=False,
-            change_kind="none",
-        )
-        lines = check_breaking._format_text_output(
-            has_breaking=True,
-            breaking_output="endpoint renamed",
-            all_changes="endpoint renamed",
-            decision=decision,
-            base_version="1.0.0",
-            head_version="2.0.0",
-            version_bump_type="major",
-            spec_path="backend/src/syntara/schemas/openapi.yaml",
-        )
-        text = "\n".join(lines)
-        assert "ALLOWED: Major version bump" in text
-
-    def test_incorrect_bump_message(self):
+    def test_version_bump_required_message(self):
         decision = check_breaking.evaluate_gate(
             has_breaking=False,
-            version_bump_type="patch",
-            acknowledged=False,
-            ack_insufficient=False,
-            justification="",
-            cve_approved=False,
-            change_kind="additive",
+            has_changes=True,
+            version_bumped=False,
+            breaking_approved=False,
         )
         lines = check_breaking._format_text_output(
             has_breaking=False,
@@ -677,17 +598,17 @@ class TestFormatTextOutput:
             all_changes="info [endpoint-added]",
             decision=decision,
             base_version="1.0.0",
-            head_version="1.0.1",
-            version_bump_type="patch",
+            head_version="1.0.0",
+            version_bump_type=None,
             spec_path="backend/src/syntara/schemas/openapi.yaml",
         )
         text = "\n".join(lines)
         assert "BLOCKED" in text
-        assert "minor version bump" in text
+        assert "info.version" in text
 
 
 class TestPostBreakingChangesComment:
-    """Tests for PR comment formatting of the new gate outcomes."""
+    """Tests for PR comment formatting of the gate outcomes."""
 
     def test_blocked_breaking_includes_spec_and_versions(self):
         comment = post_comment.format_breaking_changes_comment(
@@ -695,13 +616,10 @@ class TestPostBreakingChangesComment:
                 "has_breaking_changes": True,
                 "breaking_changes": "removed GET /legacy",
                 "all_changes": "removed GET /legacy",
-                "acknowledged": False,
-                "ack_insufficient": False,
-                "justification": "",
                 "base_version": "1.0.0",
-                "head_version": "1.0.0",
-                "version_bump_type": None,
-                "cve_approved": False,
+                "head_version": "1.1.0",
+                "version_bump_type": "minor",
+                "breaking_approved": False,
                 "spec_path": "backend/src/syntara/schemas/openapi.yaml",
                 "gate_code": "breaking_blocked",
             },
@@ -712,26 +630,42 @@ class TestPostBreakingChangesComment:
         assert "1.0.0" in comment
         assert "removed GET /legacy" in comment
         assert "Blocked" in comment
+        assert "breaking-change-approved" in comment
 
-    def test_incorrect_bump_comment(self):
+    def test_approved_breaking_comment(self):
+        comment = post_comment.format_breaking_changes_comment(
+            {
+                "has_breaking_changes": True,
+                "breaking_changes": "removed GET /legacy",
+                "all_changes": "removed GET /legacy",
+                "base_version": "1.0.0",
+                "head_version": "1.0.1",
+                "version_bump_type": "patch",
+                "breaking_approved": True,
+                "spec_path": "backend/src/syntara/schemas/openapi.yaml",
+                "gate_code": "breaking_approved",
+            },
+            "syntara-orchestration",
+            "syntara",
+        )
+        assert "Approved Override" in comment
+        assert "breaking-change-approved" in comment
+
+    def test_version_bump_required_comment(self):
         comment = post_comment.format_breaking_changes_comment(
             {
                 "has_breaking_changes": False,
                 "breaking_changes": "",
                 "all_changes": "info [endpoint-added]",
-                "acknowledged": False,
-                "ack_insufficient": False,
-                "justification": "",
                 "base_version": "1.0.0",
-                "head_version": "1.0.1",
-                "version_bump_type": "patch",
-                "cve_approved": False,
+                "head_version": "1.0.0",
+                "version_bump_type": None,
+                "breaking_approved": False,
                 "spec_path": "backend/src/syntara/schemas/openapi.yaml",
-                "gate_code": "incorrect_bump",
-                "change_kind": "additive",
+                "gate_code": "version_bump_required",
             },
             "syntara-orchestration",
             "syntara",
         )
-        assert "Incorrect Version Bump" in comment
-        assert "minor" in comment.lower()
+        assert "Version Bump Required" in comment
+        assert "info.version" in comment

--- a/backend/tests/unit/scripts/test_check_breaking_changes.py
+++ b/backend/tests/unit/scripts/test_check_breaking_changes.py
@@ -5,13 +5,15 @@ spec-change detection, bump-segment classification, and the full main() gate
 (oasdiff is mocked except in the explicitly-integration tests).
 
 Gate policy under test:
-  * Every *meaningful* OpenAPI spec change must bump info.version. Comparison is
-    canonical, so serialization-only diffs (whitespace, key order, quotes) do
-    not require a bump.
-  * The bump segment must match the change type: minor for additive changes,
-    patch for spec-only edits. A wrong-segment bump is blocked.
+  * Every *meaningful* OpenAPI spec change must update info.version. Comparison
+    is canonical, so serialization-only diffs (whitespace, key order, quotes) do
+    not require a version change.
+  * The version increment must match the change type: minor for additive
+    changes, patch for spec-only edits. An incorrect version increment is
+    blocked (gate_code: incorrect_version_increment).
   * Breaking changes are blocked in place unless the privileged
-    ``breaking-change-approved`` label is present AND the bump is a minor.
+    ``breaking-change-approved`` label is present AND the increment is a minor.
+    The approval label is matched from a JSON-encoded array, exact-case.
 """
 
 from __future__ import annotations
@@ -285,28 +287,44 @@ class TestGetVersionBumpType:
 
 
 class TestCheckApprovalLabel:
-    """Tests for check_approval_label()."""
+    """Tests for check_approval_label().
+
+    The contract is a JSON-encoded array of label names, matched exactly. This
+    guards against two authorization-bypass classes: a label name that contains
+    a comma (which a naive split would forge into the approval label) and a
+    case-variant label (which never triggers the exact-case workflow guards).
+    """
 
     def test_empty_labels(self):
         assert check_breaking.check_approval_label("") is False
 
     def test_no_approval_label(self):
-        assert check_breaking.check_approval_label("bug,enhancement") is False
+        assert check_breaking.check_approval_label('["bug", "enhancement"]') is False
 
     def test_approval_label_present(self):
-        assert check_breaking.check_approval_label("bug,breaking-change-approved,enhancement") is True
+        assert check_breaking.check_approval_label('["bug", "breaking-change-approved", "enhancement"]') is True
 
     def test_approval_label_only(self):
-        assert check_breaking.check_approval_label("breaking-change-approved") is True
+        assert check_breaking.check_approval_label('["breaking-change-approved"]') is True
 
-    def test_case_insensitive(self):
-        assert check_breaking.check_approval_label("BREAKING-CHANGE-APPROVED") is True
+    def test_invalid_json_rejected(self):
+        assert check_breaking.check_approval_label("breaking-change-approved") is False
 
-    def test_whitespace_handling(self):
-        assert check_breaking.check_approval_label("bug, breaking-change-approved , fix") is True
+    def test_non_list_json_rejected(self):
+        assert check_breaking.check_approval_label('{"label": "breaking-change-approved"}') is False
 
     def test_partial_match_rejected(self):
-        assert check_breaking.check_approval_label("not-breaking-change-approved-extra") is False
+        assert check_breaking.check_approval_label('["not-breaking-change-approved-extra"]') is False
+
+    def test_label_name_containing_comma_does_not_grant_approval(self):
+        # A single label literally named "urgent,breaking-change-approved" must
+        # not be split into two labels and accepted.
+        assert check_breaking.check_approval_label('["urgent,breaking-change-approved"]') is False
+
+    def test_case_variant_label_does_not_grant_approval(self):
+        # A case-variant label slips past the exact-case workflow guards, so it
+        # must not be accepted here either.
+        assert check_breaking.check_approval_label('["Breaking-Change-Approved"]') is False
 
 
 class TestCanonicalizeSpec:
@@ -444,7 +462,7 @@ class TestEvaluateGate:
             breaking_approved=True,
         )
         assert decision.allowed is False
-        assert decision.code == "wrong_bump_segment"
+        assert decision.code == "incorrect_version_increment"
 
     def test_breaking_approved_without_bump_blocked(self):
         decision = self._decide(
@@ -465,7 +483,7 @@ class TestEvaluateGate:
     def test_additive_with_patch_blocked(self):
         decision = self._decide(has_changes=True, version_bump_type="patch", expected_bump_type="minor")
         assert decision.allowed is False
-        assert decision.code == "wrong_bump_segment"
+        assert decision.code == "incorrect_version_increment"
 
     def test_spec_only_with_patch_allowed(self):
         decision = self._decide(has_changes=True, version_bump_type="patch", expected_bump_type="patch")
@@ -475,7 +493,7 @@ class TestEvaluateGate:
     def test_spec_only_with_minor_blocked(self):
         decision = self._decide(has_changes=True, version_bump_type="minor", expected_bump_type="patch")
         assert decision.allowed is False
-        assert decision.code == "wrong_bump_segment"
+        assert decision.code == "incorrect_version_increment"
 
     def test_change_without_bump_blocked(self):
         decision = self._decide(has_changes=True, version_bump_type=None, expected_bump_type="minor")
@@ -513,7 +531,7 @@ class TestMainGate:
             has_breaking=True,
             changelog="removed GET /legacy",
             head_description="approved breaking edit",
-            pr_labels="breaking-change-approved",
+            pr_labels='["breaking-change-approved"]',
         )
         assert code == 0
         assert result["breaking_approved"] is True
@@ -530,12 +548,12 @@ class TestMainGate:
             has_breaking=True,
             changelog="removed GET /legacy",
             head_description="approved breaking edit",
-            pr_labels="breaking-change-approved",
+            pr_labels='["breaking-change-approved"]',
         )
         assert code == 1
         assert result["version_bump_type"] == "major"
         assert result["expected_bump_type"] == "minor"
-        assert result["gate_code"] == "wrong_bump_segment"
+        assert result["gate_code"] == "incorrect_version_increment"
 
     def test_breaking_change_approved_but_no_bump_blocked(self, monkeypatch, tmp_path):
         code, result = _run_main(
@@ -545,7 +563,7 @@ class TestMainGate:
             head_version="1.0.0",
             has_breaking=True,
             changelog="removed GET /legacy",
-            pr_labels="breaking-change-approved",
+            pr_labels='["breaking-change-approved"]',
         )
         assert code == 1
         assert result["breaking_approved"] is True
@@ -583,7 +601,7 @@ class TestMainGate:
         assert code == 1
         assert result["version_bump_type"] == "patch"
         assert result["expected_bump_type"] == "minor"
-        assert result["gate_code"] == "wrong_bump_segment"
+        assert result["gate_code"] == "incorrect_version_increment"
 
     def test_spec_only_patch_bump_allowed(self, monkeypatch, tmp_path):
         # Description-only edit: oasdiff reports no structural entries -> expects patch.
@@ -617,7 +635,7 @@ class TestMainGate:
         assert code == 1
         assert result["version_bump_type"] == "minor"
         assert result["expected_bump_type"] == "patch"
-        assert result["gate_code"] == "wrong_bump_segment"
+        assert result["gate_code"] == "incorrect_version_increment"
 
     def test_meaningful_change_no_bump_blocked(self, monkeypatch, tmp_path):
         code, result = _run_main(
@@ -695,6 +713,29 @@ class TestMainGate:
         with pytest.raises(SystemExit) as exc:
             check_breaking.main()
         assert int(exc.value.code or 0) == 0
+        assert not output.exists()
+
+    def test_deleted_spec_on_head_ref_errors_cleanly(self, monkeypatch, tmp_path):
+        # If the spec exists on base but is gone on head, exit 2 with a clear
+        # message instead of crashing on f.write(None).
+        def _fake(ref: str, _spec_path: str) -> str | None:
+            return None if ref == "HEAD" else _spec_yaml("1.0.0")
+
+        monkeypatch.setattr(check_breaking, "get_spec_from_git", _fake)
+        output = tmp_path / "breaking-results.json"
+        argv = [
+            "check-breaking-changes.py",
+            "--base",
+            "origin/devel",
+            "--head",
+            "HEAD",
+            "--output",
+            str(output),
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+        with pytest.raises(SystemExit) as exc:
+            check_breaking.main()
+        assert int(exc.value.code or 0) == 2
         assert not output.exists()
 
     def test_text_output_includes_spec_and_versions(self, monkeypatch, tmp_path):
@@ -861,7 +902,7 @@ class TestOasdiffIntegration:
         assert result["expected_bump_type"] == "minor"
         # Patch bump for an additive change is the wrong segment.
         assert code == 1
-        assert result["gate_code"] == "wrong_bump_segment"
+        assert result["gate_code"] == "incorrect_version_increment"
 
 
 class TestFormatTextOutput:
@@ -915,7 +956,7 @@ class TestFormatTextOutput:
         assert "breaking-change-approved" in text
         assert "version_bumped: true" in text
 
-    def test_wrong_bump_segment(self):
+    def test_incorrect_version_increment(self):
         decision = check_breaking.evaluate_gate(
             has_breaking=False,
             has_changes=True,
@@ -1036,7 +1077,7 @@ class TestPostBreakingChangesComment:
         assert "minor" in comment
         assert "**version_bumped:** `false`" in comment
 
-    def test_wrong_bump_segment_comment(self):
+    def test_incorrect_version_increment_comment(self):
         comment = post_comment.format_breaking_changes_comment(
             {
                 "has_breaking_changes": False,
@@ -1048,12 +1089,12 @@ class TestPostBreakingChangesComment:
                 "expected_bump_type": "minor",
                 "breaking_approved": False,
                 "spec_path": "backend/src/syntara/schemas/openapi.yaml",
-                "gate_code": "wrong_bump_segment",
+                "gate_code": "incorrect_version_increment",
             },
             "syntara-orchestration",
             "syntara",
         )
-        assert "Wrong Version Bump Segment" in comment
+        assert "Incorrect Version Increment" in comment
         assert "minor" in comment
         assert "patch" in comment
         assert "**version_bumped:** `true`" in comment
@@ -1076,6 +1117,33 @@ class TestAckPathRemoved:
         makefile = (BACKEND_ROOT / "Makefile").read_text()
         assert "--pr-body" not in makefile
 
+    def test_makefile_does_not_eval_untrusted_labels(self):
+        # Untrusted PR label text must not be re-parsed by the shell; the recipe
+        # invokes the checker directly (if/else), never via `eval`.
+        makefile = (BACKEND_ROOT / "Makefile").read_text()
+        assert "eval $$CMD" not in makefile
+        assert "eval $CMD" not in makefile
+
+
+class TestLabelInjectionSafety:
+    """Untrusted PR label text must never reach a shell for re-parsing."""
+
+    def test_workflow_passes_labels_via_env_not_interpolation(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "openapi-breaking-changes.yml").read_text()
+        # Labels are forwarded through an env var, not substituted into the run
+        # script (which GitHub Actions would expand before the shell parses it).
+        assert "OPENAPI_PR_LABELS: ${{ steps.labels.outputs.labels }}" in workflow
+        assert '--pr-labels "$OPENAPI_PR_LABELS"' in workflow
+        assert '--pr-labels "${{ steps.labels.outputs.labels }}"' not in workflow
+
+    def test_workflow_emits_labels_as_json_array(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "openapi-breaking-changes.yml").read_text()
+        assert "JSON.stringify(labels)" in workflow
+
+    def test_ci_backend_forwards_labels_as_json_array(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "ci-backend.yml").read_text()
+        assert "toJSON(github.event.pull_request.labels.*.name)" in workflow
+
 
 class TestBreakingChangeLabelGuard:
     """Contract tests for unauthorized label application being removed.
@@ -1091,7 +1159,9 @@ class TestBreakingChangeLabelGuard:
     def test_triggers_on_label_added(self):
         text = LABEL_GUARD_WORKFLOW.read_text()
         assert "pull_request_target:" in text
-        assert "types: [labeled]" in text
+        # Broadened so the guard reports a (skipped) check on every PR and can be
+        # made a required status check; the labeled event is what actually runs it.
+        assert "labeled" in text
         assert "github.event.label.name == 'breaking-change-approved'" in text
 
     def test_verifies_syntara_leads_membership(self):
@@ -1110,8 +1180,15 @@ class TestBreakingChangeLabelGuard:
     def test_fails_closed_without_org_token(self):
         text = LABEL_GUARD_WORKFLOW.read_text()
         assert "SYNTARA_LEADS_READ_TOKEN" in text
-        assert "secrets.GITHUB_TOKEN" in text
+        # A missing token fails fast in a preflight step rather than silently
+        # falling back to GITHUB_TOKEN (which cannot read team membership).
+        assert "Ensure org-read token is configured" in text
+        assert "secrets.GITHUB_TOKEN" not in text
         assert "isMember = false" in text
+
+    def test_membership_check_uses_only_org_read_token(self):
+        text = LABEL_GUARD_WORKFLOW.read_text()
+        assert "github-token: ${{ secrets.SYNTARA_LEADS_READ_TOKEN }}" in text
 
 
 class TestOpenapiBreakingChangesWorkflow:

--- a/backend/tests/unit/scripts/test_check_breaking_changes.py
+++ b/backend/tests/unit/scripts/test_check_breaking_changes.py
@@ -108,7 +108,7 @@ def _run_main(
     raw = output.read_text() if output.exists() else ""
     is_text = extra_args is not None and "text" in extra_args
     result: dict[str, Any] = {} if is_text or not raw else json.loads(raw)
-    return int(exc.value.code), result
+    return int(exc.value.code or 0), result
 
 
 class TestExtractInfoVersion:
@@ -368,7 +368,7 @@ class TestEvaluateGate:
         justification: str = "",
         cve_approved: bool = False,
         change_kind: str = "none",
-    ) -> check_breaking.GateDecision:
+    ) -> Any:
         return check_breaking.evaluate_gate(
             has_breaking=has_breaking,
             version_bump_type=version_bump_type,

--- a/backend/tests/unit/scripts/test_check_breaking_changes.py
+++ b/backend/tests/unit/scripts/test_check_breaking_changes.py
@@ -1,18 +1,24 @@
 """Tests for backend/scripts/openapi/check-breaking-changes.py.
 
-Covers version helpers, the breaking-change approval label, spec-change
-detection, and the full main() gate (oasdiff is mocked).
+Covers version helpers, the breaking-change approval label, canonical
+spec-change detection, bump-segment classification, and the full main() gate
+(oasdiff is mocked except in the explicitly-integration tests).
 
 Gate policy under test:
-  * Every OpenAPI spec change must bump info.version (major/minor/patch).
+  * Every *meaningful* OpenAPI spec change must bump info.version. Comparison is
+    canonical, so serialization-only diffs (whitespace, key order, quotes) do
+    not require a bump.
+  * The bump segment must match the change type: minor for additive changes,
+    patch for spec-only edits. A wrong-segment bump is blocked.
   * Breaking changes are blocked in place unless the privileged
-    ``breaking-change-approved`` label is present.
+    ``breaking-change-approved`` label is present AND the bump is a minor.
 """
 
 from __future__ import annotations
 
 import importlib
 import json
+import shutil
 import sys
 import textwrap
 from pathlib import Path
@@ -35,10 +41,14 @@ REQUIRED_JSON_FIELDS = (
     "base_version",
     "head_version",
     "version_bump_type",
+    "expected_bump_type",
     "breaking_approved",
     "spec_path",
     "gate_code",
 )
+
+# A representative structural (additive) changelog entry as oasdiff emits it.
+ADDITIVE_ENTRY = {"id": "endpoint-added", "text": "endpoint added", "level": 1}
 
 
 def _spec_yaml(version: str, *, description: str | None = None) -> str:
@@ -58,16 +68,31 @@ def _run_main(
     head_version: str,
     has_breaking: bool,
     changelog: str,
+    changelog_entries: list[dict[str, Any]] | None = None,
     pr_labels: str = "",
     extra_args: list[str] | None = None,
     head_description: str | None = None,
+    base_spec_text: str | None = None,
+    head_spec_text: str | None = None,
 ) -> tuple[int, dict[str, Any]]:
-    """Invoke main() with mocked oasdiff and return (exit_code, json_result)."""
+    """Invoke main() with mocked oasdiff and return (exit_code, json_result).
+
+    ``has_meaningful_change`` uses the real canonical comparison of the written
+    base/head files, so control it via ``head_description`` (spec-only diff) or
+    explicit ``base_spec_text`` / ``head_spec_text`` overrides. ``has_breaking``
+    and ``changelog_entries`` are mocked to drive the breaking/segment logic.
+    """
     base_spec = tmp_path / "base.yaml"
     head_spec = tmp_path / "head.yaml"
     output = tmp_path / "breaking-results.json"
-    _write_spec(base_spec, base_version)
-    _write_spec(head_spec, head_version, description=head_description)
+    if base_spec_text is not None:
+        base_spec.write_text(base_spec_text)
+    else:
+        _write_spec(base_spec, base_version)
+    if head_spec_text is not None:
+        head_spec.write_text(head_spec_text)
+    else:
+        _write_spec(head_spec, head_version, description=head_description)
 
     monkeypatch.setattr(
         check_breaking,
@@ -78,6 +103,11 @@ def _run_main(
         check_breaking,
         "get_all_changes",
         lambda *_args, **_kwargs: changelog,
+    )
+    monkeypatch.setattr(
+        check_breaking,
+        "get_changelog_entries",
+        lambda *_args, **_kwargs: (changelog_entries if changelog_entries is not None else []),
     )
 
     argv = [
@@ -279,31 +309,80 @@ class TestCheckApprovalLabel:
         assert check_breaking.check_approval_label("not-breaking-change-approved-extra") is False
 
 
-class TestSpecHasChanges:
-    """Tests for spec_has_changes()."""
+class TestCanonicalizeSpec:
+    """Tests for canonicalize_spec()."""
 
-    def test_identical_content_no_changelog(self):
+    def test_parses_and_strips_info_version(self):
+        ok, data = check_breaking.canonicalize_spec(_spec_yaml("1.0.0"))
+        assert ok is True
+        assert "version" not in data["info"]
+
+    def test_none_content(self):
+        ok, data = check_breaking.canonicalize_spec("")
+        assert ok is True
+        assert data is None
+
+    def test_invalid_yaml_reports_not_ok(self):
+        ok, data = check_breaking.canonicalize_spec("key: [unterminated")
+        assert ok is False
+        assert data is None
+
+
+class TestHasMeaningfulChange:
+    """Tests for has_meaningful_change() (canonical comparison)."""
+
+    def test_identical_content(self):
         spec = _spec_yaml("1.0.0")
-        assert check_breaking.spec_has_changes(spec, spec, has_breaking=False, all_changes="") is False
+        assert check_breaking.has_meaningful_change(spec, spec, has_breaking=False) is False
 
-    def test_identical_content_no_changes_text(self):
-        spec = _spec_yaml("1.0.0")
-        assert check_breaking.spec_has_changes(spec, spec, has_breaking=False, all_changes="No changes") is False
+    def test_version_only_change_is_not_meaningful(self):
+        # A bare version bump with no other diff is not a "meaningful" change.
+        base = _spec_yaml("1.0.0")
+        head = _spec_yaml("1.1.0")
+        assert check_breaking.has_meaningful_change(base, head, has_breaking=False) is False
 
-    def test_content_diff_without_oasdiff_output(self):
+    def test_description_change_is_meaningful(self):
         base = _spec_yaml("1.0.0")
         head = _spec_yaml("1.0.0", description="tweaked")
-        assert check_breaking.spec_has_changes(base, head, has_breaking=False, all_changes="") is True
+        assert check_breaking.has_meaningful_change(base, head, has_breaking=False) is True
+
+    def test_serialization_only_diff_is_not_meaningful(self):
+        # Same data, different quote style / key order / whitespace.
+        base = 'openapi: "3.1.0"\ninfo:\n  title: Syntara API\n  version: 1.0.0\npaths: {}\n'
+        head = "info:\n  version: 1.0.0\n  title: 'Syntara API'\n\nopenapi: '3.1.0'\npaths: {}\n"
+        assert check_breaking.has_meaningful_change(base, head, has_breaking=False) is False
 
     def test_breaking_always_counts(self):
         spec = _spec_yaml("1.0.0")
-        assert check_breaking.spec_has_changes(spec, spec, has_breaking=True, all_changes="") is True
+        assert check_breaking.has_meaningful_change(spec, spec, has_breaking=True) is True
 
-    def test_changelog_fallback_when_content_matches(self):
-        spec = _spec_yaml("1.0.0")
-        assert (
-            check_breaking.spec_has_changes(spec, spec, has_breaking=False, all_changes="info [endpoint-added]") is True
+    def test_unparseable_falls_back_to_raw_compare(self):
+        base = "key: [unterminated"
+        head = "key: [unterminated  "
+        assert check_breaking.has_meaningful_change(base, head, has_breaking=False) is True
+
+
+class TestClassifyExpectedSegment:
+    """Tests for classify_expected_segment()."""
+
+    def test_no_change(self):
+        segment = check_breaking.classify_expected_segment(has_breaking=False, has_changes=False, changelog_entries=[])
+        assert segment is None
+
+    def test_additive_change_expects_minor(self):
+        segment = check_breaking.classify_expected_segment(
+            has_breaking=False, has_changes=True, changelog_entries=[ADDITIVE_ENTRY]
         )
+        assert segment == "minor"
+
+    def test_spec_only_change_expects_patch(self):
+        # Canonical diff exists but oasdiff reports no structural entries.
+        segment = check_breaking.classify_expected_segment(has_breaking=False, has_changes=True, changelog_entries=[])
+        assert segment == "patch"
+
+    def test_breaking_change_expects_minor(self):
+        segment = check_breaking.classify_expected_segment(has_breaking=True, has_changes=True, changelog_entries=[])
+        assert segment == "minor"
 
 
 class TestEvaluateGate:
@@ -314,13 +393,15 @@ class TestEvaluateGate:
         *,
         has_breaking: bool = False,
         has_changes: bool = False,
-        version_bumped: bool = False,
+        version_bump_type: str | None = None,
+        expected_bump_type: str | None = None,
         breaking_approved: bool = False,
     ) -> Any:  # noqa: ANN401 - GateDecision comes from a dynamically imported (hyphenated) module
         return check_breaking.evaluate_gate(
             has_breaking=has_breaking,
             has_changes=has_changes,
-            version_bumped=version_bumped,
+            version_bump_type=version_bump_type,
+            expected_bump_type=expected_bump_type,
             breaking_approved=breaking_approved,
         )
 
@@ -330,44 +411,74 @@ class TestEvaluateGate:
         assert decision.code == "ok"
 
     def test_breaking_no_label_blocked(self):
-        decision = self._decide(has_breaking=True, has_changes=True, version_bumped=True)
+        decision = self._decide(
+            has_breaking=True, has_changes=True, version_bump_type="minor", expected_bump_type="minor"
+        )
         assert decision.allowed is False
         assert decision.code == "breaking_blocked"
 
     def test_breaking_no_label_blocked_even_without_bump(self):
         # Breaking-without-approval is the dominant reason regardless of bump state.
-        decision = self._decide(has_breaking=True, has_changes=True, version_bumped=False)
+        decision = self._decide(has_breaking=True, has_changes=True, expected_bump_type="minor")
         assert decision.allowed is False
         assert decision.code == "breaking_blocked"
 
-    def test_breaking_approved_with_bump_allowed(self):
+    def test_breaking_approved_with_minor_bump_allowed(self):
         decision = self._decide(
             has_breaking=True,
             has_changes=True,
-            version_bumped=True,
+            version_bump_type="minor",
+            expected_bump_type="minor",
             breaking_approved=True,
         )
         assert decision.allowed is True
         assert decision.code == "breaking_approved"
 
-    def test_breaking_approved_without_bump_blocked(self):
-        # Even an approved breaking change must bump info.version.
+    def test_breaking_approved_with_major_bump_blocked(self):
+        # An approved in-place breaking change must be a minor bump, not major.
         decision = self._decide(
             has_breaking=True,
             has_changes=True,
-            version_bumped=False,
+            version_bump_type="major",
+            expected_bump_type="minor",
+            breaking_approved=True,
+        )
+        assert decision.allowed is False
+        assert decision.code == "wrong_bump_segment"
+
+    def test_breaking_approved_without_bump_blocked(self):
+        decision = self._decide(
+            has_breaking=True,
+            has_changes=True,
+            version_bump_type=None,
+            expected_bump_type="minor",
             breaking_approved=True,
         )
         assert decision.allowed is False
         assert decision.code == "version_bump_required"
 
-    def test_non_breaking_with_bump_allowed(self):
-        decision = self._decide(has_changes=True, version_bumped=True)
+    def test_additive_with_minor_allowed(self):
+        decision = self._decide(has_changes=True, version_bump_type="minor", expected_bump_type="minor")
         assert decision.allowed is True
         assert decision.code == "ok"
 
-    def test_non_breaking_without_bump_blocked(self):
-        decision = self._decide(has_changes=True, version_bumped=False)
+    def test_additive_with_patch_blocked(self):
+        decision = self._decide(has_changes=True, version_bump_type="patch", expected_bump_type="minor")
+        assert decision.allowed is False
+        assert decision.code == "wrong_bump_segment"
+
+    def test_spec_only_with_patch_allowed(self):
+        decision = self._decide(has_changes=True, version_bump_type="patch", expected_bump_type="patch")
+        assert decision.allowed is True
+        assert decision.code == "ok"
+
+    def test_spec_only_with_minor_blocked(self):
+        decision = self._decide(has_changes=True, version_bump_type="minor", expected_bump_type="patch")
+        assert decision.allowed is False
+        assert decision.code == "wrong_bump_segment"
+
+    def test_change_without_bump_blocked(self):
+        decision = self._decide(has_changes=True, version_bump_type=None, expected_bump_type="minor")
         assert decision.allowed is False
         assert decision.code == "version_bump_required"
 
@@ -380,9 +491,10 @@ class TestMainGate:
             monkeypatch,
             tmp_path,
             base_version="1.0.0",
-            head_version="2.0.0",
+            head_version="1.1.0",
             has_breaking=True,
             changelog="removed GET /legacy",
+            head_description="breaking edit",
         )
         assert code == 1
         assert result["has_breaking_changes"] is True
@@ -392,20 +504,38 @@ class TestMainGate:
         for field in REQUIRED_JSON_FIELDS:
             assert field in result, f"Missing required field: {field}"
 
-    def test_breaking_change_with_approval_label(self, monkeypatch, tmp_path):
+    def test_breaking_change_with_approval_label_minor_bump(self, monkeypatch, tmp_path):
         code, result = _run_main(
             monkeypatch,
             tmp_path,
             base_version="1.0.0",
-            head_version="1.0.1",
+            head_version="1.1.0",
             has_breaking=True,
             changelog="removed GET /legacy",
+            head_description="approved breaking edit",
             pr_labels="breaking-change-approved",
         )
         assert code == 0
         assert result["breaking_approved"] is True
         assert result["version_bumped"] is True
+        assert result["expected_bump_type"] == "minor"
         assert result["gate_code"] == "breaking_approved"
+
+    def test_breaking_change_approved_but_major_bump_blocked(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="2.0.0",
+            has_breaking=True,
+            changelog="removed GET /legacy",
+            head_description="approved breaking edit",
+            pr_labels="breaking-change-approved",
+        )
+        assert code == 1
+        assert result["version_bump_type"] == "major"
+        assert result["expected_bump_type"] == "minor"
+        assert result["gate_code"] == "wrong_bump_segment"
 
     def test_breaking_change_approved_but_no_bump_blocked(self, monkeypatch, tmp_path):
         code, result = _run_main(
@@ -422,7 +552,7 @@ class TestMainGate:
         assert result["version_bumped"] is False
         assert result["gate_code"] == "version_bump_required"
 
-    def test_non_breaking_minor_bump_allowed(self, monkeypatch, tmp_path):
+    def test_additive_minor_bump_allowed(self, monkeypatch, tmp_path):
         code, result = _run_main(
             monkeypatch,
             tmp_path,
@@ -430,16 +560,16 @@ class TestMainGate:
             head_version="1.1.0",
             has_breaking=False,
             changelog="info [endpoint-added] in API added GET /widgets",
+            changelog_entries=[ADDITIVE_ENTRY],
             head_description="new endpoint",
         )
         assert code == 0
         assert result["has_changes"] is True
         assert result["version_bump_type"] == "minor"
-        assert result["version_bumped"] is True
+        assert result["expected_bump_type"] == "minor"
         assert result["gate_code"] == "ok"
 
-    def test_non_breaking_patch_bump_allowed(self, monkeypatch, tmp_path):
-        # Bump *type* is not enforced — any bump satisfies the gate for non-breaking changes.
+    def test_additive_patch_bump_wrong_segment_blocked(self, monkeypatch, tmp_path):
         code, result = _run_main(
             monkeypatch,
             tmp_path,
@@ -447,14 +577,49 @@ class TestMainGate:
             head_version="1.0.1",
             has_breaking=False,
             changelog="info [endpoint-added] in API added GET /widgets",
+            changelog_entries=[ADDITIVE_ENTRY],
             head_description="new endpoint",
+        )
+        assert code == 1
+        assert result["version_bump_type"] == "patch"
+        assert result["expected_bump_type"] == "minor"
+        assert result["gate_code"] == "wrong_bump_segment"
+
+    def test_spec_only_patch_bump_allowed(self, monkeypatch, tmp_path):
+        # Description-only edit: oasdiff reports no structural entries -> expects patch.
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.0.1",
+            has_breaking=False,
+            changelog="",
+            changelog_entries=[],
+            head_description="clarified wording",
         )
         assert code == 0
         assert result["has_changes"] is True
         assert result["version_bump_type"] == "patch"
+        assert result["expected_bump_type"] == "patch"
         assert result["gate_code"] == "ok"
 
-    def test_non_breaking_no_bump_blocked(self, monkeypatch, tmp_path):
+    def test_spec_only_minor_bump_wrong_segment_blocked(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.1.0",
+            has_breaking=False,
+            changelog="",
+            changelog_entries=[],
+            head_description="clarified wording",
+        )
+        assert code == 1
+        assert result["version_bump_type"] == "minor"
+        assert result["expected_bump_type"] == "patch"
+        assert result["gate_code"] == "wrong_bump_segment"
+
+    def test_meaningful_change_no_bump_blocked(self, monkeypatch, tmp_path):
         code, result = _run_main(
             monkeypatch,
             tmp_path,
@@ -462,6 +627,7 @@ class TestMainGate:
             head_version="1.0.0",
             has_breaking=False,
             changelog="info [endpoint-added] in API added GET /widgets",
+            changelog_entries=[ADDITIVE_ENTRY],
             head_description="new endpoint",
         )
         assert code == 1
@@ -469,7 +635,10 @@ class TestMainGate:
         assert result["version_bumped"] is False
         assert result["gate_code"] == "version_bump_required"
 
-    def test_oasdiff_silent_content_change_requires_bump(self, monkeypatch, tmp_path):
+    def test_serialization_only_change_passes_without_bump(self, monkeypatch, tmp_path):
+        base = 'openapi: "3.1.0"\ninfo:\n  title: Syntara API\n  version: 1.0.0\npaths: {}\n'
+        # Same data, reordered keys and different quote style, no version bump.
+        head = "info:\n  version: 1.0.0\n  title: 'Syntara API'\nopenapi: '3.1.0'\npaths: {}\n"
         code, result = _run_main(
             monkeypatch,
             tmp_path,
@@ -477,11 +646,14 @@ class TestMainGate:
             head_version="1.0.0",
             has_breaking=False,
             changelog="",
-            head_description="metadata only",
+            changelog_entries=[],
+            base_spec_text=base,
+            head_spec_text=head,
         )
-        assert code == 1
-        assert result["has_changes"] is True
-        assert result["gate_code"] == "version_bump_required"
+        assert code == 0
+        assert result["has_changes"] is False
+        assert result["version_bumped"] is False
+        assert result["gate_code"] == "ok"
 
     def test_no_changes(self, monkeypatch, tmp_path):
         code, result = _run_main(
@@ -498,9 +670,32 @@ class TestMainGate:
         assert result["version_bumped"] is False
         assert result["base_version"] == "1.0.0"
         assert result["head_version"] == "1.0.0"
+        assert result["expected_bump_type"] is None
         assert result["gate_code"] == "ok"
         for field in REQUIRED_JSON_FIELDS:
             assert field in result, f"Missing required field: {field}"
+
+    def test_new_spec_on_base_ref_skips_gate(self, monkeypatch, tmp_path):
+        # A new major version introduced as a new spec at a new path has no base
+        # to compare against, so the gate does not fire (exit 0, no output).
+        monkeypatch.setattr(check_breaking, "get_spec_from_git", lambda *_a, **_k: None)
+        output = tmp_path / "breaking-results.json"
+        argv = [
+            "check-breaking-changes.py",
+            "--base",
+            "origin/devel",
+            "--head",
+            "HEAD",
+            "--spec-path",
+            "backend/src/syntara/schemas/v2/openapi.yaml",
+            "--output",
+            str(output),
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+        with pytest.raises(SystemExit) as exc:
+            check_breaking.main()
+        assert int(exc.value.code or 0) == 0
+        assert not output.exists()
 
     def test_text_output_includes_spec_and_versions(self, monkeypatch, tmp_path):
         code, _result = _run_main(
@@ -516,8 +711,157 @@ class TestMainGate:
         text = (tmp_path / "breaking-results.json").read_text()
         assert "backend/src/syntara/schemas/openapi.yaml" in text
         assert "1.0.0 -> 1.0.0" in text
+        assert "version_bumped: false" in text
         assert "BREAKING CHANGES DETECTED" in text
         assert "removed GET /legacy" in text
+
+    def test_json_failure_emits_text_error_on_stderr(self, monkeypatch, tmp_path, capsys):
+        # CI writes JSON to --output; the job log must still name spec, versions,
+        # version_bumped, and the breaking changes.
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.0.0",
+            head_version="1.1.0",
+            has_breaking=True,
+            changelog="removed GET /legacy",
+            head_description="breaking edit",
+        )
+        assert code == 1
+        assert result["version_bumped"] is True
+        err = capsys.readouterr().err
+        assert "backend/src/syntara/schemas/openapi.yaml" in err
+        assert "1.0.0 -> 1.1.0" in err
+        assert "version_bumped: true" in err
+        assert "removed GET /legacy" in err
+
+
+_INTEGRATION_BASE = textwrap.dedent("""\
+    openapi: "3.1.0"
+    info:
+      title: Test API
+      version: 1.0.0
+    paths:
+      /things:
+        get:
+          operationId: list_things
+          summary: List things
+          responses:
+            '200':
+              description: ok
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      labels:
+                        type: object
+                        additionalProperties:
+                          type: string
+""")
+
+# Same as base but the additionalProperties (dynamic-map) schema changed, plus a patch bump.
+_INTEGRATION_DYNAMIC_MAP = textwrap.dedent("""\
+    openapi: "3.1.0"
+    info:
+      title: Test API
+      version: 1.0.1
+    paths:
+      /things:
+        get:
+          operationId: list_things
+          summary: List things
+          responses:
+            '200':
+              description: ok
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      labels:
+                        type: object
+                        additionalProperties: true
+""")
+
+# Base plus a new endpoint (additive) with only a patch bump (wrong segment).
+_INTEGRATION_ADDITIVE = textwrap.dedent("""\
+    openapi: "3.1.0"
+    info:
+      title: Test API
+      version: 1.0.1
+    paths:
+      /things:
+        get:
+          operationId: list_things
+          summary: List things
+          responses:
+            '200':
+              description: ok
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      labels:
+                        type: object
+                        additionalProperties:
+                          type: string
+      /gadgets:
+        get:
+          operationId: list_gadgets
+          summary: List gadgets
+          responses:
+            '200':
+              description: ok
+""")
+
+
+@pytest.mark.skipif(shutil.which("oasdiff") is None, reason="oasdiff not installed")
+class TestOasdiffIntegration:
+    """Integration tests exercising the real oasdiff binary."""
+
+    def _run(self, monkeypatch, tmp_path, base: str, head: str, *, pr_labels: str = "") -> tuple[int, dict[str, Any]]:
+        base_spec = tmp_path / "base.yaml"
+        head_spec = tmp_path / "head.yaml"
+        output = tmp_path / "breaking-results.json"
+        base_spec.write_text(base)
+        head_spec.write_text(head)
+        argv = [
+            "check-breaking-changes.py",
+            "--base-spec",
+            str(base_spec),
+            "--head-spec",
+            str(head_spec),
+            "--spec-path",
+            "backend/src/syntara/schemas/openapi.yaml",
+            "--output",
+            str(output),
+            "--pr-labels",
+            pr_labels,
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+        with pytest.raises(SystemExit) as exc:
+            check_breaking.main()
+        return int(exc.value.code or 0), json.loads(output.read_text())
+
+    def test_dynamic_map_content_change_not_breaking(self, monkeypatch, tmp_path):
+        # Changing an additionalProperties (dynamic-map) field is not breaking.
+        code, result = self._run(monkeypatch, tmp_path, _INTEGRATION_BASE, _INTEGRATION_DYNAMIC_MAP)
+        assert result["has_breaking_changes"] is False
+        assert result["has_changes"] is True
+        # oasdiff reports no structural entry -> treated as a patch-level edit.
+        assert result["expected_bump_type"] == "patch"
+        assert code == 0
+        assert result["gate_code"] == "ok"
+
+    def test_additive_endpoint_requires_minor(self, monkeypatch, tmp_path):
+        code, result = self._run(monkeypatch, tmp_path, _INTEGRATION_BASE, _INTEGRATION_ADDITIVE)
+        assert result["has_breaking_changes"] is False
+        assert result["expected_bump_type"] == "minor"
+        # Patch bump for an additive change is the wrong segment.
+        assert code == 1
+        assert result["gate_code"] == "wrong_bump_segment"
 
 
 class TestFormatTextOutput:
@@ -525,7 +869,7 @@ class TestFormatTextOutput:
 
     def test_non_breaking_with_bump(self):
         decision = check_breaking.GateDecision(
-            allowed=True, code="ok", message="Non-breaking spec change with a version bump"
+            allowed=True, code="ok", message="Non-breaking spec change with a correct 'patch' version bump"
         )
         lines = check_breaking._format_text_output(
             has_breaking=False,
@@ -534,19 +878,23 @@ class TestFormatTextOutput:
             decision=decision,
             base_version="1.0.0",
             head_version="1.0.1",
+            version_bumped=True,
             version_bump_type="patch",
+            expected_bump_type="patch",
             spec_path="backend/src/syntara/schemas/openapi.yaml",
         )
         text = "\n".join(lines)
         assert "version bump" in text
         assert "1.0.0 -> 1.0.1" in text
+        assert "version_bumped: true" in text
         assert "backend/src/syntara/schemas/openapi.yaml" in text
 
     def test_breaking_blocked(self):
         decision = check_breaking.evaluate_gate(
             has_breaking=True,
             has_changes=True,
-            version_bumped=True,
+            version_bump_type="minor",
+            expected_bump_type="minor",
             breaking_approved=False,
         )
         lines = check_breaking._format_text_output(
@@ -556,40 +904,49 @@ class TestFormatTextOutput:
             decision=decision,
             base_version="1.0.0",
             head_version="1.1.0",
+            version_bumped=True,
             version_bump_type="minor",
+            expected_bump_type="minor",
             spec_path="backend/src/syntara/schemas/openapi.yaml",
         )
         text = "\n".join(lines)
         assert "BREAKING CHANGES DETECTED" in text
         assert "BLOCKED" in text
         assert "breaking-change-approved" in text
+        assert "version_bumped: true" in text
 
-    def test_breaking_approved(self):
+    def test_wrong_bump_segment(self):
         decision = check_breaking.evaluate_gate(
-            has_breaking=True,
+            has_breaking=False,
             has_changes=True,
-            version_bumped=True,
-            breaking_approved=True,
+            version_bump_type="patch",
+            expected_bump_type="minor",
+            breaking_approved=False,
         )
         lines = check_breaking._format_text_output(
-            has_breaking=True,
-            breaking_output="field removed",
-            all_changes="field removed",
+            has_breaking=False,
+            breaking_output="",
+            all_changes="added GET /widgets",
             decision=decision,
             base_version="1.0.0",
             head_version="1.0.1",
+            version_bumped=True,
             version_bump_type="patch",
+            expected_bump_type="minor",
             spec_path="backend/src/syntara/schemas/openapi.yaml",
         )
         text = "\n".join(lines)
-        assert "ALLOWED" in text
-        assert "breaking-change-approved" in text
+        assert "BLOCKED" in text
+        assert "minor" in text
+        assert "Expected bump: minor" in text
+        assert "version_bumped: true" in text
 
     def test_version_bump_required_message(self):
         decision = check_breaking.evaluate_gate(
             has_breaking=False,
             has_changes=True,
-            version_bumped=False,
+            version_bump_type=None,
+            expected_bump_type="minor",
             breaking_approved=False,
         )
         lines = check_breaking._format_text_output(
@@ -599,12 +956,15 @@ class TestFormatTextOutput:
             decision=decision,
             base_version="1.0.0",
             head_version="1.0.0",
+            version_bumped=False,
             version_bump_type=None,
+            expected_bump_type="minor",
             spec_path="backend/src/syntara/schemas/openapi.yaml",
         )
         text = "\n".join(lines)
         assert "BLOCKED" in text
         assert "info.version" in text
+        assert "version_bumped: false" in text
 
 
 class TestPostBreakingChangesComment:
@@ -619,6 +979,7 @@ class TestPostBreakingChangesComment:
                 "base_version": "1.0.0",
                 "head_version": "1.1.0",
                 "version_bump_type": "minor",
+                "expected_bump_type": "minor",
                 "breaking_approved": False,
                 "spec_path": "backend/src/syntara/schemas/openapi.yaml",
                 "gate_code": "breaking_blocked",
@@ -631,6 +992,7 @@ class TestPostBreakingChangesComment:
         assert "removed GET /legacy" in comment
         assert "Blocked" in comment
         assert "breaking-change-approved" in comment
+        assert "**version_bumped:** `true`" in comment
 
     def test_approved_breaking_comment(self):
         comment = post_comment.format_breaking_changes_comment(
@@ -639,8 +1001,9 @@ class TestPostBreakingChangesComment:
                 "breaking_changes": "removed GET /legacy",
                 "all_changes": "removed GET /legacy",
                 "base_version": "1.0.0",
-                "head_version": "1.0.1",
-                "version_bump_type": "patch",
+                "head_version": "1.1.0",
+                "version_bump_type": "minor",
+                "expected_bump_type": "minor",
                 "breaking_approved": True,
                 "spec_path": "backend/src/syntara/schemas/openapi.yaml",
                 "gate_code": "breaking_approved",
@@ -660,6 +1023,7 @@ class TestPostBreakingChangesComment:
                 "base_version": "1.0.0",
                 "head_version": "1.0.0",
                 "version_bump_type": None,
+                "expected_bump_type": "minor",
                 "breaking_approved": False,
                 "spec_path": "backend/src/syntara/schemas/openapi.yaml",
                 "gate_code": "version_bump_required",
@@ -669,3 +1033,95 @@ class TestPostBreakingChangesComment:
         )
         assert "Version Bump Required" in comment
         assert "info.version" in comment
+        assert "minor" in comment
+        assert "**version_bumped:** `false`" in comment
+
+    def test_wrong_bump_segment_comment(self):
+        comment = post_comment.format_breaking_changes_comment(
+            {
+                "has_breaking_changes": False,
+                "breaking_changes": "",
+                "all_changes": "added GET /widgets",
+                "base_version": "1.0.0",
+                "head_version": "1.0.1",
+                "version_bump_type": "patch",
+                "expected_bump_type": "minor",
+                "breaking_approved": False,
+                "spec_path": "backend/src/syntara/schemas/openapi.yaml",
+                "gate_code": "wrong_bump_segment",
+            },
+            "syntara-orchestration",
+            "syntara",
+        )
+        assert "Wrong Version Bump Segment" in comment
+        assert "minor" in comment
+        assert "patch" in comment
+        assert "**version_bumped:** `true`" in comment
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+BACKEND_ROOT = Path(__file__).resolve().parents[3]
+LABEL_GUARD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "breaking-change-label-guard.yml"
+
+
+class TestAckPathRemoved:
+    """The breaking-change-ack PR-body override must not remain as a bypass."""
+
+    def test_check_breaking_changes_has_no_pr_body_flag(self):
+        source = Path(check_breaking.__file__).read_text()
+        assert "--pr-body" not in source
+        assert "breaking-change-ack" not in source
+
+    def test_makefile_does_not_pass_pr_body_to_breaking_check(self):
+        makefile = (BACKEND_ROOT / "Makefile").read_text()
+        assert "--pr-body" not in makefile
+
+
+class TestBreakingChangeLabelGuard:
+    """Contract tests for unauthorized label application being removed.
+
+    The guard is a pull_request_target GitHub Action (inline JS, no PR code
+    executed). These tests lock the workflow to: verify syntara-leads
+    membership, and on failure remove the label, comment, and fail the check.
+    """
+
+    def test_workflow_exists(self):
+        assert LABEL_GUARD_WORKFLOW.is_file()
+
+    def test_triggers_on_label_added(self):
+        text = LABEL_GUARD_WORKFLOW.read_text()
+        assert "pull_request_target:" in text
+        assert "types: [labeled]" in text
+        assert "github.event.label.name == 'breaking-change-approved'" in text
+
+    def test_verifies_syntara_leads_membership(self):
+        text = LABEL_GUARD_WORKFLOW.read_text()
+        assert "syntara-leads" in text
+        assert "getMembershipForUserInOrg" in text
+        assert "res.data.state === 'active'" in text
+
+    def test_unauthorized_application_removed(self):
+        text = LABEL_GUARD_WORKFLOW.read_text()
+        assert "issues.removeLabel" in text
+        assert "issues.createComment" in text
+        assert "core.setFailed" in text
+        assert "label has been removed" in text
+
+    def test_fails_closed_without_org_token(self):
+        text = LABEL_GUARD_WORKFLOW.read_text()
+        assert "SYNTARA_LEADS_READ_TOKEN" in text
+        assert "secrets.GITHUB_TOKEN" in text
+        assert "isMember = false" in text
+
+
+class TestOpenapiBreakingChangesWorkflow:
+    """The CI job must surface spec, versions, and version_bumped on failure."""
+
+    def test_prints_results_json_on_failure(self):
+        workflow = REPO_ROOT / ".github" / "workflows" / "openapi-breaking-changes.yml"
+        text = workflow.read_text()
+        assert "Show breaking-change results on failure" in text
+        assert "cat breaking-results.json" in text
+        assert "version_bumped" in text
+        assert "--pr-labels" in text
+        assert "breaking-change-ack" not in text

--- a/backend/tools/ci/verify_test_structure.py
+++ b/backend/tools/ci/verify_test_structure.py
@@ -213,6 +213,7 @@ def verify_test_structure(repo_root: Path) -> tuple[bool, list[str], list[str]]:
         "validators",
         "websocket",
         "workflow",
+        "scripts",
     }
 
     # These source domains are allowed to have no tests


### PR DESCRIPTION
## Description

Enforce the AO REST API Versioning and Deprecation Policy in CI tooling for the bundled OpenAPI spec. Every PR that changes `backend/src/syntara/schemas/openapi.yaml` is now gated on three rules:

1. **Mandatory version bump** — every *meaningful* spec change must bump `info.version`. The bump is how the engineer signals their interpretation of the change to reviewers and how API consumers become aware of spec updates. A spec change with no bump is blocked. Serialization-only diffs (whitespace, key order, quoting) are **not** meaningful — comparison is canonical/semantic (PyYAML), so cosmetic edits do not require a bump.
2. **Correct bump segment** — CI enforces *which* segment must move:
   - Additive changes (oasdiff reports structural entries) → **minor**
   - Spec-only edits with no structural entries (description/example/annotation) → **patch**
   - Approved in-place breaking changes → **minor** (never major; see below)

   A bump in the wrong segment is blocked (`incorrect_version_increment`).
3. **Breaking changes blocked in place** — breaking changes never apply in place. A new major version is a new spec served from a separate URL path (e.g. `/api/v2/`), so it does not register as a breaking change against the current spec. The only override for an in-place breaking change is the privileged `breaking-change-approved` GitHub label, and an approved breaking change must still bump by a minor segment.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

- [x] `check-breaking-changes.py`:
  - Canonical (semantic) spec comparison via PyYAML — serialization-only diffs do not count as a change, so they require no bump.
  - Requires an `info.version` bump on every meaningful spec change and enforces the **correct segment** (minor for additive, patch for spec-only edits).
  - Breaking changes blocked in place unless the PR has the `breaking-change-approved` label; an approved breaking change must bump by a **minor** segment.
  - Correct oasdiff exit-code handling: runs `oasdiff breaking` with `--fail-on ERR` and maps exit 0/1 to not-breaking/breaking, exiting 2 on any other code. Previously `oasdiff breaking` returned exit 0 even with breaking changes present (silently passing the gate), and tool errors (e.g. exit 102) were misread as breaking.
  - Resolves the git ref before reading the spec, so a typo'd or unfetched base ref exits 2 with a clear error instead of collapsing to "new spec, nothing to check" and skipping the gate.
  - `--pr-labels` must be a JSON array: a malformed value fails loudly (exit 2) rather than silently reading as "not approved".
- [x] `breaking-results.json` output: `has_breaking_changes`, `breaking_changes`, `all_changes`, `has_changes`, `version_bumped`, `base_version`, `head_version`, `version_bump_type`, `expected_bump_type`, `breaking_approved`, `spec_path`, `gate_code`
- [x] `gate_code` values: `ok`, `breaking_approved`, `breaking_blocked`, `version_bump_required`, `incorrect_version_increment`
- [x] Error / PR-comment output includes spec path, base/head version, bump type, expected bump type, and the breaking changes (or the missing/wrong-bump reason)
- [x] **Breaking Change Label Guard** workflow (`.github/workflows/breaking-change-label-guard.yml`) restricts who may apply the privileged `breaking-change-approved` label to the `syntara-leads` team. It fails closed: an unauthorized actor has the label removed with an explanatory PR comment, and a missing `SYNTARA_LEADS_READ_TOKEN` fails the workflow run itself as a configuration error (no label removal or comment in that case). Governed via `.github/CODEOWNERS`.
- [x] `openapi-breaking-changes.yml` re-runs on add/remove of the `breaking-change-approved` label, forwards PR labels to the check, and surfaces `breaking-results.json` on gate failure
- [x] `(Backend) Check OpenAPI Breaking Changes` in `ci-backend.yml` forwards `OPENAPI_PR_LABELS` so the override can pass the required check
- [x] Makefile passes `PR_LABELS` / `OPENAPI_PR_LABELS` through to the local check (dead PR-body ack path removed)
- [x] Unit tests (110) incl. wrong-segment, serialization-only, approved-breaking-minor, new-major-at-new-path, blocked/approved breaking, non-breaking with/without bump, oasdiff exit-code mapping, changelog-entry JSON parsing (empty/invalid/non-list), git ref resolution (missing file vs unresolvable ref), malformed `--pr-labels` failing loudly, and real-oasdiff integration (dynamic-map, additive, and removed-endpoint breaking blocked/approved) (`backend/tests/unit/scripts/test_check_breaking_changes.py`)
- [x] Docs updated: `openapi-spec-management.md`, `ui-api-parity.md`, `CONTRIBUTING.md`, `scripts/openapi/README.md`

## Gate Summary

| Change type | Result |
|---|---|
| No meaningful spec change (incl. serialization-only diff) | Allowed (`ok`) |
| Additive change, bumped by minor | Allowed (`ok`) |
| Spec-only edit, bumped by patch | Allowed (`ok`) |
| Meaningful spec change, no version bump | Blocked (`version_bump_required`) |
| Change bumped by the wrong segment | Blocked (`incorrect_version_increment`) |
| Breaking change, no approval label | Blocked (`breaking_blocked`) |
| Breaking change, `breaking-change-approved` label + minor bump | Allowed (`breaking_approved`) |
| Breaking change, approval label but no/wrong bump | Blocked (`version_bump_required` / `incorrect_version_increment`) |

## Out of Scope

- Bumping `info.version` from `0.1.0` to `1.0.0` for GA (AAP-85274)
- Serving a real `/api/v2/` surface — this PR only enforces the versioning gate on the bundled spec
- Frontend / contract generation changes

## Related Issues

Fixes AAP-85272
Related to AAP-85274

## How to Test

1. From `backend/`, run the unit tests (oasdiff is mocked where needed):

   ```bash
   uv run pytest tests/unit/scripts/test_check_breaking_changes.py -q
   ```

2. Optional local check against `devel` (requires `oasdiff`):

   ```bash
   make check-openapi-breaking
   ```

3. Policy cases to confirm:

   | Scenario | Expected |
   |---|---|
   | Breaking change, no `breaking-change-approved` label | Fail (`breaking_blocked`) |
   | Breaking change + `breaking-change-approved` label + minor bump | Pass (`breaking_approved`) |
   | Breaking change + label but no/wrong bump | Fail (`version_bump_required` / `incorrect_version_increment`) |
   | Additive change + minor bump | Pass (`ok`) |
   | Additive change + patch bump | Fail (`incorrect_version_increment`) |
   | Spec-only edit + patch bump | Pass (`ok`) |
   | Meaningful spec change, no version bump | Fail (`version_bump_required`) |
   | Serialization-only diff (whitespace/key order), no bump | Pass (`ok`) |
   | No spec changes | Pass (`ok`) |

## Backend Checklist

- [x] I have added tests for new functionality
- [x] Database migrations are included if schema changed (N/A — no schema change)
- [x] No sensitive information (keys, passwords, etc.) is included

## Action Items (repo admin)

The label-guard enforcement in this PR fails closed until these one-time setup steps are completed by a repo/org admin:

- [ ] Create the `breaking-change-approved` GitHub label (name must match exactly)
- [x] Ensure the `syntara-leads` team exists with the correct members (the guard authorizes label application against this team)
- [ ] Provision the `SYNTARA_LEADS_READ_TOKEN` secret, a fine-grained PAT or GitHub App token with organization **Members: read**. Without it the guard cannot confirm membership, so it fails the workflow run itself as a configuration error (it does not remove the label or comment in that case). Make the guard a required status check so the merge is blocked until the token is provisioned.

## Additional Notes

Who may apply the `breaking-change-approved` label is enforced in CI by the Breaking Change Label Guard workflow (`.github/workflows/breaking-change-label-guard.yml`), restricted to the `syntara-leads` team and governed via `.github/CODEOWNERS`. CI here only checks that the label is present; the guard is the enforcement point for who may add it.

