### PR TITLE
fix: allow workflow import when LLM model is unavailable on target instance

### DIFF
--- a/backend/src/api_client/syntara_api_client/models/workflow_create.py
+++ b/backend/src/api_client/syntara_api_client/models/workflow_create.py
@@ -32,6 +32,8 @@ class WorkflowCreate:
             project_id (UUID): Project to assign workflow to
             description (None | str | Unset): Workflow description
             labels (WorkflowCreateLabels | Unset): Workflow labels
+            is_import (bool | Unset): When true, unavailable LLM models are cleared with warnings instead of rejecting the
+                request. Use when importing workflows from other instances. Default: False.
     """
 
     name: str
@@ -39,6 +41,7 @@ class WorkflowCreate:
     project_id: UUID
     description: None | str | Unset = UNSET
     labels: WorkflowCreateLabels | Unset = UNSET
+    is_import: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -64,6 +67,8 @@ class WorkflowCreate:
         if not isinstance(self.labels, Unset):
             labels = self.labels.to_dict()
 
+        is_import = self.is_import
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -77,6 +82,8 @@ class WorkflowCreate:
             field_dict["description"] = description
         if labels is not UNSET:
             field_dict["labels"] = labels
+        if is_import is not UNSET:
+            field_dict["is_import"] = is_import
 
         return field_dict
 
@@ -124,12 +131,15 @@ class WorkflowCreate:
         else:
             labels = WorkflowCreateLabels.from_dict(_labels)
 
+        is_import = d.pop("is_import", UNSET)
+
         workflow_create = cls(
             name=name,
             workflow_definition=workflow_definition,
             project_id=project_id,
             description=description,
             labels=labels,
+            is_import=is_import,
         )
 
         workflow_create.additional_properties = d

--- a/backend/src/cli/orchestrator_cli/openapi.yaml
+++ b/backend/src/cli/orchestrator_cli/openapi.yaml
@@ -35525,6 +35525,11 @@ components:
           format: uuid
           title: Project Id
           description: Project to assign workflow to
+        is_import:
+          type: boolean
+          title: Is Import
+          description: When true, unavailable LLM models are cleared with warnings instead of rejecting the request. Use when importing workflows from other instances.
+          default: false
     WorkflowUpdate:
       type: object
       title: WorkflowUpdate

--- a/backend/src/syntara/schemas/openapi-public.yaml
+++ b/backend/src/syntara/schemas/openapi-public.yaml
@@ -34602,6 +34602,11 @@ components:
           format: uuid
           title: Project Id
           description: Project to assign workflow to
+        is_import:
+          type: boolean
+          title: Is Import
+          description: When true, unavailable LLM models are cleared with warnings instead of rejecting the request. Use when importing workflows from other instances.
+          default: false
     WorkflowUpdate:
       type: object
       title: WorkflowUpdate

--- a/backend/src/syntara/schemas/openapi.yaml
+++ b/backend/src/syntara/schemas/openapi.yaml
@@ -35525,6 +35525,11 @@ components:
           format: uuid
           title: Project Id
           description: Project to assign workflow to
+        is_import:
+          type: boolean
+          title: Is Import
+          description: When true, unavailable LLM models are cleared with warnings instead of rejecting the request. Use when importing workflows from other instances.
+          default: false
     WorkflowUpdate:
       type: object
       title: WorkflowUpdate

--- a/backend/src/syntara/schemas/workflows/v2/shared-schemas.yaml
+++ b/backend/src/syntara/schemas/workflows/v2/shared-schemas.yaml
@@ -803,6 +803,11 @@ components:
           format: uuid
           title: Project Id
           description: Project to assign workflow to
+        is_import:
+          type: boolean
+          title: Is Import
+          description: When true, unavailable LLM models are cleared with warnings instead of rejecting the request. Use when importing workflows from other instances.
+          default: false
 
     WorkflowUpdate:
       type: object

--- a/backend/src/syntara/workflows/models/workflow.py
+++ b/backend/src/syntara/workflows/models/workflow.py
@@ -190,6 +190,11 @@ class WorkflowCreate(WorkflowBase):
 
     workflow_definition: WorkflowDefinition | dict[str, Any] = Field(..., description="Workflow definition object")
     project_id: UUID = Field(..., description="Project to assign workflow to")
+    is_import: bool = Field(
+        default=False,
+        description="When true, unavailable LLM models are cleared with warnings "
+        "instead of rejecting the request. Use when importing workflows from other instances.",
+    )
 
 
 class WorkflowUpdate(SQLModel):

--- a/backend/src/syntara/workflows/router.py
+++ b/backend/src/syntara/workflows/router.py
@@ -284,6 +284,7 @@ async def create_workflow(
         labels=request.labels,
         workflow_definition=_definition_to_dict(request.workflow_definition),
         project_id=request.project_id,
+        is_import=request.is_import,
     )
     read = WorkflowRead.model_validate(workflow, from_attributes=True)
     if _has_validation_issues(result):

--- a/backend/src/syntara/workflows/services/workflow_service.py
+++ b/backend/src/syntara/workflows/services/workflow_service.py
@@ -463,6 +463,8 @@ class WorkflowService(BaseService):
         labels: dict[str, Any],
         workflow_definition: dict[str, Any],
         project_id: UUID,
+        *,
+        is_import: bool = False,
     ) -> tuple[Workflow, WorkflowVersion, ValidationResult]:
         """Create a new V2 workflow with initial version.
 
@@ -472,6 +474,8 @@ class WorkflowService(BaseService):
             labels: Optional key-value labels
             workflow_definition: V2 workflow definition as dict (triggers + nodes + edges)
             project_id: Project to assign workflow to
+            is_import: When True, missing LLM models are cleared with warnings
+                instead of raising errors (allows import of workflows from other instances)
 
         Returns:
             Tuple of (created workflow, initial version, validation result)
@@ -512,7 +516,9 @@ class WorkflowService(BaseService):
 
         await self._validate_credential_project_scope(workflow_definition, project_id)
         await self._validate_no_secret_url_conflicts(workflow_definition)
-        ref_findings = await validate_workflow_references(self.session, workflow_definition, project_id)
+        ref_findings = await validate_workflow_references(
+            self.session, workflow_definition, project_id, is_import=is_import
+        )
         if ref_findings:
             result = ValidationResult.from_findings([*result.findings, *ref_findings])
             has_validation_issues = True

--- a/backend/src/syntara/workflows/validators/workflow_integrations.py
+++ b/backend/src/syntara/workflows/validators/workflow_integrations.py
@@ -135,11 +135,22 @@ async def _validate_integration_types(
 async def _validate_llm_model_references(
     session: AsyncSession,
     workflow_definition: dict[str, Any],
-) -> set[UUID]:
-    """Validate that all LLM model references exist and are enabled. Returns their parent integration IDs."""
+    *,
+    allow_cleanup: bool = False,
+) -> tuple[set[UUID], list[ValidationFinding]]:
+    """Validate LLM model references in a workflow definition.
+
+    When allow_cleanup is False (default, used for save/publish), missing or
+    disabled models raise SafeValueError.
+
+    When allow_cleanup is True (used for import), unavailable models are cleared
+    from node parameters in-place and returned as warning findings.
+
+    Returns (parent_integration_ids_of_valid_models, warning_findings).
+    """
     model_ids = _extract_llm_model_ids(workflow_definition)
     if not model_ids:
-        return set()
+        return set(), []
     parsed = [UUID(mid) for mid in model_ids]
     result = await session.execute(
         select(LLMModel.id, LLMModel.integration_id, LLMModel.enabled, LLMModel.name).where(
@@ -149,14 +160,39 @@ async def _validate_llm_model_references(
     rows = result.all()
     found_ids = {row.id for row in rows}
     missing = {UUID(mid) for mid in model_ids} - found_ids
-    if missing:
-        msg = "The previously selected LLM model is no longer available"
-        raise SafeValueError(msg)
-    for row in rows:
-        if not row.enabled:
-            msg = f"LLM model '{row.name}' is disabled"
+
+    if not allow_cleanup:
+        if missing:
+            msg = "The previously selected LLM model is no longer available"
             raise SafeValueError(msg)
-    return {row.integration_id for row in rows}
+        for row in rows:
+            if not row.enabled:
+                msg = f"LLM model '{row.name}' is disabled"
+                raise SafeValueError(msg)
+        return {row.integration_id for row in rows}, []
+
+    available = {str(row.id) for row in rows if row.enabled}
+    unavailable_ids = model_ids - available
+    if not unavailable_ids:
+        return {row.integration_id for row in rows}, []
+
+    findings: list[ValidationFinding] = []
+    for node in workflow_definition.get("nodes", []):
+        params = node.get("parameters", {})
+        mid = params.get("llm_model_id")
+        if mid and mid in unavailable_ids:
+            params.pop("llm_model_id", None)
+            findings.append(
+                ValidationFinding(
+                    severity=ValidationSeverity.warning,
+                    category=ValidationCategory.invalid_reference,
+                    message="The previously selected LLM model is no longer available and was removed",
+                    node_id=node.get("id"),
+                )
+            )
+
+    remaining_integration_ids = {row.integration_id for row in rows if str(row.id) in available}
+    return remaining_integration_ids, findings
 
 
 async def _validate_integration_scope(
@@ -269,20 +305,28 @@ async def validate_workflow_references(
     session: AsyncSession,
     workflow_definition: dict[str, Any],
     project_id: UUID,
+    *,
+    is_import: bool = False,
 ) -> list[ValidationFinding]:
     """Validate all external references in a workflow definition.
 
-    Integrations and LLM models produce hard errors (required for node execution).
-    Unavailable tools are auto-cleared with warnings (optional, node still functions).
-    Parent integrations of selected tools are also checked — a disabled or out-of-scope
-    integration produces a hard error even though individual tools are auto-cleared.
+    Integrations produce hard errors (required for node execution).
+    Unavailable tools are always auto-cleared with warnings.
 
-    Returns warning findings for any tools that were auto-cleared.
+    LLM model handling depends on context:
+    - Normal save/publish (is_import=False): missing/disabled models raise hard errors.
+    - Import (is_import=True): missing/disabled models are auto-cleared with warnings,
+      allowing the workflow to be imported in a draft state.
+
+    Returns warning findings for any resources that were auto-cleared.
     """
-    model_integration_ids = await _validate_llm_model_references(session, workflow_definition)
+    model_integration_ids, model_findings = await _validate_llm_model_references(
+        session, workflow_definition, allow_cleanup=is_import
+    )
     tool_integration_ids = await _extract_tool_parent_integration_ids(session, workflow_definition)
     await _validate_integration_scope(
         session, workflow_definition, project_id, model_integration_ids | tool_integration_ids
     )
     await _validate_integration_types(session, workflow_definition)
-    return await _clean_unavailable_tool_selections(session, workflow_definition)
+    tool_findings = await _clean_unavailable_tool_selections(session, workflow_definition)
+    return model_findings + tool_findings

--- a/backend/tests/integration/workflows/services/test_workflow_reference_validation.py
+++ b/backend/tests/integration/workflows/services/test_workflow_reference_validation.py
@@ -389,6 +389,57 @@ class TestLLMModelValidation:
 
 
 # ---------------------------------------------------------------------------
+# LLM Model validation — import mode (is_import=True)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestLLMModelImportCleanup:
+    """When is_import=True, missing/disabled LLM models are cleared with warnings instead of errors."""
+
+    async def test_deleted_model_cleared_on_import(
+        self, test_db_session: AsyncSession, test_user: User, test_project_id: UUID
+    ) -> None:
+        deleted_id = str(uuid4())
+        definition = _agentic_definition(llm_model_id=deleted_id)
+        findings = await validate_workflow_references(test_db_session, definition, test_project_id, is_import=True)
+        assert len(findings) == 1
+        assert findings[0].severity == "warning"
+        assert "no longer available" in findings[0].message
+        assert findings[0].node_id == "node-1"
+        assert "llm_model_id" not in definition["nodes"][0]["parameters"]
+
+    async def test_disabled_model_cleared_on_import(
+        self, test_db_session: AsyncSession, test_user: User, test_project_id: UUID
+    ) -> None:
+        intg = await _create_integration(test_db_session, test_user, integration_type=IntegrationType.LLM_PROVIDER)
+        model = await _create_llm_model(test_db_session, test_user, intg, enabled=False, name="gpt-disabled")
+        definition = _agentic_definition(llm_model_id=str(model.id))
+        findings = await validate_workflow_references(test_db_session, definition, test_project_id, is_import=True)
+        assert len(findings) == 1
+        assert findings[0].severity == "warning"
+        assert "no longer available" in findings[0].message
+        assert "llm_model_id" not in definition["nodes"][0]["parameters"]
+
+    async def test_valid_model_not_cleared_on_import(
+        self, test_db_session: AsyncSession, test_user: User, test_project_id: UUID
+    ) -> None:
+        intg = await _create_integration(test_db_session, test_user, integration_type=IntegrationType.LLM_PROVIDER)
+        model = await _create_llm_model(test_db_session, test_user, intg)
+        definition = _agentic_definition(llm_model_id=str(model.id))
+        findings = await validate_workflow_references(test_db_session, definition, test_project_id, is_import=True)
+        assert findings == []
+        assert definition["nodes"][0]["parameters"]["llm_model_id"] == str(model.id)
+
+    async def test_save_mode_still_rejects_deleted_model(
+        self, test_db_session: AsyncSession, test_user: User, test_project_id: UUID
+    ) -> None:
+        definition = _agentic_definition(llm_model_id=str(uuid4()))
+        with pytest.raises(SafeValueError, match="no longer available"):
+            await validate_workflow_references(test_db_session, definition, test_project_id, is_import=False)
+
+
+# ---------------------------------------------------------------------------
 # Tool validation
 # ---------------------------------------------------------------------------
 

--- a/frontend/packages/syntara-contracts/src/workflow-api.ts
+++ b/frontend/packages/syntara-contracts/src/workflow-api.ts
@@ -729,6 +729,12 @@ export interface components {
        * @description Project to assign workflow to
        */
       project_id: string
+      /**
+       * Is Import
+       * @description When true, unavailable LLM models are cleared with warnings instead of rejecting the request. Use when importing workflows from other instances.
+       * @default false
+       */
+      is_import?: boolean
     }
     /**
      * WorkflowUpdate

--- a/frontend/packages/syntara-ui/src/routes/builder/components/BuilderDialogs.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/BuilderDialogs.tsx
@@ -50,7 +50,10 @@ type BuilderDialogsProps = Readonly<{
   triggerInputSchema?: Record<string, unknown>
   pendingImport: PendingImportData | null
   setPendingImport: (data: PendingImportData | null) => void
-  importDeps: Omit<UseBuilderImportHandlersParams, 'dispatch' | 'markDirty' | 'showSuccess' | 'showError' | 'showInfo'>
+  importDeps: Omit<
+    UseBuilderImportHandlersParams,
+    'dispatch' | 'markDirty' | 'showAlert' | 'showSuccess' | 'showError' | 'showInfo'
+  >
   runStepDialog: DialogState<RunStepDialogData>
   runStepTriggerNodeId?: string
   onRunStepExecutionCreated?: (executionId: string, options: RunStepExecutionCreatedOptions) => void
@@ -154,9 +157,9 @@ export function BuilderDialogs({
 }: BuilderDialogsProps) {
   const isDirty = useWorkflowStore((state) => state.isDirty)
   const markDirty = useWorkflowStore((state) => state.markDirty)
-  const { showSuccess, showError: showImportError, showInfo } = useAlerts()
+  const { showAlert, showSuccess, showError: showImportError, showInfo } = useAlerts()
   const { handleImportCurrent, handleImportNew, clearPendingImport } = useBuilderImportHandlers(
-    { ...importDeps, dispatch, markDirty, showSuccess, showError: showImportError, showInfo },
+    { ...importDeps, dispatch, markDirty, showAlert, showSuccess, showError: showImportError, showInfo },
     pendingImport,
     setPendingImport
   )

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderImportHandlers.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderImportHandlers.test.ts
@@ -37,6 +37,7 @@ function createParams(overrides: Partial<UseBuilderImportHandlersParams> = {}): 
     selectedProject: { id: 'proj-1' },
     createWorkflow: vi.fn(),
     setLocation: vi.fn(),
+    showAlert: vi.fn(),
     showSuccess: vi.fn(),
     showError: vi.fn(),
     showInfo: vi.fn(),
@@ -95,7 +96,7 @@ describe('useBuilderImportHandlers', () => {
       expect(params.createWorkflow).not.toHaveBeenCalled()
     })
 
-    it('calls createWorkflow with correct payload', () => {
+    it('calls createWorkflow with correct payload including is_import', () => {
       const params = createParams()
       const { result } = renderHook(() => useBuilderImportHandlers(params, mockPendingImport, vi.fn()))
 
@@ -107,6 +108,7 @@ describe('useBuilderImportHandlers', () => {
         name: 'Imported Workflow',
         description: 'A test workflow',
         project_id: 'proj-1',
+        is_import: true,
       })
     })
 
@@ -130,15 +132,45 @@ describe('useBuilderImportHandlers', () => {
       act(() => result.current.handleImportNew())
 
       const createCall = vi.mocked(params.createWorkflow).mock.calls[0]
-      const onSuccess = createCall[1]?.onSuccess as (data: { id?: string }) => void
-      act(() => onSuccess({ id: 'new-wf-1' }))
+      const onSuccess = createCall[1]?.onSuccess as (data: { id: string }) => void
+      act(() => onSuccess({ id: 'new-wf-1' } as never))
 
       expect(setPendingImport).toHaveBeenCalledWith(null)
       expect(params.showSuccess).toHaveBeenCalledWith({
         title: 'Workflow imported',
         description: 'Created "Imported Workflow"',
       })
+      expect(params.showAlert).not.toHaveBeenCalled()
       expect(params.setLocation).toHaveBeenCalledWith('/workflow-builder/new-wf-1')
+    })
+
+    it('shows persistent warning alert when import has validation warnings', () => {
+      const params = createParams()
+      const setPendingImport = vi.fn()
+      const { result } = renderHook(() => useBuilderImportHandlers(params, mockPendingImport, setPendingImport))
+
+      act(() => result.current.handleImportNew())
+
+      const createCall = vi.mocked(params.createWorkflow).mock.calls[0]
+      const onSuccess = createCall[1]?.onSuccess as (data: Record<string, unknown>) => void
+      act(() =>
+        onSuccess({
+          id: 'new-wf-2',
+          validation_result: {
+            warning_count: 1,
+            findings: [{ severity: 'warning', category: 'invalid_reference', message: 'LLM model was removed' }],
+          },
+        } as never)
+      )
+
+      expect(params.showAlert).toHaveBeenCalledWith({
+        variant: 'warning',
+        autoDismiss: false,
+        title: 'Workflow imported with warnings',
+        description: 'LLM model was removed',
+      })
+      expect(params.showSuccess).not.toHaveBeenCalled()
+      expect(params.setLocation).toHaveBeenCalledWith('/workflow-builder/new-wf-2')
     })
 
     it('shows error on create failure', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderImportHandlers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderImportHandlers.ts
@@ -1,7 +1,7 @@
 import type { WorkflowAPI } from '@syntara/contracts'
 import { useCallback } from 'react'
 
-import type { AlertMessage } from '../../../providers/alerts'
+import type { AlertConfig, AlertMessage } from '../../../providers/alerts'
 import { getErrorMessage } from '../../../utils/apiErrors'
 import type { BuilderAction } from '../builderReducer'
 import { applyImportToCanvas, type PendingImportData } from '../useWorkflowImportExport'
@@ -17,6 +17,7 @@ export type UseBuilderImportHandlersParams = {
   selectedProject: { id: string } | null
   createWorkflow: UseBuilderSaveWorkflowParams['createWorkflow']
   setLocation: (to: string) => void
+  showAlert: (config: AlertConfig) => void
   showSuccess: (options: AlertMessage) => void
   showError: (options: AlertMessage) => void
   showInfo: (options: AlertMessage) => void
@@ -27,7 +28,17 @@ export function useBuilderImportHandlers(
   pendingImport: PendingImportData | null,
   setPendingImport: (data: PendingImportData | null) => void
 ) {
-  const { dispatch, markDirty, selectedProject, createWorkflow, setLocation, showSuccess, showError, showInfo } = params
+  const {
+    dispatch,
+    markDirty,
+    selectedProject,
+    createWorkflow,
+    setLocation,
+    showAlert,
+    showSuccess,
+    showError,
+    showInfo,
+  } = params
 
   const handleImportCurrent = useCallback(() => {
     if (!pendingImport) return
@@ -57,18 +68,26 @@ export function useBuilderImportHandlers(
           description: importDescription,
           workflow_definition: fullDefinition as unknown as CreateWorkflowBody['workflow_definition'],
           project_id: projectId,
+          is_import: true,
         },
       },
       {
         onSuccess: (data) => {
           setPendingImport(null)
-          const newId =
-            typeof data === 'object' && data !== null && 'id' in data
-              ? String((data as Record<string, unknown>).id)
-              : undefined
-          showSuccess({ title: 'Workflow imported', description: `Created "${importName}"` })
-          if (newId) {
-            setLocation(`/workflow-builder/${newId}`)
+          const { validation_result: validationResult } = data
+          if (validationResult?.warning_count) {
+            const warnings = (validationResult.findings ?? []).map((f) => f.message).join('; ')
+            showAlert({
+              variant: 'warning',
+              autoDismiss: false,
+              title: 'Workflow imported with warnings',
+              description: warnings || `Created "${importName}" with ${validationResult.warning_count} warning(s)`,
+            })
+          } else {
+            showSuccess({ title: 'Workflow imported', description: `Created "${importName}"` })
+          }
+          if (data.id) {
+            setLocation(`/workflow-builder/${data.id}`)
           }
         },
         onError: (error) => {
@@ -76,7 +95,7 @@ export function useBuilderImportHandlers(
         },
       }
     )
-  }, [pendingImport, selectedProject, createWorkflow, showSuccess, showError, setLocation, setPendingImport])
+  }, [pendingImport, selectedProject, createWorkflow, showAlert, showSuccess, showError, setLocation, setPendingImport])
 
   const clearPendingImport = useCallback(() => {
     setPendingImport(null)

--- a/frontend/packages/syntara-ui/src/routes/workflows/ImportWorkflowDialog.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/ImportWorkflowDialog.test.tsx
@@ -149,7 +149,7 @@ describe('ImportWorkflowDialog', () => {
       expect(mockPost).toHaveBeenCalled()
     })
     const callArgs = mockPost.mock.calls[0] as [string, { body: Record<string, unknown> }]
-    expect(callArgs[1].body).toEqual(expect.objectContaining({ project_id: 'p1' }))
+    expect(callArgs[1].body).toEqual(expect.objectContaining({ project_id: 'p1', is_import: true }))
     expect(mockShowAlert).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'success',
@@ -298,7 +298,22 @@ describe('ImportWorkflowDialog', () => {
     const user = userEvent.setup()
     const onSuccess = vi.fn()
     const onClose = vi.fn()
-    mockPost.mockResolvedValue({ data: { id: 'new-wf', has_validation_issues: true } })
+    mockPost.mockResolvedValue({
+      data: {
+        id: 'new-wf',
+        has_validation_issues: true,
+        validation_result: {
+          warning_count: 1,
+          findings: [
+            {
+              severity: 'warning',
+              category: 'invalid_reference',
+              message: 'The previously selected LLM model is no longer available and was removed',
+            },
+          ],
+        },
+      },
+    })
 
     const validContent = JSON.stringify({
       triggers: [{ id: 't1', type: 'webhook' }],
@@ -318,11 +333,46 @@ describe('ImportWorkflowDialog', () => {
         expect.objectContaining({
           variant: 'warning',
           title: 'Workflow imported with warnings',
+          description: 'The previously selected LLM model is no longer available and was removed',
         })
       )
     })
     expect(onSuccess).toHaveBeenCalled()
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('falls back to created-name description when warnings have no finding messages', async () => {
+    const user = userEvent.setup()
+    mockPost.mockResolvedValue({
+      data: {
+        id: 'new-wf',
+        has_validation_issues: true,
+        validation_result: { warning_count: 1, findings: [] },
+      },
+    })
+
+    const validContent = JSON.stringify({
+      triggers: [{ id: 't1', type: 'webhook' }],
+      nodes: [{ id: 'n1', type: 'action' }],
+      edges: [{ from: 't1', to: 'n1' }],
+    })
+
+    render(<ImportWorkflowDialog {...defaultProps} />)
+
+    const file = new File([validContent], 'workflow.json', { type: 'application/json' })
+    await user.upload(getFileInput(), file)
+    await user.type(screen.getByLabelText(/Workflow name/i), 'Imported WF')
+    await user.click(screen.getByRole('button', { name: /^Import$/i }))
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'warning',
+          title: 'Workflow imported with warnings',
+          description: 'Created "Imported WF"',
+        })
+      )
+    })
   })
 
   it('includes Open workflow action link when import returns an id', async () => {

--- a/frontend/packages/syntara-ui/src/routes/workflows/ImportWorkflowDialog.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/ImportWorkflowDialog.tsx
@@ -30,6 +30,16 @@ import { parseWorkflowFile, validateFileSize } from '../../utils/downloadWorkflo
 import { importWorkflowSchema } from './importWorkflowSchema'
 import type { ImportWorkflowFormData } from './importWorkflowSchema'
 
+type ImportFinding = { message?: string }
+
+function importAlertDescription(wfName: string, findings?: ImportFinding[] | null): string {
+  const warnings = (findings ?? [])
+    .map((finding) => finding.message)
+    .filter((message): message is string => Boolean(message))
+    .join('; ')
+  return warnings || `Created "${wfName}"`
+}
+
 /**
  * Builds a full V2WorkflowDefinition from a parsed file and the user-supplied name.
  */
@@ -105,10 +115,15 @@ export function ImportWorkflowDialog({ isOpen, onClose, onSuccess }: ImportWorkf
     setFileError(null)
   }
 
-  const onImportSuccess = (wfName: string, hasValidationIssues: boolean, createdId?: string) => {
+  const onImportSuccess = (
+    wfName: string,
+    hasValidationIssues: boolean,
+    createdId?: string,
+    findings?: ImportFinding[] | null
+  ) => {
     const variant = hasValidationIssues ? 'warning' : 'success'
     const title = hasValidationIssues ? 'Workflow imported with warnings' : 'Workflow imported'
-    const description = `Created "${wfName}"`
+    const description = importAlertDescription(wfName, findings)
     const openInEditor = createdId
       ? () => detachPromise(navigate({ to: '/workflow-builder/$workflowId', params: { workflowId: createdId } }))
       : undefined
@@ -140,6 +155,7 @@ export function ImportWorkflowDialog({ isOpen, onClose, onSuccess }: ImportWorkf
           name: data.name,
           workflow_definition: fullDefinition,
           project_id: selectedProjectId,
+          is_import: true,
         },
       })
 
@@ -148,7 +164,12 @@ export function ImportWorkflowDialog({ isOpen, onClose, onSuccess }: ImportWorkf
         return
       }
 
-      onImportSuccess(data.name, result?.has_validation_issues === true, result?.id)
+      onImportSuccess(
+        data.name,
+        result?.has_validation_issues === true,
+        result?.id,
+        result?.validation_result?.findings
+      )
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to parse file'
       setFileError(message)


### PR DESCRIPTION
## Description

When importing a JSON workflow that references an LLM model not configured on the target instance, the import now succeeds with a warning instead of failing with a 422 error. The workflow is imported in a draft state with the unavailable model reference cleared, allowing the user to reconfigure the model post-import.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **Backend validator** (`workflow_integrations.py`): Refactored `_validate_llm_model_references` to accept an `allow_cleanup` flag. When `True` (import mode), missing or disabled LLM models are cleared from node parameters in-place and returned as `ValidationFinding` warnings. When `False` (default save/publish), the existing hard-error behavior is preserved.
- **Backend service** (`workflow_service.py`): Added `is_import` parameter to `create_workflow()`, threaded to `validate_workflow_references()`.
- **Backend schema** (`workflow.py`): Added `is_import` field to `WorkflowCreate` schema.
- **Backend router** (`router.py`): Passes `is_import` from the request body to the service.
- **Frontend import handler** (`useBuilderImportHandlers.ts`): Sends `is_import: true` when creating a workflow via import. Shows validation warnings in the success toast when models were cleared.
- **Frontend contracts** (`workflow-api.ts`): Added `is_import` field to `WorkflowCreate` type.
- **Regression tests**: Added `TestLLMModelImportCleanup` test class with 4 tests covering deleted model cleanup, disabled model cleanup, valid model preservation, and save-mode rejection.

## Out of Scope

- Integration-level validation (missing integrations still raise hard errors regardless of import mode). Integrations are required for node execution — unlike models which can be reconfigured post-import.
- Frontend UI changes for displaying model stale detection in the builder canvas (already handled by existing `LLMModelSelector.onStaleDetected`).

## Root Cause Analysis

The bug was in `_validate_llm_model_references` (`workflow_integrations.py:135-159`). When an imported workflow referenced an LLM model ID not present in the database, the function raised `SafeValueError` — a hard 422 HTTP error that blocked the entire import.

The codebase already had the correct pattern for graceful degradation: `_clean_unavailable_tool_selections` (same file) handles missing tools by clearing them in-place and returning `ValidationFinding` warnings. The fix applies this same pattern to LLM model references, scoped only to import operations.

## Similar Bug Detection

Two similar patterns were found in the same file for integration validation (lines 222, 235-240). These were intentionally left as hard errors since integrations are required for node execution, unlike LLM models which can be reconfigured post-import.

## Mutation Testing

[SKIP] Integration test infrastructure unavailable in sandbox (regopy/libatomic + PostgreSQL required). Tests validated syntactically and by lint/type-check. Run in CI to confirm.

## How to Test

1. Export a workflow that uses a specific LLM model (e.g., Sonnet)
2. Import the workflow on an instance where that model is not configured
3. Verify the import succeeds with a warning message about the cleared model
4. Open the imported workflow in the builder
5. Verify the node shows a stale model warning and prompts to select a new model
6. Also verify: saving/publishing a workflow with a deleted model still fails with the existing error

## Backend Checklist

- [x] I have run `make lint` and code passes all checks
- [ ] I have run `make test` and all tests pass (requires CI)
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [x] No sensitive information is included

## Frontend Checklist

- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [ ] Screenshots or screen recordings are attached for UI changes

## General Checklist

- [x] Code follows the project's coding conventions
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented (N/A — non-breaking)

Assisted-by: Claude Code / Opus 4.6 (Anthropic)