### PR TITLE
fix(ui): restore concise integrations empty state copy

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationEmptyState.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationEmptyState.test.tsx
@@ -14,13 +14,13 @@ describe('IntegrationEmptyState', () => {
   it('renders empty state message', () => {
     render(<IntegrationEmptyState />)
 
-    expect(screen.getByText('No integrations have been configured yet.')).toBeInTheDocument()
+    expect(screen.getByText('No integrations yet')).toBeInTheDocument()
   })
 
   it('renders description text', () => {
     render(<IntegrationEmptyState />)
 
-    expect(screen.getByText(/Configure integrations to use them in workflows/i)).toBeInTheDocument()
+    expect(screen.getByText(/Configure integrations to connect external tools and services/i)).toBeInTheDocument()
   })
 
   it('renders configure integration button', () => {

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationEmptyState.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationEmptyState.tsx
@@ -8,8 +8,8 @@ export function IntegrationEmptyState({ canCreate = true }: Readonly<{ canCreate
   const navigate = useNavigate()
   return (
     <NxEmptyStateNoData
-      title="No integrations have been configured yet."
-      description="Configure integrations to use them in workflows. Integrations will allow for monitoring of server health and performance metrics, view server logs, and manage server settings and configurations."
+      title="No integrations yet"
+      description="Configure integrations to connect external tools and services for use in workflows."
       buttonText={canCreate ? 'Configure integration' : undefined}
       addData={
         canCreate ? () => detachPromise(navigate({ to: AppRoute.Configuration.Integrations.Configure })) : undefined

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/Integrations.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/Integrations.test.tsx
@@ -299,7 +299,7 @@ describe('Integrations Component', () => {
       render(<Integrations />, { wrapper })
 
       // Check for empty state message (no filters active, so shows empty state not filter empty)
-      expect(screen.getByText('No integrations have been configured yet.')).toBeInTheDocument()
+      expect(screen.getByText('No integrations yet')).toBeInTheDocument()
       // Multiple "Configure integration" buttons exist (header + empty state), so use getAllByText
       expect(screen.getAllByText('Configure integration').length).toBeGreaterThan(0)
     })
@@ -318,7 +318,7 @@ describe('Integrations Component', () => {
       render(<Integrations />, { wrapper })
 
       expect(screen.getByText('No results found')).toBeInTheDocument()
-      expect(screen.queryByText('No integrations have been configured yet.')).not.toBeInTheDocument()
+      expect(screen.queryByText('No integrations yet')).not.toBeInTheDocument()
     })
   })
 
@@ -1596,7 +1596,7 @@ describe('Integrations Component', () => {
 
       render(<Integrations />, { wrapper })
 
-      expect(screen.getByText('No integrations have been configured yet.')).toBeInTheDocument()
+      expect(screen.getByText('No integrations yet')).toBeInTheDocument()
       expect(screen.queryByRole('button', { name: 'Configure integration' })).not.toBeInTheDocument()
     })
   })


### PR DESCRIPTION
## Description

Restores the shorter, clearer empty state messaging that was lost during the router migration rebase.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] Title: "No integrations yet" (from "No integrations have been configured yet.")
- [x] Description: clearer focus on integration purpose vs implementation details
- [x] Updated component and integration tests

## Out of Scope

Backend changes, visual regression baseline updates (copy-only change)

## Related Issues

N/A

## How to Test

1. Navigate to `/configuration/integrations` with no integrations configured
2. Verify empty state shows concise title and description
3. Run unit tests: `npx vitest run src/routes/configuration/integrations`

## Backend Checklist

N/A — frontend-only change

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

N/A — copy-only change

## Additional Notes

The verbose copy was accidentally restored in the router migration during rebase conflict resolution. This reverts to the UX-validated shorter version.

🤖 PR description AI-assisted