### PR TITLE
fix(approvals): accept `decision_notes` alias on decision requests

### DIFF
--- a/backend/src/api_client/syntara_api_client/models/approval_decision_request.py
+++ b/backend/src/api_client/syntara_api_client/models/approval_decision_request.py
@@ -26,7 +26,8 @@ class ApprovalDecisionRequest:
 
                 This is a subset of ApprovalRequestStatus representing only the
                 values that can be submitted in decision requests.
-            notes (None | str | Unset): Optional notes explaining the decision
+            notes (None | str | Unset): Optional notes explaining the decision. Accepts either `notes` or `decision_notes`
+                (the key returned in responses) as the request field name.
     """
 
     status: ApprovalDecisionStatus

--- a/backend/src/api_client/syntara_api_client/models/batch_approval_decision.py
+++ b/backend/src/api_client/syntara_api_client/models/batch_approval_decision.py
@@ -22,7 +22,8 @@ class BatchApprovalDecision:
         status (BatchApprovalDecisionStatus): Status values that can be submitted in batch approval decisions.
 
             This is a subset of ApprovalRequestStatus containing only system-actionable values.
-        notes (None | str | Unset): Optional notes explaining the decision
+        notes (None | str | Unset): Optional notes explaining the decision. Accepts either `notes` or `decision_notes`
+            (the key returned in responses) as the request field name.
     """
 
     approval_id: UUID

--- a/backend/src/cli/orchestrator_cli/openapi.yaml
+++ b/backend/src/cli/orchestrator_cli/openapi.yaml
@@ -29094,7 +29094,7 @@ components:
               maxLength: 2000
             - type: 'null'
           title: Notes
-          description: Optional notes explaining the decision
+          description: Optional notes explaining the decision. Accepts either `notes` or `decision_notes` (the key returned in responses) as the request field name.
     BatchApprovalDecisionStatus:
       type: string
       title: BatchApprovalDecisionStatus
@@ -29129,7 +29129,7 @@ components:
               maxLength: 2000
             - type: 'null'
           title: Notes
-          description: Optional notes explaining the decision
+          description: Optional notes explaining the decision. Accepts either `notes` or `decision_notes` (the key returned in responses) as the request field name.
     BatchApprovalRequest:
       type: object
       title: BatchApprovalRequest

--- a/backend/src/syntara/approvals/models/api_models.py
+++ b/backend/src/syntara/approvals/models/api_models.py
@@ -11,7 +11,7 @@ from typing import Any, ClassVar
 from uuid import UUID
 
 import nh3
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import AliasChoices, ConfigDict, Field, field_validator
 from sqlmodel import SQLModel
 
 from syntara.core.constants import FieldLimits
@@ -192,7 +192,13 @@ class ApprovalDecisionRequest(SQLModel):
 
     status: ApprovalDecisionStatus = Field(..., description="Decision status")
     notes: str | None = Field(
-        None, max_length=FieldLimits.DESCRIPTION_MAX_LENGTH, description="Optional notes explaining the decision"
+        None,
+        max_length=FieldLimits.DESCRIPTION_MAX_LENGTH,
+        description=(
+            "Optional notes explaining the decision. Accepts either `notes` or "
+            "`decision_notes` (the key returned in responses) as the request field name."
+        ),
+        validation_alias=AliasChoices("notes", "decision_notes"),
     )
 
     @field_validator("notes", mode="before")
@@ -210,7 +216,13 @@ class BatchApprovalDecision(SQLModel):
     approval_id: UUID = Field(..., description="ID of the approval request")
     status: BatchApprovalDecisionStatus = Field(..., description="Decision status")
     notes: str | None = Field(
-        None, max_length=FieldLimits.DESCRIPTION_MAX_LENGTH, description="Optional notes explaining the decision"
+        None,
+        max_length=FieldLimits.DESCRIPTION_MAX_LENGTH,
+        description=(
+            "Optional notes explaining the decision. Accepts either `notes` or "
+            "`decision_notes` (the key returned in responses) as the request field name."
+        ),
+        validation_alias=AliasChoices("notes", "decision_notes"),
     )
 
     @field_validator("notes", mode="before")

--- a/backend/src/syntara/schemas/approvals/openapi.yaml
+++ b/backend/src/syntara/schemas/approvals/openapi.yaml
@@ -667,7 +667,7 @@ components:
               maxLength: 2000
             - type: "null"
           title: Notes
-          description: Optional notes explaining the decision
+          description: Optional notes explaining the decision. Accepts either `notes` or `decision_notes` (the key returned in responses) as the request field name.
 
     BatchApprovalDecisionStatus:
       type: string
@@ -704,7 +704,7 @@ components:
               maxLength: 2000
             - type: "null"
           title: Notes
-          description: Optional notes explaining the decision
+          description: Optional notes explaining the decision. Accepts either `notes` or `decision_notes` (the key returned in responses) as the request field name.
 
     BatchApprovalRequest:
       type: object

--- a/backend/src/syntara/schemas/openapi.yaml
+++ b/backend/src/syntara/schemas/openapi.yaml
@@ -29094,7 +29094,7 @@ components:
               maxLength: 2000
             - type: 'null'
           title: Notes
-          description: Optional notes explaining the decision
+          description: Optional notes explaining the decision. Accepts either `notes` or `decision_notes` (the key returned in responses) as the request field name.
     BatchApprovalDecisionStatus:
       type: string
       title: BatchApprovalDecisionStatus
@@ -29129,7 +29129,7 @@ components:
               maxLength: 2000
             - type: 'null'
           title: Notes
-          description: Optional notes explaining the decision
+          description: Optional notes explaining the decision. Accepts either `notes` or `decision_notes` (the key returned in responses) as the request field name.
     BatchApprovalRequest:
       type: object
       title: BatchApprovalRequest

--- a/backend/tests/integration/approvals/test_batch_approval.py
+++ b/backend/tests/integration/approvals/test_batch_approval.py
@@ -130,6 +130,54 @@ class TestBatchApprovalContract:
             assert call_kwargs["decision_notes"] == batch_payload["decisions"][i]["notes"]
 
     @pytest.mark.asyncio
+    async def test_batch_approval_accepts_decision_notes_alias(
+        self,
+        auth_client: AsyncClient,
+        approvals_factory: ApprovalsFactory,
+        executions_factory: ExecutionsFactory,
+    ) -> None:
+        """Regression for AAP-87655: batch decisions accept the ``decision_notes`` alias.
+
+        A decision that supplies the response-shaped ``decision_notes`` key must have
+        its notes stored, echoed in the result, and forwarded on the workflow signal
+        rather than silently dropped.
+        """
+        # Arrange
+        executions = await executions_factory.create_executions(count=1)
+        approvals = await approvals_factory.create_pending_approvals(count=1, execution_id=executions[0].id)
+
+        batch_payload = {
+            "decisions": [
+                {"approval_id": str(approvals[0].id), "status": "approved", "decision_notes": "Batch alias note"},
+            ]
+        }
+
+        # Act
+        with patch("syntara.approvals.services.approval_service.WorkflowApiClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.send_approval_signal = AsyncMock()
+
+            response = await auth_client.post("/api/v1/approvals/batch", json=batch_payload)
+
+        # Assert - value is not silently dropped
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_success"] == 1
+        assert data["total_failed"] == 0
+        assert data["results"][0]["decision_notes"] == "Batch alias note"
+
+        mock_client.send_approval_signal.assert_called_once_with(
+            execution_id=approvals[0].execution_id,
+            approval_node_id=approvals[0].approval_node_id,
+            decision="approved",
+            approval_id=approvals[0].id,
+            decided_by=ANY,
+            decided_at=ANY,
+            decision_notes="Batch alias note",
+        )
+
+    @pytest.mark.asyncio
     async def test_batch_approval_mixed_success_failure_response_schema(
         self,
         auth_client: AsyncClient,

--- a/backend/tests/integration/approvals/test_decide_approval.py
+++ b/backend/tests/integration/approvals/test_decide_approval.py
@@ -138,6 +138,50 @@ class TestDecideApprovalContract:
         )
 
     @pytest.mark.asyncio
+    async def test_decide_approval_accepts_decision_notes_alias(
+        self,
+        auth_client: AsyncClient,
+        approvals_factory: ApprovalsFactory,
+        executions_factory: ExecutionsFactory,
+    ) -> None:
+        """Regression for AAP-87655: request accepts the ``decision_notes`` alias.
+
+        Consumers that model their request on the response schema send
+        ``decision_notes``. Previously this key was silently dropped; it must now
+        populate the notes field, be stored, echoed in the response, and forwarded
+        on the workflow signal.
+        """
+        # Arrange
+        executions = await executions_factory.create_executions(count=1)
+        approvals = await approvals_factory.create_pending_approvals(count=1, execution_id=executions[0].id)
+        approval_id = str(approvals[0].id)
+
+        # Act - submit using the response-shaped `decision_notes` key
+        with patch("syntara.approvals.services.approval_service.WorkflowApiClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.send_approval_signal = AsyncMock()
+
+            decision_payload = {"status": "approved", "decision_notes": "Approved via alias key"}
+            response = await auth_client.patch(f"/api/v1/approvals/{approval_id}", json=decision_payload)
+
+        # Assert - value is not silently dropped
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "approved"
+        assert data["decision_notes"] == "Approved via alias key"
+
+        mock_client.send_approval_signal.assert_called_once_with(
+            execution_id=approvals[0].execution_id,
+            approval_node_id=approvals[0].approval_node_id,
+            decision="approved",
+            approval_id=approvals[0].id,
+            decided_by=ANY,
+            decided_at=ANY,
+            decision_notes="Approved via alias key",
+        )
+
+    @pytest.mark.asyncio
     async def test_decide_approval_without_notes(
         self,
         auth_client: AsyncClient,

--- a/backend/tests/unit/approvals/models/test_decision_notes_sanitization.py
+++ b/backend/tests/unit/approvals/models/test_decision_notes_sanitization.py
@@ -250,3 +250,54 @@ class TestDecisionNotesSanitization:
             payload = payload.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
         with pytest.raises(ValidationError, match="deeply nested HTML encoding"):
             BatchApprovalDecision(approval_id=uuid4(), status="approved", notes=payload)
+
+
+class TestDecisionNotesAlias:
+    """Both request models accept ``notes`` and its ``decision_notes`` alias (AAP-87655).
+
+    The response schema returns the field as ``decision_notes``; consumers that model
+    their request on the response previously lost the value silently. Both keys must now
+    populate the same ``notes`` field, and sanitization must still run through the alias.
+    """
+
+    def test_single_accepts_decision_notes_alias(self) -> None:
+        request = ApprovalDecisionRequest.model_validate({"status": "approved", "decision_notes": "looks good"})
+        assert request.notes == "looks good"
+
+    def test_single_accepts_canonical_notes(self) -> None:
+        request = ApprovalDecisionRequest.model_validate({"status": "approved", "notes": "looks good"})
+        assert request.notes == "looks good"
+
+    def test_single_both_keys_produce_identical_result(self) -> None:
+        by_notes = ApprovalDecisionRequest.model_validate({"status": "approved", "notes": "same"})
+        by_alias = ApprovalDecisionRequest.model_validate({"status": "approved", "decision_notes": "same"})
+        assert by_notes.notes == by_alias.notes == "same"
+
+    def test_single_alias_input_is_sanitized(self) -> None:
+        """Sanitization runs on the field regardless of which alias supplied the value."""
+        request = ApprovalDecisionRequest.model_validate(
+            {"status": "approved", "decision_notes": "<script>alert(1)</script>keep"}
+        )
+        assert request.notes == "keep"
+
+    def test_batch_accepts_decision_notes_alias(self) -> None:
+        decision = BatchApprovalDecision.model_validate(
+            {"approval_id": str(uuid4()), "status": "approved", "decision_notes": "batch note"}
+        )
+        assert decision.notes == "batch note"
+
+    def test_batch_both_keys_produce_identical_result(self) -> None:
+        approval_id = str(uuid4())
+        by_notes = BatchApprovalDecision.model_validate(
+            {"approval_id": approval_id, "status": "approved", "notes": "same"}
+        )
+        by_alias = BatchApprovalDecision.model_validate(
+            {"approval_id": approval_id, "status": "approved", "decision_notes": "same"}
+        )
+        assert by_notes.notes == by_alias.notes == "same"
+
+    def test_batch_alias_input_is_sanitized(self) -> None:
+        decision = BatchApprovalDecision.model_validate(
+            {"approval_id": str(uuid4()), "status": "approved", "decision_notes": "<b>bold</b> note"}
+        )
+        assert decision.notes == "bold note"

--- a/frontend/packages/syntara-contracts/src/approvals-api.ts
+++ b/frontend/packages/syntara-contracts/src/approvals-api.ts
@@ -357,7 +357,7 @@ export interface components {
       status: components['schemas']['ApprovalDecisionStatus']
       /**
        * Notes
-       * @description Optional notes explaining the decision
+       * @description Optional notes explaining the decision. Accepts either `notes` or `decision_notes` (the key returned in responses) as the request field name.
        */
       notes?: string | null
     }
@@ -384,7 +384,7 @@ export interface components {
       status: components['schemas']['BatchApprovalDecisionStatus']
       /**
        * Notes
-       * @description Optional notes explaining the decision
+       * @description Optional notes explaining the decision. Accepts either `notes` or `decision_notes` (the key returned in responses) as the request field name.
        */
       notes?: string | null
     }


### PR DESCRIPTION
## Description

The approval decision API returned notes as decision_notes in responses but only accepted notes on input. Consumers who modeled their request body on the response schema (sending decision_notes) had their notes silently dropped — no error, just data loss. This PR makes both ApprovalDecisionRequest and BatchApprovalDecision accept either notes or decision_notes via a Pydantic AliasChoices, keeping notes as the canonical field name so the API contract is unchanged and fully backward-compatible.

Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

Changes Made

ApprovalDecisionRequest.notes and BatchApprovalDecision.notes now use validation_alias=AliasChoices("notes", "decision_notes") — both keys populate the same field; notes stays canonical
Documented the accepted alias in both field descriptions
Regenerated OpenAPI specs (schemas/approvals/openapi.yaml source → bundled schemas/openapi.yaml + cli/orchestrator_cli/openapi.yaml), the Python API client, and the frontend TS contracts (all docstring-only, no structural changes)
Added unit tests for dual-alias acceptance + sanitization through the alias
Added integration regression tests for the PATCH (/approvals/{id}) and batch (/approvals/batch) endpoints

How to Test

1. Create/publish a workflow with an approval step and run it to generate a pending approval.
2. PATCH /api/v1/approvals/{id} with {"status": "approved", "decision_notes": "my note"}.
3. Confirm the response decision_notes is "my note" (previously it was null).
4. Repeat with {"status": "approved", "notes": "my note"} — still works (backward compatible).
5. Same for POST /api/v1/approvals/batch with a decision using either notes or decision_notes.

Backend Checklist
  
- [ ] I have run make test and all tests pass (in backend/)
- [x] I have run make lint and code passes all checks (ruff on changed files)
- [x] I have run make format to ensure consistent formatting
- [x] I have run make typecheck and all types are correct
- [x] I have added tests for new functionality
- [ ] No sensitive information (keys, passwords, etc.) is included

  Frontend Checklist

- [x] I have run npm test and all tests pass (in frontend/)
- [x] I have run npm run lint and code passes all checks
- [x] I have run npm run tsc and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality (N/A — only regenerated approvals-api.ts JSDoc; no FE code change)
- [x] Accessibility has been considered (N/A — no UI change)
- [x] Screenshots or screen recordings are attached for UI changes (N/A — no UI change)

General Checklist

- [x] Code follows the project's coding conventions
- [x] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps (N/A — non-breaking)