### PR TITLE
fix(ui): convert run history rows from buttons to links (AAP-82275)

### DIFF
--- a/frontend/packages/syntara-ui/e2e/run-history-filtering.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/run-history-filtering.spec.ts
@@ -351,8 +351,10 @@ test.describe('Run history panel filtering', { tag: '@pr-check' }, () => {
     const runIdText = `Run ID: ${truncatedRunId(COMPLETED_ID)}`
     await expect(app.getByText(runIdText)).toBeVisible()
 
-    // Scope metadata assertions to the same list item that contains this Run ID
-    const row = app.getByRole('button', { name: new RegExp(runIdText) })
+    // Overlay row link is a sibling of the metadata; scope via the listitem that owns that link
+    const row = app.getByRole('listitem').filter({
+      has: app.getByRole('link', { name: new RegExp(runIdText) }),
+    })
     await expect(row.getByText(/Elapsed time:/)).toBeVisible()
     await expect(row.getByText(/Version:/)).toBeVisible()
   })

--- a/frontend/packages/syntara-ui/eslint.config.js
+++ b/frontend/packages/syntara-ui/eslint.config.js
@@ -164,10 +164,15 @@ export default tseslint.config(
       ],
     },
   },
-  // NxLink.tsx wraps TanStack Link for general use. SynPageBreadcrumbs also
-  // imports Link directly because NxLink renders a PF6 Button (wrong for breadcrumb styling).
+  // NxLink.tsx wraps TanStack Link for general use. SynPageBreadcrumbs and
+  // HistoryListItemLink import Link directly because NxLink renders a PF6 Button
+  // (wrong for breadcrumb items and stretched list-row overlays).
   {
-    files: ['**/components/NxLink.tsx', '**/components/layout/SynPageBreadcrumbs.tsx'],
+    files: [
+      '**/components/NxLink.tsx',
+      '**/components/layout/SynPageBreadcrumbs.tsx',
+      '**/routes/builder/HistoryListItemLink.tsx',
+    ],
     rules: {
       '@typescript-eslint/no-restricted-imports': 'off',
     },

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.test.tsx
@@ -1149,7 +1149,7 @@ describe('BuilderContent', () => {
       })
 
       const user = userEvent.setup()
-      const row = screen.getByRole('button', { name: /Completed/i })
+      const row = screen.getByRole('link', { name: /Execution from/ })
       expect(row).toBeInTheDocument()
       await user.click(row)
       await waitFor(() => {

--- a/frontend/packages/syntara-ui/src/routes/builder/HistoryListItemLink.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/HistoryListItemLink.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'vitest-axe'
+
+import { HistoryListItemLink } from './HistoryListItemLink'
+
+describe('HistoryListItemLink', () => {
+  const onSelect = vi.fn()
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders an anchor with the correct href', () => {
+    render(<HistoryListItemLink to="/foo/bar" onSelect={onSelect} aria-label="test link" />)
+
+    const link = screen.getByRole('link', { name: 'test link' })
+    expect(link).toHaveAttribute('href', '/foo/bar')
+  })
+
+  it('applies the PF simple-list item-link class', () => {
+    render(<HistoryListItemLink to="/x" onSelect={onSelect} aria-label="link" />)
+
+    expect(screen.getByRole('link')).toHaveClass('pf-v6-c-simple-list__item-link')
+  })
+
+  it('omits the PF simple-list item-link class in overlay mode', () => {
+    render(<HistoryListItemLink to="/x" onSelect={onSelect} overlay aria-label="link" />)
+
+    expect(screen.getByRole('link')).not.toHaveClass('pf-v6-c-simple-list__item-link')
+  })
+
+  it('appends custom className', () => {
+    render(<HistoryListItemLink to="/x" onSelect={onSelect} className="my-extra" aria-label="link" />)
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveClass('pf-v6-c-simple-list__item-link')
+    expect(link).toHaveClass('my-extra')
+  })
+
+  it('sets aria-current and pf-m-current when selected', () => {
+    render(<HistoryListItemLink to="/x" onSelect={onSelect} isSelected aria-label="link" />)
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('aria-current', 'page')
+    expect(link).toHaveClass('pf-m-current')
+  })
+
+  it('omits aria-current and pf-m-current when not selected', () => {
+    render(<HistoryListItemLink to="/x" onSelect={onSelect} aria-label="link" />)
+
+    const link = screen.getByRole('link')
+    expect(link).not.toHaveAttribute('aria-current')
+    expect(link).not.toHaveClass('pf-m-current')
+  })
+
+  it('sets data-item-id', () => {
+    render(<HistoryListItemLink to="/x" onSelect={onSelect} data-item-id="abc" aria-label="link" />)
+
+    expect(screen.getByRole('link')).toHaveAttribute('data-item-id', 'abc')
+  })
+
+  it('calls onSelect on unmodified click', async () => {
+    const user = userEvent.setup()
+    render(<HistoryListItemLink to="/x" onSelect={onSelect} aria-label="link" />)
+
+    await user.click(screen.getByRole('link'))
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onSelect on Ctrl+click', async () => {
+    const user = userEvent.setup()
+    render(<HistoryListItemLink to="/x" onSelect={onSelect} aria-label="link" />)
+
+    await user.keyboard('{Control>}')
+    await user.click(screen.getByRole('link'))
+    await user.keyboard('{/Control}')
+
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('does not call onSelect on Meta+click', async () => {
+    const user = userEvent.setup()
+    render(<HistoryListItemLink to="/x" onSelect={onSelect} aria-label="link" />)
+
+    await user.keyboard('{Meta>}')
+    await user.click(screen.getByRole('link'))
+    await user.keyboard('{/Meta}')
+
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('renders children', () => {
+    render(
+      <HistoryListItemLink to="/x" onSelect={onSelect} aria-label="link">
+        <span>Row content</span>
+      </HistoryListItemLink>
+    )
+
+    expect(screen.getByText('Row content')).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <nav>
+        <HistoryListItemLink to="/x" onSelect={onSelect} aria-label="Test link" />
+      </nav>
+    )
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no accessibility violations when selected', async () => {
+    const { container } = render(
+      <nav>
+        <HistoryListItemLink to="/x" onSelect={onSelect} isSelected aria-label="Selected link" />
+      </nav>
+    )
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/builder/HistoryListItemLink.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/HistoryListItemLink.tsx
@@ -1,0 +1,64 @@
+import { Link } from '@tanstack/react-router'
+import type { ComponentProps, MouseEvent, ReactNode } from 'react'
+
+type TanStackTo = ComponentProps<typeof Link>['to']
+
+type HistoryListItemLinkProps = Readonly<{
+  to: string
+  isSelected?: boolean
+  onSelect: () => void
+  children?: ReactNode
+  className?: string
+  'aria-label'?: string
+  'data-item-id'?: string
+  /**
+   * When true the `<a>` is rendered without PF's `pf-v6-c-simple-list__item-link`
+   * class so it can be absolutely-positioned as an overlay without PF's
+   * `position: relative` fighting the overlay layout.
+   */
+  overlay?: boolean
+}>
+
+function isModifiedClick(event: MouseEvent<HTMLAnchorElement>): boolean {
+  return event.metaKey || event.altKey || event.ctrlKey || event.shiftKey
+}
+
+/**
+ * PatternFly Simple List item rendered as a TanStack Router `<Link>` so rows get
+ * link semantics (open in new tab, SR role, client-side routing) while unmodified
+ * left-click still runs `onSelect`. NxLink is a PF Button, so it cannot be used here.
+ */
+export function HistoryListItemLink({
+  to,
+  isSelected = false,
+  onSelect,
+  children,
+  className,
+  'aria-label': ariaLabel,
+  'data-item-id': dataItemId,
+  overlay = false,
+}: HistoryListItemLinkProps) {
+  const pfClass = overlay ? '' : 'pf-v6-c-simple-list__item-link'
+  const selectedClass = isSelected ? ' pf-m-current' : ''
+  const extraClass = className ? ` ${className}` : ''
+
+  return (
+    <Link
+      // TanStack Router expects literal route strings; history hrefs are dynamic
+      to={to as TanStackTo}
+      className={`${pfClass}${selectedClass}${extraClass}`.trim()}
+      aria-current={isSelected ? 'page' : undefined}
+      aria-label={ariaLabel}
+      data-item-id={dataItemId}
+      onClick={(event) => {
+        if (isModifiedClick(event)) {
+          return
+        }
+        event.preventDefault()
+        onSelect()
+      }}
+    >
+      {children}
+    </Link>
+  )
+}

--- a/frontend/packages/syntara-ui/src/routes/builder/WorkflowHistoryCard.module.css
+++ b/frontend/packages/syntara-ui/src/routes/builder/WorkflowHistoryCard.module.css
@@ -5,6 +5,11 @@
 
 .historyRowStack {
   gap: var(--pf-t--global--spacer--sm);
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
+  padding-block: var(--pf-t--global--spacer--md);
+  padding-inline: var(--pf-t--global--spacer--md);
 }
 
 .historyMetaStack {
@@ -40,10 +45,25 @@
   position: relative;
 }
 
+.historyRowOverlay {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  display: block;
+}
+
+.historyRowRaised {
+  pointer-events: auto;
+  position: relative;
+  z-index: 2;
+}
+
 .historyRowKebab {
   position: absolute;
   top: var(--pf-t--global--spacer--md);
   right: var(--pf-t--global--spacer--md);
+  z-index: 2;
+  pointer-events: auto;
 }
 
 .simpleList {

--- a/frontend/packages/syntara-ui/src/routes/builder/WorkflowHistoryCard.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/WorkflowHistoryCard.test.tsx
@@ -1,7 +1,7 @@
 import { SimpleList } from '@patternfly/react-core'
 import type { ExecutionsAPI } from '@syntara/contracts'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -185,7 +185,7 @@ describe('WorkflowHistoryCard', () => {
   it('calls onExecutionSelect with the execution id when row is clicked', async () => {
     const user = userEvent.setup()
     renderCard(<WorkflowHistoryCard {...defaultProps} executions={[baseExecution]} />)
-    const row = screen.getByRole('button', { name: /running/i })
+    const row = screen.getByRole('link', { name: /Execution from/ })
     await user.click(row)
     expect(mockOnExecutionSelect).toHaveBeenCalledWith(baseExecution.id)
   })
@@ -194,15 +194,14 @@ describe('WorkflowHistoryCard', () => {
     renderCard(
       <WorkflowHistoryCard {...defaultProps} executions={[baseExecution]} selectedExecutionId={baseExecution.id} />
     )
-    const buttons = screen.getAllByRole('button')
-    const rowButton = buttons.find((btn) => btn.textContent?.includes('Jan 15, 2024'))!
-    expect(rowButton).toHaveClass('pf-m-current')
+    const rowLink = screen.getByRole('link', { name: /Execution from/ })
+    expect(rowLink).toHaveClass('pf-m-current')
   })
 
   it('does not highlight an unselected row', () => {
     renderCard(<WorkflowHistoryCard {...defaultProps} executions={[baseExecution]} selectedExecutionId="other-id" />)
-    const rowButton = screen.getByRole('button', { name: /running/i })
-    expect(rowButton).not.toHaveClass('pf-m-current')
+    const rowLink = screen.getByRole('link', { name: /Execution from/ })
+    expect(rowLink).not.toHaveClass('pf-m-current')
   })
 
   it('renders a SimpleList when executions are present', () => {
@@ -406,25 +405,27 @@ describe('ExecutionHistoryRow', () => {
   it('calls onSelect when row is clicked', async () => {
     const user = userEvent.setup()
     renderRow(baseExecution)
-    await user.click(screen.getByRole('button'))
+    const rowLink = screen.getByRole('link', { name: /Execution from/ })
+    await user.click(rowLink)
     expect(mockOnSelect).toHaveBeenCalledTimes(1)
   })
 
   it('applies pf-m-current class when isSelected is true', () => {
     renderRow(baseExecution, true)
-    expect(screen.getByRole('button')).toHaveClass('pf-m-current')
+    const rowLink = screen.getByRole('link', { name: /Execution from/ })
+    expect(rowLink).toHaveClass('pf-m-current')
   })
 
   it('does not apply pf-m-current class when isSelected is false', () => {
     renderRow(baseExecution, false)
-    expect(screen.getByRole('button')).not.toHaveClass('pf-m-current')
+    const rowLink = screen.getByRole('link', { name: /Execution from/ })
+    expect(rowLink).not.toHaveClass('pf-m-current')
   })
 
-  it('uses within to check layout structure', () => {
+  it('renders row metadata in the list item', () => {
     renderRow(baseExecution)
-    const row = screen.getByRole('button')
-    expect(within(row).getByText(/Jan 15, 2024/)).toBeInTheDocument()
-    expect(within(row).getByText('Run ID: 12345678')).toBeInTheDocument()
+    expect(screen.getByText(/Jan 15, 2024/)).toBeInTheDocument()
+    expect(screen.getByText('Run ID: 12345678')).toBeInTheDocument()
   })
 
   it('displays version publish name when available', () => {
@@ -452,8 +453,8 @@ describe('ExecutionHistoryRow', () => {
       workflow_version: 5,
       workflow_version_name: 'v5 release',
     })
-    const link = screen.getByRole('link', { name: /v5 release/ })
-    expect(link).toHaveAttribute('href', '/workflow-builder/wf-1?version=5')
+    const versionLink = screen.getByRole('link', { name: /v5 release/ })
+    expect(versionLink).toHaveAttribute('href', '/workflow-builder/wf-1?version=5')
   })
 
   it('does not display version when workflow_version is null', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/WorkflowHistoryCard.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/WorkflowHistoryCard.tsx
@@ -48,8 +48,9 @@ import { useRetryExecution } from '../executions/useRetryExecution'
 import type { ExecutionMetadata } from '../workflows/stores/useExecutionStore'
 
 import { StatusLabel } from './ExecutionStatus'
-import { getDateGroupLabel } from './historyDateUtils'
-import { getClearFiltersHandler } from './hooks/historyRowModel'
+import { formatHistoryDateTime, getDateGroupLabel } from './historyDateUtils'
+import { HistoryListItemLink } from './HistoryListItemLink'
+import { executionDetailHref, getClearFiltersHandler, workflowVersionHref } from './hooks/historyRowModel'
 import styles from './WorkflowHistoryCard.module.css'
 
 type Execution = ExecutionsAPI.components['schemas']['ExecutionRead']
@@ -134,62 +135,71 @@ export function ExecutionHistoryRow({ execution, onSelect, isSelected }: Executi
   const truncatedId = execution.id ? execution.id.slice(0, TRUNCATED_ID_LENGTH) : null
   const isTestRun = (execution as { execution_metadata?: ExecutionMetadata }).execution_metadata?.mode === 'test'
   const retryable = isExecutionRetryable(execution.status, execution.mode)
+  const executionHref = executionDetailHref(execution.id)
+  const runIdLabel = truncatedId ? `Run ID: ${truncatedId}` : null
+  const versionHref =
+    execution.workflow_version != null && execution.workflow_id
+      ? workflowVersionHref(execution.workflow_id, execution.workflow_version)
+      : null
+  const dateLabel = execution.created_at
+    ? `Execution from ${formatHistoryDateTime(execution.created_at)}`
+    : `Execution ${truncatedId ?? execution.id}`
+  const rowLabel = runIdLabel ? `${dateLabel}, ${runIdLabel}` : dateLabel
 
   /* v8 ignore start -- phantom branches from compiled JSX props/ternaries in history row layout */
   return (
-    // eslint-disable-next-line syntara/prefer-pf-list-components -- SimpleListItem renders a <button> wrapper, causing invalid nested <button> with the kebab menu (https://github.com/patternfly/patternfly-react/issues/11368)
+    // eslint-disable-next-line syntara/prefer-pf-list-components -- SimpleListItem renders a <button> wrapper, causing invalid nested interactive elements (https://github.com/patternfly/patternfly-react/issues/11368)
     <li className={`pf-v6-c-simple-list__item ${styles.historyRowItem}`}>
-      <button
-        type="button"
-        className={`pf-v6-c-simple-list__item-link ${isSelected ? 'pf-m-current' : ''}`}
-        onClick={onSelect}
+      <HistoryListItemLink
+        to={executionHref}
+        isSelected={isSelected}
+        onSelect={onSelect}
         data-item-id={execution.id}
-      >
-        <Stack className={styles.historyRowStack}>
-          <FlexItem className={styles.historyRowTitle}>
-            {execution.created_at && (
-              <Content component={ContentVariants.p} className={styles.historyRowDatetime}>
-                <ExecutionTimestamp dateString={execution.created_at} />
-              </Content>
-            )}
-          </FlexItem>
-          <Stack className={styles.historyMetaStack}>
-            <Content component={ContentVariants.small} className={styles.historyRowMeta}>
-              {elapsedLabel}
+        aria-label={rowLabel}
+        overlay
+        className={styles.historyRowOverlay}
+      />
+      <Stack className={styles.historyRowStack}>
+        <FlexItem className={styles.historyRowTitle}>
+          {execution.created_at && (
+            <Content component={ContentVariants.p} className={styles.historyRowDatetime}>
+              <ExecutionTimestamp dateString={execution.created_at} />
             </Content>
-            {truncatedId && (
-              <Content component={ContentVariants.small} className={styles.historyRowMeta}>
-                {`Run ID: ${truncatedId}`}
-              </Content>
-            )}
-            {execution.workflow_version != null && execution.workflow_id && (
-              <Content component={ContentVariants.small} className={styles.historyRowMeta}>
-                {'Version: '}
-                <NxLink
-                  to={`/workflow-builder/${execution.workflow_id}?version=${String(execution.workflow_version)}`}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {execution.workflow_version_name ? (
-                    <Truncate content={execution.workflow_version_name} />
-                  ) : (
-                    <ExecutionTimestamp dateString={execution.workflow_version_created_at} />
-                  )}
-                </NxLink>
-              </Content>
-            )}
-            {execution.retried_from_execution_id && (
-              <Content component={ContentVariants.small} className={`${styles.historyRowMeta} ${styles.retriedFrom}`}>
-                {`Retried from: ${execution.retried_from_execution_id.slice(0, TRUNCATED_ID_LENGTH)}`}
-              </Content>
-            )}
-          </Stack>
-          <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }} flexWrap={{ default: 'wrap' }}>
-            {execution.status && <StatusLabel status={execution.status} />}
-            <ApprovalPendingBadge approvalPending={execution.approval_pending} />
-            {isTestRun && <NxLabel color="purple">Test run</NxLabel>}
-          </Flex>
+          )}
+        </FlexItem>
+        <Stack className={styles.historyMetaStack}>
+          <Content component={ContentVariants.small} className={styles.historyRowMeta}>
+            {elapsedLabel}
+          </Content>
+          {runIdLabel && (
+            <Content component={ContentVariants.small} className={styles.historyRowMeta}>
+              {runIdLabel}
+            </Content>
+          )}
+          {versionHref && (
+            <Content component={ContentVariants.small} className={styles.historyRowMeta}>
+              {'Version: '}
+              <NxLink to={versionHref} className={styles.historyRowRaised}>
+                {execution.workflow_version_name ? (
+                  <Truncate content={execution.workflow_version_name} />
+                ) : (
+                  <ExecutionTimestamp dateString={execution.workflow_version_created_at} />
+                )}
+              </NxLink>
+            </Content>
+          )}
+          {execution.retried_from_execution_id && (
+            <Content component={ContentVariants.small} className={`${styles.historyRowMeta} ${styles.retriedFrom}`}>
+              {`Retried from: ${execution.retried_from_execution_id.slice(0, TRUNCATED_ID_LENGTH)}`}
+            </Content>
+          )}
         </Stack>
-      </button>
+        <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }} flexWrap={{ default: 'wrap' }}>
+          {execution.status && <StatusLabel status={execution.status} />}
+          <ApprovalPendingBadge approvalPending={execution.approval_pending} />
+          {isTestRun && <NxLabel color="purple">Test run</NxLabel>}
+        </Flex>
+      </Stack>
       {retryable && (
         <div className={styles.historyRowKebab}>
           <HistoryRowRetryAction execution={execution} />

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/historyRowModel.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/historyRowModel.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   buildExecutionHistoryRowModel,
+  executionDetailHref,
   getClearFiltersHandler,
   resolveVersionStatusForBadge,
   shouldShowSecondaryVersionDatetime,
+  workflowVersionHref,
 } from './historyRowModel'
 
 describe('buildExecutionHistoryRowModel', () => {
@@ -122,6 +124,16 @@ describe('resolveVersionStatusForBadge', () => {
     expect(resolveVersionStatusForBadge('nope')).toBeNull()
     expect(resolveVersionStatusForBadge(null)).toBeNull()
     expect(resolveVersionStatusForBadge(undefined)).toBeNull()
+  })
+})
+
+describe('history row URL helpers', () => {
+  it('builds a workflow-builder URL for a given workflow version', () => {
+    expect(workflowVersionHref('wf-42', 7)).toBe('/workflow-builder/wf-42?version=7')
+  })
+
+  it('builds an executions URL for a given execution id', () => {
+    expect(executionDetailHref('exec-abc')).toBe('/executions/exec-abc')
   })
 })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/historyRowModel.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/historyRowModel.ts
@@ -80,6 +80,14 @@ export function resolveVersionStatusForBadge(status: string | null | undefined):
   return null
 }
 
+export function workflowVersionHref(workflowId: string, version: number): string {
+  return `/workflow-builder/${workflowId}?version=${String(version)}`
+}
+
+export function executionDetailHref(executionId: string): string {
+  return `/executions/${executionId}`
+}
+
 export function getClearFiltersHandler<T>(
   onFilterChange: ((filters: T[]) => void) | undefined
 ): (() => void) | undefined {


### PR DESCRIPTION
## Description

Run history execution rows in the workflow builder were rendered as `<button>` elements, preventing users from right-clicking to open in a new tab and causing screen readers to announce them incorrectly. This converts them to real `<a>` links using a CSS overlay pattern, improving both accessibility (WCAG 2.1 SC 4.1.2) and standard browser link behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- [x] New `HistoryListItemLink` component — renders a real `<a>` tag with PatternFly Simple List styling, handling modified clicks (Ctrl/Cmd) for native "open in new tab" while unmodified clicks run `onSelect`
- [x] `ExecutionHistoryRow` converted from `<button>` to overlay `<a>` link pattern — the entire row is a link to the execution detail page
- [x] CSS overlay layering (`z-index` + `pointer-events`) preserves nested version `NxLink` and kebab menu as independently clickable
- [x] `workflowVersionHref()` and `executionDetailHref()` helpers centralize URL construction in `historyRowModel.ts`
- [x] Unit tests updated from `getByRole('button')` to `getByRole('link')` across 3 test files
- [x] E2E test selector updated to target `<li>` instead of `<button>` role

## Out of Scope

- Version History panel rows (not part of AAP-82275)
- "Currently published" button in Version History panel

## Related Issues

Fixes AAP-82275

## How to Test

1. Open the workflow builder for any workflow
2. Open the Run History panel (right sidebar)
3. **Right-click** on a run history row → verify "Open in new tab" appears in context menu
4. **Ctrl/Cmd+click** on a row → verify it opens the execution detail page in a new tab
5. **Normal click** on a row → verify it selects the row (same as before)
6. **Click the version link** inside a row → verify it navigates to the version in the builder
7. **Click the kebab menu** (retry) → verify it still works
8. Use a **screen reader** → verify rows are announced as links, not buttons

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab

## General Checklist

- [x] Code follows the project's coding conventions
- [x] No secrets or credentials are included in this PR

## Additional Notes

- The pre-existing `eslint-disable-next-line syntara/prefer-pf-list-components` suppression on the `<li>` element was retained (comment text updated) — it exists because PF `SimpleListItem` renders a `<button>` wrapper that would cause nested interactive element violations.
- `HistoryListItemLink` includes `vitest-axe` accessibility tests and uses `aria-current="page"` for selected state.


Made with [Cursor](https://cursor.com)