### PR TITLE
fix(AAP-88713): Approval fallback_decision validation now respects system continue_on_default_setting

### DIFF
--- a/backend/src/syntara/workflows/router.py
+++ b/backend/src/syntara/workflows/router.py
@@ -21,7 +21,6 @@ from syntara.authz.engine import VisibilityResult
 from syntara.core.database.session import get_db
 from syntara.core.models import User
 from syntara.core.syntara_router import NO_PERMISSION, SyntaraRouter
-from syntara.settings.cache.settings_cache import get_runtime_settings
 from syntara.workflows.error_handlers import build_validation_problem_response
 from syntara.workflows.exceptions import WorkflowDefinitionInvalidError
 from syntara.workflows.executions_router import get_temporal_execution_service
@@ -51,19 +50,13 @@ from syntara.workflows.models.execution import ExecutionRead, TestExecutionCreat
 from syntara.workflows.models.workflow_definition import WorkflowDefinition
 from syntara.workflows.services import ExecutionService, WorkflowService
 from syntara.workflows.utils.serialization import deserialize_workflow_version
-from syntara.workflows.validators import workflow_validator
+from syntara.workflows.validators import get_system_continue_on_failure, workflow_validator
 from syntara.workflows.workflow_engine.services.temporal_execution_service import TemporalExecutionService
 
 
 def _has_validation_issues(result: ValidationResult) -> bool:
     """Return True when the validation result has errors or warnings."""
     return result.error_count > 0 or result.warning_count > 0
-
-
-async def _get_system_continue_on_failure() -> bool:
-    """Fetch the admin-level continue_on_failure default from settings cache."""
-    cache = get_runtime_settings()
-    return await cache.get_bool("workflow_engine.continue_on_failure", default=False)
 
 
 class _ValidationRoute(APIRoute):
@@ -259,10 +252,11 @@ async def validate_workflow_definition(
     """Validate a workflow definition without saving it.
 
     Requires authentication but no specific workflow/project permission:
-    validation is a stateless, side-effect-free check of caller-supplied
-    data with no workflow_id or project_id in scope to authorize against.
+    no workflow_id or project_id is in scope to authorize against.
+    Reads the admin-level continue_on_failure default from the settings
+    cache to resolve approval fallback_decision warnings accurately.
     """
-    system_cof = await _get_system_continue_on_failure()
+    system_cof = await get_system_continue_on_failure()
     result = workflow_validator.collect_findings(
         request.workflow_definition,
         system_continue_on_failure=system_cof,

--- a/backend/src/syntara/workflows/router.py
+++ b/backend/src/syntara/workflows/router.py
@@ -252,9 +252,8 @@ async def validate_workflow_definition(
     """Validate a workflow definition without saving it.
 
     Requires authentication but no specific workflow/project permission:
-    no workflow_id or project_id is in scope to authorize against.
-    Reads the admin-level continue_on_failure default from the settings
-    cache to resolve approval fallback_decision warnings accurately.
+    validation is a stateless, side-effect-free check of caller-supplied
+    data with no workflow_id or project_id in scope to authorize against.
     """
     system_cof = await get_system_continue_on_failure()
     result = workflow_validator.collect_findings(

--- a/backend/src/syntara/workflows/router.py
+++ b/backend/src/syntara/workflows/router.py
@@ -21,6 +21,7 @@ from syntara.authz.engine import VisibilityResult
 from syntara.core.database.session import get_db
 from syntara.core.models import User
 from syntara.core.syntara_router import NO_PERMISSION, SyntaraRouter
+from syntara.settings.cache.settings_cache import get_runtime_settings
 from syntara.workflows.error_handlers import build_validation_problem_response
 from syntara.workflows.exceptions import WorkflowDefinitionInvalidError
 from syntara.workflows.executions_router import get_temporal_execution_service
@@ -57,6 +58,12 @@ from syntara.workflows.workflow_engine.services.temporal_execution_service impor
 def _has_validation_issues(result: ValidationResult) -> bool:
     """Return True when the validation result has errors or warnings."""
     return result.error_count > 0 or result.warning_count > 0
+
+
+async def _get_system_continue_on_failure() -> bool:
+    """Fetch the admin-level continue_on_failure default from settings cache."""
+    cache = get_runtime_settings()
+    return await cache.get_bool("workflow_engine.continue_on_failure", default=False)
 
 
 class _ValidationRoute(APIRoute):
@@ -255,7 +262,11 @@ async def validate_workflow_definition(
     validation is a stateless, side-effect-free check of caller-supplied
     data with no workflow_id or project_id in scope to authorize against.
     """
-    result = workflow_validator.collect_findings(request.workflow_definition)
+    system_cof = await _get_system_continue_on_failure()
+    result = workflow_validator.collect_findings(
+        request.workflow_definition,
+        system_continue_on_failure=system_cof,
+    )
     if not result.is_valid:
         raise WorkflowDefinitionInvalidError(result)
     return result

--- a/backend/src/syntara/workflows/services/workflow_service.py
+++ b/backend/src/syntara/workflows/services/workflow_service.py
@@ -29,7 +29,6 @@ from syntara.credentials.models.credential import Credential
 from syntara.credentials.models.credential_type import CredentialType
 from syntara.metrics.dependencies import get_metrics_recorder
 from syntara.metrics.types import ComponentLabel, MetricType
-from syntara.settings.cache.settings_cache import get_runtime_settings
 from syntara.workflows.audit.workflow_lifecycle import WorkflowAction, WorkflowLifecycleEvent
 from syntara.workflows.audit.workflow_version import (
     WorkflowVersionCreatedEvent,
@@ -61,7 +60,11 @@ from syntara.workflows.models.workflow_publish_event import PublishAction, Workf
 from syntara.workflows.services.scheduled_trigger_service import ScheduledTriggerService
 from syntara.workflows.services.webhook_trigger_service import WEBHOOK_TRIGGER_TYPES, WebhookTriggerService
 from syntara.workflows.services.workflow_diff import generate_change_summary
-from syntara.workflows.validators import validate_workflow_references, workflow_validator
+from syntara.workflows.validators import (
+    get_system_continue_on_failure,
+    validate_workflow_references,
+    workflow_validator,
+)
 
 if TYPE_CHECKING:
     from syntara.workflows.models import WorkflowVersionListResponse
@@ -85,12 +88,6 @@ def reset_workflow_creation_counters() -> None:
 def _has_validation_issues(result: ValidationResult) -> bool:
     """Return True when the validation result has errors or warnings."""
     return result.error_count > 0 or result.warning_count > 0
-
-
-async def _get_system_continue_on_failure() -> bool:
-    """Fetch the admin-level continue_on_failure default from settings cache."""
-    cache = get_runtime_settings()
-    return await cache.get_bool("workflow_engine.continue_on_failure", default=False)
 
 
 class WorkflowConvertResourceMixin(ConvertResourceMixin):
@@ -489,7 +486,7 @@ class WorkflowService(BaseService):
         """
         recorder = get_metrics_recorder()
         component = ComponentLabel.WORKFLOW_ENGINE
-        system_cof = await _get_system_continue_on_failure()
+        system_cof = await get_system_continue_on_failure()
 
         with recorder.time(
             MetricType.WORKFLOW_VALIDATION_DURATION,
@@ -1042,7 +1039,7 @@ class WorkflowService(BaseService):
 
         """
         recorder = get_metrics_recorder()
-        system_cof = await _get_system_continue_on_failure()
+        system_cof = await get_system_continue_on_failure()
 
         with recorder.time(
             MetricType.WORKFLOW_VALIDATION_DURATION,
@@ -1237,7 +1234,7 @@ class WorkflowService(BaseService):
             )
 
         definition = target_version.workflow_definition
-        system_cof = await _get_system_continue_on_failure()
+        system_cof = await get_system_continue_on_failure()
         result = workflow_validator.collect_findings(
             definition,
             system_continue_on_failure=system_cof,

--- a/backend/src/syntara/workflows/services/workflow_service.py
+++ b/backend/src/syntara/workflows/services/workflow_service.py
@@ -29,6 +29,7 @@ from syntara.credentials.models.credential import Credential
 from syntara.credentials.models.credential_type import CredentialType
 from syntara.metrics.dependencies import get_metrics_recorder
 from syntara.metrics.types import ComponentLabel, MetricType
+from syntara.settings.cache.settings_cache import get_runtime_settings
 from syntara.workflows.audit.workflow_lifecycle import WorkflowAction, WorkflowLifecycleEvent
 from syntara.workflows.audit.workflow_version import (
     WorkflowVersionCreatedEvent,
@@ -84,6 +85,12 @@ def reset_workflow_creation_counters() -> None:
 def _has_validation_issues(result: ValidationResult) -> bool:
     """Return True when the validation result has errors or warnings."""
     return result.error_count > 0 or result.warning_count > 0
+
+
+async def _get_system_continue_on_failure() -> bool:
+    """Fetch the admin-level continue_on_failure default from settings cache."""
+    cache = get_runtime_settings()
+    return await cache.get_bool("workflow_engine.continue_on_failure", default=False)
 
 
 class WorkflowConvertResourceMixin(ConvertResourceMixin):
@@ -482,12 +489,16 @@ class WorkflowService(BaseService):
         """
         recorder = get_metrics_recorder()
         component = ComponentLabel.WORKFLOW_ENGINE
+        system_cof = await _get_system_continue_on_failure()
 
         with recorder.time(
             MetricType.WORKFLOW_VALIDATION_DURATION,
             labels={"component": component.value, "operation": "create"},
         ):
-            result = workflow_validator.collect_findings(workflow_definition)
+            result = workflow_validator.collect_findings(
+                workflow_definition,
+                system_continue_on_failure=system_cof,
+            )
 
         has_validation_issues = _has_validation_issues(result)
         if has_validation_issues:
@@ -1031,12 +1042,16 @@ class WorkflowService(BaseService):
 
         """
         recorder = get_metrics_recorder()
+        system_cof = await _get_system_continue_on_failure()
 
         with recorder.time(
             MetricType.WORKFLOW_VALIDATION_DURATION,
             labels={"component": ComponentLabel.WORKFLOW_ENGINE.value, "operation": "version_update"},
         ):
-            result = workflow_validator.collect_findings(workflow_definition)
+            result = workflow_validator.collect_findings(
+                workflow_definition,
+                system_continue_on_failure=system_cof,
+            )
 
         workflow.has_validation_issues = _has_validation_issues(result)
         if workflow.has_validation_issues:
@@ -1222,7 +1237,11 @@ class WorkflowService(BaseService):
             )
 
         definition = target_version.workflow_definition
-        result = workflow_validator.collect_findings(definition)
+        system_cof = await _get_system_continue_on_failure()
+        result = workflow_validator.collect_findings(
+            definition,
+            system_continue_on_failure=system_cof,
+        )
         if len(definition.get("nodes", [])) == 0:
             result = ValidationResult.from_findings(
                 [

--- a/backend/src/syntara/workflows/validators/__init__.py
+++ b/backend/src/syntara/workflows/validators/__init__.py
@@ -3,15 +3,25 @@
 This module provides validation for workflow definitions and metadata.
 """
 
+from syntara.settings.cache.settings_cache import get_runtime_settings
+
 from .workflow_definition import WorkflowValidator, collect_scheduled_trigger_config_findings
 from .workflow_integrations import validate_workflow_references
 
 # Convenience singleton instance for easy usage
 workflow_validator = WorkflowValidator()
 
+
+async def get_system_continue_on_failure() -> bool:
+    """Fetch the admin-level continue_on_failure default from settings cache."""
+    cache = get_runtime_settings()
+    return await cache.get_bool("workflow_engine.continue_on_failure", default=False)
+
+
 __all__ = [
     "WorkflowValidator",
     "collect_scheduled_trigger_config_findings",
+    "get_system_continue_on_failure",
     "validate_workflow_references",
     "workflow_validator",
 ]

--- a/backend/src/syntara/workflows/validators/workflow_definition.py
+++ b/backend/src/syntara/workflows/validators/workflow_definition.py
@@ -226,6 +226,8 @@ def _check_converge_node_findings(
 
 def _check_approval_node_findings(
     workflow_definition: dict[str, Any],
+    *,
+    system_continue_on_failure: bool = False,
 ) -> list[ValidationFinding]:
     """Warn when fallback_decision is set without continue_on_failure."""
     findings: list[ValidationFinding] = []
@@ -237,7 +239,9 @@ def _check_approval_node_findings(
             continue
         params = node.get("parameters", {})
         settings = node.get("settings") or {}
-        if params.get("fallback_decision") == "approve" and not settings.get("continue_on_failure"):
+        node_cof = settings.get("continue_on_failure")
+        effective_cof = node_cof if node_cof is not None else system_continue_on_failure
+        if params.get("fallback_decision") == "approve" and not effective_cof:
             node_name = node.get("name") or node_id
             findings.append(
                 ValidationFinding(
@@ -247,7 +251,7 @@ def _check_approval_node_findings(
                         f"Approval step '{node_name}' has fallback_decision set to 'approve' "
                         f"but continue_on_failure is not enabled. "
                         f"The fallback will have no effect unless "
-                        f"continue_on_failure is enabled in the step settings."
+                        f"continue_on_failure is enabled in the step or system settings."
                     ),
                     node_id=node_id,
                     field_path="parameters.fallback_decision",
@@ -528,11 +532,19 @@ class WorkflowValidator:
         msg = f"Workflow definition schema validation failed: {'; '.join(details)}"
         raise SafeValueError(msg)
 
-    def _collect_findings(self, workflow_definition: dict[str, Any]) -> list[ValidationFinding]:
+    def _collect_findings(
+        self,
+        workflow_definition: dict[str, Any],
+        *,
+        system_continue_on_failure: bool = False,
+    ) -> list[ValidationFinding]:
         """Run all validators and return individual findings.
 
         Args:
             workflow_definition: Workflow definition dictionary to validate
+            system_continue_on_failure: Admin-level default for continue_on_failure,
+                used to resolve approval fallback_decision warnings when a node
+                inherits the system default.
 
         Returns:
             List of ValidationFinding objects, one per issue
@@ -574,7 +586,12 @@ class WorkflowValidator:
             findings.extend(_check_cycles_findings(workflow_definition, node_ids))
             findings.extend(_check_orphaned_nodes_findings(workflow_definition, node_ids))
             findings.extend(_check_converge_node_findings(workflow_definition))
-            findings.extend(_check_approval_node_findings(workflow_definition))
+            findings.extend(
+                _check_approval_node_findings(
+                    workflow_definition,
+                    system_continue_on_failure=system_continue_on_failure,
+                )
+            )
             findings.extend(check_template_expressions(workflow_definition, node_ids))
 
         findings.extend(collect_scheduled_trigger_config_findings(workflow_definition))
@@ -613,17 +630,30 @@ class WorkflowValidator:
                 )
         return findings
 
-    def collect_findings(self, workflow_definition: dict[str, Any]) -> ValidationResult:
+    def collect_findings(
+        self,
+        workflow_definition: dict[str, Any],
+        *,
+        system_continue_on_failure: bool = False,
+    ) -> ValidationResult:
         """Run all validation checks and return a structured ValidationResult.
 
         Args:
             workflow_definition: Workflow definition dictionary to validate
+            system_continue_on_failure: Admin-level default for continue_on_failure,
+                used to resolve approval fallback_decision warnings when a node
+                inherits the system default.
 
         Returns:
             ValidationResult with individual findings, counts, and validity
 
         """
-        return ValidationResult.from_findings(self._collect_findings(workflow_definition))
+        return ValidationResult.from_findings(
+            self._collect_findings(
+                workflow_definition,
+                system_continue_on_failure=system_continue_on_failure,
+            )
+        )
 
     def _validate_graph_structure(self, workflow_definition: dict[str, Any], node_ids: set[str]) -> None:
         edge_findings = _check_edge_references_findings(workflow_definition, node_ids)

--- a/backend/tests/unit/workflows/conftest.py
+++ b/backend/tests/unit/workflows/conftest.py
@@ -14,6 +14,12 @@ _catalog_defaults: dict[str, int] = {
     if s.key.startswith("workflow_engine.") and isinstance(s.default_value, int)
 }
 
+_catalog_bool_defaults: dict[str, bool] = {
+    s.key: bool(s.default_value)
+    for s in SETTINGS_CATALOG
+    if s.key.startswith("workflow_engine.") and isinstance(s.default_value, bool)
+}
+
 
 @pytest.fixture(autouse=True)
 def _mock_runtime_settings() -> Generator[None, None, None]:
@@ -29,6 +35,7 @@ def _mock_runtime_settings() -> Generator[None, None, None]:
 
     mock_cache = AsyncMock(spec=SettingsCache)
     mock_cache.get_int.side_effect = lambda key, **_kw: _catalog_defaults.get(key, 0)
+    mock_cache.get_bool.side_effect = lambda key, **_kw: _catalog_bool_defaults.get(key, False)
 
     set_runtime_settings(mock_cache)
     yield

--- a/backend/tests/unit/workflows/validators/test_workflow_definition_validator.py
+++ b/backend/tests/unit/workflows/validators/test_workflow_definition_validator.py
@@ -898,6 +898,58 @@ class TestApprovalNodeValidation:
         assert len(warnings) == 1
         assert warnings[0].node_id == "approval_1"
 
+    def test_fallback_approve_with_system_cof_enabled_no_warning(self, validator: WorkflowValidator) -> None:
+        """Node inherits system default (continue_on_failure=True) — no warning."""
+        result = validator.collect_findings(
+            _approval_definition(params={"fallback_decision": "approve"}),
+            system_continue_on_failure=True,
+        )
+        approval_findings = [f for f in result.findings if f.category == ValidationCategory.approval_configuration]
+        assert approval_findings == []
+
+    def test_fallback_approve_with_system_cof_disabled_produces_warning(self, validator: WorkflowValidator) -> None:
+        """Node inherits system default (continue_on_failure=False) — warning fires."""
+        result = validator.collect_findings(
+            _approval_definition(params={"fallback_decision": "approve"}),
+            system_continue_on_failure=False,
+        )
+        warnings = [
+            f
+            for f in result.findings
+            if f.category == ValidationCategory.approval_configuration and f.severity == ValidationSeverity.warning
+        ]
+        assert len(warnings) == 1
+        assert warnings[0].node_id == "approval_1"
+
+    def test_node_explicit_cof_false_overrides_system_cof_true(self, validator: WorkflowValidator) -> None:
+        """Node explicitly disables CoF — warning fires even if system default is True."""
+        result = validator.collect_findings(
+            _approval_definition(
+                params={"fallback_decision": "approve"},
+                settings={"continue_on_failure": False},
+            ),
+            system_continue_on_failure=True,
+        )
+        warnings = [
+            f
+            for f in result.findings
+            if f.category == ValidationCategory.approval_configuration and f.severity == ValidationSeverity.warning
+        ]
+        assert len(warnings) == 1
+        assert warnings[0].node_id == "approval_1"
+
+    def test_node_explicit_cof_true_overrides_system_cof_false(self, validator: WorkflowValidator) -> None:
+        """Node explicitly enables CoF — no warning even if system default is False."""
+        result = validator.collect_findings(
+            _approval_definition(
+                params={"fallback_decision": "approve"},
+                settings={"continue_on_failure": True},
+            ),
+            system_continue_on_failure=False,
+        )
+        approval_findings = [f for f in result.findings if f.category == ValidationCategory.approval_configuration]
+        assert approval_findings == []
+
 
 class TestScheduledTriggerConfigFindings:
     """collect_findings enforces ScheduledTriggerConfig (IANA timezone) beyond JSON Schema."""


### PR DESCRIPTION
## Description

The backend validation warning for `fallback_decision` on approval nodes only checked the node-level `continue_on_failure` setting, ignoring the admin system default. When a node used "follow the system" (`continue_on_failure` unset) and the system default had continue-on-failure enabled, the warning fired incorrectly on save.

This fix resolves the effective `continue_on_failure` the same way the runtime engine does: node explicit → system default → `false`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- [x] `_check_approval_node_findings` now accepts `system_continue_on_failure` and resolves effective CoF before deciding whether to warn
- [x] `collect_findings` / `_collect_findings` pass the system default through
- [x] Router (`/validate` endpoint) and `WorkflowService` (create, version update, publish) fetch the admin default from `SettingsCache` before calling validation
- [x] 4 new unit tests covering system default resolution and node-explicit override precedence
- [x] Warning message updated: "step settings" → "step or system settings"

## Out of Scope

- Frontend changes — the UI (`FallbackDecisionField` / `useEffectiveContinueOnFailure`) already resolves through the admin default correctly.
- Runtime engine changes — `node_settings_resolver.resolve_continue_on_failure` is already correct.


## How to Test

1. Go to **Admin → Settings** and enable **Continue on failure (default)**
2. Create or edit a workflow with an approval node
3. Set the approval's on-failure behavior to **System default**
4. Set the fallback decision to **Approve**
5. Save the workflow
6. **Expected**: No validation warning appears
7. **Before fix**: Warning incorrectly appeared: _"Approval step 'Approval' has fallback_decision set to 'approve' but continue_on_failure is not enabled."_

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed — N/A
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

N/A — no frontend changes.

## Visual Regression

N/A — no UI changes.

## General Checklist

- [x] Code follows the project's coding conventions
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps — N/A

## Additional Notes

The fix mirrors the same resolution order used by the runtime engine in `node_settings_resolver.resolve_continue_on_failure`: node explicit setting takes precedence over the system default, which takes precedence over the hardcoded `False` fallback. This ensures the validation warning is consistent with actual runtime behavior.