### PR TITLE
fix(workflows): preserve URL query string when http request params are empty

### DIFF
--- a/backend/src/syntara/workflows/workflow_engine/activities/http_request_activity.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/http_request_activity.py
@@ -5,7 +5,7 @@ import json
 import time
 from http import HTTPStatus
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlparse, urlsplit, urlunsplit
 
 import httpx
 import structlog
@@ -26,6 +26,18 @@ from syntara.workflows.workflow_engine.utils.credential_scrubber import ensure_r
 from .common import HEARTBEAT_STOP_MONITOR, ActivityExecutionError, is_retryable_http_status
 
 logger = structlog.stdlib.get_logger(__name__)
+
+
+def _resolve_httpx_params(request_url: str, query_params: dict[str, Any]) -> tuple[str, dict[str, Any] | None]:
+    """Return httpx url/params; empty query_params → None so URL query is preserved."""
+    if not query_params:
+        return request_url, None
+
+    split = urlsplit(request_url)
+    url_params = dict(parse_qsl(split.query, keep_blank_values=True))
+    merged = {**url_params, **query_params}
+    clean_url = urlunsplit((split.scheme, split.netloc, split.path, "", split.fragment))
+    return clean_url, merged
 
 
 def _add_credential_auth_headers(headers: dict[str, Any], extra_vars: dict[str, Any]) -> None:
@@ -152,6 +164,7 @@ async def execute_http_request_activity(
         raise ApplicationError(str(exc), type="SSRFValidationError", non_retryable=True) from None
 
     timeout_seconds = int(input_config.get(constants.ENGINE_TIMEOUT_SECONDS_KEY, 30))
+    request_url, request_params = _resolve_httpx_params(request_url, config.query_params)
 
     start_time = time.time()
 
@@ -161,7 +174,7 @@ async def execute_http_request_activity(
                 method=config.method.value,
                 url=request_url,
                 headers=headers,
-                params=config.query_params,
+                params=request_params,
                 json=config.body if isinstance(config.body, dict) else None,
                 content=config.body if isinstance(config.body, str) else None,
                 timeout=float(timeout_seconds),

--- a/backend/tests/unit/workflows/workflow_engine/activities/test_http_request_activity.py
+++ b/backend/tests/unit/workflows/workflow_engine/activities/test_http_request_activity.py
@@ -10,6 +10,7 @@ from temporalio.exceptions import ApplicationError
 from syntara.workflows.workflow_engine.activities.common import ActivityExecutionError
 from syntara.workflows.workflow_engine.activities.http_request_activity import (
     _add_credential_auth_headers,
+    _resolve_httpx_params,
     execute_http_request_activity,
 )
 
@@ -166,6 +167,52 @@ class TestExecuteHttpRequestActivitySuccess:
         with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=resp) as mock_req:
             await execute_http_request_activity(config, None)
         assert mock_req.call_args.kwargs["params"] == {"page": "1"}
+
+    @pytest.mark.asyncio
+    async def test_empty_query_params_preserves_url_query_string(self) -> None:
+        resp = _mock_response(200, json_body={})
+        config = {
+            **VALID_CONFIG,
+            "url": "https://example.com/get?token=abc123&keep=yes",
+        }
+        with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=resp) as mock_req:
+            await execute_http_request_activity(config, None)
+        assert mock_req.call_args.kwargs["url"] == "https://example.com/get?token=abc123&keep=yes"
+        assert mock_req.call_args.kwargs["params"] is None
+
+    @pytest.mark.asyncio
+    async def test_query_params_merge_with_url_query_string(self) -> None:
+        resp = _mock_response(200, json_body={})
+        config = {
+            **VALID_CONFIG,
+            "url": "https://example.com/api?token=from-url&keep=yes",
+            "query_params": {"token": "from-params", "page": "1"},
+        }
+        with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=resp) as mock_req:
+            await execute_http_request_activity(config, None)
+        assert mock_req.call_args.kwargs["url"] == "https://example.com/api"
+        assert mock_req.call_args.kwargs["params"] == {
+            "token": "from-params",
+            "keep": "yes",
+            "page": "1",
+        }
+
+
+class TestResolveHttpxParams:
+    """Tests for _resolve_httpx_params."""
+
+    def test_empty_params_returns_none(self) -> None:
+        url, params = _resolve_httpx_params("https://example.com/get?a=1", {})
+        assert url == "https://example.com/get?a=1"
+        assert params is None
+
+    def test_merge_prefers_explicit_params(self) -> None:
+        url, params = _resolve_httpx_params(
+            "https://example.com/get?a=url&b=1",
+            {"a": "explicit", "c": "2"},
+        )
+        assert url == "https://example.com/get"
+        assert params == {"a": "explicit", "b": "1", "c": "2"}
 
 
 class TestExecuteHttpRequestActivityFailures:


### PR DESCRIPTION
 ## Description

HTTP request activity was passing empty `query_params={}` to httpx as `params={}`, which clears any query string already on the URL. Empty params now become `None` (preserve URL query). When both URL query and explicit params are set, they are merged (explicit wins).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] `_resolve_httpx_params` in `http_request_activity.py`
- [x] Unit tests for preserve + merge behavior
- [ ] Include any new dependencies or configuration changes

## Out of Scope

 
## Related Issues

<!-- leave blank or link your tracker issue if required -->

## How to Test

1. Create workflow: Manual trigger  ->  REST API (Action)
2. Method `GET`, URL `https://postman-echo.com/get?token=abc123&keep=yes`
3. Leave query params empty ->  Save - >  Run
4. Output `args` should include `token` and `keep`

## Screenshot
### before
<img width="1500" height="836" alt="Screenshot 2026-08-18 at 4 49 36 PM" src="https://github.com/user-attachments/assets/657fbfa9-6310-4f87-87bd-75f9be78c86a" />

### after
<img width="2992" height="1658" alt="image" src="https://github.com/user-attachments/assets/9196ffc8-7210-4409-bbcd-178077a5aacd" />


## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [x] Database migrations are included if schema changed *(N/A)*
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

N/A — backend only

## Visual Regression

N/A — no UI changes

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps *(N/A)*

## Screenshots / Demo (if applicable)

N/A

## Additional Notes

 