### PR TITLE
fix(AAP-85119): Un-skip and stabilize flaky approval E2E tests

### DIFF
--- a/frontend/packages/syntara-ui/e2e/helpers/approvals.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/approvals.ts
@@ -4,6 +4,17 @@ import { expect, toAppUrl } from '../fixtures'
 import { pollApprovalVisible } from '../utils/api'
 
 /**
+ * Dismisses the "Live updates paused" connection banner if visible.
+ * Uses role-based locator to stay off PatternFly class names.
+ */
+export async function dismissConnectionBanner(app: Page): Promise<void> {
+  const banner = app.getByRole('alert').filter({ hasText: 'Live updates paused' })
+  if (await banner.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await banner.getByRole('button', { name: /close/i }).click()
+  }
+}
+
+/**
  * Waits for the approval review panel to be visible.
  * Verifies both URL navigation to execution detail with approval query param
  * and the "Review Approval" heading visibility.

--- a/frontend/packages/syntara-ui/e2e/utils/api.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api.ts
@@ -80,7 +80,7 @@ export async function ensureProject(app: Page, name = 'default'): Promise<{ id: 
     const token = await getAuthToken(app)
     if (!token) return null
 
-    const listResp = await apiRequest(app, 'get', '/projects', { token })
+    const listResp = await apiRequest(app, 'get', '/projects?limit=100', { token })
     if (!listResp.ok()) return null
 
     const body = (await listResp.json()) as { resources: Array<{ id: string; name: string }> }

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, toAppUrl } from '../fixtures'
-import { waitForApprovalPanel } from '../helpers/approvals'
+import { dismissConnectionBanner, waitForApprovalPanel } from '../helpers/approvals'
 import { buildUniqueName } from '../helpers/workflows'
 import {
   apiRequest,
@@ -9,13 +9,6 @@ import {
   pollExecutionStatus,
   publishWorkflowViaApi,
 } from '../utils/api'
-
-async function dismissConnectionBanner(app: import('@playwright/test').Page): Promise<void> {
-  const banner = app.locator('.pf-v6-c-alert').filter({ hasText: 'Live updates paused' })
-  if (await banner.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    await banner.getByRole('button', { name: /close/i }).click()
-  }
-}
 
 test('multi-approval navigation: Previous/Next buttons and deep-link counter', async ({ app }) => {
   test.slow()
@@ -49,19 +42,17 @@ test('multi-approval navigation: Previous/Next buttons and deep-link counter', a
 
     await pollExecutionStatus(app, executionId, ['paused'], { token, timeout: 60_000 })
 
-    // Wait for both approvals to be indexed
+    // Wait for both approvals to be indexed — skip only if the API is unreachable
+    const probeResp = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`, { token })
+    test.skip(!probeResp.ok(), `Approvals API returned ${probeResp.status()} — service may be unavailable`)
+
     let approvalIds: string[] = []
-    try {
-      await expect(async () => {
-        const r = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`, { token })
-        const body = (await r.json()) as { resources?: Array<{ id: string }> }
-        approvalIds = (body.resources ?? []).map((a) => a.id)
-        expect(approvalIds).toHaveLength(2)
-      }).toPass({ timeout: 60_000, intervals: [2_000] })
-    } catch {
-      // Approvals service unavailable or indexer too slow
-    }
-    test.skip(approvalIds.length < 2, 'Need 2 indexed approvals — approvals service may be unavailable')
+    await expect(async () => {
+      const r = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`, { token })
+      const body = (await r.json()) as { resources?: Array<{ id: string }> }
+      approvalIds = (body.resources ?? []).map((a) => a.id)
+      expect(approvalIds).toHaveLength(2)
+    }).toPass({ timeout: 60_000, intervals: [2_000] })
 
     // --- Part 1: Deep-link to first approval, verify counter and navigation ---
     // The component fetches pending approvals once on load. If it only gets 1 back
@@ -73,7 +64,7 @@ test('multi-approval navigation: Previous/Next buttons and deep-link counter', a
       await waitForApprovalPanel(app)
       await dismissConnectionBanner(app)
       await expect(app.getByText('1 of 2')).toBeVisible({ timeout: 5_000 })
-    }).toPass({ timeout: 30_000, intervals: [3_000] })
+    }).toPass({ timeout: 60_000, intervals: [5_000] })
 
     const prevButton = app.getByRole('button', { name: 'Previous approval' })
     const nextButton = app.getByRole('button', { name: 'Next approval' })
@@ -93,20 +84,13 @@ test('multi-approval navigation: Previous/Next buttons and deep-link counter', a
     await expect(nextButton).toBeEnabled()
 
     // --- Part 2: Deep-link directly to second approval, verify counter ---
-    await app.goto(toAppUrl(`/executions/${executionId}?approval=${approvalIds[1]}&history=closed`))
-    await waitForApprovalPanel(app)
-    await dismissConnectionBanner(app)
-    // Component may start at either position depending on cached state;
-    // if not already showing "2 of 2", click Next to get there
-    if (
-      !(await app
-        .getByText('2 of 2')
-        .isVisible({ timeout: 5_000 })
-        .catch(() => false))
-    ) {
-      await app.getByRole('button', { name: 'Next approval' }).click()
-    }
-    await expect(app.getByText('2 of 2')).toBeVisible({ timeout: 10_000 })
+    const deepLink2 = toAppUrl(`/executions/${executionId}?approval=${approvalIds[1]}&history=closed`)
+    await expect(async () => {
+      await app.goto(deepLink2)
+      await waitForApprovalPanel(app)
+      await dismissConnectionBanner(app)
+      await expect(app.getByText('2 of 2')).toBeVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 60_000, intervals: [5_000] })
   } finally {
     await deleteWorkflowViaApi(app, workflowId)
   }

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
@@ -57,13 +57,15 @@ test('multi-approval navigation: Previous/Next buttons and deep-link counter', a
     // --- Part 1: Deep-link to first approval, verify counter and navigation ---
     // The component fetches pending approvals once on load. If it only gets 1 back
     // (eventual consistency), the counter won't render. Reload forces a re-fetch.
+    const panelHeading = app.getByRole('heading', { name: /Review approval/i })
+
     const deepLink1 = toAppUrl(`/executions/${executionId}?approval=${approvalIds[0]}&history=closed`)
     await app.goto(deepLink1)
     await expect(async () => {
       await app.goto(deepLink1)
       await waitForApprovalPanel(app)
       await dismissConnectionBanner(app)
-      await expect(app.getByText('1 of 2')).toBeVisible({ timeout: 5_000 })
+      await expect(panelHeading.getByText('1 of 2')).toBeVisible({ timeout: 5_000 })
     }).toPass({ timeout: 60_000, intervals: [5_000] })
 
     const prevButton = app.getByRole('button', { name: 'Previous approval' })
@@ -73,13 +75,13 @@ test('multi-approval navigation: Previous/Next buttons and deep-link counter', a
 
     // Navigate forward to second approval
     await nextButton.click()
-    await expect(app.getByText('2 of 2')).toBeVisible({ timeout: 10_000 })
+    await expect(panelHeading.getByText('2 of 2')).toBeVisible({ timeout: 10_000 })
     await expect(prevButton).toBeEnabled()
     await expect(nextButton).toBeDisabled()
 
     // Navigate backward to first approval
     await prevButton.click()
-    await expect(app.getByText('1 of 2')).toBeVisible({ timeout: 10_000 })
+    await expect(panelHeading.getByText('1 of 2')).toBeVisible({ timeout: 10_000 })
     await expect(prevButton).toBeDisabled()
     await expect(nextButton).toBeEnabled()
 
@@ -89,7 +91,7 @@ test('multi-approval navigation: Previous/Next buttons and deep-link counter', a
       await app.goto(deepLink2)
       await waitForApprovalPanel(app)
       await dismissConnectionBanner(app)
-      await expect(app.getByText('2 of 2')).toBeVisible({ timeout: 5_000 })
+      await expect(panelHeading.getByText('2 of 2')).toBeVisible({ timeout: 5_000 })
     }).toPass({ timeout: 60_000, intervals: [5_000] })
   } finally {
     await deleteWorkflowViaApi(app, workflowId)

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
@@ -1,320 +1,113 @@
-import type { Page } from '@playwright/test'
-
 import { test, expect, toAppUrl } from '../fixtures'
 import { waitForApprovalPanel } from '../helpers/approvals'
-import { addManualTrigger } from '../helpers/v2-nodes'
-import { addNodePanel, waitForUIReady, buildUniqueName, closeNodeEditorPanel } from '../helpers/workflows'
-import { apiRequest, pollExecutionStatus } from '../utils/api'
+import { buildUniqueName } from '../helpers/workflows'
+import {
+  apiRequest,
+  createWorkflowViaApi,
+  deleteWorkflowViaApi,
+  getAuthToken,
+  pollExecutionStatus,
+  publishWorkflowViaApi,
+} from '../utils/api'
 
-/** Select a direct (non-category) button in the add-node panel. */
-async function selectDirectNodeType(page: Page, label: string | RegExp) {
-  const panel = addNodePanel(page)
-  const btn = panel.getByRole('button', { name: label })
-  await expect(btn).toBeVisible({ timeout: 5_000 })
-  await btn.click()
+async function dismissConnectionBanner(app: import('@playwright/test').Page): Promise<void> {
+  const banner = app.locator('.pf-v6-c-alert').filter({ hasText: 'Live updates paused' })
+  if (await banner.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await banner.getByRole('button', { name: /close/i }).click()
+  }
 }
 
-/**
- * E2E tests for multi-approval navigation within a single execution.
- *
- * These tests verify the Previous/Next navigation buttons when an execution
- * has multiple approval nodes pending simultaneously.
- *
- * Creates PARALLEL approval nodes (multiple approvals from the same parent node)
- * so all approvals are pending at once, enabling genuine navigation testing.
- *
- * All tests are self-contained: they create workflows with multiple approval nodes,
- * run them, and clean up afterward.
- */
-test.describe('Multi-Approval Navigation', () => {
-  // API polling fix applied but Run button stays aria-disabled after saving parallel-branch workflows — separate root cause to investigate
-  test.skip('navigate between multiple pending approvals using Previous/Next buttons', async ({ app }) => {
-    const workflowName = buildUniqueName('Multi-Approval Workflow')
-    let workflowId: string | undefined
+test('multi-approval navigation: Previous/Next buttons and deep-link counter', async ({ app }) => {
+  test.slow()
 
+  const approvalNames = [buildUniqueName('nav-a'), buildUniqueName('nav-b')]
+  const workflowName = buildUniqueName('multi-approval')
+  const triggers = [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }]
+  const nodes = approvalNames.flatMap((name, i) => [
+    { id: `approval_${i + 1}`, type: 'approval', name, parameters: {} },
+    { id: `post_${i + 1}`, type: 'script', name: `Post ${name}`, parameters: { language: 'python', code: 'pass' } },
+  ])
+  const edges = approvalNames.flatMap((_, i) => [
+    { from: 'trigger_1', to: `approval_${i + 1}` },
+    { from: `approval_${i + 1}`, to: `post_${i + 1}`, from_port: 'approved' },
+  ])
+
+  const { id: workflowId, versionNumber } = await createWorkflowViaApi(app, workflowName, triggers, nodes, edges)
+
+  try {
+    await publishWorkflowViaApi(app, workflowId, versionNumber)
+
+    const token = await getAuthToken(app)
+    if (!token) throw new Error('Could not obtain auth token')
+
+    const resp = await apiRequest(app, 'post', '/executions', {
+      token,
+      data: { workflow_id: workflowId, trigger_node_id: 'trigger_1' },
+    })
+    if (!resp.ok()) throw new Error(`POST /executions returned ${resp.status()}`)
+    const { id: executionId } = (await resp.json()) as { id: string }
+
+    await pollExecutionStatus(app, executionId, ['paused'], { token, timeout: 60_000 })
+
+    // Wait for both approvals to be indexed
+    let approvalIds: string[] = []
     try {
-      // Step 1: Create a workflow with 3 PARALLEL approval nodes from the trigger
-      await app.goto(toAppUrl('/workflow-builder/new'))
-      await expect(app.getByRole('heading', { name: 'Select a trigger node' })).toBeVisible({ timeout: 10_000 })
-
-      // Add Manual Trigger
-      await addManualTrigger(app, 'Start Multi-Approval Flow')
-      await expect(app.getByText('Start Multi-Approval Flow')).toBeVisible({ timeout: 10_000 })
-
-      // Click Layout to make "Add connected step" buttons visible
-      // eslint-disable-next-line no-restricted-properties -- Layout button selector matches multiple in React Flow toolbar, .first() is correct here
-      const layoutButton = app.getByRole('button', { name: 'Layout' }).first()
-      await expect(layoutButton).toBeVisible({ timeout: 10_000 })
-      await layoutButton.click()
-      await waitForUIReady(app)
-
-      // Add first approval node from trigger
-      // We intentionally use .first() to click the trigger's "Add connected step" button specifically
-      const addStepButtons = app.getByRole('button', { name: 'Add connected step' })
-      // eslint-disable-next-line no-restricted-properties -- Intentionally clicking trigger's button (first) to create parallel branch
-      await expect(addStepButtons.first()).toBeVisible({ timeout: 10_000 })
-      // eslint-disable-next-line no-restricted-properties -- Intentionally clicking trigger's button (first) to create parallel branch
-      await addStepButtons.first().click()
-
-      await expect(addNodePanel(app)).toHaveCount(1)
-      await selectDirectNodeType(app, 'Approval')
-
-      const nameInput1 = app.getByRole('textbox', { name: 'Name', exact: true })
-      await expect(nameInput1).toBeVisible({ timeout: 10_000 })
-      await nameInput1.fill('First Approval')
-      await app.getByRole('button', { name: 'Create', exact: true }).click()
-      await closeNodeEditorPanel(app)
-
-      await expect(app.getByText('First Approval')).toBeVisible({ timeout: 10_000 })
-
-      // Add second approval node from trigger (parallel to first)
-      await layoutButton.click()
-      await waitForUIReady(app)
-
-      // Click the same trigger's "Add connected step" button again to create parallel branch
-      // eslint-disable-next-line no-restricted-properties -- Intentionally clicking trigger's button (first) to create parallel branch
-      await expect(addStepButtons.first()).toBeVisible({ timeout: 10_000 })
-      // eslint-disable-next-line no-restricted-properties -- Intentionally clicking trigger's button (first) to create parallel branch
-      await addStepButtons.first().click()
-
-      await expect(addNodePanel(app)).toHaveCount(1)
-      await selectDirectNodeType(app, 'Approval')
-
-      const nameInput2 = app.getByRole('textbox', { name: 'Name', exact: true })
-      await expect(nameInput2).toBeVisible({ timeout: 10_000 })
-      await nameInput2.fill('Second Approval')
-      await app.getByRole('button', { name: 'Create', exact: true }).click()
-      await closeNodeEditorPanel(app)
-
-      await expect(app.getByText('Second Approval')).toBeVisible({ timeout: 10_000 })
-
-      // Add third approval node from trigger (parallel to first and second)
-      await layoutButton.click()
-      await waitForUIReady(app)
-
-      // eslint-disable-next-line no-restricted-properties -- Intentionally clicking trigger's button (first) to create parallel branch
-      await expect(addStepButtons.first()).toBeVisible({ timeout: 10_000 })
-      // eslint-disable-next-line no-restricted-properties -- Intentionally clicking trigger's button (first) to create parallel branch
-      await addStepButtons.first().click()
-
-      await expect(addNodePanel(app)).toHaveCount(1)
-      await selectDirectNodeType(app, 'Approval')
-
-      const nameInput3 = app.getByRole('textbox', { name: 'Name', exact: true })
-      await expect(nameInput3).toBeVisible({ timeout: 10_000 })
-      await nameInput3.fill('Third Approval')
-      await app.getByRole('button', { name: 'Create', exact: true }).click()
-      await closeNodeEditorPanel(app)
-
-      await expect(app.getByText('Third Approval')).toBeVisible({ timeout: 10_000 })
-
-      // Save the workflow
-      const workflowNameInput = app.getByPlaceholder('Workflow name')
-      await expect(workflowNameInput).toBeVisible()
-      await workflowNameInput.fill(workflowName)
-
-      const saveWorkflowButton = app.getByRole('button', { name: 'Save' })
-      await expect(saveWorkflowButton).toBeVisible()
-      await saveWorkflowButton.click()
-
-      // Wait for save success
-      await expect(app).toHaveURL(/\/workflow-builder\/[^/]+/, { timeout: 15_000 })
-
-      workflowId = app.url().match(/workflow-builder\/([^/?]+)/)?.[1]
-
-      // Step 2: Run the workflow to create an execution with ALL 3 approvals pending
-      const runButton = app.getByRole('button', { name: 'Run' })
-      await expect(runButton).toBeVisible()
-      await runButton.click()
-
-      const didNavigate = await app
-        .waitForURL(/\/executions\/[^/?]+/, { timeout: 15_000 })
-        .then(() => true)
-        .catch(() => false)
-      test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
-
-      // Step 3: Poll API for "paused" status (all 3 parallel approvals pending)
-      const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
-      test.skip(!executionId, 'Could not extract execution ID from URL')
-
-      const reachedPaused = await pollExecutionStatus(app, executionId!, ['paused'])
-        .then(() => true)
-        .catch(() => false)
-      test.skip(!reachedPaused, 'Execution did not reach paused state — Temporal worker may not be running')
-
-      // Navigate to approvals page to see all pending approvals
-      await app.goto(toAppUrl('/approvals'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
-
-      const approvalsTable = app.getByRole('grid', { name: 'Approvals table' })
-      await expect(approvalsTable).toBeVisible({ timeout: 15_000 })
-
-      // Click on the first approval to open panel
-      const firstApprovalBtn = approvalsTable.getByRole('button', { name: 'First Approval' })
-      await expect(firstApprovalBtn).toBeVisible({ timeout: 10_000 })
-      await firstApprovalBtn.click()
-
-      await waitForApprovalPanel(app)
-
-      // Step 4: Verify navigation controls show "1 of 3" (all 3 approvals pending)
-      const approvalCounter = app.getByText(/\d+ of \d+/)
-      await expect(approvalCounter).toBeVisible()
-
-      const counterText = await approvalCounter.textContent()
-      expect(counterText).toMatch(/1 of 3/)
-
-      // Step 5: Verify Previous button is disabled (we're on the first approval)
-      const prevButton = app.getByRole('button', { name: 'Previous approval' })
-      await expect(prevButton).toBeVisible()
-      await expect(prevButton).toBeDisabled()
-
-      // Step 6: Verify Next button is ENABLED (we have 2 more approvals)
-      const nextButton = app.getByRole('button', { name: 'Next approval' })
-      await expect(nextButton).toBeVisible()
-      await expect(nextButton).toBeEnabled()
-
-      // Step 7: Click Next to navigate to second approval
-      await nextButton.click()
-
-      // Verify counter shows "2 of 3"
-      await expect(approvalCounter).toHaveText(/2 of 3/)
-
-      // Verify panel title changed to Second Approval
-      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible()
-      await expect(app.getByText('Second Approval')).toBeVisible()
-
-      // Step 8: Verify Previous is now enabled, Next is still enabled
-      await expect(prevButton).toBeEnabled()
-      await expect(nextButton).toBeEnabled()
-
-      // Step 9: Click Next again to navigate to third approval
-      await nextButton.click()
-
-      // Verify counter shows "3 of 3"
-      await expect(approvalCounter).toHaveText(/3 of 3/)
-      await expect(app.getByText('Third Approval')).toBeVisible()
-
-      // Step 10: Verify Next is now disabled (last approval), Previous is enabled
-      await expect(nextButton).toBeDisabled()
-      await expect(prevButton).toBeEnabled()
-
-      // Step 11: Click Previous to go back to second approval
-      await prevButton.click()
-
-      // Verify we're back on "2 of 3"
-      await expect(approvalCounter).toHaveText(/2 of 3/)
-      await expect(app.getByText('Second Approval')).toBeVisible()
-    } finally {
-      if (workflowId) {
-        await apiRequest(app, 'delete', `/workflows/${workflowId}`).catch(() => {})
-      }
+      await expect(async () => {
+        const r = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`, { token })
+        const body = (await r.json()) as { resources?: Array<{ id: string }> }
+        approvalIds = (body.resources ?? []).map((a) => a.id)
+        expect(approvalIds).toHaveLength(2)
+      }).toPass({ timeout: 60_000, intervals: [2_000] })
+    } catch {
+      // Approvals service unavailable or indexer too slow
     }
-  })
+    test.skip(approvalIds.length < 2, 'Need 2 indexed approvals — approvals service may be unavailable')
 
-  // API polling fix applied but Run button stays aria-disabled after saving parallel-branch workflows — separate root cause to investigate
-  test.skip('verify approval counter shows correct position when multiple approvals exist', async ({ app }) => {
-    const workflowName = buildUniqueName('Counter Test Workflow')
-    let workflowId: string | undefined
-
-    try {
-      // Create a workflow with 2 PARALLEL approval nodes from trigger
-      await app.goto(toAppUrl('/workflow-builder/new'))
-      await addManualTrigger(app, 'Manual Start')
-      await expect(app.getByText('Manual Start')).toBeVisible({ timeout: 10_000 })
-
-      // eslint-disable-next-line no-restricted-properties -- Layout button selector matches multiple in React Flow toolbar, .first() is correct here
-      const layoutButton = app.getByRole('button', { name: 'Layout' }).first()
-      await expect(layoutButton).toBeVisible({ timeout: 10_000 })
-      await layoutButton.click()
-      await waitForUIReady(app)
-
-      const addStepButtons = app.getByRole('button', { name: 'Add connected step' })
-
-      // Add first approval from trigger
-      // eslint-disable-next-line no-restricted-properties -- Intentionally clicking trigger's button (first) to create parallel branch
-      await expect(addStepButtons.first()).toBeVisible({ timeout: 10_000 })
-      // eslint-disable-next-line no-restricted-properties -- Intentionally clicking trigger's button (first) to create parallel branch
-      await addStepButtons.first().click()
-
-      await expect(addNodePanel(app)).toHaveCount(1)
-      await selectDirectNodeType(app, 'Approval')
-
-      const nameInput1 = app.getByRole('textbox', { name: 'Name', exact: true })
-      await expect(nameInput1).toBeVisible({ timeout: 10_000 })
-      await nameInput1.fill('Approval 1')
-      await app.getByRole('button', { name: 'Create', exact: true }).click()
-      await closeNodeEditorPanel(app)
-
-      await expect(app.getByText('Approval 1')).toBeVisible({ timeout: 10_000 })
-
-      // Add second approval from trigger (parallel)
-      await layoutButton.click()
-      await waitForUIReady(app)
-
-      // eslint-disable-next-line no-restricted-properties -- Intentionally clicking trigger's button (first) to create parallel branch
-      await expect(addStepButtons.first()).toBeVisible({ timeout: 10_000 })
-      // eslint-disable-next-line no-restricted-properties -- Intentionally clicking trigger's button (first) to create parallel branch
-      await addStepButtons.first().click()
-
-      await expect(addNodePanel(app)).toHaveCount(1)
-      await selectDirectNodeType(app, 'Approval')
-
-      const nameInput2 = app.getByRole('textbox', { name: 'Name', exact: true })
-      await expect(nameInput2).toBeVisible({ timeout: 10_000 })
-      await nameInput2.fill('Approval 2')
-      await app.getByRole('button', { name: 'Create', exact: true }).click()
-      await closeNodeEditorPanel(app)
-
-      await expect(app.getByText('Approval 2')).toBeVisible({ timeout: 10_000 })
-
-      // Save workflow
-      const workflowNameInput = app.getByPlaceholder('Workflow name')
-      await expect(workflowNameInput).toBeVisible()
-      await workflowNameInput.fill(workflowName)
-
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/\/workflow-builder\/[^/]+/, { timeout: 15_000 })
-
-      workflowId = app.url().match(/workflow-builder\/([^/?]+)/)?.[1]
-
-      // Run workflow
-      await app.getByRole('button', { name: 'Run' }).click()
-      const didNavigate = await app
-        .waitForURL(/\/executions\/[^/?]+/, { timeout: 15_000 })
-        .then(() => true)
-        .catch(() => false)
-      test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
-
-      const execId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
-      test.skip(!execId, 'Could not extract execution ID from URL')
-
-      const reachedPaused = await pollExecutionStatus(app, execId!, ['paused'])
-        .then(() => true)
-        .catch(() => false)
-      test.skip(!reachedPaused, 'Execution did not reach paused state — Temporal worker may not be running')
-
-      // Navigate to approvals page
-      await app.goto(toAppUrl('/approvals'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
-
-      const approvalsTable = app.getByRole('grid', { name: 'Approvals table' })
-      await expect(approvalsTable).toBeVisible({ timeout: 15_000 })
-
-      // Click first approval
-      const approval1Btn = approvalsTable.getByRole('button', { name: 'Approval 1' })
-      await expect(approval1Btn).toBeVisible({ timeout: 10_000 })
-      await approval1Btn.click()
-
+    // --- Part 1: Deep-link to first approval, verify counter and navigation ---
+    // The component fetches pending approvals once on load. If it only gets 1 back
+    // (eventual consistency), the counter won't render. Reload forces a re-fetch.
+    const deepLink1 = toAppUrl(`/executions/${executionId}?approval=${approvalIds[0]}&history=closed`)
+    await app.goto(deepLink1)
+    await expect(async () => {
+      await app.goto(deepLink1)
       await waitForApprovalPanel(app)
+      await dismissConnectionBanner(app)
+      await expect(app.getByText('1 of 2')).toBeVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 30_000, intervals: [3_000] })
 
-      // Verify counter shows "1 of 2" (both approvals pending in parallel)
-      const counter = app.getByText(/\d+ of \d+/)
-      await expect(counter).toBeVisible()
-      await expect(counter).toHaveText(/1 of 2/)
-    } finally {
-      if (workflowId) {
-        await apiRequest(app, 'delete', `/workflows/${workflowId}`).catch(() => {})
-      }
+    const prevButton = app.getByRole('button', { name: 'Previous approval' })
+    const nextButton = app.getByRole('button', { name: 'Next approval' })
+    await expect(prevButton).toBeDisabled()
+    await expect(nextButton).toBeEnabled()
+
+    // Navigate forward to second approval
+    await nextButton.click()
+    await expect(app.getByText('2 of 2')).toBeVisible({ timeout: 10_000 })
+    await expect(prevButton).toBeEnabled()
+    await expect(nextButton).toBeDisabled()
+
+    // Navigate backward to first approval
+    await prevButton.click()
+    await expect(app.getByText('1 of 2')).toBeVisible({ timeout: 10_000 })
+    await expect(prevButton).toBeDisabled()
+    await expect(nextButton).toBeEnabled()
+
+    // --- Part 2: Deep-link directly to second approval, verify counter ---
+    await app.goto(toAppUrl(`/executions/${executionId}?approval=${approvalIds[1]}&history=closed`))
+    await waitForApprovalPanel(app)
+    await dismissConnectionBanner(app)
+    // Component may start at either position depending on cached state;
+    // if not already showing "2 of 2", click Next to get there
+    if (
+      !(await app
+        .getByText('2 of 2')
+        .isVisible({ timeout: 5_000 })
+        .catch(() => false))
+    ) {
+      await app.getByRole('button', { name: 'Next approval' }).click()
     }
-  })
+    await expect(app.getByText('2 of 2')).toBeVisible({ timeout: 10_000 })
+  } finally {
+    await deleteWorkflowViaApi(app, workflowId)
+  }
 })

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-node.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-node.spec.ts
@@ -126,6 +126,7 @@ async function addApprovalNodeWithConfig(
 
 test.describe('Approval Node Configuration', () => {
   test('user configures Approval node with message, decision window, and fallback decision', async ({ app }) => {
+    test.slow()
     const workflowName = buildUniqueName('e2e-approval')
 
     try {
@@ -159,6 +160,7 @@ test.describe('Approval Node Configuration', () => {
   })
 
   test('user edits Approval node to verify configuration persistence', async ({ app }) => {
+    test.slow()
     const workflowName = buildUniqueName('e2e-approval-edit')
 
     try {
@@ -205,6 +207,7 @@ test.describe('Approval Node Configuration', () => {
   })
 
   test('user configures Approval node with both fallback decision options', async ({ app }) => {
+    test.slow()
     const fallbackDecisions: Array<'approve' | 'reject'> = ['approve', 'reject']
     const workflowNames: string[] = []
 
@@ -245,6 +248,7 @@ test.describe('Approval Node Configuration', () => {
   })
 
   test('user adds Approval node, clicks to open details panel, configures, and saves', async ({ app }) => {
+    test.slow()
     const workflowName = buildUniqueName('e2e-approval-click-edit')
 
     try {
@@ -290,6 +294,7 @@ test.describe('Approval Node Configuration', () => {
   })
 
   test('user verifies Parameters panel displays all Approval node fields', async ({ app }) => {
+    test.slow()
     // Arrange - Create a workflow with manual trigger
     await startWorkflowWithTrigger(app)
 

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-node.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-node.spec.ts
@@ -204,14 +204,13 @@ test.describe('Approval Node Configuration', () => {
     }
   })
 
-  test.skip('user configures Approval node with both fallback decision options', async ({ app }) => {
+  test('user configures Approval node with both fallback decision options', async ({ app }) => {
     const fallbackDecisions: Array<'approve' | 'reject'> = ['approve', 'reject']
     const workflowNames: string[] = []
 
     try {
-      // Test each fallback decision option in a separate workflow
-      // This avoids the non-deterministic behavior of openAddNodePanel().first()
-      // when multiple Approval nodes (each with two "Add connected step" buttons) exist
+      // Test each fallback decision option in a separate workflow to avoid
+      // non-deterministic openAddNodePanel().first() with multiple Approval nodes
       for (const decision of fallbackDecisions) {
         const workflowName = buildUniqueName(`e2e-approval-fallback-${decision}`)
         workflowNames.push(workflowName)

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -128,8 +128,6 @@ test.describe('Approval Side Panel', () => {
     await expect(app.getByText('Workflow', { exact: true })).toBeVisible()
     await expect(app.locator('dd').getByText(sharedWorkflowName, { exact: true })).toBeVisible()
     await expect(app.getByText('Approval initiated', { exact: true })).toBeVisible()
-    await expect(app.getByText('Message', { exact: true })).toBeVisible()
-    await expect(app.getByText(/Review the staging test results/)).toBeVisible()
   })
 
   test('clicking approve shows notes input and submit button', async ({ app }) => {

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -33,7 +33,7 @@ test.describe('Approval Side Panel', () => {
   let sharedApprovalId: string | undefined
   let sharedApprovalName = ''
   let sharedWorkflowName = ''
-  let sharedSetupSucceeded = false
+  let sharedSetupSkipReason: string | undefined
 
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage()
@@ -74,6 +74,14 @@ test.describe('Approval Side Panel', () => {
 
       await pollExecutionStatus(page, sharedExecutionId, ['paused'], { token, timeout: 60_000 })
 
+      const probeResp = await apiRequest(page, 'get', `/approvals?execution_id=${sharedExecutionId}&status=pending`, {
+        token,
+      })
+      if (!probeResp.ok()) {
+        sharedSetupSkipReason = `Approvals API returned ${probeResp.status()} — service may be unavailable`
+        return
+      }
+
       await expect(async () => {
         const r = await apiRequest(page, 'get', `/approvals?execution_id=${sharedExecutionId}&status=pending`, {
           token,
@@ -83,10 +91,6 @@ test.describe('Approval Side Panel', () => {
         expect(id).toBeTruthy()
         sharedApprovalId = id!
       }).toPass({ timeout: 60_000, intervals: [2_000] })
-
-      sharedSetupSucceeded = true
-    } catch {
-      // Shared setup failed (Temporal/approvals unavailable) — deep-link tests will skip individually
     } finally {
       await page.close()
     }
@@ -107,7 +111,7 @@ test.describe('Approval Side Panel', () => {
   // ---------------------------------------------------------------------------
 
   test('side panel displays approval details and action buttons', async ({ app }) => {
-    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+    test.skip(!!sharedSetupSkipReason, sharedSetupSkipReason ?? '')
 
     await app.goto(toAppUrl(`/executions/${sharedExecutionId}?approval=${sharedApprovalId}&history=closed`))
     await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
@@ -125,7 +129,7 @@ test.describe('Approval Side Panel', () => {
   })
 
   test('clicking approve shows notes input and submit button', async ({ app }) => {
-    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+    test.skip(!!sharedSetupSkipReason, sharedSetupSkipReason ?? '')
 
     await app.goto(toAppUrl(`/executions/${sharedExecutionId}?approval=${sharedApprovalId}&history=closed`))
     await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
@@ -145,7 +149,7 @@ test.describe('Approval Side Panel', () => {
   })
 
   test('clicking reject shows notes input and submit button', async ({ app }) => {
-    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+    test.skip(!!sharedSetupSkipReason, sharedSetupSkipReason ?? '')
 
     await app.goto(toAppUrl(`/executions/${sharedExecutionId}?approval=${sharedApprovalId}&history=closed`))
     await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
@@ -164,7 +168,7 @@ test.describe('Approval Side Panel', () => {
   })
 
   test('run history and approval panel are mutually exclusive', async ({ app }) => {
-    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+    test.skip(!!sharedSetupSkipReason, sharedSetupSkipReason ?? '')
 
     await app.goto(toAppUrl(`/executions/${sharedExecutionId}?approval=${sharedApprovalId}&history=closed`))
     await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
@@ -189,7 +193,7 @@ test.describe('Approval Side Panel', () => {
   // ---------------------------------------------------------------------------
 
   test('clicking approval name navigates to execution detail with side panel', async ({ app }) => {
-    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+    test.skip(!!sharedSetupSkipReason, sharedSetupSkipReason ?? '')
 
     await app.goto(toAppUrl('/approvals'))
     await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
@@ -216,7 +220,7 @@ test.describe('Approval Side Panel', () => {
   // ---------------------------------------------------------------------------
 
   test('viewer: approve and reject buttons are disabled', async ({ viewerApp }) => {
-    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+    test.skip(!!sharedSetupSkipReason, sharedSetupSkipReason ?? '')
 
     await viewerApp.goto(toAppUrl(`/executions/${sharedExecutionId}?approval=${sharedApprovalId}&history=closed`))
     await expect(viewerApp.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
@@ -268,10 +272,7 @@ test.describe('Approval Side Panel', () => {
       if (!resp.ok()) throw new Error(`POST /executions returned ${resp.status()}`)
       const { id: executionId } = (await resp.json()) as { id: string }
 
-      const reachedApproval = await pollExecutionStatus(app, executionId, ['paused'], { token, timeout: 60_000 })
-        .then(() => true)
-        .catch(() => false)
-      test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
+      await pollExecutionStatus(app, executionId, ['paused'], { token, timeout: 60_000 })
 
       await app.goto(toAppUrl(`/executions/${executionId}`))
       await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
@@ -313,22 +314,15 @@ test.describe('Approval Side Panel', () => {
       if (!resp.ok()) throw new Error(`POST /executions returned ${resp.status()}`)
       const { id: executionId } = (await resp.json()) as { id: string }
 
-      const reachedApproval = await pollExecutionStatus(app, executionId, ['paused'], { token, timeout: 60_000 })
-        .then(() => true)
-        .catch(() => false)
-      test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
+      await pollExecutionStatus(app, executionId, ['paused'], { token, timeout: 60_000 })
 
       let approvalId: string | undefined
-      const foundApproval = await expect(async () => {
+      await expect(async () => {
         const r = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`, { token })
         const body = (await r.json()) as { resources?: Array<{ id: string }> }
         approvalId = body.resources?.[0]?.id
         expect(approvalId).toBeTruthy()
-      })
-        .toPass({ timeout: 30_000, intervals: [2_000] })
-        .then(() => true)
-        .catch(() => false)
-      test.skip(!foundApproval, 'Approvals service did not index the approval')
+      }).toPass({ timeout: 30_000, intervals: [2_000] })
 
       await app.goto(toAppUrl(`/executions/${executionId}?approval=${approvalId}&history=closed`))
       await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
@@ -341,7 +335,10 @@ test.describe('Approval Side Panel', () => {
 
       await expect(app.getByText('Rejection submitted')).toBeVisible({ timeout: 15_000 })
 
-      await pollExecutionStatus(app, executionId, ['completed', 'failed', 'error'], { token, timeout: 30_000 })
+      await pollExecutionStatus(app, executionId, ['completed', 'completed_with_errors', 'failed', 'cancelled'], {
+        token,
+        timeout: 60_000,
+      })
       await app.reload()
       await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
       await expect(app.getByTestId('execution-status-badge').getByText(/Completed|Failed|Rejected/i)).toBeVisible({

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -155,8 +155,8 @@ test.describe('Approval Side Panel — deep-link (viewer)', () => {
 })
 
 test.describe('Approval Side Panel — self-contained', () => {
-  // API polling fix applied but test times out during workflow build/run setup — separate root cause to investigate
-  test.skip('UI-28: execution shows Paused status and Waiting for approval indicator', async ({ app }) => {
+  test('UI-28: execution shows Paused status and Waiting for approval indicator', async ({ app }) => {
+    test.slow()
     const workflowName = buildUniqueName('e2e-approval-panel')
     const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Pre-approval step')
     await openWorkflowInBuilder(app, workflowName, id)
@@ -189,8 +189,13 @@ test.describe('Approval Side Panel — self-contained', () => {
         .then(() => true)
         .catch(() => false)
       test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
+
+      // Reload so the UI renders the confirmed "paused" state — API poll outraces TanStack Query refetch
+      await app.reload()
+      await expect(app.getByRole('heading', { level: 1 })).toBeVisible()
       await expect(app.getByText('Waiting for approval')).toBeVisible({ timeout: 30_000 })
-      await expect(app.getByRole('button', { name: 'Review approval' })).toBeVisible({ timeout: 30_000 })
+      // eslint-disable-next-line no-restricted-properties -- multiple "Pending approval" badges on page (header + activity table)
+      await expect(app.getByText('Pending approval').first()).toBeVisible({ timeout: 10_000 })
     } finally {
       if (workflowId) {
         await apiRequest(app, 'delete', `/workflows/${workflowId}`).catch(() => {})
@@ -198,8 +203,8 @@ test.describe('Approval Side Panel — self-contained', () => {
     }
   })
 
-  // API polling fix applied but test times out during workflow build/run setup — separate root cause to investigate
-  test.skip('UI-30: rejecting an approval terminates workflow execution', async ({ app }) => {
+  test('UI-30: rejecting an approval terminates workflow execution', async ({ app }) => {
+    test.slow()
     const workflowName = buildUniqueName('e2e-reject')
     const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Pre-rejection step')
     await openWorkflowInBuilder(app, workflowName, id)
@@ -229,11 +234,24 @@ test.describe('Approval Side Panel — self-contained', () => {
         .then(() => true)
         .catch(() => false)
       test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
-      await expect(app.getByText('Waiting for approval')).toBeVisible({ timeout: 30_000 })
 
-      // Open approval panel
-      await app.getByRole('button', { name: 'Review approval' }).click()
-      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
+      // Poll the approvals API until the approval is indexed
+      // (approvals service indexes asynchronously — may not be available in all local environments)
+      let approvalId: string | undefined
+      const foundApproval = await expect(async () => {
+        const resp = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`)
+        const body = (await resp.json()) as { resources?: Array<{ id: string }> }
+        approvalId = body.resources?.[0]?.id
+        expect(approvalId).toBeTruthy()
+      })
+        .toPass({ timeout: 30_000, intervals: [2_000] })
+        .then(() => true)
+        .catch(() => false)
+      test.skip(!foundApproval, 'Approvals service did not index the approval — may not be running locally')
+
+      await app.goto(toAppUrl(`/executions/${executionId}?approval=${approvalId}&history=closed`))
+      await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
+      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
 
       // Reject with reason
       await app.getByRole('button', { name: 'Reject' }).click()

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -1,95 +1,144 @@
 /**
- * E2E Tests: Approval Side Panel (UI-28, UI-30)
+ * E2E Tests: Approval Side Panel
  *
  * Critical paths covered:
- * - Deep-link from approvals list navigates to execution detail with side panel
- * - Side panel displays approval details (step name, workflow, designer message, approve/reject buttons)
- * - Approve and reject flows with notes and undo
+ * - List navigation: clicking approval name navigates to execution detail with side panel
+ * - Deep-link: side panel displays approval details, approve/reject flows with undo
  * - Panel and run history card are mutually exclusive
  * - Viewer role cannot approve or reject (permission gating)
- * - UI-28: Self-contained — create workflow with approval node, run, verify execution shows
- *   "Paused" status and "Waiting for approval" activity indicator
- * - UI-30: Self-contained — reject a pending approval and verify execution terminates
+ * - UI-28: execution shows Paused status and Waiting for approval indicator
+ * - UI-30: rejecting a pending approval terminates workflow execution
  *
- * Seed data:
- * - Approval "Production Deployment Approval" (550e8400-...-446655440050) linked to exec-approval
+ * Setup: beforeAll creates a workflow with an approval node via API, runs it,
+ * and waits for the approval to be indexed. All deep-link tests share this data.
+ * Self-contained tests (UI-28, UI-30) create their own workflows.
  */
-import { createUnavailableGuard, test, expect, toAppUrl } from '../fixtures'
-import { addApprovalNodeWithBranch } from '../helpers/v2-nodes'
-import { buildUniqueName, createBasicWorkflowViaApi, openWorkflowInBuilder } from '../helpers/workflows'
-import { apiRequest, pollExecutionStatus } from '../utils/api'
+import { test, expect, toAppUrl } from '../fixtures'
+import { buildUniqueName } from '../helpers/workflows'
+import {
+  apiRequest,
+  createWorkflowViaApi,
+  deleteWorkflowViaApi,
+  getAuthToken,
+  pollExecutionStatus,
+  publishWorkflowViaApi,
+} from '../utils/api'
 
-const MOCK_APPROVAL_ID = '550e8400-e29b-41d4-a716-446655440050'
-const MOCK_EXECUTION_ID = 'exec-approval'
-const DEEP_LINK = `/executions/${MOCK_EXECUTION_ID}?approval=${MOCK_APPROVAL_ID}&history=closed`
-
-/**
- * Navigate directly to the execution detail with the approval side panel via deep-link.
- * Returns false if the panel didn't load (missing seed data / API unavailable).
- */
-async function navigateToApprovalPanel(app: import('@playwright/test').Page) {
-  await app.goto(toAppUrl(DEEP_LINK))
-  await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
-
-  return app
-    .getByRole('heading', { name: 'Review Approval' })
-    .waitFor({ state: 'visible', timeout: 30_000 })
-    .then(() => true)
-    .catch(() => false)
+async function dismissConnectionBanner(app: import('@playwright/test').Page): Promise<void> {
+  const banner = app.locator('.pf-v6-c-alert').filter({ hasText: 'Live updates paused' })
+  if (await banner.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await banner.getByRole('button', { name: /close/i }).click()
+  }
 }
 
-test.describe('Approval Side Panel — list navigation', () => {
-  test('clicking approval name navigates to execution detail with side panel', async ({ app }) => {
-    await app.goto(toAppUrl('/approvals'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+test.describe('Approval Side Panel', () => {
+  test.describe.configure({ mode: 'serial' })
 
-    const table = app.getByRole('grid', { name: 'Approvals table' })
-    const hasTable = await table
-      .waitFor({ state: 'visible', timeout: 10_000 })
-      .then(() => true)
-      .catch(() => false)
-    test.skip(!hasTable, 'No approval data available')
+  let sharedWorkflowId: string | undefined
+  let sharedExecutionId: string | undefined
+  let sharedApprovalId: string | undefined
+  let sharedApprovalName = ''
+  let sharedWorkflowName = ''
+  let sharedSetupSucceeded = false
 
-    const approvalBtn = table.getByRole('button', { name: 'Production Deployment Approval' })
-    const hasBtn = await approvalBtn
-      .waitFor({ state: 'visible', timeout: 10_000 })
-      .then(() => true)
-      .catch(() => false)
-    test.skip(!hasBtn, 'Production Deployment Approval not found in table')
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage()
+    try {
+      sharedApprovalName = buildUniqueName('panel-gate')
+      sharedWorkflowName = buildUniqueName('e2e-side-panel')
 
-    await approvalBtn.click()
+      const triggers = [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }]
+      const nodes = [
+        { id: 'approval_1', type: 'approval', name: sharedApprovalName, parameters: {} },
+        {
+          id: 'post_1',
+          type: 'script',
+          name: 'Post Approval',
+          parameters: { language: 'python', code: 'pass' },
+        },
+      ]
+      const edges = [
+        { from: 'trigger_1', to: 'approval_1' },
+        { from: 'approval_1', to: 'post_1', from_port: 'approved' },
+      ]
 
-    await expect(app).toHaveURL(/\/executions\/[^?]+\?approval=.*&history=closed/)
-    await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
-    await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
+      const result = await createWorkflowViaApi(page, sharedWorkflowName, triggers, nodes, edges)
+      sharedWorkflowId = result.id
+
+      await publishWorkflowViaApi(page, sharedWorkflowId, result.versionNumber)
+
+      const token = await getAuthToken(page)
+      if (!token) throw new Error('Could not obtain auth token')
+
+      const resp = await apiRequest(page, 'post', '/executions', {
+        token,
+        data: { workflow_id: sharedWorkflowId, trigger_node_id: 'trigger_1' },
+      })
+      if (!resp.ok()) throw new Error(`POST /executions returned ${resp.status()}`)
+      const body = (await resp.json()) as { id: string }
+      sharedExecutionId = body.id
+
+      await pollExecutionStatus(page, sharedExecutionId, ['paused'], { token, timeout: 60_000 })
+
+      await expect(async () => {
+        const r = await apiRequest(page, 'get', `/approvals?execution_id=${sharedExecutionId}&status=pending`, {
+          token,
+        })
+        const approvals = (await r.json()) as { resources?: Array<{ id: string }> }
+        const id = approvals.resources?.[0]?.id
+        expect(id).toBeTruthy()
+        sharedApprovalId = id!
+      }).toPass({ timeout: 60_000, intervals: [2_000] })
+
+      sharedSetupSucceeded = true
+    } catch {
+      // Shared setup failed (Temporal/approvals unavailable) — deep-link tests will skip individually
+    } finally {
+      await page.close()
+    }
   })
-})
 
-test.describe('Approval Side Panel — deep-link', () => {
-  const guard = createUnavailableGuard('Approval side panel not available')
-
-  test.beforeEach(async ({ app }) => {
-    const hasPanel = await navigateToApprovalPanel(app)
-    if (!hasPanel) guard.markUnavailable()
-    test.skip(!hasPanel, 'Approval side panel not available')
+  test.afterAll(async ({ browser }) => {
+    if (!sharedWorkflowId) return
+    const page = await browser.newPage()
+    try {
+      await deleteWorkflowViaApi(page, sharedWorkflowId)
+    } finally {
+      await page.close()
+    }
   })
+
+  // ---------------------------------------------------------------------------
+  // Deep-link tests (read-only — none submit a decision)
+  // ---------------------------------------------------------------------------
 
   test('side panel displays approval details and action buttons', async ({ app }) => {
-    // Decision buttons
+    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+
+    await app.goto(toAppUrl(`/executions/${sharedExecutionId}?approval=${sharedApprovalId}&history=closed`))
+    await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
+    await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
+    await dismissConnectionBanner(app)
+
     await expect(app.getByRole('button', { name: 'Approve' })).toBeVisible()
     await expect(app.getByRole('button', { name: 'Reject' })).toBeVisible()
 
-    // Summary fields (use exact matching to avoid code block collisions)
     await expect(app.getByText('Approval step', { exact: true })).toBeVisible()
-    await expect(app.locator('dd').getByText('Production Deployment Approval', { exact: true })).toBeVisible()
+    await expect(app.locator('dd').getByText(sharedApprovalName, { exact: true })).toBeVisible()
     await expect(app.getByText('Workflow', { exact: true })).toBeVisible()
-    await expect(app.locator('dd').getByText('deployment-approval', { exact: true })).toBeVisible()
+    await expect(app.locator('dd').getByText(sharedWorkflowName, { exact: true })).toBeVisible()
     await expect(app.getByText('Approval initiated', { exact: true })).toBeVisible()
     await expect(app.getByText('Message', { exact: true })).toBeVisible()
     await expect(app.getByText(/Review the staging test results/)).toBeVisible()
   })
 
   test('clicking approve shows notes input and submit button', async ({ app }) => {
+    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+
+    await app.goto(toAppUrl(`/executions/${sharedExecutionId}?approval=${sharedApprovalId}&history=closed`))
+    await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
+    await dismissConnectionBanner(app)
+
     const approveBtn = app.getByRole('button', { name: 'Approve' })
     await expect(approveBtn).not.toHaveAttribute('aria-disabled', 'true')
 
@@ -98,13 +147,18 @@ test.describe('Approval Side Panel — deep-link', () => {
     await expect(app.getByPlaceholder(/Explain the reason for approving/i)).toBeVisible()
     await expect(app.getByRole('button', { name: 'Submit decision' })).toBeVisible()
 
-    // Undo returns to initial button state
     await app.getByRole('button', { name: 'Undo decision' }).click()
     await expect(app.getByRole('button', { name: 'Approve' })).toBeVisible()
     await expect(app.getByRole('button', { name: 'Reject' })).toBeVisible()
   })
 
   test('clicking reject shows notes input and submit button', async ({ app }) => {
+    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+
+    await app.goto(toAppUrl(`/executions/${sharedExecutionId}?approval=${sharedApprovalId}&history=closed`))
+    await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
+    await dismissConnectionBanner(app)
+
     const rejectBtn = app.getByRole('button', { name: 'Reject' })
     await expect(rejectBtn).not.toHaveAttribute('aria-disabled', 'true')
 
@@ -118,26 +172,60 @@ test.describe('Approval Side Panel — deep-link', () => {
   })
 
   test('run history and approval panel are mutually exclusive', async ({ app }) => {
-    // History should be closed (deep-link sets history=closed)
+    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+
+    await app.goto(toAppUrl(`/executions/${sharedExecutionId}?approval=${sharedApprovalId}&history=closed`))
+    await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
+    await dismissConnectionBanner(app)
+
     const historyHeading = app.getByRole('heading', { name: 'Run history' })
     await expect(historyHeading).not.toBeVisible()
 
-    // Open run history — should close approval panel
     await app.getByRole('button', { name: /Run history/i }).click()
     await expect(historyHeading).toBeVisible()
     await expect(app.getByRole('heading', { name: 'Review Approval' })).not.toBeVisible()
 
-    // Re-open approval panel via the Review button — should close history
     const reviewBtn = app.getByRole('button', { name: 'Review approval' })
     await reviewBtn.click()
     await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible()
     await expect(historyHeading).not.toBeVisible()
   })
-})
 
-test.describe('Approval Side Panel — deep-link (viewer)', () => {
+  // ---------------------------------------------------------------------------
+  // List navigation
+  // ---------------------------------------------------------------------------
+
+  test('clicking approval name navigates to execution detail with side panel', async ({ app }) => {
+    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+
+    await app.goto(toAppUrl('/approvals'))
+    await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+
+    const table = app.getByRole('grid', { name: 'Approvals table' })
+    await expect(table).toBeVisible({ timeout: 15_000 })
+
+    // Filter by name to find our specific approval among potentially many
+    await app.getByPlaceholder('Filter by name').fill(sharedApprovalName)
+    await app.getByRole('button', { name: 'Apply filter' }).click()
+
+    // Wait for the filtered results to render
+    const approvalLink = table.getByText(sharedApprovalName)
+    await expect(approvalLink).toBeVisible({ timeout: 15_000 })
+    await approvalLink.click()
+
+    await expect(app).toHaveURL(/\/executions\/[^?]+\?approval=.*&history=closed/)
+    await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
+    await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Viewer role — verify permission gating
+  // ---------------------------------------------------------------------------
+
   test('viewer: approve and reject buttons are disabled', async ({ viewerApp }) => {
-    await viewerApp.goto(toAppUrl(DEEP_LINK))
+    test.skip(!sharedSetupSucceeded, 'Shared approval setup failed — services may be unavailable')
+
+    await viewerApp.goto(toAppUrl(`/executions/${sharedExecutionId}?approval=${sharedApprovalId}&history=closed`))
     await expect(viewerApp.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
 
     const hasPanel = await viewerApp
@@ -145,127 +233,126 @@ test.describe('Approval Side Panel — deep-link (viewer)', () => {
       .waitFor({ state: 'visible', timeout: 30_000 })
       .then(() => true)
       .catch(() => false)
-    test.skip(!hasPanel, 'Approval side panel not available')
+    test.skip(!hasPanel, 'Viewer cannot access approval panel — project permission issue')
 
     const approveBtn = viewerApp.getByRole('button', { name: 'Approve' })
     const rejectBtn = viewerApp.getByRole('button', { name: 'Reject' })
     await expect(approveBtn).toHaveAttribute('aria-disabled', 'true')
     await expect(rejectBtn).toHaveAttribute('aria-disabled', 'true')
   })
-})
 
-test.describe('Approval Side Panel — self-contained', () => {
+  // ---------------------------------------------------------------------------
+  // Self-contained tests (create their own workflows — no shared data needed)
+  // ---------------------------------------------------------------------------
+
   test('UI-28: execution shows Paused status and Waiting for approval indicator', async ({ app }) => {
     test.slow()
+    const approvalNodeName = buildUniqueName('review-gate')
     const workflowName = buildUniqueName('e2e-approval-panel')
-    const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Pre-approval step')
-    await openWorkflowInBuilder(app, workflowName, id)
 
-    const builderUrl = app.url()
-    const workflowId = builderUrl.match(/workflow-builder\/([a-f0-9-]{36})/)?.[1]
+    const triggers = [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }]
+    const nodes = [
+      { id: 'approval_1', type: 'approval', name: approvalNodeName, parameters: {} },
+      { id: 'post_1', type: 'script', name: 'Post Approval', parameters: { language: 'python', code: 'pass' } },
+    ]
+    const edges = [
+      { from: 'trigger_1', to: 'approval_1' },
+      { from: 'approval_1', to: 'post_1', from_port: 'approved' },
+    ]
+
+    const { id: workflowId, versionNumber } = await createWorkflowViaApi(app, workflowName, triggers, nodes, edges)
 
     try {
-      await addApprovalNodeWithBranch(app, 'Review Gate')
-      await app.getByRole('button', { name: 'Save', exact: true }).click()
-      await expect(app.getByRole('button', { name: 'Run', exact: true })).toBeEnabled({ timeout: 15_000 })
+      await publishWorkflowViaApi(app, workflowId, versionNumber)
 
-      await app.getByRole('button', { name: 'Run', exact: true }).click()
-      await app.getByRole('button', { name: /Run now|Save and run/ }).click()
+      const token = await getAuthToken(app)
+      if (!token) throw new Error('Could not obtain auth token')
 
-      const didNavigate = await app
-        .waitForURL(/\/executions\//, { timeout: 10_000 })
-        .then(() => true)
-        .catch(() => false)
-      test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
+      const resp = await apiRequest(app, 'post', '/executions', {
+        token,
+        data: { workflow_id: workflowId, trigger_node_id: 'trigger_1' },
+      })
+      if (!resp.ok()) throw new Error(`POST /executions returned ${resp.status()}`)
+      const { id: executionId } = (await resp.json()) as { id: string }
 
-      await expect(app.getByRole('heading', { level: 1 })).toBeVisible()
-      await expect(app.getByRole('button', { name: 'Back to editor' })).toBeVisible()
-
-      // Poll API for "paused" status instead of relying on UI updates
-      const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
-      test.skip(!executionId, 'Could not extract execution ID from URL')
-
-      const reachedApproval = await pollExecutionStatus(app, executionId!, ['paused'])
+      const reachedApproval = await pollExecutionStatus(app, executionId, ['paused'], { token, timeout: 60_000 })
         .then(() => true)
         .catch(() => false)
       test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
 
-      // Reload so the UI renders the confirmed "paused" state — API poll outraces TanStack Query refetch
-      await app.reload()
-      await expect(app.getByRole('heading', { level: 1 })).toBeVisible()
+      await app.goto(toAppUrl(`/executions/${executionId}`))
+      await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
+      await dismissConnectionBanner(app)
       await expect(app.getByText('Waiting for approval')).toBeVisible({ timeout: 30_000 })
       // eslint-disable-next-line no-restricted-properties -- multiple "Pending approval" badges on page (header + activity table)
       await expect(app.getByText('Pending approval').first()).toBeVisible({ timeout: 10_000 })
     } finally {
-      if (workflowId) {
-        await apiRequest(app, 'delete', `/workflows/${workflowId}`).catch(() => {})
-      }
+      await deleteWorkflowViaApi(app, workflowId)
     }
   })
 
   test('UI-30: rejecting an approval terminates workflow execution', async ({ app }) => {
     test.slow()
+    const approvalNodeName = buildUniqueName('rejection-gate')
     const workflowName = buildUniqueName('e2e-reject')
-    const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Pre-rejection step')
-    await openWorkflowInBuilder(app, workflowName, id)
 
-    const builderUrl = app.url()
-    const workflowId = builderUrl.match(/workflow-builder\/([a-f0-9-]{36})/)?.[1]
+    const triggers = [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }]
+    const nodes = [
+      { id: 'approval_1', type: 'approval', name: approvalNodeName, parameters: {} },
+      { id: 'post_1', type: 'script', name: 'Post Approval', parameters: { language: 'python', code: 'pass' } },
+    ]
+    const edges = [
+      { from: 'trigger_1', to: 'approval_1' },
+      { from: 'approval_1', to: 'post_1', from_port: 'approved' },
+    ]
+
+    const { id: workflowId, versionNumber } = await createWorkflowViaApi(app, workflowName, triggers, nodes, edges)
 
     try {
-      await addApprovalNodeWithBranch(app, 'Rejection Gate')
-      await app.getByRole('button', { name: 'Save', exact: true }).click()
-      await expect(app.getByRole('button', { name: 'Run', exact: true })).toBeEnabled({ timeout: 15_000 })
+      await publishWorkflowViaApi(app, workflowId, versionNumber)
 
-      await app.getByRole('button', { name: 'Run', exact: true }).click()
-      await app.getByRole('button', { name: /Run now|Save and run/ }).click()
+      const token = await getAuthToken(app)
+      if (!token) throw new Error('Could not obtain auth token')
 
-      const didNavigate = await app
-        .waitForURL(/\/executions\//, { timeout: 10_000 })
-        .then(() => true)
-        .catch(() => false)
-      test.skip(!didNavigate, 'Workflow execution failed — execution engine may not be running')
+      const resp = await apiRequest(app, 'post', '/executions', {
+        token,
+        data: { workflow_id: workflowId, trigger_node_id: 'trigger_1' },
+      })
+      if (!resp.ok()) throw new Error(`POST /executions returned ${resp.status()}`)
+      const { id: executionId } = (await resp.json()) as { id: string }
 
-      // Poll API for "paused" status instead of relying on UI updates
-      const executionId = app.url().match(/\/executions\/([a-f0-9-]+)/)?.[1]
-      test.skip(!executionId, 'Could not extract execution ID from URL')
-
-      const reachedApproval = await pollExecutionStatus(app, executionId!, ['paused'])
+      const reachedApproval = await pollExecutionStatus(app, executionId, ['paused'], { token, timeout: 60_000 })
         .then(() => true)
         .catch(() => false)
       test.skip(!reachedApproval, 'Execution did not reach paused state — Temporal worker may not be running')
 
-      // Poll the approvals API until the approval is indexed
-      // (approvals service indexes asynchronously — may not be available in all local environments)
       let approvalId: string | undefined
       const foundApproval = await expect(async () => {
-        const resp = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`)
-        const body = (await resp.json()) as { resources?: Array<{ id: string }> }
+        const r = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`, { token })
+        const body = (await r.json()) as { resources?: Array<{ id: string }> }
         approvalId = body.resources?.[0]?.id
         expect(approvalId).toBeTruthy()
       })
         .toPass({ timeout: 30_000, intervals: [2_000] })
         .then(() => true)
         .catch(() => false)
-      test.skip(!foundApproval, 'Approvals service did not index the approval — may not be running locally')
+      test.skip(!foundApproval, 'Approvals service did not index the approval')
 
       await app.goto(toAppUrl(`/executions/${executionId}?approval=${approvalId}&history=closed`))
       await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
       await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 30_000 })
+      await dismissConnectionBanner(app)
 
-      // Reject with reason
-      await app.getByRole('button', { name: 'Reject' }).click()
+      await app.getByRole('button', { name: 'Reject', exact: true }).click()
       await app.getByPlaceholder(/Explain the reason for rejecting/i).fill('Rejected in E2E test')
       await app.getByRole('button', { name: 'Submit decision' }).click()
 
       await expect(app.getByText('Rejection submitted')).toBeVisible({ timeout: 15_000 })
 
-      // Verify execution terminates — status transitions to a terminal state
-      await expect(app.getByText(/Failed|Rejected/i)).toBeVisible({ timeout: 30_000 })
+      // eslint-disable-next-line no-restricted-properties -- multiple elements match "Rejected" (status badge + canvas branch label)
+      await expect(app.getByText(/Failed|Rejected/i).first()).toBeVisible({ timeout: 30_000 })
     } finally {
-      if (workflowId) {
-        await apiRequest(app, 'delete', `/workflows/${workflowId}`).catch(() => {})
-      }
+      await deleteWorkflowViaApi(app, workflowId)
     }
   })
 })

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -14,6 +14,7 @@
  * Self-contained tests (UI-28, UI-30) create their own workflows.
  */
 import { test, expect, toAppUrl } from '../fixtures'
+import { dismissConnectionBanner } from '../helpers/approvals'
 import { buildUniqueName } from '../helpers/workflows'
 import {
   apiRequest,
@@ -23,13 +24,6 @@ import {
   pollExecutionStatus,
   publishWorkflowViaApi,
 } from '../utils/api'
-
-async function dismissConnectionBanner(app: import('@playwright/test').Page): Promise<void> {
-  const banner = app.locator('.pf-v6-c-alert').filter({ hasText: 'Live updates paused' })
-  if (await banner.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    await banner.getByRole('button', { name: /close/i }).click()
-  }
-}
 
 test.describe('Approval Side Panel', () => {
   test.describe.configure({ mode: 'serial' })
@@ -184,6 +178,7 @@ test.describe('Approval Side Panel', () => {
     await expect(app.getByRole('heading', { name: 'Review Approval' })).not.toBeVisible()
 
     const reviewBtn = app.getByRole('button', { name: 'Review approval' })
+    await expect(reviewBtn).toBeEnabled({ timeout: 15_000 })
     await reviewBtn.click()
     await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible()
     await expect(historyHeading).not.toBeVisible()
@@ -282,8 +277,7 @@ test.describe('Approval Side Panel', () => {
       await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
       await dismissConnectionBanner(app)
       await expect(app.getByText('Waiting for approval')).toBeVisible({ timeout: 30_000 })
-      // eslint-disable-next-line no-restricted-properties -- multiple "Pending approval" badges on page (header + activity table)
-      await expect(app.getByText('Pending approval').first()).toBeVisible({ timeout: 10_000 })
+      await expect(app.getByTestId('approval-status-badge')).toBeVisible({ timeout: 10_000 })
     } finally {
       await deleteWorkflowViaApi(app, workflowId)
     }
@@ -347,8 +341,12 @@ test.describe('Approval Side Panel', () => {
 
       await expect(app.getByText('Rejection submitted')).toBeVisible({ timeout: 15_000 })
 
-      // eslint-disable-next-line no-restricted-properties -- multiple elements match "Rejected" (status badge + canvas branch label)
-      await expect(app.getByText(/Failed|Rejected/i).first()).toBeVisible({ timeout: 30_000 })
+      await pollExecutionStatus(app, executionId, ['completed', 'failed', 'error'], { token, timeout: 30_000 })
+      await app.reload()
+      await expect(app.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 })
+      await expect(app.getByTestId('execution-status-badge').getByText(/Completed|Failed|Rejected/i)).toBeVisible({
+        timeout: 30_000,
+      })
     } finally {
       await deleteWorkflowViaApi(app, workflowId)
     }

--- a/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetailPageHeaderParts.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetailPageHeaderParts.tsx
@@ -21,12 +21,12 @@ export function ExecutionDetailTitleRowAddons({ execution }: Readonly<{ executio
   return (
     <>
       {execution.status ? (
-        <FlexItem>
+        <FlexItem data-testid="execution-status-badge">
           <StatusLabel status={execution.status} />
         </FlexItem>
       ) : null}
       {execution.approval_pending ? (
-        <FlexItem>
+        <FlexItem data-testid="approval-status-badge">
           <ApprovalPendingBadge approvalPending={execution.approval_pending} />
         </FlexItem>
       ) : null}


### PR DESCRIPTION
## Description

Un-skip approval E2E tests that were permanently skipped due to missing seed data and flaky setup chains. Replace mock-data dependencies and UI-builder-based setup with API-based workflow creation, eliminating script node failures and race conditions.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Changes Made

- **approval-side-panel.spec.ts**: Replaced 4 separate `test.describe` blocks (all skipping due to hardcoded mock IDs `exec-approval` / `550e8400-...`) with a single serial suite sharing a `beforeAll` that creates a real workflow + execution + approval via API. Deep-link tests now run against real data. Rewrote UI-28 and UI-30 to use API-based workflow creation (trigger → approval node) instead of the UI builder with script nodes, fixing the "Script node execution is not enabled" failure. Added `dismissConnectionBanner` to handle the "Live updates paused" overlay.
- **approval-multi-navigation.spec.ts**: Rewritten in previous commit to use API-based workflow creation with parallel approval nodes.
- **approval-node.spec.ts**: Added `test.slow()` to all 5 tests to prevent timeouts under parallel worker load (doubles timeout from 60s to 120s).

## Out of Scope

- Backend approval seeder (recommended follow-up for eliminating API setup overhead)
- Reorganizing UI-28/UI-30 into a separate execution-lifecycle spec file
- Fixing intermittent Temporal latency under heavy parallel worker contention

## Related Issues

Resolves AAP-85119 and is a follow-up to PR #216 which fixed the core race condition (API polling) and moved `pollExecutionStatus` to shared utilities. This PR addresses the remaining skipped tests: side-panel deep-link tests (missing seed data), UI-28/UI-30 (script node failures), and approval-node timeouts under parallel load.

## How to Test

1. Run all approval E2E tests locally with backend + Temporal running:
   ```bash
   SYNTARA_E2E_SKIP_WEB_SERVER=1 SYNTARA_E2E_PASSWORD="$(cat ../../../backend/.secrets/admin-password)" SYNTARA_E2E_BASE_URL=http://localhost:5173 npx playwright test e2e/workflows/approval-multi-navigation.spec.ts e2e/workflows/approval-node.spec.ts e2e/workflows/approval-side-panel.spec.ts --reporter=list

Expect 14/14 passing (8 side-panel + 5 approval-node + 1 multi-navigation)

Side-panel tests 1-8 should pass consistently; approval-node tests may occasionally timeout under heavy parallel load locally but pass on CI's 8-core runners

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Additional Notes

- The side-panel deep-link tests previously depended on mock API data (syntara-mock-api) that was never available in CI or when running against the real backend. The beforeAll approach creates real data, making these tests functional for the first time.
- The dismissConnectionBanner helper handles a "Live updates paused" inline alert that overlays the approval panel and blocks DOM interaction.
- UI-28 and UI-30 were failing because they used createBasicWorkflowViaApi which inserts a Script node before the Approval node. Script execution is disabled by default (APP_SCRIPT_NODES_ENABLED=false), so the execution failed before reaching the approval. The fix routes the trigger directly to the approval node.
