### PR TITLE
fix(script-nodes): add filesystem sandbox for script node execution

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -144,6 +144,8 @@ APP_ROUTER_EXCLUDE_MODULES=
 
 # Script Execution Settings
 # APP_SCRIPT_NODES_ENABLED=false           # Enable Developer Preview Script node execution in workflows
+# APP_SCRIPT_SANDBOX_ENABLED=true          # Enable filesystem sandbox (Landlock/unshare) for script nodes
+# APP_SCRIPT_SANDBOX_ALLOWED_PATHS=[]      # Extra read-only paths for sandboxed scripts (JSON array)
 APP_SCRIPT_CLEANUP_TERMINATE_TIMEOUT=1.0  # Timeout for graceful process termination
 APP_SCRIPT_CLEANUP_KILL_TIMEOUT=0.5       # Timeout for forceful process kill
 APP_MAX_ENV_VAR_LENGTH=32768              # Maximum length per environment variable (32KB)

--- a/backend/containers/syntara/Containerfile
+++ b/backend/containers/syntara/Containerfile
@@ -106,6 +106,9 @@ ARG APP_SEGMENT_WRITE_KEY=""
 USER root
 
 # Install Python 3.12 runtime and dependencies via RPM
+# util-linux provides unshare(1) and pivot_root(8) for script node
+# filesystem sandbox (mount namespace isolation when Landlock LSM
+# is unavailable). util-linux-core alone lacks pivot_root.
 RUN microdnf install --setopt=install_weak_deps=0 --nodocs -y \
         libatomic \
         python3.12 \
@@ -113,6 +116,7 @@ RUN microdnf install --setopt=install_weak_deps=0 --nodocs -y \
         python3.12-cffi \
         openblas-serial \
         libgomp \
+        util-linux \
     && microdnf clean all
 
 # Set python3 symlink via alternatives

--- a/backend/src/syntara/core/config/base.py
+++ b/backend/src/syntara/core/config/base.py
@@ -1481,15 +1481,37 @@ class WorkflowEngineSettings(BaseSettings):
         ge=1024,
     )
 
-    # SECURITY: Script nodes execute arbitrary user-supplied code (bash/Python)
-    # directly in the Temporal worker process without additional sandboxing. Enabling this
-    # grants any user with workflow:create + execution:run permissions the ability
-    # to run arbitrary commands on the worker infrastructure, with access to all
-    # environment variables.
-    # Enabling Script Node is not recommended for production deployments.
+    # SECURITY: Script nodes execute arbitrary user-supplied code (bash/Python).
+    # When sandbox is enabled (default), scripts run with allowlist-based
+    # filesystem isolation via Landlock LSM (RHEL 10+) or user namespace +
+    # mount namespace with pivot_root (RHEL 9). If neither is available,
+    # execution is refused (fail-closed). Baseline preexec hardening
+    # (PR_SET_NO_NEW_PRIVS, dropped supplementary groups, restricted CWD) is
+    # always applied regardless of which tier is active.
     script_nodes_enabled: bool = Field(
         default=False,
         description="Enable Script node execution in workflows (Developer Preview)",
+    )
+
+    script_sandbox_enabled: bool = Field(
+        default=True,
+        description=(
+            "Enable filesystem sandbox for script node execution. "
+            "Uses Landlock LSM when available, falls back to "
+            "unshare with user/mount/PID namespace and pivot_root. "
+            "If neither tier is available, script execution is refused."
+        ),
+    )
+
+    script_sandbox_allowed_paths: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Additional filesystem paths to make accessible to script "
+            "subprocesses (read-only). Built-in allowed paths "
+            "(Python/bash interpreters, shared libraries, /proc/self) "
+            "are always accessible. Denied prefixes: /proc, /etc, /run, "
+            "/dev, /sys, /tmp, /home, /root, /opt, /var."
+        ),
     )
 
     agent_orchestrator_base_url: HttpUrl = Field(  # type: ignore[assignment]

--- a/backend/src/syntara/workflows/workflow_engine/activities/script_activity.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/script_activity.py
@@ -1,7 +1,7 @@
 """Script activity executors for bash and Python.
 
 This module provides functionality to execute bash and Python scripts as workflow activities.
-Scripts run in isolated subprocesses with timeout and error handling.
+Scripts run in sandboxed subprocesses with filesystem isolation, timeout, and error handling.
 """
 
 import asyncio
@@ -9,7 +9,6 @@ import contextlib
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +25,13 @@ from syntara.workflows.workflow_engine.models.workflow_definition import (
 )
 
 from .common import HEARTBEAT_STOP_MONITOR, ActivityExecutionError
+from .script_sandbox import (
+    build_pivot_root_command,
+    cleanup_sandbox,
+    create_sandbox_context,
+    resolve_python_executable,
+    sanitize_env_for_sandbox,
+)
 
 SAFE_ENV_ALLOWLIST: frozenset[str] = frozenset(
     {
@@ -386,13 +392,38 @@ async def _execute_script_common(
     env = _prepare_script_env(environment)
     process = None
 
+    settings = get_settings()
     try:
-        # Execute script asynchronously with custom environment
+        sandbox_ctx = create_sandbox_context(
+            sandbox_enabled=settings.script_sandbox_enabled,
+            extra_allowed_paths=settings.script_sandbox_allowed_paths,
+        )
+    except (RuntimeError, ValueError) as e:
+        msg = f"Sandbox setup failed: {e}"
+        raise ApplicationError(msg, type="SandboxUnavailable", non_retryable=True) from e
+    sandbox_dir = sandbox_ctx["sandbox_dir"]
+    tier = sandbox_ctx["tier"]
+    activity.logger.info("Script sandbox tier: %s", tier)
+
+    try:
+        exec_command = command
+        exec_env = env
+        if tier == "unshare":
+            exec_command = build_pivot_root_command(
+                command,
+                sandbox_dir,
+                sandbox_ctx.get("extra_allowed_paths"),
+            )
+        if tier in ("landlock", "unshare"):
+            exec_env = sanitize_env_for_sandbox(env, sandbox_dir)
+
         process = await asyncio.create_subprocess_exec(
-            *command,
+            *exec_command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env=env,
+            env=exec_env,
+            cwd=sandbox_dir,
+            preexec_fn=sandbox_ctx["preexec_fn"],
         )
 
         # Read stdout/stderr with size limits to prevent worker OOM,
@@ -436,9 +467,9 @@ async def _execute_script_common(
         ) from e
 
     finally:
-        # Ensure process cleanup to avoid event loop warnings
         if process:
             await _cleanup_process(process)
+        cleanup_sandbox(sandbox_dir)
 
 
 @activity.defn(name=ActivityName.SCRIPT)
@@ -448,12 +479,17 @@ async def execute_script_activity(  # noqa: C901
 ) -> dict[str, Any]:
     """Execute a script for V2 workflows (unified bash/python activity).
 
-    SECURITY: Script nodes execute arbitrary user-supplied code (bash/Python)
-    directly in the Temporal worker process without additional sandboxing. Enabling this
-    grants any user with workflow:create + execution:run permissions the ability
-    to run arbitrary commands on the worker infrastructure, with access to all
-    environment variables.
-    Enabling Script Node is not recommended for production deployments.
+    SECURITY: Script nodes execute arbitrary user-supplied code (bash/Python).
+    When APP_SCRIPT_SANDBOX_ENABLED is True (default), scripts run with
+    allowlist-based filesystem isolation (filesystem-only, no network):
+    - Tier 1 (Landlock LSM): kernel-enforced per-process allowlist
+    - Tier 2 (unshare): bind-mount allowlist + pivot_root + nested
+      unshare --user to drop CAP_SYS_ADMIN before exec
+    If neither tier is available, execution is refused (fail-closed,
+    raises SandboxUnavailable). Scripts are stdlib-only — venv
+    site-packages are not on the allowlist. Baseline hardening
+    (PR_SET_NO_NEW_PRIVS, dropped groups, restricted CWD) is always
+    applied regardless of tier.
 
     This activity handles both bash and python scripts based on the 'language'
     field in config, delegating to the appropriate helper function.
@@ -509,8 +545,10 @@ async def execute_script_activity(  # noqa: C901
         if cgroup_limit:
             code = _prepend_memory_limit(code, language, int(cgroup_limit * 0.75))
 
-        # Build command based on language
-        command = ["bash", "-c", code] if language == "bash" else [sys.executable, "-c", code]
+        # Build command based on language — use resolved path so venv
+        # symlinks don't point outside the Landlock allowlist
+        python_exe = resolve_python_executable()
+        command = ["bash", "-c", code] if language == "bash" else [python_exe, "-c", code]
 
         # Execute script
         result = await _execute_script_common(command, environment, timeout, max_output_bytes)

--- a/backend/src/syntara/workflows/workflow_engine/activities/script_sandbox.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/script_sandbox.py
@@ -1,0 +1,870 @@
+"""Filesystem sandbox for script node execution.
+
+Provides process-level isolation so user-supplied scripts cannot read
+host secrets (JWT signing keys, encryption keys, database credentials)
+from the Temporal worker's filesystem. Filesystem-only — network access
+is not restricted.
+
+Uses a tiered allowlist approach — only explicitly permitted paths are
+accessible, everything else is blocked:
+
+Tier 1: Landlock LSM (RHEL 10 default, RHEL 9 with Landlock-enabled kernels)
+    Kernel-enforced per-process filesystem allowlist via syscalls.
+    Applied in ``preexec_fn`` (child only). Scripts are stdlib-only
+    (site-packages not on the allowlist by default).
+
+Tier 2: User namespace + mount namespace (RHEL 9 fallback)
+    ``unshare --user --map-root-user --mount --pid --fork --kill-child``
+    with bind-mount allowlist and ``pivot_root``. The old root is detached
+    (``umount -l``, tmpfs overlay as fallback). A nested ``unshare --user``
+    (without ``--map-root-user``) drops ``CAP_SYS_ADMIN`` before exec so
+    scripts cannot undo the overlay. ``chmod 1777`` on the sandbox dir
+    and ``/tmp`` ensures the unprivileged nested user can still write.
+
+If neither tier is available and ``script_sandbox_enabled`` is True,
+script execution is refused (fail-closed).
+
+Baseline preexec hardening (restricted CWD, PR_SET_NO_NEW_PRIVS,
+dropped groups, restrictive umask) is always applied regardless of tier.
+"""
+
+import contextlib
+import ctypes
+import ctypes.util
+import os
+import shutil
+import subprocess as _sp
+import sys
+import sysconfig
+import tempfile
+from pathlib import Path
+from typing import Any, ClassVar
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PR_SET_NO_NEW_PRIVS = 38  # prctl(2) option number
+
+# Named Landlock ABI version thresholds (avoid magic numbers in comparisons)
+_LANDLOCK_ABI_V2 = 2
+_LANDLOCK_ABI_V3 = 3
+
+# Landlock syscall numbers (same on x86_64 and aarch64)
+_NR_LANDLOCK_CREATE_RULESET = 444
+_NR_LANDLOCK_ADD_RULE = 445
+_NR_LANDLOCK_RESTRICT_SELF = 446
+
+LANDLOCK_CREATE_RULESET_VERSION = 1 << 0
+LANDLOCK_RULE_PATH_BENEATH = 1
+
+# Landlock filesystem access rights — defined for ABI completeness.
+# Only a subset is referenced directly (EXECUTE, WRITE_FILE, READ_FILE,
+# READ_DIR); the rest contribute implicitly via the _ABI_V*_MASK bitmasks.
+LANDLOCK_ACCESS_FS_EXECUTE = 1 << 0
+LANDLOCK_ACCESS_FS_WRITE_FILE = 1 << 1
+LANDLOCK_ACCESS_FS_READ_FILE = 1 << 2
+LANDLOCK_ACCESS_FS_READ_DIR = 1 << 3
+LANDLOCK_ACCESS_FS_REMOVE_DIR = 1 << 4
+LANDLOCK_ACCESS_FS_REMOVE_FILE = 1 << 5
+LANDLOCK_ACCESS_FS_MAKE_CHAR = 1 << 6
+LANDLOCK_ACCESS_FS_MAKE_DIR = 1 << 7
+LANDLOCK_ACCESS_FS_MAKE_REG = 1 << 8
+LANDLOCK_ACCESS_FS_MAKE_SOCK = 1 << 9
+LANDLOCK_ACCESS_FS_MAKE_FIFO = 1 << 10
+LANDLOCK_ACCESS_FS_MAKE_BLOCK = 1 << 11
+LANDLOCK_ACCESS_FS_MAKE_SYM = 1 << 12
+LANDLOCK_ACCESS_FS_REFER = 1 << 13  # ABI v2, kernel 5.19+
+LANDLOCK_ACCESS_FS_TRUNCATE = 1 << 14  # ABI v3, kernel 6.2+
+
+# Cumulative bitmasks — all access rights available in each ABI version.
+# Used as handled_access_fs to tell the kernel which rights to enforce.
+_ABI_V1_MASK = (1 << 13) - 1
+_ABI_V2_MASK = (1 << 14) - 1
+_ABI_V3_MASK = (1 << 15) - 1
+
+# Composite access masks for ALLOWED_PATHS rules
+_READ_ONLY = LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR
+_READ_EXECUTE = _READ_ONLY | LANDLOCK_ACCESS_FS_EXECUTE
+_READ_WRITE = _READ_ONLY | LANDLOCK_ACCESS_FS_WRITE_FILE
+
+# open(2) flags for Landlock path FD acquisition
+O_PATH = 0o10000000
+O_CLOEXEC = 0o2000000
+
+# Landlock READ_DIR on parent directories enables traversal to children.
+# Individual file rules use READ_FILE only (READ_DIR is invalid for files
+# and causes EINVAL from the kernel).
+_TRAVERSE = LANDLOCK_ACCESS_FS_READ_DIR
+
+# Allowlist of paths scripts are permitted to access.
+# Everything NOT on this list is blocked by both Tier 1 and Tier 2.
+ALLOWED_PATHS: tuple[tuple[str, int], ...] = (
+    # /usr — interpreters, libraries, runtime data (read + execute)
+    ("/usr", _READ_EXECUTE),
+    # Compat symlinks for non-RHEL systems where /bin != /usr/bin
+    ("/bin", _READ_EXECUTE),
+    ("/sbin", _READ_EXECUTE),
+    ("/lib", _READ_ONLY),
+    ("/lib64", _READ_ONLY),
+    # /dev — traverse-only, individual devices below.
+    # NOT all of /dev — /dev/shm is shared memory visible to other processes.
+    ("/dev", _TRAVERSE),
+    ("/dev/null", _READ_WRITE),
+    ("/dev/urandom", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/dev/zero", LANDLOCK_ACCESS_FS_READ_FILE),
+    # /proc — traverse only, then /proc/self gets read access.
+    # This prevents scripts from reading /proc/<worker_pid>/environ
+    # which would leak all worker secrets.
+    ("/proc", _TRAVERSE),
+    ("/proc/self", _READ_ONLY),
+    # /etc — traverse only at top level, individual entries below.
+    # NOT all of /etc — secrets may be mounted at /etc/secrets.
+    ("/etc", _TRAVERSE),
+    ("/etc/localtime", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/etc/resolv.conf", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/etc/hosts", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/etc/nsswitch.conf", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/etc/ld.so.cache", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/etc/ld.so.conf", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/etc/ld.so.conf.d", _READ_ONLY),
+    ("/etc/ssl/certs", _READ_ONLY),
+    ("/etc/ssl/cert.pem", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/etc/pki/tls/certs", _READ_ONLY),
+    ("/etc/pki/tls/cert.pem", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/etc/pki/ca-trust", _READ_ONLY),
+    ("/etc/alternatives", _READ_ONLY),
+    ("/etc/bashrc", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/etc/profile", LANDLOCK_ACCESS_FS_READ_FILE),
+    ("/etc/profile.d", _READ_ONLY),
+)
+
+# Paths for Tier 2 bind-mount (directories only, resolved at build time).
+# /tmp is NOT included — the new root is already a tmpfs, so scripts
+# write to the tmpfs directly. Binding host /tmp would leak data between
+# concurrent scripts and expose anything the worker left there.
+_TIER2_BIND_DIRS: tuple[str, ...] = ("/usr",)
+
+# Individual devices to bind-mount in Tier 2 (not all of /dev).
+_TIER2_DEV_NODES: tuple[str, ...] = (
+    "/dev/null",
+    "/dev/urandom",
+    "/dev/zero",
+)
+
+# cert.pem files are not listed here — they are symlinks that resolve
+# into directories already bind-mounted (e.g. /etc/pki/ca-trust).
+_TIER2_ETC_FILES: tuple[str, ...] = (
+    "/etc/localtime",
+    "/etc/resolv.conf",
+    "/etc/hosts",
+    "/etc/nsswitch.conf",
+    "/etc/ld.so.cache",
+    "/etc/ld.so.conf",
+    "/etc/ld.so.conf.d",
+    "/etc/ssl/certs",
+    "/etc/pki/tls/certs",
+    "/etc/pki/ca-trust",
+    "/etc/alternatives",
+    "/etc/bashrc",
+    "/etc/profile",
+    "/etc/profile.d",
+)
+# NOTE: Both tiers restrict /etc to individual files/dirs. Tier 2
+# bind-mounts them; Tier 1 uses traverse-only on /etc with per-file
+# READ_FILE rules. Secrets under /etc/secrets are not allowlisted.
+
+# ---------------------------------------------------------------------------
+# Landlock ctypes structs
+# ---------------------------------------------------------------------------
+
+
+class _LandlockRulesetAttr(ctypes.Structure):
+    """Maps to kernel ``struct landlock_ruleset_attr``. Packed to match the 8-byte kernel layout."""
+
+    _pack_ = 1
+    _fields_: ClassVar[list[tuple[str, type]]] = [("handled_access_fs", ctypes.c_uint64)]
+
+
+class _LandlockPathBeneathAttr(ctypes.Structure):
+    """Maps to kernel ``struct landlock_path_beneath_attr``. Packed to match the 12-byte kernel layout."""
+
+    _pack_ = 1
+    _fields_: ClassVar[list[tuple[str, type]]] = [
+        ("allowed_access", ctypes.c_uint64),
+        ("parent_fd", ctypes.c_int32),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_cached_libc: ctypes.CDLL | None = None
+
+
+def _get_libc() -> ctypes.CDLL | None:
+    """Load and cache libc for Landlock syscalls. Returns None if unavailable."""
+    global _cached_libc  # noqa: PLW0603
+    if _cached_libc is not None:
+        return _cached_libc
+    libc_name = ctypes.util.find_library("c")
+    if not libc_name:
+        return None
+    try:
+        libc = ctypes.CDLL(libc_name, use_errno=True)
+        libc.syscall.restype = ctypes.c_long
+        _cached_libc = libc
+        return libc
+    except OSError:
+        return None
+
+
+def _set_no_new_privs() -> None:
+    """Set PR_SET_NO_NEW_PRIVS so the subprocess cannot escalate privileges.
+
+    Best-effort: failure is silently ignored. Landlock's ``restrict_self``
+    requires this flag or ``CAP_SYS_ADMIN``.
+    """
+    libc = _get_libc()
+    if not libc:
+        return
+    with contextlib.suppress(OSError, AttributeError):
+        libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)
+
+
+def _drop_supplementary_groups() -> None:
+    """Drop all supplementary groups to reduce filesystem access scope.
+
+    Best-effort: failure is silently ignored (e.g. unprivileged process).
+    """
+    with contextlib.suppress(OSError, PermissionError):
+        os.setgroups([])
+
+
+def _shell_quote(s: str) -> str:
+    """Single-quote a string for safe embedding in a shell command."""
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _get_python_runtime_paths() -> list[str]:
+    """Discover Python interpreter and stdlib paths at runtime.
+
+    Returns resolved absolute paths for the interpreter directory and
+    standard library. Paths under the venv (e.g. /opt/app-root/.venv)
+    are excluded — only system paths under /usr are included. Scripts
+    are stdlib-only by design.
+    """
+    paths = []
+    real_exe = os.path.realpath(sys.executable)
+    exe_dir = str(Path(real_exe).parent)
+    if exe_dir and exe_dir.startswith("/usr"):
+        paths.append(exe_dir)
+
+    for key in ("stdlib", "platstdlib"):
+        p = sysconfig.get_path(key)
+        if p:
+            real_p = os.path.realpath(p)
+            if real_p not in paths and real_p.startswith("/usr"):
+                paths.append(real_p)
+
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: Landlock LSM
+# ---------------------------------------------------------------------------
+
+_cached_landlock_abi: int | None = None
+
+
+def _detect_landlock_abi() -> int:
+    """Probe the kernel for Landlock support.
+
+    Returns the ABI version (>= 1) on success, -1 on failure.
+    Result is cached for the process lifetime.
+    """
+    global _cached_landlock_abi  # noqa: PLW0603
+    if _cached_landlock_abi is not None:
+        return _cached_landlock_abi
+
+    libc = _get_libc()
+    if not libc:
+        _cached_landlock_abi = -1
+        return -1
+
+    try:
+        result = libc.syscall(_NR_LANDLOCK_CREATE_RULESET, 0, 0, LANDLOCK_CREATE_RULESET_VERSION)
+        _cached_landlock_abi = result if result >= 1 else -1
+    except OSError:
+        _cached_landlock_abi = -1
+
+    return _cached_landlock_abi
+
+
+def _handled_access_for_abi(abi: int) -> int:
+    """Compute the handled_access_fs bitmask for a given ABI version."""
+    if abi >= _LANDLOCK_ABI_V3:
+        return _ABI_V3_MASK
+    if abi >= _LANDLOCK_ABI_V2:
+        return _ABI_V2_MASK
+    return _ABI_V1_MASK
+
+
+def _create_ruleset(handled_access_fs: int) -> int:
+    """Create a Landlock ruleset. Returns the ruleset FD or -1."""
+    libc = _get_libc()
+    if not libc:
+        return -1
+    attr = _LandlockRulesetAttr(handled_access_fs=handled_access_fs)
+    return int(
+        libc.syscall(
+            _NR_LANDLOCK_CREATE_RULESET,
+            ctypes.byref(attr),
+            ctypes.sizeof(attr),
+            0,
+        )
+    )
+
+
+def _add_path_rule(ruleset_fd: int, path: str, allowed_access: int) -> bool:
+    """Add a path-beneath rule to a Landlock ruleset.
+
+    Skips paths that don't exist on this system (returns True).
+    For non-directory paths (files, device nodes, symlinks), READ_DIR
+    is automatically stripped because the kernel rejects it with EINVAL.
+
+    Args:
+        ruleset_fd: File descriptor of the Landlock ruleset.
+        path: Filesystem path to add (resolved via ``os.path.realpath``).
+        allowed_access: Bitmask of ``LANDLOCK_ACCESS_FS_*`` rights to grant.
+
+    Returns:
+        True if the rule was added (or the path doesn't exist), False on
+        syscall failure. Callers should treat False on critical paths
+        (sandbox_dir, /usr) as a fatal sandbox setup error.
+
+    """
+    real_path = os.path.realpath(path)
+    if not Path(real_path).exists():
+        return True
+
+    libc = _get_libc()
+    if not libc:
+        return False
+
+    try:
+        path_fd = os.open(real_path, O_PATH | O_CLOEXEC)
+    except OSError:
+        return False
+
+    try:
+        if not Path(real_path).is_dir():
+            allowed_access = allowed_access & ~LANDLOCK_ACCESS_FS_READ_DIR
+
+        attr = _LandlockPathBeneathAttr(
+            allowed_access=allowed_access,
+            parent_fd=path_fd,
+        )
+        result = libc.syscall(
+            _NR_LANDLOCK_ADD_RULE,
+            ruleset_fd,
+            LANDLOCK_RULE_PATH_BENEATH,
+            ctypes.byref(attr),
+            0,
+        )
+        return int(result) == 0
+    finally:
+        os.close(path_fd)
+
+
+def _restrict_self(ruleset_fd: int) -> bool:
+    """Apply the ruleset to the current process. Returns True on success."""
+    libc = _get_libc()
+    if not libc:
+        return False
+    result = libc.syscall(_NR_LANDLOCK_RESTRICT_SELF, ruleset_fd, 0)
+    return int(result) == 0
+
+
+def _apply_landlock_sandbox(
+    sandbox_dir: str,
+    abi_version: int,
+    extra_allowed_paths: list[str] | None = None,
+) -> bool:
+    """Apply Landlock filesystem restrictions to the current process.
+
+    Non-critical rule failures (optional /etc files, /dev nodes) are
+    tolerated — scripts may lose access to that path but the sandbox
+    still holds. The sandbox_dir rule is critical — failure causes the
+    entire apply to return False, which triggers ``os._exit(1)`` in
+    the caller.
+
+    Args:
+        sandbox_dir: Ephemeral working directory the script writes to.
+        abi_version: Landlock ABI version from ``_detect_landlock_abi``.
+        extra_allowed_paths: Operator-configured additional read-only paths.
+
+    Returns:
+        True if Landlock was successfully applied, False on failure.
+
+    """
+    handled = _handled_access_for_abi(abi_version)
+    ruleset_fd = _create_ruleset(handled)
+    if ruleset_fd < 0:
+        return False
+
+    try:
+        for path, access in ALLOWED_PATHS:
+            _add_path_rule(ruleset_fd, path, access & handled)
+
+        for py_path in _get_python_runtime_paths():
+            _add_path_rule(ruleset_fd, py_path, _READ_EXECUTE & handled)
+
+        # sandbox_dir is critical — scripts must be able to write here
+        if not _add_path_rule(ruleset_fd, sandbox_dir, handled):
+            return False
+
+        if extra_allowed_paths:
+            for p in extra_allowed_paths:
+                _add_path_rule(ruleset_fd, p, _READ_ONLY & handled)
+
+        return _restrict_self(ruleset_fd)
+    finally:
+        os.close(ruleset_fd)
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: User namespace + mount namespace
+# ---------------------------------------------------------------------------
+
+_cached_unshare_userns: bool | None = None
+
+
+def _detect_unshare_userns() -> bool:
+    """Probe whether the full production unshare command works.
+
+    Tests ``unshare --user --map-root-user --mount --pid --fork
+    --kill-child`` with ``mount --make-rprivate /``.
+    Result is cached for the process lifetime.
+    """
+    global _cached_unshare_userns  # noqa: PLW0603
+    if _cached_unshare_userns is not None:
+        return _cached_unshare_userns
+
+    if shutil.which("unshare") is None:
+        _cached_unshare_userns = False
+        return False
+
+    try:
+        result = _sp.run(
+            [  # noqa: S607
+                "unshare",
+                "--user",
+                "--map-root-user",
+                "--mount",
+                "--pid",
+                "--fork",
+                "--kill-child",
+                "bash",
+                "-c",
+                "mount --make-rprivate /",
+            ],
+            check=False,
+            capture_output=True,
+            timeout=5,
+        )
+        _cached_unshare_userns = result.returncode == 0
+    except Exception:  # noqa: BLE001
+        _cached_unshare_userns = False
+
+    return _cached_unshare_userns
+
+
+def _build_bind_mounts(parts: list[str]) -> None:
+    """Bind-mount allowed directories into the new root."""
+    for bind_dir in _TIER2_BIND_DIRS:
+        real = os.path.realpath(bind_dir)
+        if Path(real).is_dir():
+            qr = _shell_quote(real)
+            parts.append(f"mkdir -p $NEWROOT{qr}")
+            parts.append(f"mount --bind {qr} $NEWROOT{qr}")
+
+
+def _build_dev_mounts(parts: list[str]) -> None:
+    """Bind-mount individual device nodes (not all of /dev, avoids /dev/shm)."""
+    parts.append("mkdir -p $NEWROOT/dev")
+    for dev_node in _TIER2_DEV_NODES:
+        if Path(dev_node).exists():
+            qd = _shell_quote(dev_node)
+            parts.append(f"touch $NEWROOT{qd}")
+            parts.append(f"mount --bind {qd} $NEWROOT{qd}")
+
+
+def _build_etc_mounts(parts: list[str]) -> None:
+    """Bind-mount individual /etc files and directories."""
+    parts.append("mkdir -p $NEWROOT/etc")
+    for etc_path in _TIER2_ETC_FILES:
+        real = os.path.realpath(etc_path)
+        if not Path(real).exists():
+            continue
+        rel = os.path.relpath(real, "/")
+        qr = _shell_quote(real)
+        qrel = _shell_quote(rel)
+        if Path(real).is_dir():
+            parts.append(f"mkdir -p $NEWROOT/{qrel}")
+            parts.append(f"mount --bind {qr} $NEWROOT/{qrel}")
+        else:
+            parent = _shell_quote(str(Path(rel).parent))
+            parts.append(f"mkdir -p $NEWROOT/{parent}")
+            parts.append(f"touch $NEWROOT/{qrel}")
+            parts.append(f"mount --bind {qr} $NEWROOT/{qrel}")
+
+
+def _build_symlinks(parts: list[str]) -> None:
+    """Create RHEL compat symlinks (/bin -> /usr/bin etc.)."""
+    for link, target in [("/bin", "/usr/bin"), ("/sbin", "/usr/sbin"), ("/lib", "/usr/lib"), ("/lib64", "/usr/lib64")]:
+        real_link = os.path.realpath(link)
+        real_target = os.path.realpath(target)
+        if real_link == real_target and Path(link).is_symlink():
+            parts.append(f"ln -sf {target} $NEWROOT{link}")
+
+
+def _build_extra_paths(parts: list[str], extra_allowed_paths: list[str] | None) -> None:
+    """Bind-mount extra operator-configured paths (directories and files)."""
+    if not extra_allowed_paths:
+        return
+    for p in extra_allowed_paths:
+        real = os.path.realpath(p)
+        qr = _shell_quote(real)
+        if Path(real).is_dir():
+            parts.append(f"mkdir -p $NEWROOT{qr}")
+            parts.append(f"mount --bind {qr} $NEWROOT{qr}")
+        elif Path(real).exists():
+            parent = _shell_quote(str(Path(real).parent))
+            parts.append(f"mkdir -p $NEWROOT/{parent}")
+            parts.append(f"touch $NEWROOT{qr}")
+            parts.append(f"mount --bind {qr} $NEWROOT{qr}")
+
+
+def _build_python_runtime_mounts(parts: list[str]) -> None:
+    """Bind-mount Python runtime paths."""
+    for py_path in _get_python_runtime_paths():
+        if Path(py_path).is_dir():
+            qp = _shell_quote(py_path)
+            parts.append(f"mkdir -p $NEWROOT{qp}")
+            parts.append(f"mount --bind {qp} $NEWROOT{qp}")
+
+
+def _build_pivot_and_exec(
+    parts: list[str],
+    sandbox_dir: str,
+    command: list[str],
+) -> None:
+    """Pivot root, detach old root, drop privileges, and exec the script."""
+    # /tmp inside the new root for scripts that ignore TMPDIR
+    parts.append("mkdir -p $NEWROOT/tmp")
+    parts.append("chmod 1777 $NEWROOT/tmp")
+
+    # Pivot root and detach old root.
+    # After pivot_root, /old contains the original filesystem (including
+    # secrets). Try umount -l first (needs /proc); fall back to a tmpfs
+    # overlay if umount fails.
+    parts.append("mkdir -p $NEWROOT/old")
+    parts.append("pivot_root $NEWROOT $NEWROOT/old")
+    parts.append(f"cd {_shell_quote(sandbox_dir)}")
+    parts.append(
+        "if umount -l /old 2>/dev/null; then "
+        "rmdir /old 2>/dev/null || true; "
+        "else mount -t tmpfs tmpfs /old || exit 1; fi"
+    )
+
+    # Make sandbox dir and /tmp world-writable before dropping privileges,
+    # so the unprivileged nested user namespace can write to them.
+    parts.append(f"chmod 1777 {_shell_quote(sandbox_dir)}")
+    parts.append("chmod 1777 /tmp 2>/dev/null || true")
+
+    # Execute the script inside a nested user namespace (without
+    # --map-root-user) so it runs as an unprivileged user and cannot
+    # umount the /old overlay or perform other mount operations.
+    if command[0] == "bash":
+        script_exec = f"bash -c {_shell_quote(command[2])}"
+    else:
+        script_exec = f"{_shell_quote(command[0])} -c {_shell_quote(command[2])}"
+    parts.append(f"exec unshare --user -- {script_exec}")
+
+
+def build_pivot_root_command(
+    command: list[str],
+    sandbox_dir: str,
+    extra_allowed_paths: list[str] | None = None,
+) -> list[str]:
+    """Wrap *command* in a fully isolated unshare sandbox.
+
+    The wrapper does (in order):
+    1. ``unshare --user --map-root-user --mount --pid --fork --kill-child``
+    2. Bind-mount only allowlisted paths into a tmpfs new root
+    3. ``pivot_root`` into the new root
+    4. Detach the old root (``umount -l``; tmpfs overlay as fallback)
+    5. ``chmod 1777`` the sandbox dir so the nested userns can write
+    6. ``exec unshare --user --`` to drop ``CAP_SYS_ADMIN`` before
+       running the script (prevents ``umount /old``)
+
+    ``--pid --fork`` creates a PID namespace so /proc only shows the
+    script. ``--kill-child`` reaps the forked PID 1 on activity timeout.
+
+    Args:
+        command: Must be ``[interpreter, "-c", source_code]``.
+        sandbox_dir: Ephemeral working directory for the script.
+        extra_allowed_paths: Operator-configured additional paths to
+            bind-mount (read-only for directories, read for files).
+
+    Returns:
+        The wrapped command list for ``asyncio.create_subprocess_exec``.
+
+    """
+    parts = [
+        "set -e",
+        "mount --make-rprivate /",
+        "NEWROOT=$(mktemp -d)",
+        "mount -t tmpfs tmpfs $NEWROOT",
+    ]
+
+    _build_bind_mounts(parts)
+    _build_dev_mounts(parts)
+    _build_etc_mounts(parts)
+
+    # Fresh procfs (may fail in restricted container runtimes)
+    parts.append("mkdir -p $NEWROOT/proc")
+    parts.append("mount -t proc proc $NEWROOT/proc 2>/dev/null || true")
+
+    # Sandbox working directory
+    parts.append(f"mkdir -p $NEWROOT{_shell_quote(sandbox_dir)}")
+
+    _build_symlinks(parts)
+    _build_extra_paths(parts, extra_allowed_paths)
+    _build_python_runtime_mounts(parts)
+    _build_pivot_and_exec(parts, sandbox_dir, command)
+
+    wrapper = "; ".join(parts)
+    return ["unshare", "--user", "--map-root-user", "--mount", "--pid", "--fork", "--kill-child", "bash", "-c", wrapper]
+
+
+# ---------------------------------------------------------------------------
+# Preexec and context
+# ---------------------------------------------------------------------------
+
+
+SANDBOX_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+
+def sanitize_env_for_sandbox(env: dict[str, str], sandbox_dir: str) -> dict[str, str]:
+    """Replace PATH and temp directory vars for sandboxed execution.
+
+    PATH is restricted to standard system directories (the worker's PATH
+    may include directories outside the allowlist). TMPDIR, TMP, and TEMP
+    are set to the sandbox directory so Python's tempfile, bash mktemp,
+    and other tools write there instead of host /tmp (which is blocked
+    under Landlock). HOME is left as the worker home (writes to ~ will
+    fail under the allowlist).
+
+    Args:
+        env: Original environment dict (not mutated).
+        sandbox_dir: Ephemeral sandbox directory path.
+
+    Returns:
+        A new dict with sanitized PATH and temp vars.
+
+    """
+    env = dict(env)
+    env["PATH"] = SANDBOX_PATH
+    env["TMPDIR"] = sandbox_dir
+    env["TMP"] = sandbox_dir
+    env["TEMP"] = sandbox_dir
+    return env
+
+
+def resolve_python_executable() -> str:
+    """Return the real path to the Python interpreter.
+
+    Under Landlock, venv symlinks (e.g. /opt/app-root/.venv/bin/python3)
+    point to paths outside the allowlist. The real path
+    (e.g. /usr/bin/python3.12) is on the allowlist.
+
+    Returns:
+        Absolute resolved path to the Python binary.
+
+    """
+    return os.path.realpath(sys.executable)
+
+
+def sandbox_preexec_fn(
+    sandbox_dir: str,
+    *,
+    apply_landlock: bool = False,
+    abi_version: int = -1,
+    extra_allowed_paths: list[str] | None = None,
+) -> None:
+    """Pre-exec function applied to every script subprocess.
+
+    Called after fork() but before exec() — changes are confined to the
+    child process and do not affect the Temporal worker. Always applies
+    baseline hardening (CWD, umask, no_new_privs, groups). When
+    ``apply_landlock`` is True, also applies Landlock; if Landlock
+    application fails, calls ``os._exit(1)`` with a stderr message
+    so the script never executes without isolation.
+
+    Args:
+        sandbox_dir: Ephemeral working directory for the script.
+        apply_landlock: Whether to apply Landlock filesystem restrictions.
+        abi_version: Landlock ABI version (from ``_detect_landlock_abi``).
+        extra_allowed_paths: Additional read-only paths for the allowlist.
+
+    THREADING CAVEAT: Temporal workers are multi-threaded. When fork() is
+    called, only the calling thread is copied; locks held by other threads
+    remain locked in the child. This function uses only thin POSIX wrappers
+    (os.chdir, os.umask, os.open, os.close) and direct ctypes syscalls to
+    minimize deadlock risk. If deadlocks are observed in production,
+    replace the Landlock application with a compiled helper binary invoked
+    before exec.
+
+    """
+    with contextlib.suppress(OSError):
+        os.chdir(sandbox_dir)
+    os.umask(0o077)
+    _set_no_new_privs()
+    _drop_supplementary_groups()
+
+    if (
+        apply_landlock
+        and abi_version >= 1
+        and not _apply_landlock_sandbox(sandbox_dir, abi_version, extra_allowed_paths)
+    ):
+        sys.stderr.write("FATAL: Landlock sandbox failed to apply — refusing to exec\n")
+        sys.stderr.flush()
+        os._exit(1)
+
+
+# Prefixes that operators must not add via extra_allowed_paths — they would
+# undermine the sandbox by exposing secrets or the entire filesystem.
+# Checked by prefix so /etc/secrets and /run/secrets are also rejected.
+_DENIED_EXTRA_PREFIXES: tuple[str, ...] = (
+    "/proc",
+    "/etc",
+    "/run",
+    "/dev",
+    "/sys",
+    "/tmp",  # noqa: S108
+    "/home",
+    "/root",
+    "/opt",
+    "/var",
+)
+
+
+def _validate_extra_allowed_paths(paths: list[str] | None) -> None:
+    """Reject extra_allowed_paths that would undermine the sandbox.
+
+    Denied prefixes: ``/proc``, ``/etc``, ``/run``, ``/dev``, ``/sys``,
+    ``/tmp``, ``/home``, ``/root``, ``/opt``, ``/var``, and ``/``.
+    """
+    if not paths:
+        return
+    for p in paths:
+        # Check both the raw path and the resolved path (macOS resolves
+        # /tmp → /private/tmp, /var → /private/var, /etc → /private/etc)
+        candidates = {p, os.path.realpath(p)}
+        for candidate in candidates:
+            if candidate == "/":
+                msg = "extra_allowed_paths cannot include '/' — it would undermine the sandbox"
+                raise ValueError(msg)
+        for candidate in candidates:
+            for prefix in _DENIED_EXTRA_PREFIXES:
+                if candidate == prefix or candidate.startswith(prefix + "/"):
+                    msg = f"extra_allowed_paths cannot include {p!r} — it would undermine the sandbox"
+                    raise ValueError(msg)
+
+
+def create_sandbox_context(
+    *,
+    sandbox_enabled: bool,
+    extra_allowed_paths: list[str] | None = None,
+) -> dict[str, Any]:
+    """Prepare sandbox artefacts for a single script execution.
+
+    Args:
+        sandbox_enabled: Whether to require filesystem isolation.
+        extra_allowed_paths: Operator-configured additional paths.
+
+    Returns:
+        A dict with:
+        - ``sandbox_dir``: path to the ephemeral temp directory.
+        - ``tier``: active tier (``landlock``, ``unshare``, or ``baseline``).
+          ``baseline`` is only returned when ``sandbox_enabled`` is False.
+        - ``preexec_fn``: callable for ``subprocess.Popen(preexec_fn=…)``.
+        - ``extra_allowed_paths``: (unshare tier only) passed through for
+          ``build_pivot_root_command``.
+
+    Raises:
+        RuntimeError: If ``sandbox_enabled`` is True but neither Landlock nor
+            unshare is available (fail-closed).
+        ValueError: If ``extra_allowed_paths`` contains a denied prefix.
+
+    """
+    _validate_extra_allowed_paths(extra_allowed_paths)
+    sandbox_dir = tempfile.mkdtemp(prefix="script-sandbox-")
+
+    if not sandbox_enabled:
+
+        def _preexec() -> None:
+            sandbox_preexec_fn(sandbox_dir)
+
+        return {
+            "sandbox_dir": sandbox_dir,
+            "tier": "baseline",
+            "preexec_fn": _preexec,
+        }
+
+    abi = _detect_landlock_abi()
+    if abi >= 1:
+
+        def _preexec() -> None:
+            sandbox_preexec_fn(
+                sandbox_dir,
+                apply_landlock=True,
+                abi_version=abi,
+                extra_allowed_paths=extra_allowed_paths,
+            )
+
+        return {
+            "sandbox_dir": sandbox_dir,
+            "tier": "landlock",
+            "preexec_fn": _preexec,
+        }
+
+    if _detect_unshare_userns():
+
+        def _preexec() -> None:
+            sandbox_preexec_fn(sandbox_dir)
+
+        return {
+            "sandbox_dir": sandbox_dir,
+            "tier": "unshare",
+            "extra_allowed_paths": extra_allowed_paths,
+            "preexec_fn": _preexec,
+        }
+
+    cleanup_sandbox(sandbox_dir)
+    msg = (
+        "Script sandbox is enabled but neither Landlock LSM nor "
+        "unshare --user --mount is available. Script execution refused. "
+        "Install util-linux, enable user namespaces, or upgrade "
+        "to a kernel with Landlock support."
+    )
+    raise RuntimeError(msg)
+
+
+def cleanup_sandbox(sandbox_dir: str) -> None:
+    """Remove the ephemeral sandbox directory. Errors are silently ignored."""
+    with contextlib.suppress(Exception):
+        shutil.rmtree(sandbox_dir, ignore_errors=True)

--- a/backend/tests/unit/workflows/activities/conftest.py
+++ b/backend/tests/unit/workflows/activities/conftest.py
@@ -18,6 +18,26 @@ def _mock_service_identity() -> Generator[None, None, None]:
 
 @pytest.fixture(autouse=True)
 def _enable_script_nodes() -> Generator[None, None, None]:
-    """Enable script nodes for activity unit tests."""
+    """Enable script nodes for activity unit tests.
+
+    On platforms without Landlock or unshare (e.g. macOS), also disables
+    the sandbox to prevent fail-closed from blocking all script tests.
+    """
+    from syntara.core.config.base import get_settings
+    from syntara.workflows.workflow_engine.activities.script_sandbox import (
+        _detect_landlock_abi,
+        _detect_unshare_userns,
+    )
+
     with enable_script_nodes():
-        yield
+        settings = get_settings()
+        sandbox_available = _detect_landlock_abi() >= 1 or _detect_unshare_userns()
+        if not sandbox_available:
+            original_sandbox = settings.script_sandbox_enabled
+            object.__setattr__(settings, "script_sandbox_enabled", False)
+            try:
+                yield
+            finally:
+                object.__setattr__(settings, "script_sandbox_enabled", original_sandbox)
+        else:
+            yield

--- a/backend/tests/unit/workflows/activities/test_script_activity.py
+++ b/backend/tests/unit/workflows/activities/test_script_activity.py
@@ -3,6 +3,7 @@
 import asyncio
 import sys
 from collections.abc import Generator
+from pathlib import Path
 from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -332,9 +333,9 @@ echo "Result: $result"
 
     @pytest.mark.asyncio
     async def test_script_with_file_operations(self) -> None:
-        """Test script that creates and reads temporary file."""
+        """Test script that creates and reads temporary file in the sandbox CWD."""
         script = """
-tmpfile=$(mktemp)
+tmpfile=$(mktemp ./tmp.XXXXXXXXXX)
 echo "test content" > "$tmpfile"
 cat "$tmpfile"
 rm "$tmpfile"
@@ -707,7 +708,7 @@ class TestSysExecutableForPython:
 
     @pytest.mark.asyncio
     async def test_python_script_uses_sys_executable(self) -> None:
-        """Python script subprocess should use the same interpreter as the host process."""
+        """Python script subprocess should use the resolved interpreter path."""
         script = """
 import sys
 print(sys.executable)
@@ -717,8 +718,10 @@ print(sys.executable)
 
         output = result["output"]
         assert output["return_code"] == 0
-        # The subprocess should report the same executable as the host
-        assert sys.executable in output["stdout"]
+        # The subprocess uses the resolved real path (not venv symlink)
+        import os
+
+        assert os.path.realpath(sys.executable) in output["stdout"]
 
     @pytest.mark.asyncio
     async def test_bash_script_does_not_use_sys_executable(self) -> None:
@@ -937,9 +940,12 @@ class TestScriptEnvironmentSanitization:
         assert "leaked_master_key" not in output["stdout"]
         assert "KEY=empty" in output["stdout"]
 
+    @pytest.mark.skipif(sys.platform != "linux", reason="PATH sanitization requires Linux sandbox")
     @pytest.mark.asyncio
     async def test_script_can_read_path(self) -> None:
-        """A bash script must still be able to read PATH."""
+        """A bash script must still be able to read PATH (sanitized)."""
+        from syntara.workflows.workflow_engine.activities.script_sandbox import SANDBOX_PATH
+
         input_config = {
             "language": "bash",
             "code": 'echo "PATH=$PATH"',
@@ -948,7 +954,7 @@ class TestScriptEnvironmentSanitization:
 
         output = result["output"]
         assert output["return_code"] == 0
-        assert "PATH=/" in output["stdout"]
+        assert f"PATH={SANDBOX_PATH}" in output["stdout"]
 
     @pytest.mark.asyncio
     async def test_python_env_dump_has_no_app_secrets(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1215,3 +1221,368 @@ class TestScriptNodesGate:
         result = await execute_script_activity({"language": "bash", "code": "echo gate-open"}, None)
         assert result["output"]["return_code"] == 0
         assert "gate-open" in result["output"]["stdout"]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Sandbox requires Linux")
+class TestScriptSandboxIntegration:
+    """Regression tests for AAP-87783: script nodes must not access host secrets.
+
+    These tests verify that the sandbox correctly isolates script execution,
+    preventing access to sensitive filesystem paths and environment variables.
+    """
+
+    @pytest.mark.asyncio
+    async def test_script_runs_in_temp_directory(self) -> None:
+        """Script CWD must be an ephemeral sandbox directory, not the worker dir."""
+        input_config = {"language": "bash", "code": "pwd"}
+        result = await execute_script_activity(input_config, None)
+
+        output = result["output"]
+        assert output["return_code"] == 0
+        cwd = output["stdout"].strip()
+        assert "script-sandbox-" in cwd
+        assert cwd.startswith("/tmp")  # noqa: S108
+
+    @pytest.mark.asyncio
+    async def test_python_script_runs_in_temp_directory(self) -> None:
+        """Python script CWD must be an ephemeral sandbox directory."""
+        script = "import os; print(os.getcwd())"
+        input_config = {"language": "python", "code": script}
+        result = await execute_script_activity(input_config, None)
+
+        output = result["output"]
+        assert output["return_code"] == 0
+        cwd = output["stdout"].strip()
+        assert "script-sandbox-" in cwd
+
+    @pytest.mark.asyncio
+    async def test_sandbox_dir_cleaned_up_after_execution(self) -> None:
+        """The ephemeral sandbox directory must be removed after script completes."""
+        from pathlib import Path
+
+        input_config = {"language": "bash", "code": "pwd"}
+        result = await execute_script_activity(input_config, None)
+        sandbox_dir = result["output"]["stdout"].strip()
+        assert not Path(sandbox_dir).exists(), "Sandbox directory was not cleaned up"
+
+    @pytest.mark.asyncio
+    async def test_sandbox_dir_cleaned_up_after_failure(self) -> None:
+        """Sandbox directory must be cleaned up even when the script fails."""
+        from pathlib import Path
+
+        from temporalio.exceptions import ApplicationError
+
+        input_config = {"language": "bash", "code": "pwd; exit 1"}
+        with pytest.raises(ApplicationError) as exc_info:
+            await execute_script_activity(input_config, None)
+
+        detail = exc_info.value.details[0]
+        sandbox_dir = detail["output"]["stdout"].strip()
+        assert not Path(sandbox_dir).exists(), "Sandbox directory was not cleaned up after failure"
+
+    @pytest.mark.asyncio
+    async def test_script_cannot_read_proc_environ(self) -> None:
+        """Script must not be able to read worker env vars via /proc/self/environ."""
+        script = """
+import os
+env_dump = open('/proc/self/environ', 'rb').read().decode(errors='replace')
+app_vars = [v for v in env_dump.split('\\0') if v.startswith('APP_')]
+print(len(app_vars))
+"""
+        input_config = {"language": "python", "code": script}
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert output["return_code"] == 0
+        assert output["stdout"].strip() == "0"
+
+    @pytest.mark.asyncio
+    async def test_script_cannot_read_parent_environ(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Script must not be able to read the parent process APP_* env vars."""
+        monkeypatch.setenv("APP_SECRET_ENCRYPTION_KEY", "test-secret-key-12345")
+        script = """
+import os
+env_keys = [k for k in os.environ if k.startswith('APP_')]
+print(f"APP_KEYS={len(env_keys)}")
+"""
+        input_config = {"language": "python", "code": script}
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert output["return_code"] == 0
+        assert "APP_KEYS=0" in output["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_script_creates_files_in_sandbox_not_worker_dir(self) -> None:
+        """Files created by scripts must land in the sandbox, not the worker CWD."""
+        worker_cwd = str(Path.cwd())
+        input_config = {
+            "language": "bash",
+            "code": "echo test > sandbox_test_file.txt && pwd",
+        }
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert output["return_code"] == 0
+        assert not Path(worker_cwd, "sandbox_test_file.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_preexec_no_new_privs_applied(self) -> None:
+        """Script subprocess must have PR_SET_NO_NEW_PRIVS set."""
+        script = """
+with open('/proc/self/status') as f:
+    for line in f:
+        if line.startswith('NoNewPrivs:'):
+            print(line.strip())
+            break
+"""
+        input_config = {"language": "python", "code": script}
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert output["return_code"] == 0
+        assert "NoNewPrivs:\t1" in output["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_script_path_is_sanitized(self) -> None:
+        """Script subprocess PATH must only contain standard system directories."""
+        input_config = {"language": "bash", "code": 'echo "$PATH"'}
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert output["return_code"] == 0
+        path = output["stdout"].strip()
+        for entry in path.split(":"):
+            assert entry.startswith(("/usr", "/bin", "/sbin")), f"Non-system directory in PATH: {entry}"
+
+    @pytest.mark.asyncio
+    async def test_script_cannot_read_file_outside_allowlist(self) -> None:
+        """Key regression test for AAP-87783: scripts must not read host secrets."""
+        import shutil
+        import tempfile
+
+        secret_dir = tempfile.mkdtemp(prefix="test-secret-")
+        secret_file = str(Path(secret_dir) / "jwt-key.pem")
+        try:
+            Path(secret_file).write_text("FAKE_SECRET")
+
+            # The worker CWD (/sandbox/syntara/backend) is NOT on the
+            # Landlock allowlist. A file created there must be unreadable
+            # from inside the sandboxed script.
+            # Place the secret outside /tmp to test this.
+            worker_secret = str(Path.cwd() / "_test_secret_aap87783.pem")
+            Path(worker_secret).write_text("WORKER_SECRET")
+
+            script = f"""
+results = []
+for path in ['{worker_secret}']:
+    try:
+        data = open(path).read()
+        results.append(f'LEAKED:{{data}}')
+    except PermissionError:
+        results.append('BLOCKED')
+    except FileNotFoundError:
+        results.append('BLOCKED')
+print(' '.join(results))
+"""
+            input_config = {"language": "python", "code": script}
+            result = await execute_script_activity(input_config, None)
+            output = result["output"]
+            assert output["return_code"] == 0
+            assert "BLOCKED" in output["stdout"]
+            assert "LEAKED" not in output["stdout"]
+        finally:
+            shutil.rmtree(secret_dir, ignore_errors=True)
+            if Path(worker_secret).exists():
+                Path(worker_secret).unlink()
+
+    @pytest.mark.asyncio
+    async def test_script_can_read_allowed_system_files(self) -> None:
+        """Scripts must be able to read files on the allowlist (/usr hierarchy)."""
+        input_config = {"language": "bash", "code": "ls /usr/bin > /dev/null && echo OK"}
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert output["return_code"] == 0
+        assert "OK" in output["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_script_can_execute_basic_commands(self) -> None:
+        """Standard utilities under /usr/bin must work inside the sandbox."""
+        input_config = {"language": "bash", "code": "date > /dev/null && echo CMD_OK"}
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert output["return_code"] == 0
+        assert "CMD_OK" in output["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_script_cannot_write_outside_sandbox(self) -> None:
+        """Scripts must not be able to create files outside /tmp."""
+        input_config = {
+            "language": "bash",
+            "code": "echo test > /var/test_file.txt 2>&1; echo exit_code=$?",
+        }
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert "Permission denied" in output["stdout"] or "exit_code=1" in output["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_script_cannot_read_worker_proc_environ(self) -> None:
+        """Scripts must not read the worker's /proc/<pid>/environ (F1 regression)."""
+        import os
+
+        worker_pid = os.getpid()
+        script = f"""
+import os
+try:
+    data = open('/proc/{worker_pid}/environ', 'rb').read()
+    print(f'LEAKED:{{len(data)}} bytes')
+except PermissionError:
+    print('BLOCKED')
+except FileNotFoundError:
+    print('BLOCKED')
+"""
+        input_config = {"language": "python", "code": script}
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert output["return_code"] == 0
+        assert "BLOCKED" in output["stdout"]
+        assert "LEAKED" not in output["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_script_can_read_proc_self(self) -> None:
+        """Scripts must be able to read /proc/self for introspection."""
+        script = """
+with open('/proc/self/status') as f:
+    line = f.readline().strip()
+    print(f'STATUS:{line}')
+"""
+        input_config = {"language": "python", "code": script}
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert output["return_code"] == 0
+        assert "STATUS:Name:" in output["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_script_cannot_read_etc_secrets(self) -> None:
+        """Scripts must not be able to read arbitrary /etc files (F4 regression)."""
+        script = """
+try:
+    open('/etc/shadow').read()
+    print('LEAKED')
+except PermissionError:
+    print('BLOCKED')
+except FileNotFoundError:
+    print('BLOCKED')
+"""
+        input_config = {"language": "python", "code": script}
+        result = await execute_script_activity(input_config, None)
+        output = result["output"]
+        assert output["return_code"] == 0
+        assert "BLOCKED" in output["stdout"]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Sandbox requires Linux")
+class TestScriptSandboxUnshare:
+    """Regression tests that force execution through the unshare tier.
+
+    These patch Landlock ABI to -1 so create_sandbox_context falls
+    through to unshare. Skipped if unshare is not available.
+    """
+
+    @staticmethod
+    def _unshare_works() -> bool:
+        import shutil
+        import subprocess
+
+        if not shutil.which("unshare"):
+            return False
+        try:
+            r = subprocess.run(
+                [  # noqa: S607
+                    "unshare",
+                    "--user",
+                    "--map-root-user",
+                    "--mount",
+                    "--pid",
+                    "--fork",
+                    "--kill-child",
+                    "bash",
+                    "-c",
+                    "mount --make-rprivate /",
+                ],
+                check=False,
+                capture_output=True,
+                timeout=5,
+            )
+            return r.returncode == 0
+        except Exception:
+            return False
+
+    @pytest.mark.asyncio
+    async def test_unshare_script_cannot_read_file_outside_allowlist(self) -> None:
+        """Key AAP-87783 regression test on the unshare tier."""
+        if not self._unshare_works():
+            pytest.skip("unshare --user --map-root-user not available")
+
+        import syntara.workflows.workflow_engine.activities.script_sandbox as smod
+
+        worker_secret = str(Path.cwd() / "_test_secret_unshare.pem")
+        Path(worker_secret).write_text("WORKER_SECRET")
+
+        saved_abi = smod._cached_landlock_abi
+        saved_unshare = smod._cached_unshare_userns
+        smod._cached_landlock_abi = -1
+        smod._cached_unshare_userns = None
+        try:
+            script = f"""
+try:
+    data = open('{worker_secret}').read()
+    print(f'LEAKED:{{data}}')
+except PermissionError:
+    print('BLOCKED')
+except FileNotFoundError:
+    print('BLOCKED')
+"""
+            input_config = {"language": "python", "code": script}
+            result = await execute_script_activity(input_config, None)
+            output = result["output"]
+            assert output["return_code"] == 0
+            assert "BLOCKED" in output["stdout"]
+            assert "LEAKED" not in output["stdout"]
+        finally:
+            smod._cached_landlock_abi = saved_abi
+            smod._cached_unshare_userns = saved_unshare
+            if Path(worker_secret).exists():
+                Path(worker_secret).unlink()
+
+    @pytest.mark.asyncio
+    async def test_unshare_script_cannot_umount_old(self) -> None:
+        """Script must not be able to umount /old to reveal the original root."""
+        if not self._unshare_works():
+            pytest.skip("unshare --user --map-root-user not available")
+
+        import syntara.workflows.workflow_engine.activities.script_sandbox as smod
+
+        saved_abi = smod._cached_landlock_abi
+        saved_unshare = smod._cached_unshare_userns
+        smod._cached_landlock_abi = -1
+        smod._cached_unshare_userns = None
+        try:
+            script = """
+import subprocess, os
+# Try to umount /old (should fail — unprivileged in nested userns)
+r = subprocess.run(['umount', '/old'], capture_output=True)
+# Check if /old has host content
+try:
+    entries = os.listdir('/old')
+    if entries:
+        print(f'LEAKED:{entries[:3]}')
+    else:
+        print('BLOCKED')
+except (PermissionError, FileNotFoundError, OSError):
+    print('BLOCKED')
+"""
+            input_config = {"language": "python", "code": script}
+            result = await execute_script_activity(input_config, None)
+            output = result["output"]
+            assert output["return_code"] == 0
+            assert "BLOCKED" in output["stdout"]
+            assert "LEAKED" not in output["stdout"]
+        finally:
+            smod._cached_landlock_abi = saved_abi
+            smod._cached_unshare_userns = saved_unshare

--- a/backend/tests/unit/workflows/activities/test_script_sandbox.py
+++ b/backend/tests/unit/workflows/activities/test_script_sandbox.py
@@ -1,0 +1,695 @@
+"""Unit tests for tiered script sandbox filesystem isolation.
+
+Regression tests for AAP-87783: Script nodes must not be able to read
+host secrets (JWT signing keys, encryption keys, etc.) from the Temporal
+worker's filesystem.
+
+These tests require Linux (Landlock LSM and/or unshare are Linux-only).
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import syntara.workflows.workflow_engine.activities.script_sandbox as sandbox_mod
+from syntara.workflows.workflow_engine.activities.script_sandbox import (
+    ALLOWED_PATHS,
+    SANDBOX_PATH,
+    _detect_landlock_abi,
+    _detect_unshare_userns,
+    _get_python_runtime_paths,
+    _shell_quote,
+    build_pivot_root_command,
+    cleanup_sandbox,
+    create_sandbox_context,
+    resolve_python_executable,
+    sandbox_preexec_fn,
+    sanitize_env_for_sandbox,
+)
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="Sandbox requires Linux")
+
+# ---------------------------------------------------------------------------
+# Tier detection
+# ---------------------------------------------------------------------------
+
+
+class TestLandlockDetection:
+    """Test Landlock ABI detection via syscall probe."""
+
+    def _reset_cache(self) -> None:
+        sandbox_mod._cached_landlock_abi = None
+
+    def test_returns_integer(self) -> None:
+        """Detection returns an integer (positive ABI version or -1)."""
+        self._reset_cache()
+        try:
+            abi = _detect_landlock_abi()
+            assert isinstance(abi, int)
+            assert abi >= -1
+        finally:
+            self._reset_cache()
+
+    def test_returns_negative_when_libc_unavailable(self) -> None:
+        self._reset_cache()
+        try:
+            with patch.object(sandbox_mod, "_get_libc", return_value=None):
+                assert _detect_landlock_abi() == -1
+        finally:
+            self._reset_cache()
+
+    def test_caches_result(self) -> None:
+        self._reset_cache()
+        try:
+            first = _detect_landlock_abi()
+            with patch.object(sandbox_mod, "_get_libc", return_value=None):
+                # Should return cached result, not re-probe
+                assert _detect_landlock_abi() == first
+        finally:
+            self._reset_cache()
+
+
+class TestUnshareDetection:
+    """Test unshare --user --mount capability detection."""
+
+    def _reset_cache(self) -> None:
+        sandbox_mod._cached_unshare_userns = None
+
+    def test_returns_false_when_binary_missing(self) -> None:
+        self._reset_cache()
+        try:
+            with patch.object(shutil, "which", return_value=None):
+                assert _detect_unshare_userns() is False
+        finally:
+            self._reset_cache()
+
+    def test_returns_false_when_unshare_fails(self) -> None:
+        self._reset_cache()
+        try:
+            mock_result: subprocess.CompletedProcess[bytes] = subprocess.CompletedProcess(
+                args=["unshare", "--user", "--mount", "--pid", "--fork", "bash", "-c", "mount --make-rprivate /"],
+                returncode=1,
+            )
+            with (
+                patch.object(shutil, "which", return_value="/usr/bin/unshare"),
+                patch("syntara.workflows.workflow_engine.activities.script_sandbox._sp.run", return_value=mock_result),
+            ):
+                assert _detect_unshare_userns() is False
+        finally:
+            self._reset_cache()
+
+    def test_returns_true_when_unshare_works(self) -> None:
+        self._reset_cache()
+        try:
+            mock_result: subprocess.CompletedProcess[bytes] = subprocess.CompletedProcess(
+                args=["unshare", "--user", "--mount", "--pid", "--fork", "bash", "-c", "mount --make-rprivate /"],
+                returncode=0,
+            )
+            with (
+                patch.object(shutil, "which", return_value="/usr/bin/unshare"),
+                patch("syntara.workflows.workflow_engine.activities.script_sandbox._sp.run", return_value=mock_result),
+            ):
+                assert _detect_unshare_userns() is True
+        finally:
+            self._reset_cache()
+
+    def test_caches_result(self) -> None:
+        self._reset_cache()
+        try:
+            mock_result: subprocess.CompletedProcess[bytes] = subprocess.CompletedProcess(args=[], returncode=0)
+            with (
+                patch.object(shutil, "which", return_value="/usr/bin/unshare"),
+                patch(
+                    "syntara.workflows.workflow_engine.activities.script_sandbox._sp.run", return_value=mock_result
+                ) as mock_run,
+            ):
+                _detect_unshare_userns()
+                _detect_unshare_userns()
+                mock_run.assert_called_once()
+        finally:
+            self._reset_cache()
+
+
+# ---------------------------------------------------------------------------
+# ABI version handling
+# ---------------------------------------------------------------------------
+
+
+class TestHandledAccessForAbi:
+    """Test ABI-version-dependent bitmask computation."""
+
+    def test_abi_v1_mask(self) -> None:
+        from syntara.workflows.workflow_engine.activities.script_sandbox import (
+            _ABI_V1_MASK,
+            _handled_access_for_abi,
+        )
+
+        assert _handled_access_for_abi(1) == _ABI_V1_MASK
+
+    def test_abi_v2_mask(self) -> None:
+        from syntara.workflows.workflow_engine.activities.script_sandbox import (
+            _ABI_V2_MASK,
+            _handled_access_for_abi,
+        )
+
+        assert _handled_access_for_abi(2) == _ABI_V2_MASK
+
+    def test_abi_v3_mask(self) -> None:
+        from syntara.workflows.workflow_engine.activities.script_sandbox import (
+            _ABI_V3_MASK,
+            _handled_access_for_abi,
+        )
+
+        assert _handled_access_for_abi(3) == _ABI_V3_MASK
+
+    def test_abi_v7_uses_v3_mask(self) -> None:
+        """ABI versions above v3 still use the v3 filesystem mask."""
+        from syntara.workflows.workflow_engine.activities.script_sandbox import (
+            _ABI_V3_MASK,
+            _handled_access_for_abi,
+        )
+
+        assert _handled_access_for_abi(7) == _ABI_V3_MASK
+
+
+# ---------------------------------------------------------------------------
+# Allowed paths
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedPaths:
+    """Test the allowlist constant."""
+
+    def test_includes_usr(self) -> None:
+        paths = [p for p, _ in ALLOWED_PATHS]
+        assert "/usr" in paths
+
+    def test_dev_is_traverse_only(self) -> None:
+        """/dev parent is traverse-only; individual devices have specific access."""
+        from syntara.workflows.workflow_engine.activities.script_sandbox import _TRAVERSE
+
+        dev_entries = {p: a for p, a in ALLOWED_PATHS if p == "/dev"}
+        assert dev_entries["/dev"] == _TRAVERSE
+
+    def test_includes_dev_null(self) -> None:
+        paths = [p for p, _ in ALLOWED_PATHS]
+        assert "/dev/null" in paths
+
+    def test_includes_proc(self) -> None:
+        paths = [p for p, _ in ALLOWED_PATHS]
+        assert "/proc" in paths
+
+    def test_does_not_include_run_secrets(self) -> None:
+        paths = [p for p, _ in ALLOWED_PATHS]
+        assert "/run/secrets" not in paths
+        assert "/run" not in paths
+
+    def test_etc_is_traverse_only(self) -> None:
+        """/etc parent directory is traverse-only (READ_DIR), not full read."""
+        from syntara.workflows.workflow_engine.activities.script_sandbox import _TRAVERSE
+
+        etc_entries = [(p, a) for p, a in ALLOWED_PATHS if p == "/etc"]
+        assert len(etc_entries) == 1
+        assert etc_entries[0][1] == _TRAVERSE
+
+    def test_proc_is_traverse_only(self) -> None:
+        """/proc parent is traverse-only; /proc/self has read access."""
+        from syntara.workflows.workflow_engine.activities.script_sandbox import _READ_ONLY, _TRAVERSE
+
+        proc_entries = {p: a for p, a in ALLOWED_PATHS if p.startswith("/proc")}
+        assert proc_entries["/proc"] == _TRAVERSE
+        assert proc_entries["/proc/self"] == _READ_ONLY
+
+    def test_does_not_include_run_or_secret_paths(self) -> None:
+        paths = [p for p, _ in ALLOWED_PATHS]
+        assert "/run" not in paths
+        assert "/run/secrets" not in paths
+        assert "/etc/secrets" not in paths
+        assert "/etc/automation-orchestrator/secrets" not in paths
+
+
+# ---------------------------------------------------------------------------
+# Environment and path helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeEnvForSandbox:
+    """Test PATH and TMPDIR sanitization."""
+
+    def test_replaces_path(self) -> None:
+        env = {"PATH": "/sandbox/.local/bin:/usr/bin", "HOME": "/tmp"}  # noqa: S108
+        result = sanitize_env_for_sandbox(env, "/tmp/sandbox-123")  # noqa: S108
+        assert result["PATH"] == SANDBOX_PATH
+        assert "/sandbox" not in result["PATH"]
+
+    def test_sets_tmpdir_to_sandbox(self) -> None:
+        env = {"PATH": "/usr/bin"}
+        result = sanitize_env_for_sandbox(env, "/tmp/sandbox-456")  # noqa: S108
+        assert result["TMPDIR"] == "/tmp/sandbox-456"  # noqa: S108
+        assert result["TMP"] == "/tmp/sandbox-456"  # noqa: S108
+        assert result["TEMP"] == "/tmp/sandbox-456"  # noqa: S108
+
+    def test_preserves_other_vars(self) -> None:
+        env = {"PATH": "/something", "HOME": "/tmp", "LANG": "C"}  # noqa: S108
+        result = sanitize_env_for_sandbox(env, "/tmp/sandbox-789")  # noqa: S108
+        assert result["HOME"] == "/tmp"  # noqa: S108
+        assert result["LANG"] == "C"
+
+    def test_does_not_mutate_original(self) -> None:
+        env = {"PATH": "/original"}
+        sanitize_env_for_sandbox(env, "/tmp/sandbox-abc")  # noqa: S108
+        assert env["PATH"] == "/original"
+        assert "TMPDIR" not in env
+
+
+class TestResolvePythonExecutable:
+    """Test Python executable path resolution."""
+
+    def test_returns_real_path(self) -> None:
+        result = resolve_python_executable()
+        assert Path(result).is_absolute()
+        assert Path(result).exists()
+        assert result == os.path.realpath(result)
+
+
+class TestGetPythonRuntimePaths:
+    """Test dynamic Python path detection."""
+
+    def test_returns_list(self) -> None:
+        """Returns a list (may be empty on macOS where Python is not under /usr)."""
+        paths = _get_python_runtime_paths()
+        assert isinstance(paths, list)
+
+    def test_all_paths_are_absolute(self) -> None:
+        for p in _get_python_runtime_paths():
+            assert Path(p).is_absolute()
+
+    def test_all_paths_are_resolved(self) -> None:
+        for p in _get_python_runtime_paths():
+            assert p == os.path.realpath(p)
+
+    def test_all_paths_under_usr(self) -> None:
+        """Venv paths (e.g. /opt/app-root/.venv) must be excluded."""
+        for p in _get_python_runtime_paths():
+            assert p.startswith("/usr"), f"Non-/usr path leaked: {p}"
+
+
+class TestShellQuote:
+    """Test shell quoting."""
+
+    def test_simple_string(self) -> None:
+        assert _shell_quote("hello") == "'hello'"
+
+    def test_string_with_single_quotes(self) -> None:
+        assert _shell_quote("it's") == "'it'\\''s'"
+
+    def test_empty_string(self) -> None:
+        assert _shell_quote("") == "''"
+
+
+# ---------------------------------------------------------------------------
+# Drop supplementary groups
+# ---------------------------------------------------------------------------
+
+
+class TestDropSupplementaryGroups:
+    """Test supplementary group dropping."""
+
+    def test_does_not_raise(self) -> None:
+        """Must not raise even if setgroups fails (e.g. unprivileged)."""
+        from syntara.workflows.workflow_engine.activities.script_sandbox import _drop_supplementary_groups
+
+        _drop_supplementary_groups()
+
+    def test_handles_permission_error(self) -> None:
+        from syntara.workflows.workflow_engine.activities.script_sandbox import _drop_supplementary_groups
+
+        with patch("os.setgroups", side_effect=PermissionError("not allowed")):
+            _drop_supplementary_groups()
+
+
+# ---------------------------------------------------------------------------
+# Preexec function
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxPreexecFn:
+    """Test the preexec function applied to subprocess."""
+
+    def test_changes_cwd_to_sandbox_dir(self) -> None:
+        sandbox_dir = tempfile.mkdtemp(prefix="test-sandbox-")
+        try:
+            original_cwd = str(Path.cwd())
+            sandbox_preexec_fn(sandbox_dir)
+            assert str(Path.cwd()) == sandbox_dir
+            os.chdir(original_cwd)
+        finally:
+            shutil.rmtree(sandbox_dir, ignore_errors=True)
+
+    def test_sets_restrictive_umask(self) -> None:
+        sandbox_dir = tempfile.mkdtemp(prefix="test-sandbox-")
+        try:
+            original_cwd = str(Path.cwd())
+            original_umask = os.umask(0o022)
+            os.umask(original_umask)
+            sandbox_preexec_fn(sandbox_dir)
+            current_umask = os.umask(original_umask)
+            assert current_umask == 0o077
+            os.chdir(original_cwd)
+        finally:
+            shutil.rmtree(sandbox_dir, ignore_errors=True)
+
+    def test_handles_nonexistent_sandbox_dir(self) -> None:
+        sandbox_preexec_fn("/nonexistent/sandbox/dir")
+
+    def test_skips_landlock_when_not_requested(self) -> None:
+        sandbox_dir = tempfile.mkdtemp(prefix="test-sandbox-")
+        try:
+            original_cwd = str(Path.cwd())
+            with patch.object(sandbox_mod, "_apply_landlock_sandbox") as mock_ll:
+                sandbox_preexec_fn(sandbox_dir, apply_landlock=False)
+                mock_ll.assert_not_called()
+            os.chdir(original_cwd)
+        finally:
+            shutil.rmtree(sandbox_dir, ignore_errors=True)
+
+    def test_calls_landlock_when_requested(self) -> None:
+        sandbox_dir = tempfile.mkdtemp(prefix="test-sandbox-")
+        try:
+            original_cwd = str(Path.cwd())
+            with patch.object(sandbox_mod, "_apply_landlock_sandbox") as mock_ll:
+                sandbox_preexec_fn(sandbox_dir, apply_landlock=True, abi_version=3)
+                mock_ll.assert_called_once_with(sandbox_dir, 3, None)
+            os.chdir(original_cwd)
+        finally:
+            shutil.rmtree(sandbox_dir, ignore_errors=True)
+
+    def test_passes_extra_paths_to_landlock(self) -> None:
+        sandbox_dir = tempfile.mkdtemp(prefix="test-sandbox-")
+        try:
+            original_cwd = str(Path.cwd())
+            with patch.object(sandbox_mod, "_apply_landlock_sandbox") as mock_ll:
+                sandbox_preexec_fn(
+                    sandbox_dir,
+                    apply_landlock=True,
+                    abi_version=3,
+                    extra_allowed_paths=["/data"],
+                )
+                mock_ll.assert_called_once_with(sandbox_dir, 3, ["/data"])
+            os.chdir(original_cwd)
+        finally:
+            shutil.rmtree(sandbox_dir, ignore_errors=True)
+
+    def test_skips_landlock_when_abi_negative(self) -> None:
+        """Landlock not applied when abi_version is -1 even if apply_landlock=True."""
+        sandbox_dir = tempfile.mkdtemp(prefix="test-sandbox-")
+        try:
+            original_cwd = str(Path.cwd())
+            with patch.object(sandbox_mod, "_apply_landlock_sandbox") as mock_ll:
+                sandbox_preexec_fn(sandbox_dir, apply_landlock=True, abi_version=-1)
+                mock_ll.assert_not_called()
+            os.chdir(original_cwd)
+        finally:
+            shutil.rmtree(sandbox_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: pivot_root command building
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPivotRootCommand:
+    """Test unshare + bind-mount + pivot_root command wrapping."""
+
+    def test_wraps_bash_command(self) -> None:
+        sandbox_dir = "/tmp/test-sandbox"  # noqa: S108
+        cmd = ["bash", "-c", "echo hello"]
+        result = build_pivot_root_command(cmd, sandbox_dir)
+        assert result[0] == "unshare"
+        assert "--user" in result
+        assert "--map-root-user" in result
+        assert "--mount" in result
+        assert "--pid" in result
+        assert "--fork" in result
+        assert "--kill-child" in result
+        assert "pivot_root" in result[-1]
+        assert "echo hello" in result[-1]
+
+    def test_wraps_python_command(self) -> None:
+        sandbox_dir = "/tmp/test-sandbox"  # noqa: S108
+        cmd = ["/usr/bin/python3", "-c", "print('hello')"]
+        result = build_pivot_root_command(cmd, sandbox_dir)
+        assert result[0] == "unshare"
+        assert "pivot_root" in result[-1]
+        assert "print" in result[-1]
+
+    def test_includes_make_rprivate(self) -> None:
+        cmd = ["bash", "-c", "echo test"]
+        result = build_pivot_root_command(cmd, "/tmp/sandbox")  # noqa: S108
+        assert "make-rprivate" in result[-1]
+
+    def test_includes_fresh_procfs(self) -> None:
+        cmd = ["bash", "-c", "echo test"]
+        result = build_pivot_root_command(cmd, "/tmp/sandbox")  # noqa: S108
+        assert "mount -t proc proc" in result[-1]
+
+    def test_masks_old_root_with_tmpfs(self) -> None:
+        """Old root must be masked with tmpfs to prevent access to host secrets."""
+        cmd = ["bash", "-c", "echo test"]
+        result = build_pivot_root_command(cmd, "/tmp/sandbox")  # noqa: S108
+        assert "mount -t tmpfs tmpfs /old" in result[-1]
+
+    def test_bash_uses_exec_in_nested_userns(self) -> None:
+        """Bash scripts must exec inside a nested unprivileged user namespace."""
+        cmd = ["bash", "-c", "echo hello"]
+        result = build_pivot_root_command(cmd, "/tmp/sandbox")  # noqa: S108
+        assert "exec unshare --user -- bash -c" in result[-1]
+
+    def test_creates_tmp_in_new_root(self) -> None:
+        """New root must have /tmp for scripts that ignore TMPDIR."""
+        cmd = ["bash", "-c", "echo test"]
+        result = build_pivot_root_command(cmd, "/tmp/sandbox")  # noqa: S108
+        assert "mkdir -p $NEWROOT/tmp" in result[-1]
+
+    def test_chmod_1777_before_nested_unshare(self) -> None:
+        """Sandbox dir must be world-writable before dropping to unprivileged userns."""
+        cmd = ["bash", "-c", "echo test"]
+        result = build_pivot_root_command(cmd, "/tmp/sandbox")  # noqa: S108
+        assert "chmod 1777 '/tmp/sandbox'" in result[-1]
+
+    def test_python_interpreter_is_quoted(self) -> None:
+        """Python interpreter path must be shell-quoted in exec."""
+        cmd = ["/usr/bin/python3", "-c", "print('hello')"]
+        result = build_pivot_root_command(cmd, "/tmp/sandbox")  # noqa: S108
+        assert "exec unshare --user -- '/usr/bin/python3'" in result[-1]
+
+
+# ---------------------------------------------------------------------------
+# Context creation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSandboxContext:
+    """Test sandbox context creation and tier selection."""
+
+    def test_creates_temp_directory(self) -> None:
+        ctx = create_sandbox_context(sandbox_enabled=True)
+        try:
+            assert Path(ctx["sandbox_dir"]).is_dir()
+            assert "script-sandbox-" in ctx["sandbox_dir"]
+        finally:
+            cleanup_sandbox(ctx["sandbox_dir"])
+
+    def test_preexec_fn_callable(self) -> None:
+        ctx = create_sandbox_context(sandbox_enabled=True)
+        try:
+            assert callable(ctx["preexec_fn"])
+        finally:
+            cleanup_sandbox(ctx["sandbox_dir"])
+
+    def test_returns_tier_string(self) -> None:
+        ctx = create_sandbox_context(sandbox_enabled=True)
+        try:
+            assert ctx["tier"] in ("landlock", "unshare", "baseline")
+        finally:
+            cleanup_sandbox(ctx["sandbox_dir"])
+
+    def test_disabled_sandbox_returns_baseline(self) -> None:
+        ctx = create_sandbox_context(sandbox_enabled=False)
+        try:
+            assert ctx["tier"] == "baseline"
+        finally:
+            cleanup_sandbox(ctx["sandbox_dir"])
+
+    def test_selects_landlock_when_available(self) -> None:
+        sandbox_mod._cached_landlock_abi = None
+        try:
+            with patch.object(sandbox_mod, "_detect_landlock_abi", return_value=3):
+                ctx = create_sandbox_context(sandbox_enabled=True)
+                try:
+                    assert ctx["tier"] == "landlock"
+                finally:
+                    cleanup_sandbox(ctx["sandbox_dir"])
+        finally:
+            sandbox_mod._cached_landlock_abi = None
+
+    def test_falls_back_to_unshare(self) -> None:
+        sandbox_mod._cached_landlock_abi = None
+        sandbox_mod._cached_unshare_userns = None
+        try:
+            with (
+                patch.object(sandbox_mod, "_detect_landlock_abi", return_value=-1),
+                patch.object(sandbox_mod, "_detect_unshare_userns", return_value=True),
+            ):
+                ctx = create_sandbox_context(sandbox_enabled=True)
+                try:
+                    assert ctx["tier"] == "unshare"
+                finally:
+                    cleanup_sandbox(ctx["sandbox_dir"])
+        finally:
+            sandbox_mod._cached_landlock_abi = None
+            sandbox_mod._cached_unshare_userns = None
+
+    def test_refuses_execution_when_no_tier_available(self) -> None:
+        """When sandbox is enabled but no isolation tier works, refuse to run."""
+        sandbox_mod._cached_landlock_abi = None
+        sandbox_mod._cached_unshare_userns = None
+        try:
+            with (
+                patch.object(sandbox_mod, "_detect_landlock_abi", return_value=-1),
+                patch.object(sandbox_mod, "_detect_unshare_userns", return_value=False),
+            ):
+                with pytest.raises(RuntimeError, match="Script sandbox is enabled"):
+                    create_sandbox_context(sandbox_enabled=True)
+        finally:
+            sandbox_mod._cached_landlock_abi = None
+            sandbox_mod._cached_unshare_userns = None
+
+    def test_disabled_sandbox_allows_baseline(self) -> None:
+        """When sandbox is explicitly disabled, baseline is allowed."""
+        sandbox_mod._cached_landlock_abi = None
+        sandbox_mod._cached_unshare_userns = None
+        try:
+            with (
+                patch.object(sandbox_mod, "_detect_landlock_abi", return_value=-1),
+                patch.object(sandbox_mod, "_detect_unshare_userns", return_value=False),
+            ):
+                ctx = create_sandbox_context(sandbox_enabled=False)
+                try:
+                    assert ctx["tier"] == "baseline"
+                finally:
+                    cleanup_sandbox(ctx["sandbox_dir"])
+        finally:
+            sandbox_mod._cached_landlock_abi = None
+            sandbox_mod._cached_unshare_userns = None
+
+    def test_unshare_tier_passes_extra_allowed_paths(self) -> None:
+        """extra_allowed_paths must be available in the unshare tier context."""
+        sandbox_mod._cached_landlock_abi = None
+        sandbox_mod._cached_unshare_userns = None
+        try:
+            with (
+                patch.object(sandbox_mod, "_detect_landlock_abi", return_value=-1),
+                patch.object(sandbox_mod, "_detect_unshare_userns", return_value=True),
+            ):
+                ctx = create_sandbox_context(
+                    sandbox_enabled=True,
+                    extra_allowed_paths=["/data/shared"],
+                )
+                try:
+                    assert ctx["tier"] == "unshare"
+                    assert ctx["extra_allowed_paths"] == ["/data/shared"]
+                finally:
+                    cleanup_sandbox(ctx["sandbox_dir"])
+        finally:
+            sandbox_mod._cached_landlock_abi = None
+            sandbox_mod._cached_unshare_userns = None
+
+    def test_rejects_root_as_extra_allowed_path(self) -> None:
+        """/ as an extra allowed path must be rejected."""
+        with pytest.raises(ValueError, match="undermine the sandbox"):
+            create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/"])
+
+    def test_rejects_proc_as_extra_allowed_path(self) -> None:
+        with pytest.raises(ValueError, match="undermine the sandbox"):
+            create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/proc"])
+
+    def test_rejects_run_as_extra_allowed_path(self) -> None:
+        with pytest.raises(ValueError, match="undermine the sandbox"):
+            create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/run"])
+
+    def test_rejects_etc_secrets_by_prefix(self) -> None:
+        """Subdirectories of denied prefixes must also be rejected."""
+        with pytest.raises(ValueError, match="undermine the sandbox"):
+            create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/etc/secrets"])
+
+    def test_rejects_run_secrets_by_prefix(self) -> None:
+        with pytest.raises(ValueError, match="undermine the sandbox"):
+            create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/run/secrets"])
+
+    def test_rejects_dev_shm_by_prefix(self) -> None:
+        with pytest.raises(ValueError, match="undermine the sandbox"):
+            create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/dev/shm"])  # noqa: S108
+
+    def test_rejects_tmp_by_prefix(self) -> None:
+        with pytest.raises(ValueError, match="undermine the sandbox"):
+            create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/tmp"])  # noqa: S108
+
+    def test_rejects_var_by_prefix(self) -> None:
+        with pytest.raises(ValueError, match="undermine the sandbox"):
+            create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/var/run/secrets"])
+
+    def test_rejects_opt_by_prefix(self) -> None:
+        with pytest.raises(ValueError, match="undermine the sandbox"):
+            create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/opt/app-root"])
+
+    def test_rejects_sys_by_prefix(self) -> None:
+        with pytest.raises(ValueError, match="undermine the sandbox"):
+            create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/sys"])
+
+    def test_accepts_safe_extra_allowed_path(self) -> None:
+        ctx = create_sandbox_context(sandbox_enabled=True, extra_allowed_paths=["/data/shared"])
+        cleanup_sandbox(ctx["sandbox_dir"])
+
+    def test_extra_allowed_paths_in_pivot_root_command(self) -> None:
+        """Extra allowed paths must appear as quoted bind-mounts in the pivot_root script."""
+        extra_dir = tempfile.mkdtemp(prefix="test-extra-")
+        try:
+            cmd = ["bash", "-c", "echo test"]
+            result = build_pivot_root_command(cmd, "/tmp/sandbox", [extra_dir])  # noqa: S108
+            real_dir = os.path.realpath(extra_dir)
+            quoted = f"'{real_dir}'"
+            assert quoted in result[-1]
+            assert f"mount --bind {quoted}" in result[-1]
+        finally:
+            shutil.rmtree(extra_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupSandbox:
+    """Test sandbox cleanup."""
+
+    def test_removes_temp_directory(self) -> None:
+        sandbox_dir = tempfile.mkdtemp(prefix="test-sandbox-")
+        assert Path(sandbox_dir).exists()
+        cleanup_sandbox(sandbox_dir)
+        assert not Path(sandbox_dir).exists()
+
+    def test_handles_already_removed(self) -> None:
+        cleanup_sandbox("/nonexistent/sandbox/dir")
+
+    def test_removes_files_inside_sandbox(self) -> None:
+        sandbox_dir = tempfile.mkdtemp(prefix="test-sandbox-")
+        Path(sandbox_dir, "test_file.txt").write_text("content")
+        cleanup_sandbox(sandbox_dir)
+        assert not Path(sandbox_dir).exists()

--- a/backend/tools/test_sandbox_capabilities.py
+++ b/backend/tools/test_sandbox_capabilities.py
@@ -1,0 +1,358 @@
+"""Diagnostic script to verify sandbox capabilities inside a container.
+
+Run this inside the actual Syntara worker container to determine which
+sandbox tier is available before deploying the script node isolation fix.
+Must be run as the worker UID (1001), not root.
+
+Usage:
+    python3 tools/test_sandbox_capabilities.py
+
+    # Inside a running container:
+    podman exec <container> python3 /opt/app-root/src/tools/test_sandbox_capabilities.py
+
+    # Against the built image (as UID 1001, not root):
+    podman run --rm --user 1001 syntara:latest python3 tools/test_sandbox_capabilities.py
+"""
+
+import ctypes
+import ctypes.util
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PASS = "PASS"  # noqa: S105
+FAIL = "FAIL"
+SKIP = "SKIP"
+
+# Must match build_pivot_root_command in script_sandbox.py
+_UNSHARE_FLAGS = [
+    "--user",
+    "--map-root-user",
+    "--mount",
+    "--pid",
+    "--fork",
+    "--kill-child",
+]
+
+
+def _print_result(label: str, status: str, detail: str = "") -> None:
+    """Print a check result with pass/fail/skip marker."""
+    marker = {"PASS": "+", "FAIL": "-", "SKIP": "?"}[status]
+    msg = f"  [{marker}] {label}"
+    if detail:
+        msg += f" -- {detail}"
+    print(msg)
+
+
+def check_kernel_version() -> None:
+    """Report kernel version and whether it meets the Landlock minimum."""
+    print("\n== Kernel ==")
+    release = platform.release()
+    _print_result("Version", PASS, release)
+
+    major, minor = 0, 0
+    parts = release.split(".")
+    if len(parts) >= 2:  # noqa: PLR2004
+        try:
+            major = int(parts[0])
+            minor = int(parts[1])
+        except ValueError:
+            pass
+
+    if major > 5 or (major == 5 and minor >= 13):  # noqa: PLR2004
+        _print_result("Landlock capable (>= 5.13)", PASS)
+    else:
+        _print_result("Landlock capable (>= 5.13)", FAIL, f"kernel {major}.{minor} < 5.13")
+
+
+def check_landlock() -> tuple[str, int]:  # noqa: PLR0911
+    """Probe Landlock ABI version via syscall."""
+    print("\n== Tier 1: Landlock LSM ==")
+
+    libc_name = ctypes.util.find_library("c")
+    if not libc_name:
+        _print_result("libc available", FAIL, "ctypes.util.find_library('c') returned None")
+        return FAIL, -1
+
+    try:
+        libc = ctypes.CDLL(libc_name, use_errno=True)
+        libc.syscall.restype = ctypes.c_long
+    except OSError as e:
+        _print_result("libc loadable", FAIL, str(e))
+        return FAIL, -1
+
+    _print_result("libc available", PASS, libc_name)
+
+    arch = platform.machine()
+    if arch in ("x86_64", "aarch64"):
+        nr_create = 444
+    else:
+        _print_result("Architecture supported", FAIL, f"unknown syscall numbers for {arch}")
+        return FAIL, -1
+
+    _print_result("Architecture", PASS, arch)
+
+    result = libc.syscall(nr_create, 0, 0, 1)
+    errno_val = ctypes.get_errno()
+
+    if result >= 1:
+        _print_result("landlock_create_ruleset", PASS, f"ABI version {result}")
+        return PASS, result
+    if errno_val == 38:  # noqa: PLR2004
+        _print_result("landlock_create_ruleset", FAIL, "ENOSYS -- kernel compiled without Landlock")
+        return FAIL, -1
+    if errno_val == 95:  # noqa: PLR2004
+        _print_result("landlock_create_ruleset", FAIL, "EOPNOTSUPP -- Landlock disabled at boot")
+        return FAIL, -1
+    _print_result("landlock_create_ruleset", FAIL, f"returned {result}, errno={errno_val}")
+    return FAIL, -1
+
+
+def check_unshare_binary() -> str:
+    """Check if unshare(1) is installed."""
+    print("\n== Tier 2: User Namespace + Mount Namespace ==")
+
+    unshare_path = shutil.which("unshare")
+    if not unshare_path:
+        _print_result("unshare binary", FAIL, "not found on PATH")
+        return FAIL
+
+    _print_result("unshare binary", PASS, unshare_path)
+    return PASS
+
+
+def check_unshare_userns() -> str:
+    """Probe unshare with production flags."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["unshare", *_UNSHARE_FLAGS, "bash", "-c", "mount --make-rprivate /"],  # noqa: S607
+            check=False,
+            capture_output=True,
+            timeout=5,
+        )
+        label = f"unshare {' '.join(_UNSHARE_FLAGS)}"
+        if result.returncode == 0:
+            _print_result(label, PASS)
+            return PASS
+        stderr = result.stderr.decode(errors="replace").strip()
+        _print_result(label, FAIL, stderr)
+        return FAIL
+    except FileNotFoundError:
+        _print_result("unshare probe", SKIP, "unshare not installed")
+        return SKIP
+    except Exception as e:  # noqa: BLE001
+        _print_result("unshare probe", FAIL, str(e))
+        return FAIL
+
+
+def _production_wrapper(sandbox_dir: str, inner_script: str) -> str:
+    """Build a shell script matching production build_pivot_root_command."""
+    return (
+        "set -e; "
+        "mount --make-rprivate /; "
+        "NEWROOT=$(mktemp -d); "
+        "mount -t tmpfs tmpfs $NEWROOT; "
+        # Bind /usr only
+        "mkdir -p $NEWROOT/usr; "
+        "mount --bind /usr $NEWROOT/usr; "
+        # Symlinks for RHEL compat
+        "ln -sf usr/lib $NEWROOT/lib 2>/dev/null || true; "
+        "ln -sf usr/lib64 $NEWROOT/lib64 2>/dev/null || true; "
+        "ln -sf usr/bin $NEWROOT/bin 2>/dev/null || true; "
+        "ln -sf usr/sbin $NEWROOT/sbin 2>/dev/null || true; "
+        # Individual /dev nodes
+        "mkdir -p $NEWROOT/dev; "
+        "touch $NEWROOT/dev/null; mount --bind /dev/null $NEWROOT/dev/null; "
+        "touch $NEWROOT/dev/urandom; mount --bind /dev/urandom $NEWROOT/dev/urandom; "
+        # Fresh procfs (may fail)
+        "mkdir -p $NEWROOT/proc; "
+        "mount -t proc proc $NEWROOT/proc 2>/dev/null || true; "
+        # Private /tmp and sandbox dir
+        "mkdir -p $NEWROOT/tmp; chmod 1777 $NEWROOT/tmp; "
+        f"mkdir -p $NEWROOT{sandbox_dir}; "
+        # Pivot root
+        "mkdir -p $NEWROOT/old; "
+        "pivot_root $NEWROOT $NEWROOT/old; "
+        f"cd {sandbox_dir}; "
+        # Detach old root: umount first, tmpfs overlay as fallback
+        "if umount -l /old 2>/dev/null; then "
+        "rmdir /old 2>/dev/null || true; "
+        "else mount -t tmpfs tmpfs /old || exit 1; fi; "
+        # chmod sandbox for nested userns
+        f"chmod 1777 {sandbox_dir}; "
+        "chmod 1777 /tmp 2>/dev/null || true; "
+        # Drop privileges via nested userns, then run inner script
+        f"exec unshare --user -- bash -c {_shell_quote(inner_script)}"
+    )
+
+
+def _shell_quote(s: str) -> str:
+    """Single-quote a string for safe shell embedding."""
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def check_pivot_root() -> str:
+    """Test the full production wrapper: pivot_root, /old detach, nested unshare."""
+    try:
+        sandbox_dir = "/tmp/diag-sandbox"  # noqa: S108
+        script = _production_wrapper(sandbox_dir, "echo pivot_root_ok")
+        result = subprocess.run(  # noqa: S603
+            ["unshare", *_UNSHARE_FLAGS, "bash", "-c", script],  # noqa: S607
+            check=False,
+            capture_output=True,
+            timeout=10,
+        )
+        stdout = result.stdout.decode(errors="replace").strip()
+        if result.returncode == 0 and "pivot_root_ok" in stdout:
+            _print_result("pivot_root with production layout", PASS)
+            return PASS
+        stderr = result.stderr.decode(errors="replace").strip()
+        _print_result("pivot_root with production layout", FAIL, stderr)
+        return FAIL
+    except Exception as e:  # noqa: BLE001
+        _print_result("pivot_root with production layout", FAIL, str(e))
+        return FAIL
+
+
+def check_write_in_sandbox() -> str:
+    """Verify scripts can write to the sandbox dir after nested unshare."""
+    try:
+        sandbox_dir = "/tmp/diag-sandbox"  # noqa: S108
+        inner = "echo test_content > ./test_file.txt && cat ./test_file.txt && rm ./test_file.txt && echo write_ok"
+        script = _production_wrapper(sandbox_dir, inner)
+        result = subprocess.run(  # noqa: S603
+            ["unshare", *_UNSHARE_FLAGS, "bash", "-c", script],  # noqa: S607
+            check=False,
+            capture_output=True,
+            timeout=10,
+        )
+        stdout = result.stdout.decode(errors="replace").strip()
+        if "write_ok" in stdout:
+            _print_result("Write to sandbox dir (nested userns)", PASS)
+            return PASS
+        stderr = result.stderr.decode(errors="replace").strip()
+        _print_result("Write to sandbox dir (nested userns)", FAIL, stderr)
+        return FAIL
+    except Exception as e:  # noqa: BLE001
+        _print_result("Write to sandbox dir (nested userns)", FAIL, str(e))
+        return FAIL
+
+
+def check_secret_isolation() -> str:
+    """Verify secrets are blocked after pivot_root (production layout)."""
+    print("\n== Isolation Smoke Test ==")
+    try:
+        secret_dir = tempfile.mkdtemp(dir=str(Path.cwd()), prefix=".sandbox-test-")
+        secret_file = str(Path(secret_dir) / "test-secret.pem")
+        Path(secret_file).write_text("FAKE_SECRET_FOR_TESTING")
+
+        sandbox_dir = "/tmp/diag-sandbox"  # noqa: S108
+        inner = f"cat {secret_file} 2>&1 || echo SECRET_BLOCKED"
+        script = _production_wrapper(sandbox_dir, inner)
+        result = subprocess.run(  # noqa: S603
+            ["unshare", *_UNSHARE_FLAGS, "bash", "-c", script],  # noqa: S607
+            check=False,
+            capture_output=True,
+            timeout=10,
+        )
+        stdout = result.stdout.decode(errors="replace").strip()
+
+        if "FAKE_SECRET_FOR_TESTING" in stdout:
+            _print_result("Secret file blocked", FAIL, "secret was readable")
+            return FAIL
+        if "SECRET_BLOCKED" in stdout or "No such file" in stdout:
+            _print_result("Secret file blocked", PASS, "file not accessible")
+            return PASS
+        _print_result("Secret file blocked", FAIL, f"unexpected: {stdout[:100]}")
+        return FAIL
+    except Exception as e:  # noqa: BLE001
+        _print_result("Secret file blocked", FAIL, str(e))
+        return FAIL
+    finally:
+        shutil.rmtree(secret_dir, ignore_errors=True)
+
+
+def check_umount_old() -> str:
+    """Verify scripts cannot umount /old to reveal the original root."""
+    try:
+        sandbox_dir = "/tmp/diag-sandbox"  # noqa: S108
+        inner = "umount /old 2>/dev/null; cat /old/etc/hostname 2>/dev/null && echo OLD_LEAKED || echo OLD_SAFE"
+        script = _production_wrapper(sandbox_dir, inner)
+        result = subprocess.run(  # noqa: S603
+            ["unshare", *_UNSHARE_FLAGS, "bash", "-c", script],  # noqa: S607
+            check=False,
+            capture_output=True,
+            timeout=10,
+        )
+        stdout = result.stdout.decode(errors="replace").strip()
+        if "OLD_SAFE" in stdout:
+            _print_result("Script cannot reveal /old", PASS)
+            return PASS
+        if "OLD_LEAKED" in stdout:
+            _print_result("Script cannot reveal /old", FAIL, "host files readable after umount")
+            return FAIL
+        _print_result("Script cannot reveal /old", FAIL, f"unexpected: {stdout[:100]}")
+        return FAIL
+    except Exception as e:  # noqa: BLE001
+        _print_result("Script cannot reveal /old", FAIL, str(e))
+        return FAIL
+
+
+def main() -> None:
+    """Run all capability checks and report which sandbox tier would be active."""
+    print("=" * 60)
+    print("Script Node Sandbox Capability Diagnostic")
+    print(f"Python: {sys.executable} ({platform.python_version()})")
+    print(f"PID: {os.getpid()} | UID: {os.getuid()} | GID: {os.getgid()}")
+    print("=" * 60)
+
+    check_kernel_version()
+
+    landlock_status, abi_version = check_landlock()
+
+    unshare_bin = check_unshare_binary()
+
+    unshare_userns = SKIP
+    pivot = SKIP
+    write = SKIP
+    isolation = SKIP
+    umount_old = SKIP
+
+    if unshare_bin == PASS:
+        unshare_userns = check_unshare_userns()
+
+        if unshare_userns == PASS:
+            pivot = check_pivot_root()
+
+            if pivot == PASS:
+                write = check_write_in_sandbox()
+                isolation = check_secret_isolation()
+                umount_old = check_umount_old()
+
+    print("\n" + "=" * 60)
+    print("RESULT")
+    print("=" * 60)
+
+    if landlock_status == PASS:
+        print(f"\n  Active tier: Landlock LSM (ABI v{abi_version})")
+        print("  Filesystem isolation: kernel-enforced allowlist")
+    elif pivot == PASS:
+        print("\n  Active tier: User namespace + mount namespace (unshare)")
+        print("  Filesystem isolation: pivot_root with bind-mount allowlist")
+        results = {"write": write, "isolation": isolation, "umount_old": umount_old}
+        for name, status in results.items():
+            marker = "OK" if status == PASS else "FAILED"
+            print(f"  {name}: {marker}")
+    else:
+        print("\n  Active tier: NONE — script execution will be REFUSED")
+        print("  Install util-linux, enable user namespaces, or upgrade kernel")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


## Description

Script nodes executed user-supplied code with full access to the Temporal worker filesystem, allowing extraction of JWT signing keys and other secrets. This adds a tiered allowlist-based sandbox:

- Tier 1 (Landlock LSM): kernel-enforced filesystem allowlist via syscalls
- Tier 2 (unshare + pivot_root): bind-mount allowlist with PID namespace isolation and CAP_SYS_ADMIN drop via nested user namespace
- Fail-closed: execution refused when neither tier is available

Verified end-to-end on AWS RHEL 8 (kernel 4.18, Tier 2) and AWS RHEL 9 (kernel 5.14, Tier 1/Landlock ABI v6).

Assisted-by: Claude Code / Opus 4.6 (Anthropic)

# Detailed changes report

# AAP-87783: Script Node Filesystem Sandbox — Changes Report

## Problem

Script nodes execute user-supplied code (bash/Python) as direct subprocesses of the Temporal worker container with no filesystem isolation. An attacker with workflow creation permission can:

1. Read JWT signing keys from the filesystem (e.g. `/run/secrets/jwt-primary.pem`)
2. Read encryption keys, database credentials, and S2S TLS keys
3. Read worker environment variables via `/proc/<worker_pid>/environ`
4. Forge valid JWT tokens for any user including admin — full account takeover

The existing mitigation was environment variable allowlisting (`SAFE_ENV_ALLOWLIST`) and a feature gate (`APP_SCRIPT_NODES_ENABLED` defaults to `False`). Neither prevents filesystem reads.

## Design Decision: Tiered Allowlist Sandbox

We replaced the deny-list approach (masking known secret paths) with an **allowlist** — only explicitly permitted filesystem paths are accessible. Everything else, including secrets, is blocked automatically without needing to enumerate secret locations.

### Why tiered?

No single mechanism works across all deployment targets:

- **Landlock LSM** is the cleanest solution (kernel-enforced, no capabilities needed) but RHEL 9 default kernels do not compile it. RHEL 9 on AWS (tested: kernel 5.14.0-687) has Landlock ABI v6 — this is a custom kernel build, not the RHEL 9 default. Stock RHEL 9 returns `EOPNOTSUPP`.
- **User namespace + mount namespace** (`unshare`) works on RHEL 8/9 but requires `util-linux` (for `pivot_root`) and user namespace support from the container runtime.
- Neither may be available (e.g. OpenShift with restricted security policies).

### Detection flow (runtime, no RHEL version assumptions)

```
1. Probe landlock_create_ruleset syscall
   ├─ Returns ABI version (1+) → Tier 1: Landlock
   └─ Returns ENOSYS/EOPNOTSUPP ↓
2. Probe unshare --user --map-root-user --mount --pid --fork --kill-child
   ├─ Succeeds (exit 0) → Tier 2: unshare + pivot_root
   └─ Fails ↓
3. script_sandbox_enabled=True → RuntimeError (fail-closed)
   script_sandbox_enabled=False → Baseline preexec only
```

Both probes are cached per process lifetime (one syscall / one subprocess at worker startup).

### Tier 1: Landlock LSM

- Kernel-enforced per-process filesystem allowlist via `landlock_create_ruleset`, `landlock_add_rule`, `landlock_restrict_self` syscalls (ctypes)
- Applied in `preexec_fn` — restricts only the child process, not the Temporal worker
- Struct packing (`_pack_ = 1`) required to match kernel's 12-byte `landlock_path_beneath_attr` layout
- ABI-version-aware: `handled_access_fs` bitmask adapts to v1/v2/v3 to avoid `EINVAL` on older kernels
- `READ_DIR` automatically stripped for non-directory paths (files, device nodes) — kernel rejects it otherwise
- `/proc` is traverse-only (`READ_DIR`); `/proc/self` gets `READ_ONLY` — prevents reading `/proc/<worker_pid>/environ`
- `/etc` is traverse-only; individual files (resolv.conf, hosts, etc.) get per-file `READ_FILE` rules
- `/dev` is traverse-only; only `/dev/null`, `/dev/urandom`, `/dev/zero` are allowed
- `sandbox_dir` rule failure is fatal — `_apply_landlock_sandbox` returns False, `os._exit(1)` in child with stderr message
- Scripts run as the original UID (1001)

### Tier 2: User namespace + mount namespace

- `unshare --user --map-root-user --mount --pid --fork --kill-child` creates isolated namespaces
- `--map-root-user` required because UID 1001 cannot call `mount`/`pivot_root` without root mapping
- `--pid --fork` creates a PID namespace so fresh procfs only shows the script's processes (worker PIDs invisible)
- `--kill-child` ensures the forked PID 1 is reaped on activity timeout
- Bind-mount allowlist: only `/usr`, individual `/dev` nodes, specific `/etc` entries, and Python runtime paths
- `pivot_root` swaps the root to the new tmpfs; old root detached via `umount -l` (fallback: tmpfs overlay on `/old`)
- `chmod 1777` on sandbox dir and `/tmp` before privilege drop
- `exec unshare --user --` (without `--map-root-user`) drops `CAP_SYS_ADMIN` before script exec — prevents `umount /old`
- Scripts run as UID 65534 (nobody) — deliberate security measure to prevent mount namespace escape
- All paths in the shell wrapper are shell-quoted for safety

### Tier 3: Baseline preexec hardening (always applied)

Applied on every tier as a baseline:
- Ephemeral sandbox temp directory as CWD
- `PR_SET_NO_NEW_PRIVS` (prevents privilege escalation)
- Dropped supplementary groups
- Restrictive umask (`0o077`)
- Environment variable allowlisting (existing `SAFE_ENV_ALLOWLIST`)
- PATH sanitized to standard system directories only
- TMPDIR/TMP/TEMP set to sandbox directory
- Python executable resolved via `os.path.realpath()` to avoid venv symlinks outside allowlist

### Fail-closed behavior

When `script_sandbox_enabled=True` (default) and neither Landlock nor unshare is available, script execution is **refused** with a non-retryable `SandboxUnavailable` error. This is the correct default — operators must explicitly set `script_sandbox_enabled=False` to accept the risk.

### Operator configuration

| Setting | Default | Description |
|---------|---------|-------------|
| `APP_SCRIPT_NODES_ENABLED` | `false` | Feature gate for script nodes (unchanged) |
| `APP_SCRIPT_SANDBOX_ENABLED` | `true` | Enable filesystem sandbox |
| `APP_SCRIPT_SANDBOX_ALLOWED_PATHS` | `[]` | Extra read-only paths (denied prefixes: `/proc`, `/etc`, `/run`, `/dev`, `/sys`, `/tmp`, `/home`, `/root`, `/opt`, `/var`) |

## Files Changed

| File | Change |
|------|--------|
| `backend/src/syntara/workflows/workflow_engine/activities/script_sandbox.py` | **Rewritten** — tiered Landlock/unshare/baseline sandbox (~600 lines) |
| `backend/src/syntara/workflows/workflow_engine/activities/script_activity.py` | Updated imports, sandbox integration, PATH sanitization, Python exe resolution, tier logging, `SandboxUnavailable` error |
| `backend/src/syntara/core/config/base.py` | New settings: `script_sandbox_enabled`, `script_sandbox_allowed_paths`; updated security comments |
| `backend/containers/syntara/Containerfile` | Added `util-linux` to `microdnf install` (provides `unshare` + `pivot_root`) |
| `backend/.env.example` | Documented new settings |
| `backend/tests/unit/workflows/activities/test_script_sandbox.py` | **Rewritten** — 55+ tests covering both tiers, detection, allowlist, denied prefixes, preexec, cleanup |
| `backend/tests/unit/workflows/activities/test_script_activity.py` | Updated 2 existing tests for sandbox compat; added 15+ integration regression tests including unshare-specific tests |
| `backend/tools/test_sandbox_capabilities.py` | **New** — diagnostic script matching production wrapper for container validation |

## How We Tested

### Unit tests (179 passing)

Run in the Carbonite sandbox (Fedora kernel 6.18, Landlock ABI v7):

```bash
pytest tests/unit/workflows/activities/test_script_sandbox.py \
       tests/unit/workflows/activities/test_script_activity.py
# 179 passed, 9 warnings
```

Key test classes:
- `TestLandlockDetection` — ABI probe, caching, libc unavailability
- `TestUnshareDetection` — probe with full production flags, caching
- `TestHandledAccessForAbi` — ABI v1/v2/v3/v7 bitmask computation
- `TestAllowedPaths` — allowlist contents, `/run`/`/etc/secrets` excluded, `/etc` and `/proc` traverse-only
- `TestSandboxPreexecFn` — CWD, umask, Landlock calls, negative ABI skip
- `TestBuildPivotRootCommand` — `--map-root-user`, `--kill-child`, quoted paths, `exec bash -c`, fresh procfs, tmpfs /tmp, nested unshare
- `TestCreateSandboxContext` — tier selection, fallback, fail-closed, denied extra paths
- `TestDropSupplementaryGroups` — error handling
- `TestScriptSandboxIntegration` — end-to-end: secret reads blocked, `/proc/<pid>/environ` blocked, `/etc/shadow` blocked, CWD in sandbox, sandbox cleanup, `PR_SET_NO_NEW_PRIVS`, PATH sanitized
- `TestScriptSandboxUnshare` — forces Landlock off, verifies secret isolation and umount protection on unshare tier

### Diagnostic script

`backend/tools/test_sandbox_capabilities.py` — standalone script that reproduces the production wrapper (umount-or-tmpfs, chmod 1777, nested `unshare --user`) and checks:
- Kernel version and Landlock ABI
- `unshare` with full production flags
- `pivot_root` with production bind-mount layout
- Write to sandbox dir in nested user namespace
- Secret file blocked after pivot_root
- Script cannot `umount /old` to reveal host filesystem

### Why RHEL 8?

RHEL 8 uses kernel 4.18 — well below Landlock's 5.13 minimum. Landlock is guaranteed to return `ENOSYS`, forcing the sandbox to Tier 2 (unshare + pivot_root). This validates the production fallback path that stock RHEL 9 deployments may also use.

### Why RHEL 9?

RHEL 9 on AWS (kernel 5.14.0-687.10.1.el9_8) has Landlock ABI v6 — a custom kernel build. Stock RHEL 9 does not compile `CONFIG_SECURITY_LANDLOCK` by default and returns `EOPNOTSUPP`. Testing on AWS RHEL 9 validates the Landlock tier, but operators on stock RHEL 9 will use Tier 2 (unshare) instead.

### Infrastructure test results

#### RHEL 8 — AWS EC2 (kernel 4.18.0-553, Tier 2: unshare)

**Diagnostic:**
```
Active tier: User namespace + mount namespace (unshare)
Filesystem isolation: pivot_root with bind-mount allowlist
write: OK | isolation: OK | umount_old: OK
```

**Workflow script nodes (executed through Temporal worker):**

| Test | Script | Result |
|------|--------|--------|
| Write | `tempfile.NamedTemporaryFile(dir='.')` | `WRITE_OK: /tmp/script-sandbox-eoj76xhn/...` |
| Secrets | `os.listdir('/run/secrets')` etc. | All 4 paths `BLOCKED` (including `/opt/app-root`) |
| Env | `os.environ` APP_* check | `APP_VARS=0`, `UID=65534`, sandbox CWD, TMPDIR set |
| /proc | `open('/proc/<ppid>/environ')` | `BLOCKED:proc_environ`, `/proc/self` unavailable (proc mount restricted on kernel 4.18) |

**UID=65534 (nobody)** — deliberate. The nested `unshare --user` (without `--map-root-user`) drops `CAP_SYS_ADMIN` so the script cannot `umount /old` to reveal the host filesystem. On Landlock (Tier 1), this isn't needed because Landlock is kernel-enforced, so scripts keep UID 1001.

#### RHEL 9 — AWS EC2 (kernel 5.14.0-687, Tier 1: Landlock ABI v6)

**Diagnostic:**
```
Active tier: Landlock LSM (ABI v6)
Filesystem isolation: kernel-enforced allowlist
```

**Workflow script nodes (executed through Temporal worker):**

| Test | Script | Result |
|------|--------|--------|
| Write | `tempfile.NamedTemporaryFile(dir='.')` | `WRITE_OK: /tmp/script-sandbox-u58nf7zk/...` |
| Secrets | `os.listdir('/run/secrets')` etc. | All 4 paths `BLOCKED` |
| Env | `os.environ` APP_* check | `APP_VARS=0`, `UID=1001`, sandbox CWD, TMPDIR set |
| /proc | `open('/proc/<ppid>/environ')` | `BLOCKED:proc_environ`, `PROC_SELF:OK` |

### Side-by-side comparison

| Test | RHEL 8 (Tier 2 — unshare) | RHEL 9 (Tier 1 — Landlock) |
|------|---------------------------|---------------------------|
| **Kernel** | 4.18.0-553 (no Landlock) | 5.14.0-687 (Landlock ABI v6) |
| **Active tier** | unshare + pivot_root | Landlock LSM |
| **Script 1 — Write** | `WRITE_OK` | `WRITE_OK` |
| **Script 2 — Secrets** | All 4 `BLOCKED` | All 4 `BLOCKED` |
| **Script 3 — Env/sandbox** | `APP_VARS=0`, `UID=65534`, sandbox CWD | `APP_VARS=0`, `UID=1001`, sandbox CWD |
| **Script 4 — /proc** | `BLOCKED:proc_environ`, `/proc/self` unavailable | `BLOCKED:proc_environ`, `PROC_SELF:OK` |

**UID difference explained:** Tier 2 runs scripts as UID 65534 (nobody) because the nested `unshare --user` (without `--map-root-user`) drops `CAP_SYS_ADMIN` to prevent `umount /old`. Tier 1 (Landlock) doesn't need this — Landlock is kernel-enforced and cannot be undone from userspace, so scripts keep UID 1001.

**`/proc/self` difference explained:** On RHEL 8 (kernel 4.18), the fresh procfs mount fails inside the user namespace (`mount -t proc` restricted). The wrapper handles this gracefully (`|| true`). On RHEL 9, Landlock allows `/proc/self` via the allowlist without needing a mount.

### Test scripts used

**Script 1 — Write test:**
```python
import tempfile, os
f = tempfile.NamedTemporaryFile(dir='.', delete=False, suffix='.txt')
f.write(b'write test ok')
f.close()
print(f'WRITE_OK: {f.name}')
os.unlink(f.name)
```

**Script 2 — Secret read test:**
```python
import os
for path in ['/run/secrets', '/etc/secrets', '/root', '/opt/app-root']:
    try:
        os.listdir(path)
        print(f'LEAKED:{path}')
    except (PermissionError, FileNotFoundError):
        print(f'BLOCKED:{path}')
```

**Script 3 — Worker env test:**
```python
import os
app_vars = [k for k in os.environ if k.startswith('APP_')]
print(f'APP_VARS={len(app_vars)}')
print(f'UID={os.getuid()}')
print(f'CWD={os.getcwd()}')
print(f'TMPDIR={os.environ.get("TMPDIR", "not set")}')
```

**Script 4 — Worker /proc test:**
```python
import os
worker_ppid = os.getppid()
try:
    data = open(f'/proc/{worker_ppid}/environ', 'rb').read()
    print(f'LEAKED:{len(data)} bytes')
except (PermissionError, FileNotFoundError):
    print('BLOCKED:proc_environ')
try:
    open('/proc/self/status').readline()
    print('PROC_SELF:OK')
except (PermissionError, FileNotFoundError):
    print('PROC_SELF:BLOCKED')
```

## Key Discoveries During Implementation

1. **Landlock struct packing** — `_LandlockPathBeneathAttr` requires `_pack_ = 1` (12 bytes). Without packing, ctypes adds 4 bytes of padding, corrupting the `parent_fd` value the kernel reads.

2. **Landlock directory traversal** — Individual path rules (e.g. `/usr/bin`) don't work; Landlock needs a rule on the parent directory (`/usr`) for path traversal. Individual `/etc` files need `/etc` with `READ_DIR` (traverse-only) plus per-file `READ_FILE` rules.

3. **`READ_DIR` invalid for non-directories** — The kernel rejects `READ_DIR` on files, device nodes, and symlinks with `EINVAL`. Must strip `READ_DIR` for any non-directory path (`if not os.path.isdir(real_path)`).

4. **PATH sanitization required** — The worker's PATH includes directories outside the Landlock allowlist (e.g. venv paths). Python's subprocess PATH search hits `EACCES` on blocked directories and reports it as the error, even when the binary exists in a later allowed directory. Fix: sanitize PATH to standard system directories only.

5. **Python executable resolution** — Venv symlinks (e.g. `/opt/app-root/.venv/bin/python3`) point outside the allowlist. Must use `os.path.realpath(sys.executable)` to get the real path (e.g. `/usr/bin/python3.12`).

6. **Venv `platstdlib` leak** — `sysconfig.get_path("platstdlib")` returns a real directory under `/opt/app-root/.venv/` (not a symlink to `/usr`). The Tier 2 wrapper bind-mounted it, exposing the entire `/opt/app-root` tree. Fix: only include Python runtime paths under `/usr`.

7. **`pivot_root` requires `util-linux`** (full package) — `util-linux-core` provides `unshare` but not `pivot_root`. Changed Containerfile to install `util-linux`.

8. **`--map-root-user` required** — Worker runs as UID 1001. Without `--map-root-user`, `mount` and `pivot_root` fail with `EPERM` inside the user namespace.

9. **`umount -l /old` unreliable** — Requires `/proc/mounts` which may not be available (proc mount can fail on kernel 4.18). Fallback: tmpfs overlay on `/old`. Both paths protected by nested `unshare --user` to prevent script from undoing the overlay.

10. **RHEL 9 Landlock availability varies** — AWS RHEL 9 (kernel 5.14.0-687) has Landlock ABI v6. Stock RHEL 9 does not compile `CONFIG_SECURITY_LANDLOCK` by default. Runtime detection handles both cases.

## Residual Items (documented, not blockers)

- **Network unrestricted** — scripts can still make outbound network requests. Not in scope per  (Jira ticket covers filesystem secret access, not network exfiltration). Landlock ABI v4+ supports network rules for a future enhancement.
- **Landlock has no PID namespace** — Tier 2 uses `--pid --fork`; Tier 1 does not. `/proc` traverse-only mitigates this.
- **`preexec_fn` threading risk** — Temporal workers are multi-threaded. Landlock application in `preexec_fn` uses only thin POSIX wrappers to minimize deadlock risk. Documented in code; a compiled helper binary is the durable fix.
- **Scripts are stdlib-only** — venv site-packages are not on the allowlist. By design; operators cannot add `/opt` via `APP_SCRIPT_SANDBOX_ALLOWED_PATHS` (denied prefix).
- **`/dev/shm` blocked** — only `/dev/null`, `/dev/urandom`, `/dev/zero` are allowed. Scripts needing shared memory will fail.
- **HOME unchanged** — writes to `~` fail under the allowlist. TMPDIR/TMP/TEMP point to the sandbox dir.




## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [ ] List the specific changes made
- [ ] Include any new dependencies or configuration changes

## Out of Scope

<!-- What this PR intentionally does NOT include, to set reviewer expectations -->

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## How to Test

<!-- Manual testing directions, for example:
1. Log in as an admin
2. Go to the `/workflows` route
3. Click on a thing
4. Validate that something changed
-->

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [ ] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [ ] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->
