### PR TITLE
fix: scope retry/cancel execution permission check to the run's project

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
@@ -527,6 +527,7 @@ export function BuilderContent(props: BuilderContentProps) {
                     onPendingImport={setPendingImport}
                     isLiveRunActive={isLiveRunActive}
                     executionId={mostRecentExecutionId}
+                    projectId={builderProjectId}
                     executionStatus={mostRecentExecution?.status}
                     onBackToEditor={isLiveRunActive ? handleCloseMostRecentRunPanel : undefined}
                     hasApprovalPending={!!pendingApproval}

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderWorkflowPageHeader.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderWorkflowPageHeader.tsx
@@ -25,6 +25,7 @@ type BuilderToolbarContentProps = Readonly<{
   isLiveRunActive?: boolean
   executionId?: string | null
   executionStatus?: ExecutionStatus | null
+  projectId?: string | null
   hasApprovalPending?: boolean
   isApprovalLoading?: boolean
   isApprovalPanelOpen?: boolean
@@ -73,6 +74,7 @@ function BuilderToolbarContent({
   isLiveRunActive,
   executionId,
   executionStatus,
+  projectId,
   hasApprovalPending,
   isApprovalLoading,
   isApprovalPanelOpen,
@@ -161,7 +163,9 @@ function BuilderToolbarContent({
             Review approval
           </Button>
         )}
-        {isCancellable && executionId && <CancelExecutionButton executionId={executionId} />}
+        {isCancellable && executionId && (
+          <CancelExecutionButton executionId={executionId} resourceProject={projectId ?? undefined} />
+        )}
         <Button variant="primary" onClick={onBackToEditor}>
           Back to editor
         </Button>
@@ -294,6 +298,7 @@ export type BuilderWorkflowPageHeaderProps = Readonly<{
   isLiveRunActive?: boolean
   executionId?: string | null
   executionStatus?: ExecutionStatus | null
+  projectId?: string | null
   onBackToEditor?: () => void
   hasApprovalPending?: boolean
   isApprovalLoading?: boolean
@@ -341,6 +346,7 @@ export function BuilderWorkflowPageHeader({
   isLiveRunActive,
   executionId,
   executionStatus,
+  projectId,
   onBackToEditor,
   hasApprovalPending,
   isApprovalLoading,
@@ -378,6 +384,7 @@ export function BuilderWorkflowPageHeader({
       isLiveRunActive={isLiveRunActive}
       executionId={executionId}
       executionStatus={executionStatus}
+      projectId={projectId}
       hasApprovalPending={hasApprovalPending}
       isApprovalLoading={isApprovalLoading}
       isApprovalPanelOpen={isApprovalPanelOpen}

--- a/frontend/packages/syntara-ui/src/routes/executions/CancelExecutionButton.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/CancelExecutionButton.test.tsx
@@ -34,11 +34,11 @@ vi.mock('../../providers/alerts/AlertContext', () => ({
   }),
 }))
 
-function renderButton(executionId = 'exec-123') {
+function renderButton(executionId = 'exec-123', resourceProject?: string) {
   const queryClient = new QueryClient()
   return render(
     <QueryClientProvider client={queryClient}>
-      <CancelExecutionButton executionId={executionId} />
+      <CancelExecutionButton executionId={executionId} resourceProject={resourceProject} />
     </QueryClientProvider>
   )
 }
@@ -112,5 +112,17 @@ describe('CancelExecutionButton', () => {
     const { container } = renderButton()
     const results = await axe(container)
     expect(results).toHaveNoViolations()
+  })
+
+  it('scopes the permission check to the given project', () => {
+    renderButton('exec-123', 'proj-123')
+
+    expect(useCanI).toHaveBeenCalledWith('run', 'execution', { resourceProject: 'proj-123' })
+  })
+
+  it('checks system-scoped permission when no project is given', () => {
+    renderButton()
+
+    expect(useCanI).toHaveBeenCalledWith('run', 'execution', undefined)
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/executions/CancelExecutionButton.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/CancelExecutionButton.tsx
@@ -8,14 +8,15 @@ import { useCancelExecution } from './useCancelExecution'
 
 type CancelExecutionButtonProps = Readonly<{
   executionId: string
+  resourceProject?: string
 }>
 
 const cancelTooltip = permissionTooltip('cancel this execution', 'execution:run')
 
-export function CancelExecutionButton({ executionId }: CancelExecutionButtonProps) {
+export function CancelExecutionButton({ executionId, resourceProject }: CancelExecutionButtonProps) {
   /* v8 ignore start -- v8 emits phantom branches from compiled hook destructuring */
   const cancel = useCancelExecution(executionId)
-  const { allowed: canRun, isChecking } = useCanI('run', 'execution')
+  const { allowed: canRun, isChecking } = useCanI('run', 'execution', resourceProject ? { resourceProject } : undefined)
   const permissionDenied = !isChecking && !canRun
   const isCancelDisabled = !canRun || cancel.isPending || isChecking
   /* v8 ignore stop */

--- a/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetailPageHeaderParts.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetailPageHeaderParts.tsx
@@ -78,12 +78,13 @@ export function ExecutionDetailHeaderToolbar({
           onReviewClick={onReviewClick}
         />
       )}
-      {isCancellable && <CancelExecutionButton executionId={executionId} />}
+      {isCancellable && <CancelExecutionButton executionId={executionId} resourceProject={execution?.project_id} />}
       {isRetryable && execution && (
         <RetryExecutionButton
           executionId={executionId}
           workflowId={execution.workflow_id}
           workflowVersionId={execution.workflow_version_id}
+          resourceProject={execution.project_id}
         />
       )}
       <Button variant="secondary" onClick={onCopyToEditor}>

--- a/frontend/packages/syntara-ui/src/routes/executions/RetryExecutionButton.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/RetryExecutionButton.test.tsx
@@ -127,4 +127,16 @@ describe('RetryExecutionButton', () => {
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })
+
+  it('scopes the permission check to the given project', () => {
+    renderButton({ resourceProject: 'proj-123' })
+
+    expect(useCanI).toHaveBeenCalledWith('run', 'execution', { resourceProject: 'proj-123' })
+  })
+
+  it('checks system-scoped permission when no project is given', () => {
+    renderButton()
+
+    expect(useCanI).toHaveBeenCalledWith('run', 'execution', undefined)
+  })
 })

--- a/frontend/packages/syntara-ui/src/routes/executions/RetryExecutionButton.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/RetryExecutionButton.tsx
@@ -16,16 +16,22 @@ type RetryExecutionButtonProps = Readonly<{
   executionId: string
   workflowId: string
   workflowVersionId: string
+  resourceProject?: string
 }>
 
 const retryTooltip = permissionTooltip('retry this execution', 'execution:run')
 
-export function RetryExecutionButton({ executionId, workflowId, workflowVersionId }: RetryExecutionButtonProps) {
+export function RetryExecutionButton({
+  executionId,
+  workflowId,
+  workflowVersionId,
+  resourceProject,
+}: RetryExecutionButtonProps) {
   const retryDialog = useDialogState<void>()
   const navigate = useNavigate()
 
   /* v8 ignore start -- v8 emits phantom branches from compiled hook destructuring */
-  const { allowed: canRun, isChecking } = useCanI('run', 'execution')
+  const { allowed: canRun, isChecking } = useCanI('run', 'execution', resourceProject ? { resourceProject } : undefined)
   const permissionDenied = !isChecking && !canRun
   const isDisabled = !canRun || isChecking
 


### PR DESCRIPTION
## Summary

A project-user can run a workflow, but the Retry and Cancel buttons in the execution panel show as disabled with a "permission missing" tooltip, even though they should have access.

Root cause: `RetryExecutionButton`/`CancelExecutionButton` called `useCanI('run', 'execution')` with no project context. Without `resource_project`, the check can only match the system-scoped `execution:run` grant, which only `admin` holds. Project-scoped roles like `project-user` hold `execution:run:project`, which requires `resource_project` to be sent — so project users saw the buttons disabled even for executions they started themselves. The real REST enforcement (`PermissionChecker` on the cancel/retry endpoints) was already correct; this was purely an advisory UI check gap.

- Added an optional `resourceProject` prop to `RetryExecutionButton`/`CancelExecutionButton`, forwarded to `useCanI`, matching the existing pattern in `useWorkflowPermissions`/`useBuilderPermissions`.
- Wired `execution.project_id` through on the execution detail page.
- Threaded a `projectId` prop through `BuilderWorkflowPageHeader` → `BuilderToolbarContent` for the builder's live-run Cancel button, sourced from `BuilderContent`'s existing `builderProjectId`.

## Test plan

- [x] Unit tests: added coverage asserting `useCanI` receives the scoped/unscoped options correctly in both button components
- [x] `BuilderWorkflowPageHeader.test.tsx` / `BuilderContent.test.tsx` pass unchanged with the new prop threading
- [x] Manually verified as a `project-user` in a project: run, retry, and cancel executions from both the execution detail page and the builder's live-run view
- [x] Manually verified a `project-auditor` (read-only) role in the same project is correctly still denied retry
- [x] Manually verified a `project-user` role scoped to a different project cannot retry/cancel executions outside their project

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>