### PR TITLE
fix(AAP-88277): update ao-ui-tests Tekton bundle to fix arm64/x86_64 mismatch

### DIFF
--- a/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:69645eecb860cc36e4a807c5f4cb4872e742306d334f150110aaadbaaed2fa62
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:708f42650051e748e949a64a82559834a5a704d96c1ee65f5f4beb8222e0e0e2
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-ui-tests-early-access-pull-request.yaml
+++ b/.tekton/automation-orchestrator-ui-tests-early-access-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:69645eecb860cc36e4a807c5f4cb4872e742306d334f150110aaadbaaed2fa62
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:708f42650051e748e949a64a82559834a5a704d96c1ee65f5f4beb8222e0e0e2
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
Update the ao-ui-tests:0.1 pipeline bundle digest to the latest revision
which resolves the EC2 instance type vs AMI architecture mismatch in
provision-kind-cluster.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
