### PR TITLE
refactor(AAP-84209): migrate raw PF Label usage to NxLabel

### DIFF
--- a/frontend/packages/syntara-ui/src/components/filters/ActiveFilterChips.tsx
+++ b/frontend/packages/syntara-ui/src/components/filters/ActiveFilterChips.tsx
@@ -1,16 +1,17 @@
-import { Label, LabelGroup, ToolbarItem } from '@patternfly/react-core'
+import { LabelGroup, ToolbarItem } from '@patternfly/react-core'
 import type { ReactNode } from 'react'
 
 import type { FilterConfig, FilterFieldDefinition, FilterOperator } from '../../types/filters'
 import { formatDateChipValue } from '../../utils/dateUtils'
+import { NxLabel } from '../labels/NxLabel'
 import { WorkflowName } from '../WorkflowName'
 
 /** User-applied filter values use outlined compact labels. */
 function ActiveFilterValueLabel({ children, onClose }: Readonly<{ children: ReactNode; onClose: () => void }>) {
   return (
-    <Label variant="outline" isCompact onClose={onClose}>
+    <NxLabel variant="outline" isCompact onClose={onClose}>
       {children}
-    </Label>
+    </NxLabel>
   )
 }
 

--- a/frontend/packages/syntara-ui/src/components/filters/ActiveFilterChips.tsx
+++ b/frontend/packages/syntara-ui/src/components/filters/ActiveFilterChips.tsx
@@ -9,7 +9,7 @@ import { WorkflowName } from '../WorkflowName'
 /** User-applied filter values use outlined compact labels. */
 function ActiveFilterValueLabel({ children, onClose }: Readonly<{ children: ReactNode; onClose: () => void }>) {
   return (
-    <NxLabel variant="outline" isCompact onClose={onClose}>
+    <NxLabel variant="outline" onClose={onClose}>
       {children}
     </NxLabel>
   )

--- a/frontend/packages/syntara-ui/src/routes/access-management/DisabledBadge.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/DisabledBadge.tsx
@@ -3,7 +3,7 @@ import { NxLabel } from '../../components/labels/NxLabel'
 /** Inline "Disabled" label shown next to disabled user accounts. */
 export function DisabledBadge() {
   return (
-    <NxLabel variant="outline" isCompact style={{ marginInlineStart: 'var(--pf-t--global--spacer--sm)' }}>
+    <NxLabel variant="outline" style={{ marginInlineStart: 'var(--pf-t--global--spacer--sm)' }}>
       Disabled
     </NxLabel>
   )

--- a/frontend/packages/syntara-ui/src/routes/access-management/DisabledBadge.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/DisabledBadge.tsx
@@ -1,10 +1,10 @@
-import { Label } from '@patternfly/react-core'
+import { NxLabel } from '../../components/labels/NxLabel'
 
 /** Inline "Disabled" label shown next to disabled user accounts. */
 export function DisabledBadge() {
   return (
-    <Label variant="outline" isCompact style={{ marginInlineStart: 'var(--pf-t--global--spacer--sm)' }}>
+    <NxLabel variant="outline" isCompact style={{ marginInlineStart: 'var(--pf-t--global--spacer--sm)' }}>
       Disabled
-    </Label>
+    </NxLabel>
   )
 }

--- a/frontend/packages/syntara-ui/src/routes/access-management/MembershipSourceLabels.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/MembershipSourceLabels.tsx
@@ -10,7 +10,7 @@ export function MembershipSourceLabels({ sources }: Readonly<{ sources?: Members
     <Flex gap={{ default: 'gapXs' }} flexWrap={{ default: 'wrap' }}>
       {sources.map((s, idx) => (
         <FlexItem key={`${s.type}-${s.provider_name ?? idx}`}>
-          <NxLabel isCompact color={s.type === 'idp' ? 'blue' : 'grey'}>
+          <NxLabel color={s.type === 'idp' ? 'blue' : 'grey'}>
             {s.type === 'idp' ? (s.provider_name ?? 'IdP') : 'Manual'}
           </NxLabel>
         </FlexItem>

--- a/frontend/packages/syntara-ui/src/routes/access-management/MembershipSourceLabels.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/MembershipSourceLabels.tsx
@@ -1,4 +1,6 @@
-import { Flex, FlexItem, Label } from '@patternfly/react-core'
+import { Flex, FlexItem } from '@patternfly/react-core'
+
+import { NxLabel } from '../../components/labels/NxLabel'
 
 import type { MembershipSourceInfo } from './membershipSourceUtils'
 
@@ -8,9 +10,9 @@ export function MembershipSourceLabels({ sources }: Readonly<{ sources?: Members
     <Flex gap={{ default: 'gapXs' }} flexWrap={{ default: 'wrap' }}>
       {sources.map((s, idx) => (
         <FlexItem key={`${s.type}-${s.provider_name ?? idx}`}>
-          <Label isCompact color={s.type === 'idp' ? 'blue' : 'grey'}>
+          <NxLabel isCompact color={s.type === 'idp' ? 'blue' : 'grey'}>
             {s.type === 'idp' ? (s.provider_name ?? 'IdP') : 'Manual'}
-          </Label>
+          </NxLabel>
         </FlexItem>
       ))}
     </Flex>

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectRoleAssignmentsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectRoleAssignmentsTab.tsx
@@ -1,4 +1,4 @@
-import { Button, Label, LabelGroup, Truncate } from '@patternfly/react-core'
+import { Button, LabelGroup, Truncate } from '@patternfly/react-core'
 import { RhUiAddIcon, RhUiTrashIcon } from '@patternfly/react-icons'
 import { ActionsColumn, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import type { IAction, ThProps } from '@patternfly/react-table'
@@ -112,9 +112,9 @@ function RoleAssignmentsTable({
                 {(assignment.role_policies ?? []).length > 0 ? (
                   <LabelGroup numLabels={3}>
                     {(assignment.role_policies ?? []).map((name) => (
-                      <Label key={name} isCompact>
+                      <NxLabel key={name} isCompact>
                         {name}
-                      </Label>
+                      </NxLabel>
                     ))}
                   </LabelGroup>
                 ) : (

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectRoleAssignmentsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectRoleAssignmentsTab.tsx
@@ -112,9 +112,7 @@ function RoleAssignmentsTable({
                 {(assignment.role_policies ?? []).length > 0 ? (
                   <LabelGroup numLabels={3}>
                     {(assignment.role_policies ?? []).map((name) => (
-                      <NxLabel key={name} isCompact>
-                        {name}
-                      </NxLabel>
+                      <NxLabel key={name}>{name}</NxLabel>
                     ))}
                   </LabelGroup>
                 ) : (

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserGroupsPanel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserGroupsPanel.tsx
@@ -8,7 +8,6 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
-  Label,
   Modal,
   ModalBody,
   ModalFooter,
@@ -28,6 +27,7 @@ import { NxConfirmationDialog } from '../../../components/dialogs/NxConfirmation
 import { DisabledWithTooltip } from '../../../components/DisabledWithTooltip'
 import { FilterBar } from '../../../components/filters'
 import { IconLabel } from '../../../components/IconLabel'
+import { NxLabel } from '../../../components/labels/NxLabel'
 import { NxPageBody } from '../../../components/layout/NxPage'
 import { NxPanelContentStack } from '../../../components/layout/NxPanelContentStack'
 import { NxEmptyStateFilter } from '../../../components/states/NxEmptyStateFilter'
@@ -409,9 +409,9 @@ export function UserGroupsPanel({ userId }: Readonly<UserGroupsPanelProps>) {
                     {group.name === BUILTIN_AUTHENTICATED_GROUP_NAME && (
                       <>
                         {' '}
-                        <Label isCompact color="grey">
+                        <NxLabel isCompact color="grey">
                           All users
-                        </Label>
+                        </NxLabel>
                       </>
                     )}
                   </Td>

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserGroupsPanel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserGroupsPanel.tsx
@@ -409,9 +409,7 @@ export function UserGroupsPanel({ userId }: Readonly<UserGroupsPanelProps>) {
                     {group.name === BUILTIN_AUTHENTICATED_GROUP_NAME && (
                       <>
                         {' '}
-                        <NxLabel isCompact color="grey">
-                          All users
-                        </NxLabel>
+                        <NxLabel color="grey">All users</NxLabel>
                       </>
                     )}
                   </Td>

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/transferIdentitySteps.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/transferIdentitySteps.tsx
@@ -148,7 +148,7 @@ export function SelectUserStep({
                   <Td dataLabel="Email">{user.email}</Td>
                   <Td dataLabel="Authentication">
                     {(user.auth_sources ?? [AUTH_SOURCE_LOCAL]).map((source) => (
-                      <NxLabel key={source} isCompact color={source === AUTH_SOURCE_LOCAL ? 'grey' : 'blue'}>
+                      <NxLabel key={source} color={source === AUTH_SOURCE_LOCAL ? 'grey' : 'blue'}>
                         {source}
                       </NxLabel>
                     ))}

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/transferIdentitySteps.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/transferIdentitySteps.tsx
@@ -1,4 +1,4 @@
-import { Content, ContentVariants, EmptyState, EmptyStateBody, Label, StackItem, Title } from '@patternfly/react-core'
+import { Content, ContentVariants, EmptyState, EmptyStateBody, StackItem, Title } from '@patternfly/react-core'
 import { RhUiCubesFillIcon, RhUiKeyIcon } from '@patternfly/react-icons'
 import { Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import { useCallback, useState } from 'react'
@@ -6,6 +6,7 @@ import { useCallback, useState } from 'react'
 import { AppRoute } from '../../../app/AppRoute'
 import { flexCenteredBothAxes } from '../../../app/flexCenteredBothAxes'
 import { FilterBar } from '../../../components/filters/FilterBar'
+import { NxLabel } from '../../../components/labels/NxLabel'
 import { NxPanelContentStack } from '../../../components/layout/NxPanelContentStack'
 import { NxLink } from '../../../components/NxLink'
 import { NxEmptyStateFilter } from '../../../components/states/NxEmptyStateFilter'
@@ -147,9 +148,9 @@ export function SelectUserStep({
                   <Td dataLabel="Email">{user.email}</Td>
                   <Td dataLabel="Authentication">
                     {(user.auth_sources ?? [AUTH_SOURCE_LOCAL]).map((source) => (
-                      <Label key={source} isCompact color={source === AUTH_SOURCE_LOCAL ? 'grey' : 'blue'}>
+                      <NxLabel key={source} isCompact color={source === AUTH_SOURCE_LOCAL ? 'grey' : 'blue'}>
                         {source}
-                      </Label>
+                      </NxLabel>
                     ))}
                   </Td>
                 </Tr>

--- a/frontend/packages/syntara-ui/src/routes/access/MyPermissionsView.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/MyPermissionsView.tsx
@@ -1,9 +1,10 @@
-import { Button, Flex, Label, Tooltip } from '@patternfly/react-core'
+import { Button, Flex, Tooltip } from '@patternfly/react-core'
 import { RhUiCheckCircleIcon, RhUiCloseCircleIcon, RhUiSyncIcon } from '@patternfly/react-icons'
 import { Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import type { ThProps } from '@patternfly/react-table'
 import { useCallback, useMemo, useState } from 'react'
 
+import { NxLabel } from '../../components/labels/NxLabel'
 import { NxPanelContentStack } from '../../components/layout/NxPanelContentStack'
 import { NxListPanelTable, NxListPanelToolbar, NxListPanelView } from '../../components/panels/list/NxListPanel'
 import { NxEmptyStateNoData } from '../../components/states/NxEmptyStateNoData'
@@ -103,20 +104,20 @@ function PermissionsTableContent({
               <code>{perm.policy_name}</code>
             </Td>
             <Td dataLabel="Effect">
-              <Label
+              <NxLabel
                 color={perm.effect === 'allow' ? 'green' : 'red'}
                 icon={perm.effect === 'allow' ? <RhUiCheckCircleIcon /> : <RhUiCloseCircleIcon />}
                 isCompact
               >
                 {perm.effect}
-              </Label>
+              </NxLabel>
             </Td>
             <Td dataLabel="Actions">
               <Flex gap={{ default: 'gapXs' }} flexWrap={{ default: 'wrap' }}>
                 {perm.actions.map((a) => (
-                  <Label key={a} color="blue" isCompact>
+                  <NxLabel key={a} color="blue" isCompact>
                     {a}
-                  </Label>
+                  </NxLabel>
                 ))}
               </Flex>
             </Td>

--- a/frontend/packages/syntara-ui/src/routes/access/MyPermissionsView.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/MyPermissionsView.tsx
@@ -107,7 +107,6 @@ function PermissionsTableContent({
               <NxLabel
                 color={perm.effect === 'allow' ? 'green' : 'red'}
                 icon={perm.effect === 'allow' ? <RhUiCheckCircleIcon /> : <RhUiCloseCircleIcon />}
-                isCompact
               >
                 {perm.effect}
               </NxLabel>
@@ -115,7 +114,7 @@ function PermissionsTableContent({
             <Td dataLabel="Actions">
               <Flex gap={{ default: 'gapXs' }} flexWrap={{ default: 'wrap' }}>
                 {perm.actions.map((a) => (
-                  <NxLabel key={a} color="blue" isCompact>
+                  <NxLabel key={a} color="blue">
                     {a}
                   </NxLabel>
                 ))}

--- a/frontend/packages/syntara-ui/src/routes/access/RolesTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/RolesTab.tsx
@@ -169,13 +169,11 @@ function RolesTable({
               </Td>
               <Td dataLabel="Type">
                 {role.is_builtin ? (
-                  <NxLabel color="grey" icon={<RhUiLockIcon />} isCompact>
+                  <NxLabel color="grey" icon={<RhUiLockIcon />}>
                     Built-in
                   </NxLabel>
                 ) : (
-                  <NxLabel color="blue" isCompact>
-                    Custom
-                  </NxLabel>
+                  <NxLabel color="blue">Custom</NxLabel>
                 )}
               </Td>
               <Td isActionCell>
@@ -187,7 +185,7 @@ function RolesTable({
                 <ExpandableRowContent>
                   <LabelGroup isCompact numLabels={Infinity}>
                     {(role.policies ?? []).map((policy) => (
-                      <NxLabel key={policy} color="grey" isCompact>
+                      <NxLabel key={policy} color="grey">
                         {policy}
                       </NxLabel>
                     ))}

--- a/frontend/packages/syntara-ui/src/routes/access/RolesTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/RolesTab.tsx
@@ -1,4 +1,4 @@
-import { Button, Content, Label, LabelGroup } from '@patternfly/react-core'
+import { Button, Content, LabelGroup } from '@patternfly/react-core'
 import { RhUiAddIcon, RhUiEditFillIcon, RhUiLockIcon, RhUiTrashIcon } from '@patternfly/react-icons'
 import { ActionsColumn, ExpandableRowContent, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import type { IAction, ThProps } from '@patternfly/react-table'
@@ -8,6 +8,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { NxConfirmationDialog } from '../../components/dialogs/NxConfirmationDialog'
 import { DisabledWithTooltip } from '../../components/DisabledWithTooltip'
 import { IconLabel } from '../../components/IconLabel'
+import { NxLabel } from '../../components/labels/NxLabel'
 import { NxListPanelTable, NxListPanelToolbar, NxListPanelView } from '../../components/panels/list/NxListPanel'
 import { NxEmptyStateNoData } from '../../components/states/NxEmptyStateNoData'
 import { invalidateAuthzCaches } from '../../hooks/invalidateAuthzCaches'
@@ -168,13 +169,13 @@ function RolesTable({
               </Td>
               <Td dataLabel="Type">
                 {role.is_builtin ? (
-                  <Label color="grey" icon={<RhUiLockIcon />} isCompact>
+                  <NxLabel color="grey" icon={<RhUiLockIcon />} isCompact>
                     Built-in
-                  </Label>
+                  </NxLabel>
                 ) : (
-                  <Label color="blue" isCompact>
+                  <NxLabel color="blue" isCompact>
                     Custom
-                  </Label>
+                  </NxLabel>
                 )}
               </Td>
               <Td isActionCell>
@@ -186,9 +187,9 @@ function RolesTable({
                 <ExpandableRowContent>
                   <LabelGroup isCompact numLabels={Infinity}>
                     {(role.policies ?? []).map((policy) => (
-                      <Label key={policy} color="grey" isCompact>
+                      <NxLabel key={policy} color="grey" isCompact>
                         {policy}
-                      </Label>
+                      </NxLabel>
                     ))}
                   </LabelGroup>
                 </ExpandableRowContent>

--- a/frontend/packages/syntara-ui/src/routes/access/ScopeLabel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/ScopeLabel.tsx
@@ -1,8 +1,9 @@
-import { Button, Flex, FlexItem, Label, LabelGroup, Stack, StackItem } from '@patternfly/react-core'
+import { Button, Flex, FlexItem, LabelGroup, Stack, StackItem } from '@patternfly/react-core'
 import { RhUiLockIcon } from '@patternfly/react-icons'
 import { useNavigate } from '@tanstack/react-router'
 
 import { AppRoute } from '../../app/AppRoute'
+import { NxLabel } from '../../components/labels/NxLabel'
 import { detachPromise } from '../../utils/detachPromise'
 
 import type { PolicyStatement } from './types'
@@ -22,9 +23,9 @@ export function ScopeLabel({ scope }: Readonly<ScopeLabelProps>) {
   const display = SCOPE_DISPLAY[scope ?? ''] ?? SCOPE_DISPLAY.system
 
   return (
-    <Label color={display.color} isCompact>
+    <NxLabel color={display.color} isCompact>
       {display.label}
-    </Label>
+    </NxLabel>
   )
 }
 
@@ -35,15 +36,15 @@ type PolicyTypeLabelProps = {
 export function PolicyTypeLabel({ isBuiltin }: Readonly<PolicyTypeLabelProps>) {
   if (isBuiltin) {
     return (
-      <Label color="grey" icon={<RhUiLockIcon />} isCompact>
+      <NxLabel color="grey" icon={<RhUiLockIcon />} isCompact>
         Built-in
-      </Label>
+      </NxLabel>
     )
   }
   return (
-    <Label color="blue" isCompact>
+    <NxLabel color="blue" isCompact>
       Custom
-    </Label>
+    </NxLabel>
   )
 }
 
@@ -89,21 +90,21 @@ export function StatementsCell({ statements }: Readonly<StatementsCellProps>) {
         <StackItem key={`${stmt.effect}-${stmt.scope}-${stmt.actions.join('-')}`}>
           <Flex gap={{ default: 'gapXs' }} alignItems={{ default: 'alignItemsCenter' }} flexWrap={{ default: 'wrap' }}>
             <FlexItem>
-              <Label color={stmt.effect === 'allow' ? 'green' : 'red'} isCompact>
+              <NxLabel color={stmt.effect === 'allow' ? 'green' : 'red'} isCompact>
                 {stmt.effect === 'allow' ? 'Allow' : 'Deny'}
-              </Label>
+              </NxLabel>
             </FlexItem>
             <FlexItem>
-              <Label color="grey" isCompact>
+              <NxLabel color="grey" isCompact>
                 scope: {stmt.scope}
-              </Label>
+              </NxLabel>
             </FlexItem>
             <FlexItem>
               <LabelGroup isCompact numLabels={2}>
                 {stmt.actions.map((action) => (
-                  <Label key={action} color="grey" isCompact>
+                  <NxLabel key={action} color="grey" isCompact>
                     {action}
-                  </Label>
+                  </NxLabel>
                 ))}
               </LabelGroup>
             </FlexItem>

--- a/frontend/packages/syntara-ui/src/routes/access/ScopeLabel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/ScopeLabel.tsx
@@ -22,11 +22,7 @@ type ScopeLabelProps = {
 export function ScopeLabel({ scope }: Readonly<ScopeLabelProps>) {
   const display = SCOPE_DISPLAY[scope ?? ''] ?? SCOPE_DISPLAY.system
 
-  return (
-    <NxLabel color={display.color} isCompact>
-      {display.label}
-    </NxLabel>
-  )
+  return <NxLabel color={display.color}>{display.label}</NxLabel>
 }
 
 type PolicyTypeLabelProps = {
@@ -36,16 +32,12 @@ type PolicyTypeLabelProps = {
 export function PolicyTypeLabel({ isBuiltin }: Readonly<PolicyTypeLabelProps>) {
   if (isBuiltin) {
     return (
-      <NxLabel color="grey" icon={<RhUiLockIcon />} isCompact>
+      <NxLabel color="grey" icon={<RhUiLockIcon />}>
         Built-in
       </NxLabel>
     )
   }
-  return (
-    <NxLabel color="blue" isCompact>
-      Custom
-    </NxLabel>
-  )
+  return <NxLabel color="blue">Custom</NxLabel>
 }
 
 type ProjectLabelProps = {
@@ -90,19 +82,17 @@ export function StatementsCell({ statements }: Readonly<StatementsCellProps>) {
         <StackItem key={`${stmt.effect}-${stmt.scope}-${stmt.actions.join('-')}`}>
           <Flex gap={{ default: 'gapXs' }} alignItems={{ default: 'alignItemsCenter' }} flexWrap={{ default: 'wrap' }}>
             <FlexItem>
-              <NxLabel color={stmt.effect === 'allow' ? 'green' : 'red'} isCompact>
+              <NxLabel color={stmt.effect === 'allow' ? 'green' : 'red'}>
                 {stmt.effect === 'allow' ? 'Allow' : 'Deny'}
               </NxLabel>
             </FlexItem>
             <FlexItem>
-              <NxLabel color="grey" isCompact>
-                scope: {stmt.scope}
-              </NxLabel>
+              <NxLabel color="grey">scope: {stmt.scope}</NxLabel>
             </FlexItem>
             <FlexItem>
               <LabelGroup isCompact numLabels={2}>
                 {stmt.actions.map((action) => (
-                  <NxLabel key={action} color="grey" isCompact>
+                  <NxLabel key={action} color="grey">
                     {action}
                   </NxLabel>
                 ))}

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialWorkflowsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialWorkflowsTab.tsx
@@ -1,10 +1,11 @@
-import { Label, LabelGroup, Truncate } from '@patternfly/react-core'
+import { LabelGroup, Truncate } from '@patternfly/react-core'
 import { Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import type { ExecutionsAPI } from '@syntara/contracts'
 import { useCallback, useMemo, useState } from 'react'
 
 import { AppRoute } from '../../../app/AppRoute'
 import { credentialsClient } from '../../../client'
+import { NxLabel } from '../../../components/labels/NxLabel'
 import { NxPanelContentStack } from '../../../components/layout/NxPanelContentStack'
 import { NxListPanelTable, NxListPanelView } from '../../../components/panels/list/NxListPanel'
 import { NxEmptyStateNoData } from '../../../components/states/NxEmptyStateNoData'
@@ -97,9 +98,9 @@ function WorkflowsTable({
                 {workflow.node_names && workflow.node_names.length > 0 ? (
                   <LabelGroup numLabels={5}>
                     {workflow.node_names.map((nodeName) => (
-                      <Label key={nodeName} variant="outline" isCompact>
+                      <NxLabel key={nodeName} variant="outline" isCompact>
                         {nodeName}
-                      </Label>
+                      </NxLabel>
                     ))}
                   </LabelGroup>
                 ) : (

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialWorkflowsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialWorkflowsTab.tsx
@@ -98,7 +98,7 @@ function WorkflowsTable({
                 {workflow.node_names && workflow.node_names.length > 0 ? (
                   <LabelGroup numLabels={5}>
                     {workflow.node_names.map((nodeName) => (
-                      <NxLabel key={nodeName} variant="outline" isCompact>
+                      <NxLabel key={nodeName} variant="outline">
                         {nodeName}
                       </NxLabel>
                     ))}

--- a/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetailPageHeaderParts.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetailPageHeaderParts.tsx
@@ -1,7 +1,8 @@
-import { Button, FlexItem, Label } from '@patternfly/react-core'
+import { Button, FlexItem } from '@patternfly/react-core'
 import type { ExecutionsAPI } from '@syntara/contracts'
 
 import { ApprovalPendingBadge } from '../../components/labels/ApprovalPendingBadge'
+import { NxLabel } from '../../components/labels/NxLabel'
 import { ExecutionTimestamp } from '../../components/table/ExecutionTimestamp'
 import { StatusLabel } from '../builder/ExecutionStatus'
 import { RunHistoryToggleButton } from '../builder/RunHistoryToggleButton'
@@ -31,9 +32,9 @@ export function ExecutionDetailTitleRowAddons({ execution }: Readonly<{ executio
       ) : null}
       {execution.created_at ? (
         <FlexItem>
-          <Label>
+          <NxLabel isCompact={false}>
             Viewing run: <ExecutionTimestamp dateString={execution.created_at} />
-          </Label>
+          </NxLabel>
         </FlexItem>
       ) : null}
     </>


### PR DESCRIPTION
## Description

swap remaining raw PatternFly `Label` imports to the project `NxLabel` wrapper so system labels go through the shared compact/filled defaults.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] replace PF `Label` with `NxLabel` in the 11 call sites from AAP-84209
- [x] keep existing `variant` and `color` props. drop redundant `isCompact` (NxLabel already defaults to compact). the execution viewing-run chip keeps `isCompact={false}` so it stays the same size as the old PF default
- [ ] Include any new dependencies or configuration changes

## Out of Scope

`LabelGroup` stays PF. other raw `Label` usage (builder schema trees, `TagInput`, stories) is not in this ticket.

## Related Issues

Fixes AAP-84209

## How to Test

1. open access roles/policies, my permissions, users/groups, project role assignments, credential workflows, execution detail, and any list with active filters
2. confirm labels still render with the same colors, outline vs filled, and compact size
3. on an execution detail page, confirm the viewing run chip is not compact

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->
