### PR TITLE
fix(AAP-84211): use NxPageBody for identity provider early shells

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderDetail.tsx
@@ -12,7 +12,6 @@ import {
   Flex,
   FlexItem,
   Label,
-  StackItem,
   Switch,
   Tab,
   TabTitleText,
@@ -192,9 +191,9 @@ function IdentityProviderDetailEarlyLayout({ children }: Readonly<{ children: Re
   return (
     <NxPage>
       <NxPageHeader title="Identity Provider Details" breadcrumbs={breadcrumbsIdentityProviderDetailEarlyShell()} />
-      <StackItem isFilled style={{ minHeight: 0, overflow: 'hidden' }}>
+      <NxPageBody>
         <NxPanel isFullHeight>{children}</NxPanel>
-      </StackItem>
+      </NxPageBody>
     </NxPage>
   )
 }

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.test.tsx
@@ -233,7 +233,7 @@ describe('IdentityProviderForm', () => {
       expect(screen.getByDisplayValue('client-123')).toBeInTheDocument()
     })
 
-    it('shows not found state when provider does not exist', () => {
+    it('shows not found state when provider does not exist', async () => {
       const notFoundError = Object.assign(new Error('Not found'), { status: 404 })
       vi.mocked(identityProvidersClient.useQuery).mockReturnValue({
         data: undefined,
@@ -247,11 +247,14 @@ describe('IdentityProviderForm', () => {
         isPending: false,
       } as never)
 
-      render(<IdentityProviderForm mode="edit" />, { wrapper })
+      const { container } = render(<IdentityProviderForm mode="edit" />, { wrapper })
 
       expect(screen.getByText('Identity provider not found')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /Back to identity providers/ })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /Retry/ })).toBeInTheDocument()
+
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
     })
 
     it('shows loading state while fetching provider', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.tsx
@@ -1,12 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import {
-  Button,
-  EmptyState,
-  EmptyStateActions,
-  EmptyStateBody,
-  EmptyStateFooter,
-  StackItem,
-} from '@patternfly/react-core'
+import { Button, EmptyState, EmptyStateActions, EmptyStateBody, EmptyStateFooter } from '@patternfly/react-core'
 import { RhUiArrowLeftIcon, RhUiSearchIcon, RhUiSyncIcon } from '@patternfly/react-icons'
 import { type IdentityProvidersAPI } from '@syntara/contracts'
 import { useNavigate, useParams } from '@tanstack/react-router'
@@ -238,7 +231,7 @@ function ProviderNotFound({ onBack, onRetry }: Readonly<{ onBack: () => void; on
         title="Edit OIDC provider"
         breadcrumbs={breadcrumbsIdentityProviderFormLoading('Edit OIDC provider')}
       />
-      <StackItem isFilled style={{ minHeight: 0, overflow: 'hidden' }}>
+      <NxPageBody>
         <NxPanel isFullHeight>
           <EmptyState headingLevel="h2" titleText="Identity provider not found" icon={RhUiSearchIcon} isFullHeight>
             <EmptyStateBody>
@@ -256,7 +249,7 @@ function ProviderNotFound({ onBack, onRetry }: Readonly<{ onBack: () => void; on
             </EmptyStateFooter>
           </EmptyState>
         </NxPanel>
-      </StackItem>
+      </NxPageBody>
     </NxPage>
   )
 }


### PR DESCRIPTION
## Description

align identity provider 404, loading, and error shells with the standard page layout. they used raw `StackItem isFilled` under `NxPageHeader`. the rest of the app uses `NxPageBody` wrapping `NxPanel isFullHeight`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] `IdentityProviderDetailEarlyLayout` and `ProviderNotFound` now use `NxPageBody` instead of raw `StackItem isFilled`
- [x] axe check on the edit-form 404 empty state
- [ ] Include any new dependencies or configuration changes

## Out of Scope

wizard save/cancel in the form footer. that already landed.

## Related Issues

Fixes AAP-84211

## How to Test

1. open an identity provider detail URL with a missing id
2. confirm the 404 empty state fills the page under the header (`NxPage` > `NxPageHeader` > `NxPageBody` > `NxPanel isFullHeight`)
3. open the same missing id on the edit route and confirm the same shell
4. confirm loading and non-404 error on detail still use that early layout
5. confirm a real provider detail still renders as before

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/267bad28-4f0a-4f3f-9b72-8204663cb673" />

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->