### PR TITLE
fix(api): reject unknown query parameters with 422 instead of silentl…

### DIFF
--- a/backend/src/syntara/core/services/base.py
+++ b/backend/src/syntara/core/services/base.py
@@ -32,7 +32,7 @@ from syntara.core.utils.cursor import (
     deserialize_column_sort_value,
     extract_keyset_from_cursor,
 )
-from syntara.core.utils.filters import Filter, apply_filters, parse_filters
+from syntara.core.utils.filters import BRACKET_PATTERN, LABEL_PARAM_PATTERN, Filter, apply_filters, parse_filters
 from syntara.core.utils.labels import apply_label_filters, parse_label_filter, parse_labels_query
 from syntara.core.utils.pagination import PaginationResult, generate_response
 from syntara.core.utils.sorting import apply_sorting, parse_sort
@@ -620,31 +620,47 @@ class BaseService:
     ) -> None:
         """Validate query parameters against model field types using Pydantic.
 
+        Rejects unknown query parameters and validates values for known fields.
+
         Args:
             query_params: Raw query parameters from request
             model: BaseResource class to validate against (reads __filterable_fields__)
 
         Raises:
-            ValueError: If validation fails for any parameter
+            SafeValueError: If unknown parameters are found or validation fails
 
         """
-        for field_name, string_value in query_params.items():
-            # Skip validation for fields not in allowed list
-            if field_name not in model.__filterable_fields__:
+        filterable = model.__filterable_fields__
+        unknown_params: list[str] = []
+
+        for param_name, string_value in query_params.items():
+            if LABEL_PARAM_PATTERN.match(param_name):
                 continue
 
-            # Get field info from model
-            field_info = model.model_fields.get(field_name)
-            if field_info:
-                try:
-                    # Just validate, don't store the converted value
-                    adapter: TypeAdapter[Any] = TypeAdapter(field_info.annotation)
-                    adapter.validate_python(string_value)
-                except ValidationError as e:
-                    # Extract the first error message for cleaner output
-                    error_detail = str(e.errors()[0]["msg"]) if e.errors() else str(e)
-                    error_message = f"Invalid value for field '{field_name}': {error_detail}"
-                    raise SafeValueError(error_message) from e
+            bracket_match = BRACKET_PATTERN.match(param_name)
+            field_name = bracket_match.group(1) if bracket_match else param_name
+
+            if field_name not in filterable:
+                unknown_params.append(param_name)
+                continue
+
+            # Validate value type for plain (non-bracket) params with model field info
+            if not bracket_match:
+                field_info = model.model_fields.get(field_name)
+                if field_info:
+                    try:
+                        adapter: TypeAdapter[Any] = TypeAdapter(field_info.annotation)
+                        adapter.validate_python(string_value)
+                    except ValidationError as e:
+                        error_detail = str(e.errors()[0]["msg"]) if e.errors() else str(e)
+                        error_message = f"Invalid value for field '{field_name}': {error_detail}"
+                        raise SafeValueError(error_message) from e
+
+        if unknown_params:
+            params_str = ", ".join(sorted(unknown_params))
+            valid_str = ", ".join(sorted(filterable))
+            msg = f"Unknown query parameter(s): {params_str}. Valid filter fields are: {valid_str}"
+            raise SafeValueError(msg)
 
     async def list_resources(
         self,

--- a/backend/src/syntara/core/services/base.py
+++ b/backend/src/syntara/core/services/base.py
@@ -658,8 +658,7 @@ class BaseService:
 
         if unknown_params:
             params_str = ", ".join(sorted(unknown_params))
-            valid_str = ", ".join(sorted(filterable))
-            msg = f"Unknown query parameter(s): {params_str}. Valid filter fields are: {valid_str}"
+            msg = f"Unknown query parameter(s): {params_str}"
             raise SafeValueError(msg)
 
     async def list_resources(

--- a/backend/tests/integration/approvals/test_list_approvals.py
+++ b/backend/tests/integration/approvals/test_list_approvals.py
@@ -367,6 +367,7 @@ class TestListApprovalsContract:
         - Invalid status values return 422 Unprocessable Entity
         - Invalid UUIDs return 422 Unprocessable Entity
         - Invalid limit values return 422 Unprocessable Entity
+        - Unknown query parameters return 422 Unprocessable Entity
         - Error responses match RFC 9457 format
         """
         # Act & Assert - Invalid status value
@@ -419,5 +420,19 @@ class TestListApprovalsContract:
             title="Request Validation Error",
             detail="Validation failed: query -> limit: Input should be less than or equal to 100",
             code="REQUEST_VALIDATION_ERROR",
+            retryable=False,
+        )
+
+        # Act & Assert - Unknown query parameter is rejected instead of silently ignored.
+        # This is raised as a SafeValueError inside the service, so the RFC 9457 title/code
+        # differ from the FastAPI request-validation cases above.
+        response = await auth_client.get("/api/v1/approvals?bogus_param=value")
+        assert response.status_code == 422
+        assert_error_data(
+            response,
+            error_type="https://api.example.com/errors/validation-error",
+            title="Validation Error",
+            detail="Unknown query parameter(s): bogus_param",
+            code="VALIDATION_ERROR",
             retryable=False,
         )

--- a/backend/tests/unit/core/services/test_base_service.py
+++ b/backend/tests/unit/core/services/test_base_service.py
@@ -285,3 +285,57 @@ class TestApplyCursorPagination:
         out_col, out_val = BaseService._coerce_boolean_keyset(col, val=False)
         assert out_val == 0
         assert out_col is not col
+
+
+class TestValidateQueryParams:
+    """Tests for BaseService._validate_query_params unknown-parameter rejection."""
+
+    def _make_service(self) -> BaseService:
+        return object.__new__(BaseService)
+
+    def test_valid_filterable_field_accepted(self) -> None:
+        service = self._make_service()
+        service._validate_query_params({"name": "alice"}, Workflow)
+
+    def test_unknown_field_rejected(self) -> None:
+        service = self._make_service()
+        with pytest.raises(SafeValueError, match=r"Unknown query parameter.*order"):
+            service._validate_query_params({"order": "asc"}, Workflow)
+
+    def test_multiple_unknown_fields_all_listed(self) -> None:
+        service = self._make_service()
+        with pytest.raises(SafeValueError, match="Unknown query parameter") as exc_info:
+            service._validate_query_params({"foo": "bar", "order": "asc"}, Workflow)
+        msg = str(exc_info.value)
+        assert "foo" in msg
+        assert "order" in msg
+
+    def test_error_lists_valid_fields(self) -> None:
+        service = self._make_service()
+        with pytest.raises(SafeValueError, match="Valid filter fields") as exc_info:
+            service._validate_query_params({"bogus": "1"}, Workflow)
+        msg = str(exc_info.value)
+        assert "name" in msg
+        assert "created_at" in msg
+
+    def test_label_bracket_params_accepted(self) -> None:
+        service = self._make_service()
+        service._validate_query_params({"labels[env]": "prod"}, Workflow)
+
+    def test_bracket_notation_valid_field_accepted(self) -> None:
+        service = self._make_service()
+        service._validate_query_params({"name[contains]": "test"}, Workflow)
+
+    def test_bracket_notation_unknown_field_rejected(self) -> None:
+        service = self._make_service()
+        with pytest.raises(SafeValueError, match=r"Unknown query parameter.*bogus"):
+            service._validate_query_params({"bogus[contains]": "test"}, Workflow)
+
+    def test_empty_params_accepted(self) -> None:
+        service = self._make_service()
+        service._validate_query_params({}, Workflow)
+
+    def test_mix_of_valid_and_unknown_rejected(self) -> None:
+        service = self._make_service()
+        with pytest.raises(SafeValueError, match=r"Unknown query parameter.*foo"):
+            service._validate_query_params({"name": "alice", "foo": "bar"}, Workflow)

--- a/backend/tests/unit/core/services/test_base_service.py
+++ b/backend/tests/unit/core/services/test_base_service.py
@@ -310,13 +310,13 @@ class TestValidateQueryParams:
         assert "foo" in msg
         assert "order" in msg
 
-    def test_error_lists_valid_fields(self) -> None:
+    def test_error_does_not_leak_valid_fields(self) -> None:
         service = self._make_service()
-        with pytest.raises(SafeValueError, match="Valid filter fields") as exc_info:
+        with pytest.raises(SafeValueError, match="Unknown query parameter") as exc_info:
             service._validate_query_params({"bogus": "1"}, Workflow)
         msg = str(exc_info.value)
-        assert "name" in msg
-        assert "created_at" in msg
+        assert "Valid filter fields" not in msg
+        assert "bogus" in msg
 
     def test_label_bracket_params_accepted(self) -> None:
         service = self._make_service()
@@ -339,3 +339,12 @@ class TestValidateQueryParams:
         service = self._make_service()
         with pytest.raises(SafeValueError, match=r"Unknown query parameter.*foo"):
             service._validate_query_params({"name": "alice", "foo": "bar"}, Workflow)
+
+    def test_invalid_value_raised_before_unknown_param(self) -> None:
+        """When a known field has an invalid value AND unknown params exist.
+
+        The invalid-value error is raised first (loop order).
+        """
+        service = self._make_service()
+        with pytest.raises(SafeValueError, match=r"Invalid value for field 'is_enabled'"):
+            service._validate_query_params({"is_enabled": "not-a-bool", "bogus": "1"}, Workflow)


### PR DESCRIPTION
## Description
_validate_query_params now collects all unrecognized query parameters
  (plain, bracket-notation, and label-prefixed) and raises a single
  SafeValueError listing them alongside the valid filter fields. This
  applies to every list endpoint via the shared BaseService.

https://redhat.atlassian.net/browse/AAP-87764

Breaking change: API list endpoints now return 422 for unknown query parameters that were previously silently ignored. Clients sending extra params (e.g. order=asc) will need to remove them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [ ] List the specific changes made
- [ ] Include any new dependencies or configuration changes

## Out of Scope

<!-- What this PR intentionally does NOT include, to set reviewer expectations -->

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## How to Test

<!-- Manual testing directions, for example:
1. Log in as an admin
2. Go to the `/workflows` route
3. Click on a thing
4. Validate that something changed
-->

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [x] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->
