### PR TITLE
ci(e2e): run httpbin in-cluster instead of depending on httpbin.org

### DIFF
--- a/backend/test-sdk/src/orchestrator_test_sdk/e2e/helpers.py
+++ b/backend/test-sdk/src/orchestrator_test_sdk/e2e/helpers.py
@@ -330,11 +330,19 @@ def poll_execution_until_complete(
 
 _HTTPBIN_ALLOWED_HOSTS = {"httpbin.org", "httpbin"}
 
+# URL the *workflow worker* uses. In CI this is the in-cluster httpbin Service;
+# locally it defaults to the public instance.
 HTTPBIN_URL: str = os.environ.get("HTTPBIN_URL", "https://httpbin.org")
 
 _parsed = urllib.parse.urlparse(HTTPBIN_URL)
 if _parsed.scheme not in ("http", "https") or not any(h in (_parsed.hostname or "") for h in _HTTPBIN_ALLOWED_HOSTS):
     HTTPBIN_URL = "https://httpbin.org"
+
+# URL the *test runner* probes for availability. When httpbin runs inside the
+# cluster its Service name does not resolve from the runner, so CI points this
+# at a port-forward. Defaults to HTTPBIN_URL for local runs, where both the
+# runner and the worker reach httpbin the same way.
+HTTPBIN_PROBE_URL: str = os.environ.get("HTTPBIN_PROBE_URL", HTTPBIN_URL)
 
 
 _httpbin_cached: bool | None = None
@@ -345,7 +353,7 @@ def httpbin_available() -> bool:
     global _httpbin_cached  # noqa: PLW0603
     if _httpbin_cached is None:
         try:
-            urllib.request.urlopen(f"{HTTPBIN_URL}/status/200", timeout=5)  # noqa: S310
+            urllib.request.urlopen(f"{HTTPBIN_PROBE_URL}/status/200", timeout=5)  # noqa: S310
             _httpbin_cached = True
         except Exception:
             _httpbin_cached = False
@@ -354,5 +362,5 @@ def httpbin_available() -> bool:
 
 requires_httpbin = pytest.mark.skipif(
     not httpbin_available(),
-    reason=f"httpbin not reachable at {HTTPBIN_URL}. Set HTTPBIN_URL to override.",
+    reason=f"httpbin not reachable at {HTTPBIN_PROBE_URL}. Set HTTPBIN_URL/HTTPBIN_PROBE_URL to override.",
 )

--- a/backend/tests/e2e/credentials/test_credential_endpoints.py
+++ b/backend/tests/e2e/credentials/test_credential_endpoints.py
@@ -212,7 +212,12 @@ class TestWorkflowWithValidCredential:
         output = _get_activity_output(execution, "api_call")
         assert output.get("status_code") == 200
         body = output.get("body", {})
-        assert body.get("authenticated") is True
+        # httpbin.org reports success as "authenticated", go-httpbin (used in CI)
+        # as "authorized". Accept either — what matters is that the Basic Auth
+        # credential was resolved and the server accepted it.
+        assert body.get("authenticated") is True or body.get("authorized") is True, (
+            f"Basic Auth credential was not accepted: {body}"
+        )
         assert body.get("user") == "admin"
 
     def test_no_credential_returns_401(

--- a/backend/tools/ci/e2e/httpbin-pod.yaml
+++ b/backend/tools/ci/e2e/httpbin-pod.yaml
@@ -1,0 +1,37 @@
+---
+# In-cluster httpbin for E2E tests.
+#
+# The credential and node-settings suites drive HTTP Request nodes against
+# httpbin endpoints (/bearer, /basic-auth, /delay, /status). Pointing those at
+# the public httpbin.org made the suite fail whenever that service was down or
+# rate-limiting — an outage there is indistinguishable from a real regression.
+# go-httpbin is a drop-in implementation of the same endpoints.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+spec:
+  containers:
+    - name: httpbin
+      image: ${HTTPBIN_IMAGE}
+      imagePullPolicy: Never
+      # The image sets no ENTRYPOINT, so the binary must be named explicitly —
+      # `args` alone would replace the command and fail to exec.
+      # -max-duration must be >= the longest /delay the suite requests (10s).
+      command: ["/bin/go-httpbin", "-max-duration", "60s"]
+      ports:
+        - containerPort: 8080
+      readinessProbe:
+        httpGet:
+          path: /status/200
+          port: 8080
+        initialDelaySeconds: 2
+        periodSeconds: 2
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          memory: 128Mi

--- a/backend/tools/ci/e2e/httpbin-svc.yaml
+++ b/backend/tools/ci/e2e/httpbin-svc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+spec:
+  selector:
+    app: httpbin
+  ports:
+    - port: 8080
+      targetPort: 8080


### PR DESCRIPTION
An httpbin.org outage is indistinguishable from a real regression and has
taken down the E2E suite before. Deploy go-httpbin as an in-cluster Pod
so the suite is self-contained.

- Add httpbin-pod.yaml and httpbin-svc.yaml K8s manifests
- Add HTTPBIN_PROBE_URL for the test runner to probe via port-forward
  while the worker resolves the in-cluster Service name
- Accept both "authenticated" (httpbin.org) and "authorized" (go-httpbin)
  in test_basic_auth_credential_resolves

Refs: AAP-84784

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
