### PR TITLE
fix(ci): add job-level concurrency to frontend E2E tests

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -378,6 +378,11 @@ jobs:
     if: needs.changes.outputs.code == 'true' && github.event_name != 'push'
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 120
+    # Job-level concurrency ensures only the latest commit runs this expensive test.
+    # When a new commit is pushed, any in-progress E2E run from the prior commit is cancelled.
+    concurrency:
+      group: e2e-frontend-${{ github.head_ref || github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Free disk space
         run: |


### PR DESCRIPTION
## Description

The frontend E2E tests now cancel in-progress runs when a new commit is pushed. This prevents wasted CI resources on stale commits that are no longer at the tip of the branch.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [ ] Added job-level concurrency control to the expensive Podman Compose E2E workflow
- [ ] Included inline comment explaining the cancellation behavior

## Out of Scope

N/A

## Related Issues

N/A

## How to Test

1. Push two commits to a PR branch in quick succession
2. Verify that the first commit's E2E job is cancelled when the second starts
3. Confirm only the latest commit's E2E test completes

## Backend Checklist

N/A (CI configuration only)

## Frontend Checklist

N/A (CI configuration only)

## Visual Regression

N/A (CI configuration only)

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

N/A

## Additional Notes

This addresses observed behavior where both old and new commits ran E2E tests simultaneously. Workflow-level concurrency alone was insufficient to cancel already-running jobs.

> 🤖 PR description AI-assisted