### PR TITLE
fix: exclude healthz probe endpoints from public OpenAPI spec

### DIFF
--- a/backend/src/syntara/api/main.py
+++ b/backend/src/syntara/api/main.py
@@ -575,7 +575,7 @@ async def health_check(request: Request) -> dict[str, Any]:  # noqa: ARG001
     }
 
 
-@app.get("/healthz/live", tags=["Health"])
+@app.get("/healthz/live", tags=["Health"], include_in_schema=False)
 async def liveness_check() -> dict[str, str]:
     """Liveness probe: report whether the process itself is still serving.
 
@@ -610,7 +610,7 @@ async def liveness_check() -> dict[str, str]:
     }
 
 
-@app.get("/healthz/ready", tags=["Health"])
+@app.get("/healthz/ready", tags=["Health"], include_in_schema=False)
 async def readiness_check() -> dict[str, Any]:
     """Readiness probe: report whether the API can serve traffic.
 

--- a/backend/tests/unit/api/test_docs_endpoints.py
+++ b/backend/tests/unit/api/test_docs_endpoints.py
@@ -378,6 +378,19 @@ class TestProductionAppWiring:
 
         assert real_app.swagger_ui_parameters is None
 
+    @pytest.mark.parametrize(
+        "path",
+        ["/health", "/healthz/live", "/healthz/ready"],
+    )
+    def test_infra_endpoints_excluded_from_schema(self, path: str) -> None:
+        """Infrastructure probe endpoints must never appear in the public OpenAPI spec."""
+        from syntara.api.main import app as real_app
+
+        matching = [r for r in real_app.routes if hasattr(r, "path") and r.path == path]
+        assert matching, f"Route {path} not found in app"
+        for route in matching:
+            assert route.include_in_schema is False, f"{path} must have include_in_schema=False"
+
     def test_version_omits_docs_links_when_disabled(self) -> None:
         from syntara.api.main import app as real_app
         from syntara.auth.dependencies import get_current_user

--- a/backend/tests/unit/api/test_docs_endpoints.py
+++ b/backend/tests/unit/api/test_docs_endpoints.py
@@ -384,9 +384,11 @@ class TestProductionAppWiring:
     )
     def test_infra_endpoints_excluded_from_schema(self, path: str) -> None:
         """Infrastructure probe endpoints must never appear in the public OpenAPI spec."""
+        from starlette.routing import Route
+
         from syntara.api.main import app as real_app
 
-        matching = [r for r in real_app.routes if hasattr(r, "path") and r.path == path]
+        matching = [r for r in real_app.routes if isinstance(r, Route) and r.path == path]
         assert matching, f"Route {path} not found in app"
         for route in matching:
             assert route.include_in_schema is False, f"{path} must have include_in_schema=False"


### PR DESCRIPTION
## Description

The `/healthz/live` and `/healthz/ready` probe endpoints were showing up in the runtime OpenAPI spec served to consumers. These are Kubernetes infrastructure probes, not part of the public API contract. The older `/health` endpoint correctly had `include_in_schema=False` but the newer healthz pair was missing it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

- [x] List the specific changes made
-  Add `include_in_schema=False` to `/healthz/live` and `/healthz/ready` route decorators in main.py
- Add parametrized test covering all three infra endpoints (`/health`, `/healthz/live`, `/healthz/ready`) asserting `include_in_schema=False` on each route
- [ ] Include any new dependencies or configuration changes - N/A

## Out of Scope

N/A

## Related Issues

N/A.

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## How to Test

  1. Start the backend: `make dev`
  2. Open the runtime OpenAPI spec: `curl -sk https://localhost:8000/api_docs/v1/openapi.json | python3 -m json.tool | grep healthz`
  3. Verify no results — healthz endpoints should not appear
  4. Verify the endpoints still respond: `curl -sk https://localhost:8000/healthz/live` and `curl -sk https://localhost:8000/healthz/ready`

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed - N/A
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

N/A — backend-only change.

## Visual Regression

N/A — no UI changes.

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation - N/A
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps - N/A

## Screenshots / Demo (if applicable)

Before: 
<img width="760" height="557" alt="image" src="https://github.com/user-attachments/assets/54d4bfe2-6b8a-47d4-843b-91b75b834b07" />

After: 
<img width="760" height="403" alt="image" src="https://github.com/user-attachments/assets/c3845b70-c164-41cf-a933-fdb33f1230b7" />


## Additional Notes

The spec drift check (`make api-spec-drift`) still passes because healthz was never in the bundled sub-specs or the export tool — it only leaked through the runtime `app.openapi()` output. Verified the runtime spec is now fully clean: zero non-`/api/` paths.
