### PR TITLE
feat(metrics): replace in-process active_workflows gauge with Temporal query

### DIFF
--- a/backend/src/api_client/syntara_api_client/models/metric_type.py
+++ b/backend/src/api_client/syntara_api_client/models/metric_type.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class MetricType(str, Enum):
+    ACTIVE_WORKFLOWS = "active_workflows"
     ACTIVITY_DURATION_MS = "activity_duration_ms"
     ACTIVITY_EXECUTION_SUCCESS_RATE = "activity_execution_success_rate"
     AGENT_INVOCATION_MS = "agent_invocation_ms"

--- a/backend/src/syntara/metrics/emission.py
+++ b/backend/src/syntara/metrics/emission.py
@@ -148,7 +148,6 @@ def _emit_workflow(
     duration_ms = (execution.completed_at - execution.created_at).total_seconds() * 1000
     recorder.record(MetricType.WORKFLOW_DURATION, duration_ms, unit="ms", labels=labels)
     recorder.record(MetricType.WORKFLOW_STATUS, value=1, labels=labels)
-    recorder.decrement_gauge("active_workflows")
 
     with _workflow_completion_lock:
         _workflow_completion_counts[1] += 1

--- a/backend/src/syntara/metrics/prometheus.py
+++ b/backend/src/syntara/metrics/prometheus.py
@@ -166,6 +166,7 @@ class OrchestratorPrometheusMetrics:
         self.active_workflows = Gauge(
             "orchestrator_active_workflows",
             "Number of concurrent running workflow executions (queried from Temporal)",
+            ["component"],
             registry=self.registry,
         )
 

--- a/backend/src/syntara/metrics/prometheus.py
+++ b/backend/src/syntara/metrics/prometheus.py
@@ -165,7 +165,7 @@ class OrchestratorPrometheusMetrics:
 
         self.active_workflows = Gauge(
             "orchestrator_active_workflows",
-            "Number of currently active workflows",
+            "Number of concurrent running workflow executions (queried from Temporal)",
             registry=self.registry,
         )
 

--- a/backend/src/syntara/metrics/queue_depth_poller.py
+++ b/backend/src/syntara/metrics/queue_depth_poller.py
@@ -1,13 +1,17 @@
-"""Background poller that emits Temporal task queue depth metrics.
+"""Background poller that emits Temporal task queue depth and active workflow metrics.
 
-Periodically queries the Temporal server via ``describe_task_queue`` to
-obtain the approximate backlog count and records it as a
-``TEMPORAL_QUEUE_DEPTH`` metric in both the in-memory MetricsStore and the
-Prometheus gauge.
+Periodically queries the Temporal server to obtain:
+
+* **Queue depth** — via ``describe_task_queue`` for approximate backlog counts,
+  recorded as ``TEMPORAL_QUEUE_DEPTH``.
+* **Active workflows** — via ``count_workflows`` for the true number of
+  currently running workflow executions, recorded as ``ACTIVE_WORKFLOWS``.
+  This replaces the former in-process increment/decrement gauge which drifted
+  on pod restarts.
 
 Uses ``PeriodicWorker`` with ``coordinate=False`` so that every API-server
-instance independently polls the same Temporal task queue; Prometheus
-handles aggregation at scrape time.
+instance independently polls the same Temporal server; Prometheus handles
+aggregation at scrape time.
 """
 
 from __future__ import annotations
@@ -81,6 +85,17 @@ async def _query_queue_depth(client: Client, task_queue: str, namespace: str) ->
     return 0
 
 
+async def _query_running_workflow_count(client: Client) -> int:
+    """Query Temporal for the number of currently running workflow executions.
+
+    Uses the Temporal visibility ``count_workflows`` API with an
+    ``ExecutionStatus='Running'`` filter.  This reflects the true cluster
+    state and is not affected by pod restarts.
+    """
+    result = await client.count_workflows("ExecutionStatus='Running'")
+    return result.count
+
+
 def _make_poll_callback(
     temporal_address: str,
     namespace: str,
@@ -88,10 +103,13 @@ def _make_poll_callback(
 ) -> Any:  # noqa: ANN401
     """Build the async callback consumed by ``PeriodicWorker``.
 
-    Polls every queue in *task_queues* on each tick and emits one
-    ``TEMPORAL_QUEUE_DEPTH`` record per queue, labelled with the queue name
-    so Prometheus can distinguish background-queue depth from workflow-queue
-    depth when configuring HPA rules.
+    Each tick:
+
+    1. Emits one ``TEMPORAL_QUEUE_DEPTH`` record per queue, labelled with the
+       queue name so Prometheus can distinguish background-queue depth from
+       workflow-queue depth when configuring HPA rules.
+    2. Emits one ``ACTIVE_WORKFLOWS`` record with the true count of running
+       workflow executions obtained from Temporal's visibility API.
     """
 
     async def _poll(_sf: object) -> None:
@@ -111,6 +129,17 @@ def _make_poll_callback(
                 component=ComponentLabel.TEMPORAL_WORKER,
                 labels={"task_queue": task_queue},
             )
+
+        try:
+            running_count = await _query_running_workflow_count(client)
+        except RPCError:
+            logger.debug("workflow_count_poller_rpc_error", exc_info=True)
+            return
+        recorder.record(
+            MetricType.ACTIVE_WORKFLOWS,
+            float(running_count),
+            component=ComponentLabel.TEMPORAL_WORKER,
+        )
 
     return _poll
 

--- a/backend/src/syntara/metrics/recorder.py
+++ b/backend/src/syntara/metrics/recorder.py
@@ -288,6 +288,7 @@ class MetricsRecorder:
             # _value is a private ValueClass. The except guard handles library changes.
             return int(gauge._value.get())  # noqa: SLF001
         except Exception:  # noqa: BLE001
+            logger.debug("active_workflows_gauge_read_failed", exc_info=True)
             return 0
 
     def get_summary(self) -> MetricsSummary:

--- a/backend/src/syntara/metrics/recorder.py
+++ b/backend/src/syntara/metrics/recorder.py
@@ -275,6 +275,19 @@ class MetricsRecorder:
             labels=labels,
         )
 
+    def _get_active_workflows_from_gauge(self) -> int:
+        """Read the current active_workflows value from the Prometheus gauge.
+
+        The poller sets this via ``record(MetricType.ACTIVE_WORKFLOWS, ...)``
+        which routes through ``_dispatch_component`` → ``.labels(...).set()``.
+        Before the first poll the gauge has no samples, so we return 0.
+        """
+        try:
+            gauge = self._prometheus.active_workflows.labels(component=ComponentLabel.TEMPORAL_WORKER.value)
+            return int(gauge._value.get())  # noqa: SLF001
+        except Exception:  # noqa: BLE001
+            return 0
+
     def get_summary(self) -> MetricsSummary:
         """Build a point-in-time summary of internal counters."""
         now = datetime.now(UTC)
@@ -287,7 +300,7 @@ class MetricsRecorder:
             cache_misses=counters_snapshot.get("cache_misses", 0),
             llm_calls=counters_snapshot.get("llm_calls", 0),
             total_workflows=counters_snapshot.get("total_workflows", 0),
-            active_workflows=counters_snapshot.get("active_workflows", 0),
+            active_workflows=self._get_active_workflows_from_gauge(),
             active_llm_requests=counters_snapshot.get("active_llm_requests", 0),
             db_transactions=counters_snapshot.get("db_transactions", 0),
             period_start=now - self._store.retention,

--- a/backend/src/syntara/metrics/recorder.py
+++ b/backend/src/syntara/metrics/recorder.py
@@ -284,6 +284,8 @@ class MetricsRecorder:
         """
         try:
             gauge = self._prometheus.active_workflows.labels(component=ComponentLabel.TEMPORAL_WORKER.value)
+            # prometheus_client has no public API for reading a gauge value;
+            # _value is a private ValueClass. The except guard handles library changes.
             return int(gauge._value.get())  # noqa: SLF001
         except Exception:  # noqa: BLE001
             return 0

--- a/backend/src/syntara/metrics/recorder.py
+++ b/backend/src/syntara/metrics/recorder.py
@@ -53,6 +53,7 @@ _COMPONENT_METRIC_MAP: dict[MetricType, tuple[str, str, tuple[str, ...]]] = {
     MetricType.WORKFLOW_VALIDATION_DURATION: ("workflow_validation_duration_seconds", "histogram", ()),
     # Temporal Worker
     MetricType.TEMPORAL_QUEUE_DEPTH: ("temporal_queue_depth", "gauge", ("task_queue",)),
+    MetricType.ACTIVE_WORKFLOWS: ("active_workflows", "gauge", ()),
     MetricType.ACTIVITY_EXECUTION_SUCCESS_RATE: ("activity_execution_success_rate", "gauge", ()),
     # Execution Service
     MetricType.WORKFLOW_START_LATENCY: ("workflow_start_latency_seconds", "histogram", ()),

--- a/backend/src/syntara/metrics/types.py
+++ b/backend/src/syntara/metrics/types.py
@@ -73,6 +73,7 @@ class MetricType(StrEnum):
 
     # Temporal Worker Metrics
     TEMPORAL_QUEUE_DEPTH = "temporal_queue_depth"
+    ACTIVE_WORKFLOWS = "active_workflows"
     ACTIVITY_EXECUTION_SUCCESS_RATE = "activity_execution_success_rate"
 
     # Execution Service Metrics
@@ -174,6 +175,7 @@ METRIC_CATEGORIES: dict[MetricsCategoryType, list[MetricType]] = {
     ],
     MetricsCategoryType.TEMPORAL_WORKER: [
         MetricType.TEMPORAL_QUEUE_DEPTH,
+        MetricType.ACTIVE_WORKFLOWS,
         MetricType.ACTIVITY_EXECUTION_SUCCESS_RATE,
         MetricType.ACTIVITY_DURATION,
     ],

--- a/backend/src/syntara/schemas/internal_metrics/openapi.yaml
+++ b/backend/src/syntara/schemas/internal_metrics/openapi.yaml
@@ -351,6 +351,7 @@ components:
         - workflow_serialization_duration_ms
         - workflow_validation_duration_ms
         - temporal_queue_depth
+        - active_workflows
         - activity_execution_success_rate
         - workflow_start_latency_ms
         - workflow_completion_rate

--- a/backend/src/syntara/schemas/openapi.yaml
+++ b/backend/src/syntara/schemas/openapi.yaml
@@ -33129,6 +33129,7 @@ components:
         - workflow_serialization_duration_ms
         - workflow_validation_duration_ms
         - temporal_queue_depth
+        - active_workflows
         - activity_execution_success_rate
         - workflow_start_latency_ms
         - workflow_completion_rate

--- a/backend/src/syntara/workflows/services/execution_service.py
+++ b/backend/src/syntara/workflows/services/execution_service.py
@@ -518,7 +518,6 @@ class ExecutionService(BaseService):
             },
         )
         recorder.increment("total_workflows")
-        recorder.increment_gauge("active_workflows")
 
         self._emit_lifecycle_event(
             execution_id=execution.id,

--- a/backend/tests/integration/metrics/test_workflow_instrumentation.py
+++ b/backend/tests/integration/metrics/test_workflow_instrumentation.py
@@ -152,40 +152,6 @@ class TestWorkflowCompletionMetrics:
         assert len(list(recorder.query(metric_types={MetricType.WORKFLOW_DURATION}))) == 1
 
     @pytest.mark.asyncio
-    async def test_decrements_active_workflows_gauge(
-        self,
-        recorder: MetricsRecorder,
-        completed_execution: Execution,
-        test_db_session: AsyncSession,
-    ) -> None:
-        for _ in range(3):
-            recorder.increment_gauge("active_workflows")
-        service = _make_service(test_db_session)
-
-        with patch(PATCH_TARGET, return_value=recorder):
-            await service._emit_completion_metrics(completed_execution)
-
-        assert recorder.get_summary().active_workflows == 2
-        assert recorder.prometheus.active_workflows._value.get() == pytest.approx(2.0)
-
-    @pytest.mark.asyncio
-    async def test_active_workflows_gauge_floors_at_zero(
-        self,
-        recorder: MetricsRecorder,
-        completed_execution: Execution,
-        test_db_session: AsyncSession,
-    ) -> None:
-        """After a restart the counter is 0; completing a workflow must not go negative."""
-        assert recorder.get_summary().active_workflows == 0
-        service = _make_service(test_db_session)
-
-        with patch(PATCH_TARGET, return_value=recorder):
-            await service._emit_completion_metrics(completed_execution)
-
-        assert recorder.get_summary().active_workflows == 0
-        assert recorder.prometheus.active_workflows._value.get() == pytest.approx(0.0)
-
-    @pytest.mark.asyncio
     async def test_observes_prometheus_histogram(
         self,
         recorder: MetricsRecorder,

--- a/backend/tests/unit/metrics/test_prometheus.py
+++ b/backend/tests/unit/metrics/test_prometheus.py
@@ -97,15 +97,20 @@ class TestMetricOperations:
 
     def test_gauge_set(self, prom: OrchestratorPrometheusMetrics) -> None:
         """Gauges can be set to a value."""
-        prom.active_workflows.set(5)
-        assert prom.active_workflows._value.get() == pytest.approx(5.0)
+        prom.active_llm_requests.set(5)
+        assert prom.active_llm_requests._value.get() == pytest.approx(5.0)
 
     def test_gauge_inc_dec(self, prom: OrchestratorPrometheusMetrics) -> None:
         """Gauges can be incremented and decremented."""
-        prom.active_workflows.inc()
-        prom.active_workflows.inc()
-        prom.active_workflows.dec()
-        assert prom.active_workflows._value.get() == pytest.approx(1.0)
+        prom.active_llm_requests.inc()
+        prom.active_llm_requests.inc()
+        prom.active_llm_requests.dec()
+        assert prom.active_llm_requests._value.get() == pytest.approx(1.0)
+
+    def test_labeled_gauge_set(self, prom: OrchestratorPrometheusMetrics) -> None:
+        """Labeled gauges (active_workflows) require .labels() before .set()."""
+        prom.active_workflows.labels(component="temporal_worker").set(12)
+        assert prom.active_workflows.labels(component="temporal_worker")._value.get() == pytest.approx(12.0)
 
 
 # =============================================================================
@@ -120,7 +125,7 @@ class TestPrometheusOutput:
         """generate_latest produces valid Prometheus text format."""
         prom.requests_total.labels(status="success", endpoint="/api", interface="api").inc(10)
         prom.cache_hits_total.inc(5)
-        prom.active_workflows.set(3)
+        prom.active_workflows.labels(component="temporal_worker").set(3)
 
         output = generate_latest(prom.registry).decode("utf-8")
 

--- a/backend/tests/unit/metrics/test_queue_depth_poller.py
+++ b/backend/tests/unit/metrics/test_queue_depth_poller.py
@@ -15,6 +15,7 @@ from syntara.metrics.queue_depth_poller import (
     _ensure_client,
     _make_poll_callback,
     _query_queue_depth,
+    _query_running_workflow_count,
     get_queue_depth_poller,
 )
 
@@ -127,6 +128,35 @@ class TestQueryQueueDepth:
         assert depth == 0
 
 
+class TestQueryRunningWorkflowCount:
+    """Tests for _query_running_workflow_count visibility API helper."""
+
+    @pytest.mark.asyncio
+    async def test_returns_count_from_temporal(self) -> None:
+        """Should return the count from Temporal's count_workflows response."""
+        mock_result = MagicMock()
+        mock_result.count = 42
+
+        mock_client = MagicMock()
+        mock_client.count_workflows = AsyncMock(return_value=mock_result)
+
+        count = await _query_running_workflow_count(mock_client)
+        assert count == 42
+        mock_client.count_workflows.assert_called_once_with("ExecutionStatus='Running'")
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_running_workflows(self) -> None:
+        """Should return 0 when no workflows are running."""
+        mock_result = MagicMock()
+        mock_result.count = 0
+
+        mock_client = MagicMock()
+        mock_client.count_workflows = AsyncMock(return_value=mock_result)
+
+        count = await _query_running_workflow_count(mock_client)
+        assert count == 0
+
+
 class TestPollCallback:
     """Tests for the poll callback produced by _make_poll_callback."""
 
@@ -144,6 +174,7 @@ class TestPollCallback:
         mock_resp.stats.approximate_backlog_count = 5
         mock_resp.task_queue_status = None
         mock_client.workflow_service.describe_task_queue = AsyncMock(return_value=mock_resp)
+        mock_client.count_workflows = AsyncMock(return_value=MagicMock(count=10))
 
         mock_recorder = MagicMock()
 
@@ -163,11 +194,13 @@ class TestPollCallback:
 
         from syntara.metrics.types import ComponentLabel, MetricType
 
-        mock_recorder.record.assert_called_once_with(
-            MetricType.TEMPORAL_QUEUE_DEPTH,
-            5.0,
-            component=ComponentLabel.TEMPORAL_WORKER,
-            labels={"task_queue": "orchestrator-workflow-queue"},
+        queue_depth_calls = [
+            c for c in mock_recorder.record.call_args_list if c.args[0] == MetricType.TEMPORAL_QUEUE_DEPTH
+        ]
+        assert len(queue_depth_calls) == 1
+        assert queue_depth_calls[0] == (
+            (MetricType.TEMPORAL_QUEUE_DEPTH, 5.0),
+            {"component": ComponentLabel.TEMPORAL_WORKER, "labels": {"task_queue": "orchestrator-workflow-queue"}},
         )
 
     @pytest.mark.asyncio
@@ -178,6 +211,7 @@ class TestPollCallback:
         mock_resp.stats.approximate_backlog_count = 3
         mock_resp.task_queue_status = None
         mock_client.workflow_service.describe_task_queue = AsyncMock(return_value=mock_resp)
+        mock_client.count_workflows = AsyncMock(return_value=MagicMock(count=0))
 
         mock_recorder = MagicMock()
 
@@ -199,11 +233,13 @@ class TestPollCallback:
 
         from syntara.metrics.types import ComponentLabel, MetricType
 
-        assert mock_recorder.record.call_count == 2
-        calls = mock_recorder.record.call_args_list
-        recorded_queues = {c.kwargs["labels"]["task_queue"] for c in calls}
+        queue_depth_calls = [
+            c for c in mock_recorder.record.call_args_list if c.args[0] == MetricType.TEMPORAL_QUEUE_DEPTH
+        ]
+        assert len(queue_depth_calls) == 2
+        recorded_queues = {c.kwargs["labels"]["task_queue"] for c in queue_depth_calls}
         assert recorded_queues == set(queues)
-        for call in calls:
+        for call in queue_depth_calls:
             assert call.args == (MetricType.TEMPORAL_QUEUE_DEPTH, 3.0)
             assert call.kwargs["component"] == ComponentLabel.TEMPORAL_WORKER
 
@@ -245,6 +281,7 @@ class TestPollCallback:
                 ok_resp,
             ]
         )
+        mock_client.count_workflows = AsyncMock(return_value=MagicMock(count=3))
         mock_recorder = MagicMock()
 
         with (
@@ -265,12 +302,93 @@ class TestPollCallback:
 
         from syntara.metrics.types import ComponentLabel, MetricType
 
-        mock_recorder.record.assert_called_once_with(
-            MetricType.TEMPORAL_QUEUE_DEPTH,
-            7.0,
-            component=ComponentLabel.TEMPORAL_WORKER,
-            labels={"task_queue": "orchestrator-background-queue"},
+        queue_depth_calls = [
+            c for c in mock_recorder.record.call_args_list if c.args[0] == MetricType.TEMPORAL_QUEUE_DEPTH
+        ]
+        assert len(queue_depth_calls) == 1
+        assert queue_depth_calls[0] == (
+            (MetricType.TEMPORAL_QUEUE_DEPTH, 7.0),
+            {"component": ComponentLabel.TEMPORAL_WORKER, "labels": {"task_queue": "orchestrator-background-queue"}},
         )
+
+    @pytest.mark.asyncio
+    async def test_records_active_workflows_count(self) -> None:
+        """Callback should emit ACTIVE_WORKFLOWS from Temporal count_workflows."""
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.stats.approximate_backlog_count = 0
+        mock_resp.task_queue_status = None
+        mock_client.workflow_service.describe_task_queue = AsyncMock(return_value=mock_resp)
+        mock_client.count_workflows = AsyncMock(return_value=MagicMock(count=15))
+
+        mock_recorder = MagicMock()
+
+        with (
+            patch(
+                "syntara.metrics.queue_depth_poller.Client.connect",
+                new_callable=AsyncMock,
+                return_value=mock_client,
+            ),
+            patch(
+                "syntara.metrics.queue_depth_poller.get_metrics_recorder",
+                return_value=mock_recorder,
+            ),
+        ):
+            callback = _make_poll_callback("localhost:7233", "default", ["orchestrator-workflow-queue"])
+            await callback(None)
+
+        from syntara.metrics.types import ComponentLabel, MetricType
+
+        workflow_count_calls = [
+            c for c in mock_recorder.record.call_args_list if c.args[0] == MetricType.ACTIVE_WORKFLOWS
+        ]
+        assert len(workflow_count_calls) == 1
+        assert workflow_count_calls[0] == (
+            (MetricType.ACTIVE_WORKFLOWS, 15.0),
+            {"component": ComponentLabel.TEMPORAL_WORKER},
+        )
+
+    @pytest.mark.asyncio
+    async def test_count_workflows_rpc_error_does_not_affect_queue_depth(self) -> None:
+        """An RPCError from count_workflows should not prevent queue depth recording."""
+        from temporalio.service import RPCError, RPCStatusCode
+
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.stats.approximate_backlog_count = 4
+        mock_resp.task_queue_status = None
+        mock_client.workflow_service.describe_task_queue = AsyncMock(return_value=mock_resp)
+        mock_client.count_workflows = AsyncMock(
+            side_effect=RPCError("unavailable", RPCStatusCode.UNAVAILABLE, b""),
+        )
+
+        mock_recorder = MagicMock()
+
+        with (
+            patch(
+                "syntara.metrics.queue_depth_poller.Client.connect",
+                new_callable=AsyncMock,
+                return_value=mock_client,
+            ),
+            patch(
+                "syntara.metrics.queue_depth_poller.get_metrics_recorder",
+                return_value=mock_recorder,
+            ),
+        ):
+            callback = _make_poll_callback("localhost:7233", "default", ["orchestrator-workflow-queue"])
+            await callback(None)
+
+        from syntara.metrics.types import MetricType
+
+        queue_depth_calls = [
+            c for c in mock_recorder.record.call_args_list if c.args[0] == MetricType.TEMPORAL_QUEUE_DEPTH
+        ]
+        assert len(queue_depth_calls) == 1
+
+        workflow_count_calls = [
+            c for c in mock_recorder.record.call_args_list if c.args[0] == MetricType.ACTIVE_WORKFLOWS
+        ]
+        assert len(workflow_count_calls) == 0
 
 
 class TestGetQueueDepthPoller:

--- a/backend/tests/unit/metrics/test_recorder.py
+++ b/backend/tests/unit/metrics/test_recorder.py
@@ -97,47 +97,47 @@ class TestRecorderGaugeHelpers:
     """Tests for increment_gauge() and decrement_gauge()."""
 
     def test_increment_gauge_updates_counter_and_prometheus(self, recorder: MetricsRecorder) -> None:
-        recorder.increment_gauge("active_workflows")
-        recorder.increment_gauge("active_workflows")
+        recorder.increment_gauge("active_llm_requests")
+        recorder.increment_gauge("active_llm_requests")
 
-        assert recorder.get_summary().active_workflows == 2
-        assert recorder.prometheus.active_workflows._value.get() == pytest.approx(2.0)
+        assert recorder.get_summary().active_llm_requests == 2
+        assert recorder.prometheus.active_llm_requests._value.get() == pytest.approx(2.0)
 
     def test_decrement_gauge_updates_counter_and_prometheus(self, recorder: MetricsRecorder) -> None:
         for _ in range(3):
-            recorder.increment_gauge("active_workflows")
+            recorder.increment_gauge("active_llm_requests")
 
-        recorder.decrement_gauge("active_workflows")
+        recorder.decrement_gauge("active_llm_requests")
 
-        assert recorder.get_summary().active_workflows == 2
-        assert recorder.prometheus.active_workflows._value.get() == pytest.approx(2.0)
+        assert recorder.get_summary().active_llm_requests == 2
+        assert recorder.prometheus.active_llm_requests._value.get() == pytest.approx(2.0)
 
     def test_decrement_gauge_floors_at_zero(self, recorder: MetricsRecorder) -> None:
         """Decrementing a gauge that is already at 0 must not go negative."""
-        assert recorder.get_summary().active_workflows == 0
+        assert recorder.get_summary().active_llm_requests == 0
 
-        recorder.decrement_gauge("active_workflows")
+        recorder.decrement_gauge("active_llm_requests")
 
-        assert recorder.get_summary().active_workflows == 0
-        assert recorder.prometheus.active_workflows._value.get() == pytest.approx(0.0)
+        assert recorder.get_summary().active_llm_requests == 0
+        assert recorder.prometheus.active_llm_requests._value.get() == pytest.approx(0.0)
 
     def test_decrement_gauge_floors_after_multiple(self, recorder: MetricsRecorder) -> None:
         """Several decrements below zero all stay at 0."""
-        recorder.increment_gauge("active_workflows")
+        recorder.increment_gauge("active_llm_requests")
 
-        recorder.decrement_gauge("active_workflows")
-        recorder.decrement_gauge("active_workflows")
-        recorder.decrement_gauge("active_workflows")
+        recorder.decrement_gauge("active_llm_requests")
+        recorder.decrement_gauge("active_llm_requests")
+        recorder.decrement_gauge("active_llm_requests")
 
-        assert recorder.get_summary().active_workflows == 0
-        assert recorder.prometheus.active_workflows._value.get() == pytest.approx(0.0)
+        assert recorder.get_summary().active_llm_requests == 0
+        assert recorder.prometheus.active_llm_requests._value.get() == pytest.approx(0.0)
 
     def test_gauge_helpers_disabled_is_noop(self, disabled_recorder: MetricsRecorder) -> None:
-        disabled_recorder.increment_gauge("active_workflows")
-        assert disabled_recorder.get_summary().active_workflows == 0
+        disabled_recorder.increment_gauge("active_llm_requests")
+        assert disabled_recorder.get_summary().active_llm_requests == 0
 
-        disabled_recorder.decrement_gauge("active_workflows")
-        assert disabled_recorder.get_summary().active_workflows == 0
+        disabled_recorder.decrement_gauge("active_llm_requests")
+        assert disabled_recorder.get_summary().active_llm_requests == 0
 
 
 # =============================================================================
@@ -214,14 +214,19 @@ class TestRecorderSummary:
 
     def test_summary_reflects_increments(self, recorder: MetricsRecorder) -> None:
         """Summary counters reflect what was incremented."""
+        from syntara.metrics.types import ComponentLabel
+
         recorder.increment("requests", 10)
         recorder.increment("errors", 2)
         recorder.increment("cache_hits", 7)
         recorder.increment("cache_misses", 3)
         recorder.increment("llm_calls", 8)
         recorder.increment("total_workflows", 15)
-        for _ in range(2):
-            recorder.increment_gauge("active_workflows")
+        recorder.record(
+            MetricType.ACTIVE_WORKFLOWS,
+            2.0,
+            component=ComponentLabel.TEMPORAL_WORKER,
+        )
 
         summary = recorder.get_summary()
         assert summary.total_requests == 10
@@ -482,6 +487,35 @@ class TestRecorderPrometheus:
         )._value.get()
         assert wf_value == pytest.approx(10.0)
         assert bg_value == pytest.approx(5.0)
+
+    def test_active_workflows_updates_gauge(self, recorder: MetricsRecorder) -> None:
+        """Recording ACTIVE_WORKFLOWS sets the gauge with the component label."""
+        recorder.record(
+            MetricType.ACTIVE_WORKFLOWS,
+            15.0,
+            component=ComponentLabel.TEMPORAL_WORKER,
+        )
+        sample_value = recorder.prometheus.active_workflows.labels(
+            component="temporal_worker",
+        )._value.get()
+        assert sample_value == pytest.approx(15.0)
+
+    def test_active_workflows_overwrites_on_subsequent_record(self, recorder: MetricsRecorder) -> None:
+        """Each ACTIVE_WORKFLOWS record replaces the previous value (gauge.set semantics)."""
+        recorder.record(
+            MetricType.ACTIVE_WORKFLOWS,
+            10.0,
+            component=ComponentLabel.TEMPORAL_WORKER,
+        )
+        recorder.record(
+            MetricType.ACTIVE_WORKFLOWS,
+            3.0,
+            component=ComponentLabel.TEMPORAL_WORKER,
+        )
+        sample_value = recorder.prometheus.active_workflows.labels(
+            component="temporal_worker",
+        )._value.get()
+        assert sample_value == pytest.approx(3.0)
 
     def test_tool_execution_duration_dispatches_to_histogram_and_counter(self, recorder: MetricsRecorder) -> None:
         """TOOL_EXECUTION_DURATION updates histogram (observe) and counter (inc)."""

--- a/backend/tests/unit/metrics/test_types.py
+++ b/backend/tests/unit/metrics/test_types.py
@@ -66,6 +66,7 @@ class TestMetricType:
             "WORKFLOW_VALIDATION_DURATION",
             # Temporal Worker
             "TEMPORAL_QUEUE_DEPTH",
+            "ACTIVE_WORKFLOWS",
             "ACTIVITY_EXECUTION_SUCCESS_RATE",
             # Execution Service
             "WORKFLOW_START_LATENCY",

--- a/frontend/packages/syntara-contracts/src/metrics-api.ts
+++ b/frontend/packages/syntara-contracts/src/metrics-api.ts
@@ -222,6 +222,7 @@ export interface components {
       | 'workflow_serialization_duration_ms'
       | 'workflow_validation_duration_ms'
       | 'temporal_queue_depth'
+      | 'active_workflows'
       | 'activity_execution_success_rate'
       | 'workflow_start_latency_ms'
       | 'workflow_completion_rate'


### PR DESCRIPTION
## Description

The `orchestrator_active_workflows` Prometheus gauge previously used an in-process increment/decrement counter that drifted on pod restarts. This replaces it with a Temporal visibility API query (`count_workflows ExecutionStatus='Running'`) polled every 5s alongside the existing queue depth metric, giving SREs an accurate count of concurrent running workflows.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Extended the existing queue depth poller to also query `client.count_workflows("ExecutionStatus='Running'")` on each 5s tick
- Added `MetricType.ACTIVE_WORKFLOWS` and registered it in the component metric map for Prometheus gauge dispatch
- Removed the in-process `increment_gauge`/`decrement_gauge("active_workflows")` calls from `execution_service.py` and `emission.py`
- Updated the `orchestrator_active_workflows` gauge description to reflect it's now Temporal-queried
- Added unit tests for the new workflow count query and updated existing poller tests
- Removed integration tests that asserted on the old decrement behavior

## Related Issues

Fixes AAP-85413

## How to Test

1. Start the backend with `make dev`
2. Scrape `GET /metrics` or the worker metrics endpoint on port 9090
3. Confirm `orchestrator_active_workflows` reflects the actual number of running Temporal workflows
4. Start/complete a workflow and observe the gauge updates on the next poll cycle (~5s)
5. Restart the API pod — the gauge should recover the correct count on the next poll rather than resetting to 0

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [x] No sensitive information (keys, passwords, etc.) is included