### PR TITLE
fix(AAP-87190): reject Secret URL credential when node also has explicit URL

### DIFF
--- a/backend/src/syntara/workflows/services/workflow_service.py
+++ b/backend/src/syntara/workflows/services/workflow_service.py
@@ -24,7 +24,9 @@ from syntara.core.exceptions import SafeValueError, assert_project_id_unchanged
 from syntara.core.models import User
 from syntara.core.services import BaseService
 from syntara.core.services.extensions import ConvertResourceMixin
+from syntara.credentials.lib.auth_types import AUTH_TYPE_URL
 from syntara.credentials.models.credential import Credential
+from syntara.credentials.models.credential_type import CredentialType
 from syntara.metrics.dependencies import get_metrics_recorder
 from syntara.metrics.types import ComponentLabel, MetricType
 from syntara.workflows.audit.workflow_lifecycle import WorkflowAction, WorkflowLifecycleEvent
@@ -377,6 +379,44 @@ class WorkflowService(BaseService):
                 msg = "Not authorized to use one or more credentials in this workflow"
                 raise AuthorizationDeniedError(msg)
 
+    async def _validate_no_secret_url_conflicts(
+        self,
+        workflow_definition: dict[str, Any],
+    ) -> None:
+        """Reject HTTP request nodes that have both an explicit URL and a Secret URL credential.
+
+        A Secret URL credential provides the request destination; an explicit
+        ``parameters.url`` on the same node creates an ambiguous configuration
+        where the credential silently wins and the activity record advertises
+        the wrong host.
+        """
+        suspect: dict[str, str] = {}
+        for node in workflow_definition.get("nodes", []):
+            if node.get("type") != "http_request":
+                continue
+            params = node.get("parameters", {})
+            if params.get("url") and params.get("credential_id"):
+                suspect[params["credential_id"]] = node.get("name") or node.get("id", "unknown")
+
+        if not suspect:
+            return
+
+        stmt = (
+            select(Credential.id, CredentialType.injectors)
+            .join(CredentialType, Credential.credential_type_id == CredentialType.id)
+            .where(Credential.id.in_(list(suspect.keys())))  # type: ignore[attr-defined]
+        )
+        result = await self.session.exec(stmt)
+        for cred_id, injectors in result.all():
+            extra_vars = (injectors or {}).get("extra_vars", {})
+            if extra_vars.get("auth_type") == AUTH_TYPE_URL:
+                node_name = suspect[str(cred_id)]
+                msg = (
+                    f"Node '{node_name}' has both an explicit URL and a Secret URL credential. "
+                    "Remove the URL from node parameters or use a different credential type."
+                )
+                raise SafeValueError(msg)
+
     def _is_duplicate_name_error(self, e: IntegrityError) -> bool:
         """Check if IntegrityError is due to duplicate workflow name.
 
@@ -471,6 +511,7 @@ class WorkflowService(BaseService):
             raise BuiltinProtectionError(msg)
 
         await self._validate_credential_project_scope(workflow_definition, project_id)
+        await self._validate_no_secret_url_conflicts(workflow_definition)
         ref_findings = await validate_workflow_references(self.session, workflow_definition, project_id)
         if ref_findings:
             result = ValidationResult.from_findings([*result.findings, *ref_findings])
@@ -1015,6 +1056,7 @@ class WorkflowService(BaseService):
                 if prev_version and prev_version.workflow_definition:
                     previous_cred_ids = self._extract_credential_ids(prev_version.workflow_definition)
             await self._validate_credential_project_scope(workflow_definition, workflow.project_id, previous_cred_ids)
+            await self._validate_no_secret_url_conflicts(workflow_definition)
             ref_findings = await validate_workflow_references(self.session, workflow_definition, workflow.project_id)
             if ref_findings:
                 result = ValidationResult.from_findings([*result.findings, *ref_findings])
@@ -1205,6 +1247,7 @@ class WorkflowService(BaseService):
             await self._validate_credential_project_scope(
                 workflow_definition, workflow.project_id, previous_credential_ids=None
             )
+            await self._validate_no_secret_url_conflicts(workflow_definition)
             stale_tool_findings = await validate_workflow_references(
                 self.session, workflow_definition, workflow.project_id
             )

--- a/backend/src/syntara/workflows/services/workflow_service.py
+++ b/backend/src/syntara/workflows/services/workflow_service.py
@@ -403,7 +403,7 @@ class WorkflowService(BaseService):
 
         stmt = (
             select(Credential.id, CredentialType.injectors)
-            .join(CredentialType, Credential.credential_type_id == CredentialType.id)
+            .join(CredentialType, Credential.credential_type_id == CredentialType.id)  # type: ignore[arg-type]
             .where(Credential.id.in_(list(suspect.keys())))  # type: ignore[attr-defined]
         )
         result = await self.session.exec(stmt)

--- a/backend/src/syntara/workflows/workflow_engine/activities/http_request_activity.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/http_request_activity.py
@@ -84,6 +84,12 @@ def _resolve_credentials_and_url(
         resolved_creds = ensure_resolved_credentials_dict(resolved_creds)
         extra_vars = resolved_creds.get("extra_vars", {})
         if extra_vars.get("auth_type") == AUTH_TYPE_URL:
+            if config.url:
+                msg = (
+                    "Conflict: node has an explicit URL in parameters and a Secret URL credential attached. "
+                    "Remove the URL from node parameters or use a different credential type."
+                )
+                raise ActivityExecutionError(msg)
             secret_url = extra_vars.get("secret_url", "")
             if not secret_url:
                 msg = "Secret URL credential resolved but URL is empty. Re-save the credential with a valid URL."
@@ -91,12 +97,6 @@ def _resolve_credentials_and_url(
             parsed = urlparse(secret_url)
             if not parsed.scheme or parsed.scheme not in ("http", "https"):
                 msg = "Secret URL must use http:// or https:// scheme."
-                raise ActivityExecutionError(msg)
-            if config.url:
-                msg = (
-                    "Conflict: node has an explicit URL in parameters and a Secret URL credential attached. "
-                    "Remove the URL from node parameters or use a different credential type."
-                )
                 raise ActivityExecutionError(msg)
             request_url = secret_url
             url_from_credential = True

--- a/backend/src/syntara/workflows/workflow_engine/activities/http_request_activity.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/http_request_activity.py
@@ -92,6 +92,12 @@ def _resolve_credentials_and_url(
             if not parsed.scheme or parsed.scheme not in ("http", "https"):
                 msg = "Secret URL must use http:// or https:// scheme."
                 raise ActivityExecutionError(msg)
+            if config.url:
+                msg = (
+                    "Conflict: node has an explicit URL in parameters and a Secret URL credential attached. "
+                    "Remove the URL from node parameters or use a different credential type."
+                )
+                raise ActivityExecutionError(msg)
             request_url = secret_url
             url_from_credential = True
         else:

--- a/backend/tests/unit/workflows/services/test_credential_use_permission.py
+++ b/backend/tests/unit/workflows/services/test_credential_use_permission.py
@@ -291,3 +291,45 @@ class TestValidateNoSecretUrlConflicts:  # noqa: D101
 
         definition = self._def_with_http_node(url="https://example.com/api", credential_id=str(cred_id))
         await svc._validate_no_secret_url_conflicts(definition)
+
+    @pytest.mark.asyncio
+    async def test_multiple_nodes_only_conflicting_one_raises(self) -> None:
+        clean_cred, bad_cred = uuid4(), uuid4()
+        svc, session = _make_service()
+
+        db_result = MagicMock()
+        db_result.all.return_value = [
+            (clean_cred, {"extra_vars": {"auth_type": "bearer"}}),
+            (bad_cred, {"extra_vars": {"auth_type": "url", "secret_url": "{{url}}"}}),
+        ]
+        session.exec.return_value = db_result
+
+        definition: dict[str, object] = {
+            "schema_version": "2.0.0",
+            "nodes": [
+                {
+                    "id": "n1",
+                    "type": "http_request",
+                    "name": "API call",
+                    "parameters": {
+                        "method": "GET",
+                        "url": "https://api.example.com",
+                        "credential_id": str(clean_cred),
+                    },
+                },
+                {
+                    "id": "n2",
+                    "type": "http_request",
+                    "name": "Slack hook",
+                    "parameters": {
+                        "method": "POST",
+                        "url": "https://slack.com/hook",
+                        "credential_id": str(bad_cred),
+                    },
+                },
+            ],
+            "edges": [],
+            "triggers": [],
+        }
+        with pytest.raises(SafeValueError, match="Slack hook"):
+            await svc._validate_no_secret_url_conflicts(definition)

--- a/backend/tests/unit/workflows/services/test_credential_use_permission.py
+++ b/backend/tests/unit/workflows/services/test_credential_use_permission.py
@@ -223,3 +223,71 @@ class TestPublishWorkflowVersionCredentialCheck:  # noqa: D101
             pytest.raises(RuntimeError, match="credential scope check invoked"),
         ):
             await svc.publish_workflow_version(workflow_id, version=1, workflow_definition=inline_def)
+
+
+class TestValidateNoSecretUrlConflicts:  # noqa: D101
+    @staticmethod
+    def _def_with_http_node(
+        *, url: str | None = None, credential_id: str | None = None, node_name: str = "my-http-node"
+    ) -> dict[str, object]:
+        params: dict[str, object] = {"method": "GET"}
+        if url is not None:
+            params["url"] = url
+        if credential_id is not None:
+            params["credential_id"] = credential_id
+        return {
+            "schema_version": "2.0.0",
+            "nodes": [{"id": "n1", "type": "http_request", "name": node_name, "parameters": params}],
+            "edges": [],
+            "triggers": [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_http_nodes_returns_early(self) -> None:
+        svc, _ = _make_service()
+        definition: dict[str, object] = {
+            "schema_version": "2.0.0",
+            "nodes": [{"id": "n1", "type": "agentic", "parameters": {}}],
+            "edges": [],
+            "triggers": [],
+        }
+        await svc._validate_no_secret_url_conflicts(definition)
+
+    @pytest.mark.asyncio
+    async def test_http_node_with_url_only_no_error(self) -> None:
+        svc, _ = _make_service()
+        definition = self._def_with_http_node(url="https://example.com/api")
+        await svc._validate_no_secret_url_conflicts(definition)
+
+    @pytest.mark.asyncio
+    async def test_http_node_with_credential_only_no_error(self) -> None:
+        svc, _ = _make_service()
+        definition = self._def_with_http_node(credential_id=str(uuid4()))
+        await svc._validate_no_secret_url_conflicts(definition)
+
+    @pytest.mark.asyncio
+    async def test_secret_url_credential_with_explicit_url_raises(self) -> None:
+        cred_id = uuid4()
+        svc, session = _make_service()
+
+        db_result = MagicMock()
+        db_result.all.return_value = [(cred_id, {"extra_vars": {"auth_type": "url", "secret_url": "{{url}}"}})]
+        session.exec.return_value = db_result
+
+        definition = self._def_with_http_node(
+            url="https://example.com/api", credential_id=str(cred_id), node_name="Send webhook"
+        )
+        with pytest.raises(SafeValueError, match="Send webhook"):
+            await svc._validate_no_secret_url_conflicts(definition)
+
+    @pytest.mark.asyncio
+    async def test_non_url_credential_with_explicit_url_no_error(self) -> None:
+        cred_id = uuid4()
+        svc, session = _make_service()
+
+        db_result = MagicMock()
+        db_result.all.return_value = [(cred_id, {"extra_vars": {"auth_type": "bearer", "bearer_token": "{{token}}"}})]
+        session.exec.return_value = db_result
+
+        definition = self._def_with_http_node(url="https://example.com/api", credential_id=str(cred_id))
+        await svc._validate_no_secret_url_conflicts(definition)

--- a/backend/tests/unit/workflows/workflow_engine/activities/test_http_request_activity.py
+++ b/backend/tests/unit/workflows/workflow_engine/activities/test_http_request_activity.py
@@ -328,10 +328,10 @@ class TestSecretUrlCredential:
     """Tests for Secret URL credential type (auth_type='url')."""
 
     @pytest.mark.asyncio
-    async def test_url_from_credential_overrides_config(self) -> None:
+    async def test_url_from_credential_used_when_no_explicit_url(self) -> None:
         resp = _mock_response(200, json_body={"ok": True})
         config = {
-            **VALID_CONFIG,
+            "method": "GET",
             "_resolved_credentials": {
                 "credential_id": "cred-url-1",
                 "extra_vars": {"auth_type": "url", "secret_url": "https://hooks.slack.com/services/T/B/xxx"},
@@ -345,10 +345,22 @@ class TestSecretUrlCredential:
         assert mock_req.call_args.kwargs["url"] == "https://hooks.slack.com/services/T/B/xxx"
 
     @pytest.mark.asyncio
+    async def test_url_credential_conflicts_with_explicit_url(self) -> None:
+        config = {
+            **VALID_CONFIG,
+            "_resolved_credentials": {
+                "credential_id": "cred-url-1",
+                "extra_vars": {"auth_type": "url", "secret_url": "https://hooks.slack.com/services/T/B/xxx"},
+            },
+        }
+        with pytest.raises(ActivityExecutionError, match="Conflict"):
+            await execute_http_request_activity(config, None)
+
+    @pytest.mark.asyncio
     async def test_url_credential_does_not_set_auth_headers(self) -> None:
         resp = _mock_response(200, json_body={})
         config = {
-            **VALID_CONFIG,
+            "method": "GET",
             "_resolved_credentials": {
                 "credential_id": "cred-url-1",
                 "extra_vars": {"auth_type": "url", "secret_url": "https://hooks.slack.com/services/T/B/xxx"},
@@ -386,7 +398,7 @@ class TestSecretUrlCredential:
         resp = _mock_response(401)
         secret_url = "https://hooks.slack.com/services/T/B/supersecret"  # noqa: S105
         config = {
-            **VALID_CONFIG,
+            "method": "GET",
             "_resolved_credentials": {
                 "credential_id": "cred-url-1",
                 "extra_vars": {"auth_type": "url", "secret_url": secret_url},
@@ -404,7 +416,7 @@ class TestSecretUrlCredential:
     @pytest.mark.asyncio
     async def test_url_credential_ssrf_private_ip_rejected(self) -> None:
         config = {
-            **VALID_CONFIG,
+            "method": "GET",
             "_resolved_credentials": {
                 "credential_id": "cred-url-1",
                 "extra_vars": {"auth_type": "url", "secret_url": "https://internal.example.com/webhook"},
@@ -419,7 +431,7 @@ class TestSecretUrlCredential:
     @pytest.mark.asyncio
     async def test_url_credential_schemeless_rejected(self) -> None:
         config = {
-            **VALID_CONFIG,
+            "method": "GET",
             "_resolved_credentials": {
                 "credential_id": "cred-url-1",
                 "extra_vars": {"auth_type": "url", "secret_url": "//evil.com/hook"},

--- a/backend/tests/unit/workflows/workflow_engine/activities/test_http_request_activity.py
+++ b/backend/tests/unit/workflows/workflow_engine/activities/test_http_request_activity.py
@@ -378,7 +378,7 @@ class TestSecretUrlCredential:
     @pytest.mark.asyncio
     async def test_url_credential_empty_raises(self) -> None:
         config = {
-            **VALID_CONFIG,
+            "method": "GET",
             "_resolved_credentials": {
                 "credential_id": "cred-url-1",
                 "extra_vars": {"auth_type": "url", "secret_url": ""},


### PR DESCRIPTION
## Purpose

When an HTTP request node has both a `parameters.url` and a Secret URL credential, the credential's URL silently overrides the explicit URL at execution time while the activity record still advertises the original URL. This produces a misleading audit trail where the recorded destination was never actually contacted.

Fixes AAP-87190

## Scope

- Save-time validation in `WorkflowService._validate_no_secret_url_conflicts` that rejects HTTP request nodes with both an explicit URL and a Secret URL credential at create, version, and publish time
- Runtime guard in `_resolve_credentials_and_url` as defense-in-depth for cases where the credential type changes after a workflow is saved
- Unit tests for both the save-time validation (5 cases) and the runtime guard (1 case), plus updated existing Secret URL tests to use URL-less configs

## Out of Scope

- Frontend changes (the builder UI already disables the URL field when a Secret URL credential is selected, via AAP-82101)
- Publish-time validation for existing versions without inline definitions (credential type checks require DB access, already covered by runtime guard)

## Testing

- [x] Existing tests pass
- [x] Tests added if behavior changed

## Visual Regression

- [ ] Reviewed the visual regression comment on this PR (if present)
- [ ] If screenshots changed: changes are intentional and baselines updated

## Stack Context

Depends on: N/A
Follow-up PRs: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)