### PR TITLE
fix(workflows): expire pending approvals left over when a workflow completes

### DIFF
--- a/backend/src/syntara/workflows/workflow_engine/activities/approval_activity.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/approval_activity.py
@@ -10,6 +10,7 @@ from uuid import UUID
 import structlog
 from temporalio import activity, workflow
 from temporalio.exceptions import ApplicationError
+from temporalio.service import RPCError
 
 with workflow.unsafe.imports_passed_through():
     from syntara.approvals.audit.approval import ApprovalExpiredEvent
@@ -19,6 +20,7 @@ with workflow.unsafe.imports_passed_through():
         ApprovalsApiClientError,
     )
     from syntara.workflows.workflow_engine import constants
+    from syntara.workflows.workflow_engine.services.activity_sync_registry import get_activity_sync_service
 from syntara.workflows.workflow_engine.models.workflow_definition import ActivityName
 
 from .common import HEARTBEAT_STOP_MONITOR, ActivityExecutionError
@@ -153,6 +155,10 @@ async def _batch_update_approvals(
                 return {result_key: 0}
 
             approval_ids = [UUID(a["id"]) for a in pending]
+            # Built before the mutating call: if a record is ever missing a required
+            # field, fail before anything is changed rather than after (which would
+            # otherwise misreport a successful mutation as "0 expired, error").
+            approval_records = [{"id": a["id"], "approval_node_id": a["approval_node_id"]} for a in pending]
             batch_fn = getattr(client, batch_method_name)
             result = await batch_fn(approval_ids)
 
@@ -165,7 +171,7 @@ async def _batch_update_approvals(
                 success_count=count,
                 failed_count=result.get("total_failed", 0),
             )
-            return {result_key: count, "_approval_ids": approval_ids}
+            return {result_key: count, "_approval_records": approval_records}
 
     except ApprovalsApiClientError as e:
         logger.warning("Failed to %s approval requests", operation, execution_id=execution_id, error=str(e))
@@ -178,17 +184,23 @@ async def _batch_update_approvals(
 @activity.defn(name=ActivityName.EXPIRE_APPROVAL)
 async def expire_approval_requests_activity(
     execution_id: str,
-    node_id: str,
+    node_id: str | None = None,
 ) -> dict[str, Any]:
-    """Expire pending approval requests for a specific node after its decision window."""
+    """Expire pending approval requests.
+
+    When node_id is given, only that node's pending requests are expired (its own
+    decision window timed out). When node_id is None, all pending requests for the
+    execution are expired (the workflow reached a terminal state while other approval
+    nodes were still awaiting a decision).
+    """
     result = await _batch_update_approvals(execution_id, "expire", "batch_expire", "expired_count", node_id=node_id)
 
-    for approval_id in result.pop("_approval_ids", []):
+    for record in result.pop("_approval_records", []):
         AuditEventDispatcher.dispatch(
             ApprovalExpiredEvent(
-                approval_id=approval_id,
+                approval_id=UUID(record["id"]),
                 execution_id=UUID(execution_id),
-                approval_node_id=node_id,
+                approval_node_id=record["approval_node_id"],
             )
         )
 
@@ -201,5 +213,57 @@ async def cancel_approval_requests_activity(
 ) -> dict[str, Any]:
     """Cancel all pending approval requests when a workflow is cancelled."""
     result = await _batch_update_approvals(execution_id, "cancel", "batch_cancel", "cancelled_count")
-    result.pop("_approval_ids", None)
+    result.pop("_approval_records", None)
     return result
+
+
+@activity.defn(name=ActivityName.FAIL_DETACHED_APPROVAL)
+async def fail_detached_approval_activity(
+    workflow_id: str,
+    run_id: str | None,
+    activity_id: str,
+) -> None:
+    """Fail the async-completion APPROVAL activity for a detached approval node.
+
+    Called as a local activity from the workflow when it completes while an
+    approval branch was detached (e.g. an ANY-strategy converge already
+    satisfied by another branch). Without this, the underlying Temporal
+    activity would stay STARTED until its own start_to_close_timeout even
+    though the workflow, and the approval's DB record, have already moved on.
+    """
+    sync_service = get_activity_sync_service()
+    if sync_service is None:
+        logger.warning(
+            "Activity sync service not available; cannot fail detached approval activity",
+            activity_id=activity_id,
+            workflow_id=workflow_id,
+        )
+        return
+
+    error = ApplicationError(
+        "Approval expired: workflow completed while awaiting a decision",
+        type="ApprovalExpired",
+        non_retryable=True,
+    )
+    try:
+        handle = sync_service.temporal_client.get_async_activity_handle(
+            workflow_id=workflow_id,
+            run_id=run_id,
+            activity_id=activity_id,
+        )
+        await handle.fail(error)
+        logger.info(
+            "Detached approval activity failed via async handle",
+            activity_id=activity_id,
+            workflow_id=workflow_id,
+        )
+    except RPCError as e:
+        err_msg = str(e).lower()
+        if "not found" in err_msg or "already completed" in err_msg or "cannot find" in err_msg:
+            logger.info(
+                "Detached approval activity already resolved (idempotent)",
+                activity_id=activity_id,
+                workflow_id=workflow_id,
+            )
+        else:
+            raise

--- a/backend/src/syntara/workflows/workflow_engine/activities/registry.py
+++ b/backend/src/syntara/workflows/workflow_engine/activities/registry.py
@@ -16,6 +16,7 @@ from syntara.workflows.workflow_engine.activities.approval_activity import (
     cancel_approval_requests_activity,
     create_approval_request_activity,
     expire_approval_requests_activity,
+    fail_detached_approval_activity,
 )
 from syntara.workflows.workflow_engine.activities.approver_resolution_activity import resolve_approvers_activity
 from syntara.workflows.workflow_engine.activities.condition import condition
@@ -49,6 +50,7 @@ _TEMPORAL_ACTIVITIES: list[Callable[..., Any]] = [
     cancel_approval_requests_activity,
     create_approval_request_activity,
     expire_approval_requests_activity,
+    fail_detached_approval_activity,
     resolve_approvers_activity,
     condition,
     converge,

--- a/backend/src/syntara/workflows/workflow_engine/approval_mixin.py
+++ b/backend/src/syntara/workflows/workflow_engine/approval_mixin.py
@@ -92,19 +92,26 @@ class WorkflowApprovalMixin:
             await self._expire_approval_requests(node_id)
 
     async def _expire_remaining_approvals(self, graph: "WorkflowGraph") -> None:
-        """Expire any approvals still pending once the workflow ends.
+        """Expire any approvals left pending by a detached approval node.
 
         Covers approval nodes left pending because a converge/failure path detached
         them before a decision was recorded (e.g. two approval branches where the
         workflow reaches its terminal state after only one is decided). Also fails
         the underlying Temporal activity for each detached approval node so it
         resolves immediately instead of lingering until its own start_to_close_timeout.
-        """
-        await self._expire_approvals(None, activity_id="__internal__expire_remaining_approvals")
 
+        No-ops if nothing was detached: an approval that already resolved via its
+        own timeout (``_maybe_expire_approval``) or a normal decision needs no
+        further cleanup here.
+        """
         detached_approval_ids = [
             node_id for node_id in self._detached_nodes if graph.get_node(node_id).type == NodeType.APPROVAL
         ]
+        if not detached_approval_ids:
+            return
+
+        await self._expire_approvals(None, activity_id="__internal__expire_remaining_approvals")
+
         for node_id in detached_approval_ids:
             await self._fail_detached_approval_activity(node_id)
 

--- a/backend/src/syntara/workflows/workflow_engine/approval_mixin.py
+++ b/backend/src/syntara/workflows/workflow_engine/approval_mixin.py
@@ -16,6 +16,7 @@ from temporalio.exceptions import TimeoutError as TemporalTimeoutError
 with workflow.unsafe.imports_passed_through():
     from syntara.core.constants import FieldLimits
     from syntara.core.exceptions import SafeValueError
+    from syntara.workflows.workflow_engine.activities.approval_activity import fail_detached_approval_activity
     from syntara.workflows.workflow_engine.constants import DEFAULT_ACTIVITY_TIMEOUT_SECONDS
     from syntara.workflows.workflow_engine.models.workflow_definition import (
         ActivityName,
@@ -49,23 +50,32 @@ class WorkflowApprovalMixin:
     resolver: NamespaceResolver
     _runtime_settings: dict[str, Any]
     skipped_nodes: set[str]
+    _detached_nodes: set[str]
     _TEMPORAL_MARGIN: ClassVar[int]
 
-    async def _expire_approval_requests(self, node_id: str) -> None:
-        """Best-effort expire pending approval requests for a timed-out approval node."""
+    async def _expire_approvals(self, node_id: str | None, activity_id: str) -> None:
+        """Best-effort expire pending approval requests.
+
+        node_id=None expires every pending approval for the execution;
+        a specific node_id scopes the expiry to that node only.
+        """
         try:
             await workflow.execute_activity(
                 ActivityName.EXPIRE_APPROVAL,
                 args=[self.execution_id, node_id],
-                activity_id=f"__internal__expire_approval_{node_id}",
+                activity_id=activity_id,
                 start_to_close_timeout=timedelta(seconds=DEFAULT_ACTIVITY_TIMEOUT_SECONDS),
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
         except Exception:  # noqa: BLE001
             workflow.logger.warning(
-                "Failed to expire approval requests for node %s (best-effort)",
+                "Failed to expire approval requests (best-effort): node_id=%s",
                 node_id,
             )
+
+    async def _expire_approval_requests(self, node_id: str) -> None:
+        """Expire pending approval requests for a timed-out approval node."""
+        await self._expire_approvals(node_id, activity_id=f"__internal__expire_approval_{node_id}")
 
     async def _maybe_expire_approval(
         self,
@@ -80,6 +90,39 @@ class WorkflowApprovalMixin:
             and isinstance(error.cause, TemporalTimeoutError)
         ):
             await self._expire_approval_requests(node_id)
+
+    async def _expire_remaining_approvals(self, graph: "WorkflowGraph") -> None:
+        """Expire any approvals still pending once the workflow ends.
+
+        Covers approval nodes left pending because a converge/failure path detached
+        them before a decision was recorded (e.g. two approval branches where the
+        workflow reaches its terminal state after only one is decided). Also fails
+        the underlying Temporal activity for each detached approval node so it
+        resolves immediately instead of lingering until its own start_to_close_timeout.
+        """
+        await self._expire_approvals(None, activity_id="__internal__expire_remaining_approvals")
+
+        detached_approval_ids = [
+            node_id for node_id in self._detached_nodes if graph.get_node(node_id).type == NodeType.APPROVAL
+        ]
+        for node_id in detached_approval_ids:
+            await self._fail_detached_approval_activity(node_id)
+
+    async def _fail_detached_approval_activity(self, node_id: str) -> None:
+        """Best-effort fail the async APPROVAL activity for a single detached node."""
+        try:
+            await workflow.execute_local_activity(
+                fail_detached_approval_activity,
+                args=[workflow.info().workflow_id, workflow.info().run_id, node_id],
+                activity_id=f"__internal__fail_detached_approval_{node_id}",
+                start_to_close_timeout=timedelta(seconds=DEFAULT_ACTIVITY_TIMEOUT_SECONDS),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+        except Exception:  # noqa: BLE001
+            workflow.logger.warning(
+                "Failed to fail detached approval activity (best-effort): node_id=%s",
+                node_id,
+            )
 
     async def _cancel_approval_requests(self) -> None:
         """Best-effort cancel all pending approval requests when workflow is cancelled.

--- a/backend/src/syntara/workflows/workflow_engine/dynamic_workflow.py
+++ b/backend/src/syntara/workflows/workflow_engine/dynamic_workflow.py
@@ -120,6 +120,7 @@ class OrchestratorWorkflow(WorkflowConvergeMixin, WorkflowApprovalMixin):
         # This keeps the workflow logic independent of infrastructure concerns.
         try:
             graph = WorkflowGraph.from_dict(workflow_definition)
+            has_approval_nodes = any(node.type == NodeType.APPROVAL for node in graph.get_all_nodes())
             self._initialize_state(
                 execution_id,
                 request_id=request_id,
@@ -145,6 +146,9 @@ class OrchestratorWorkflow(WorkflowConvergeMixin, WorkflowApprovalMixin):
             await self._process_pending_tasks(pending_tasks, graph)
             self._cleanup_timeout_tasks()
             self._mark_remaining_unreachable_nodes(graph)
+
+            if has_approval_nodes:
+                await self._expire_remaining_approvals(graph)
 
             return self._build_result(execution_id, include_node_results)
 

--- a/backend/src/syntara/workflows/workflow_engine/dynamic_workflow.py
+++ b/backend/src/syntara/workflows/workflow_engine/dynamic_workflow.py
@@ -120,7 +120,6 @@ class OrchestratorWorkflow(WorkflowConvergeMixin, WorkflowApprovalMixin):
         # This keeps the workflow logic independent of infrastructure concerns.
         try:
             graph = WorkflowGraph.from_dict(workflow_definition)
-            has_approval_nodes = any(node.type == NodeType.APPROVAL for node in graph.get_all_nodes())
             self._initialize_state(
                 execution_id,
                 request_id=request_id,
@@ -147,7 +146,7 @@ class OrchestratorWorkflow(WorkflowConvergeMixin, WorkflowApprovalMixin):
             self._cleanup_timeout_tasks()
             self._mark_remaining_unreachable_nodes(graph)
 
-            if has_approval_nodes:
+            if self._detached_nodes:
                 await self._expire_remaining_approvals(graph)
 
             return self._build_result(execution_id, include_node_results)

--- a/backend/src/syntara/workflows/workflow_engine/models/workflow_definition.py
+++ b/backend/src/syntara/workflows/workflow_engine/models/workflow_definition.py
@@ -144,6 +144,7 @@ class ActivityName(StrEnum):
     APPROVER_RESOLUTION = "resolve_approvers"
     EXPIRE_APPROVAL = "expire_approval_requests"
     CANCEL_APPROVAL = "cancel_approval_requests"
+    FAIL_DETACHED_APPROVAL = "fail_detached_approval"
     ACTIVITY_MONITORING = "register_activity_monitoring"
     COMPLETE_WAIT = "complete_wait"
     FETCH_RUNTIME_SETTINGS = "fetch_workflow_runtime_settings"

--- a/backend/tests/integration/workflows/workflow_engine/services/test_approval_timeout_integration.py
+++ b/backend/tests/integration/workflows/workflow_engine/services/test_approval_timeout_integration.py
@@ -11,6 +11,7 @@ activity to batch-expire pending approval requests via the Approvals API.
 
 import asyncio
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import yaml
@@ -51,11 +52,83 @@ async def _test_approval_activity(
 @activity.defn(name=ActivityName.EXPIRE_APPROVAL)
 async def _test_expire_approval_activity(
     execution_id: str,
-    node_id: str,
+    node_id: str | None = None,
 ) -> dict[str, Any]:
     """Test expire activity that records calls for assertion."""
     _expire_calls.append((execution_id, node_id))
     return {"expired_count": 1}
+
+
+@activity.defn(name=ActivityName.APPROVAL)
+async def _test_multi_approval_activity(
+    execution_id: str,
+    approval_node_id: str,
+    name: str,
+    next_step_approved: dict[str, Any] | None,
+    workflow_context: dict[str, Any],
+    timeout_at: str | None = None,
+    next_step_rejected: dict[str, Any] | None = None,
+    approver_user_ids: list[str] | None = None,
+    approver_group_ids: list[str] | None = None,
+    project_id: str | None = None,
+) -> dict[str, Any]:
+    """Approval activity where only one of two approval nodes ever gets a decision.
+
+    ``approval_slow`` never resolves, simulating the bug scenario where a second
+    approval branch is left outstanding when the workflow completes via the
+    other (decided) branch.
+    """
+    if approval_node_id == "approval_slow":
+        await asyncio.sleep(3600)
+        return {"output": {}}
+    return {"output": {"decision": "approved", "decided_by": "tester", "decided_at": "2026-01-01T00:00:00Z"}}
+
+
+def _create_multi_approval_workflow_yaml() -> dict[str, Any]:
+    workflow_yaml = """
+schema_version: "2.0.0"
+name: multi-approval-completion-test
+description: Integration test - other pending approvals expire on workflow completion
+triggers:
+- id: trigger_manual
+  type: manual_trigger
+nodes:
+- id: approval_fast
+  type: approval
+  parameters:
+    name: Fast Approval
+    decision_window: 60
+- id: approval_slow
+  type: approval
+  parameters:
+    name: Slow Approval
+    decision_window: 60
+- id: converge_node
+  type: converge
+  parameters:
+    strategy: any
+    n_required: 1
+- id: post_converge
+  type: script
+  parameters:
+    language: python
+    code: "print('done')"
+edges:
+- from: trigger_manual
+  to: approval_fast
+- from: trigger_manual
+  to: approval_slow
+- from: approval_fast
+  to: converge_node
+  from_port: approved
+- from: approval_slow
+  to: converge_node
+  from_port: approved
+- from: converge_node
+  to: post_converge
+"""
+    result: dict[str, Any] = yaml.safe_load(workflow_yaml)
+    return result
 
 
 def _create_approval_workflow_yaml(decision_window: int = 5) -> dict[str, Any]:
@@ -238,3 +311,87 @@ class TestApprovalTimeoutIntegration:
             # Expire activity should still be called
             assert len(_expire_calls) == 1
             assert _expire_calls[0][1] == "approval_node"
+
+    async def test_other_pending_approval_expired_on_workflow_completion(
+        self, temporal_env: WorkflowEnvironment
+    ) -> None:
+        """A second approval branch left pending is expired once the workflow completes.
+
+        Reproduces the reported bug: two approval nodes converge with an ANY
+        strategy, only one is decided, and the workflow completes normally
+        while the other approval is still outstanding. It must be expired
+        rather than left in "pending" forever, and its underlying Temporal
+        activity must be resolved rather than left dangling.
+        """
+        task_queue = "multi-approval-completion-queue"
+        _expire_calls.clear()
+
+        from syntara.workflows.workflow_engine.activities.approval_activity import fail_detached_approval_activity
+        from syntara.workflows.workflow_engine.services.activity_sync_registry import (
+            get_activity_sync_service,
+            set_activity_sync_service,
+        )
+        from syntara.workflows.workflow_engine.services.temporal_execution_service import TemporalExecutionService
+
+        # fail_detached_approval_activity is a local activity invoked by direct function
+        # reference from the workflow, so it can't be swapped out via Worker registration
+        # like EXPIRE_APPROVAL. Instead, stub the ActivitySyncService's temporal_client so
+        # the real activity runs but talks to a mock instead of issuing a real async-activity
+        # completion RPC (unsupported by the time-skipping test environment).
+        mock_handle = AsyncMock()
+        mock_temporal_client = MagicMock()
+        mock_temporal_client.get_async_activity_handle.return_value = mock_handle
+        mock_sync_service = MagicMock()
+        mock_sync_service.temporal_client = mock_temporal_client
+        original_sync_service = get_activity_sync_service()
+        set_activity_sync_service(mock_sync_service)
+
+        try:
+            async with Worker(
+                temporal_env.client,
+                task_queue=task_queue,
+                workflows=[OrchestratorWorkflow],
+                activities=[
+                    manual_trigger,
+                    _test_multi_approval_activity,
+                    _test_expire_approval_activity,
+                    _test_script_activity,
+                    fetch_workflow_runtime_settings,
+                    fail_detached_approval_activity,
+                ],
+            ):
+                execution_service = TemporalExecutionService(
+                    temporal_client=temporal_env.client,
+                    task_queue=task_queue,
+                )
+
+                workflow_def = _create_multi_approval_workflow_yaml()
+
+                result = await execution_service.start_workflow(
+                    workflow_def=workflow_def,
+                    workflow_name="multi-approval-completion-test",
+                    trigger_node_id="trigger_manual",
+                )
+
+                handle = execution_service.temporal_client.get_workflow_handle(
+                    result.temporal_workflow_id, run_id=result.temporal_run_id
+                )
+                workflow_result = await asyncio.wait_for(handle.result(), timeout=30)
+
+                assert workflow_result["status"] == "completed"
+                # The still-pending "approval_slow" branch is swept up by the execution-wide
+                # expire call (node_id=None) issued when the workflow reaches completion.
+                assert len(_expire_calls) == 1
+                called_execution_id, called_node_id = _expire_calls[0]
+                assert called_node_id is None
+                assert called_execution_id is not None
+
+                # The detached branch's underlying Temporal activity is also resolved,
+                # rather than left dangling until its own start_to_close_timeout.
+                mock_temporal_client.get_async_activity_handle.assert_called_once()
+                handle_call_kwargs = mock_temporal_client.get_async_activity_handle.call_args.kwargs
+                assert handle_call_kwargs["workflow_id"] == result.temporal_workflow_id
+                assert handle_call_kwargs["activity_id"] == "approval_slow"
+                mock_handle.fail.assert_called_once()
+        finally:
+            set_activity_sync_service(original_sync_service)

--- a/backend/tests/integration/workflows/workflow_engine/services/test_approval_timeout_integration.py
+++ b/backend/tests/integration/workflows/workflow_engine/services/test_approval_timeout_integration.py
@@ -19,12 +19,13 @@ from temporalio import activity
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
+from syntara.workflows.workflow_engine.activities.converge import converge
 from syntara.workflows.workflow_engine.activities.manual_trigger import manual_trigger
 from syntara.workflows.workflow_engine.activities.runtime_settings_activity import fetch_workflow_runtime_settings
 from syntara.workflows.workflow_engine.dynamic_workflow import OrchestratorWorkflow
 from syntara.workflows.workflow_engine.models.workflow_definition import ActivityName
 
-_expire_calls: list[tuple[str, str]] = []
+_expire_calls: list[tuple[str, str | None]] = []
 
 
 @activity.defn(name=ActivityName.APPROVAL)
@@ -358,6 +359,7 @@ class TestApprovalTimeoutIntegration:
                     _test_script_activity,
                     fetch_workflow_runtime_settings,
                     fail_detached_approval_activity,
+                    converge,
                 ],
             ):
                 execution_service = TemporalExecutionService(

--- a/backend/tests/unit/workflows/activities/test_approval_activity.py
+++ b/backend/tests/unit/workflows/activities/test_approval_activity.py
@@ -5,16 +5,18 @@ Tests approval request creation via the Approvals API client.
 
 from collections.abc import Generator
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from temporalio.exceptions import ApplicationError
+from temporalio.service import RPCError, RPCStatusCode
 
 from syntara.workflows.clients.approvals_client import ApprovalsApiClientError
 from syntara.workflows.workflow_engine.activities.approval_activity import (
     ApprovalActivityError,
     create_approval_request_activity,
+    fail_detached_approval_activity,
 )
 from tests.fixtures.temporal import CompleteAsyncError
 
@@ -290,3 +292,65 @@ async def test_create_approval_request_missing_project_id(
             project_id="",
         )
     assert exc_info.value.type == "ConfigError"
+
+
+SYNC_SERVICE_PATH = "syntara.workflows.workflow_engine.activities.approval_activity.get_activity_sync_service"
+
+
+@pytest.mark.asyncio
+async def test_fail_detached_approval_activity_fails_via_handle() -> None:
+    """Fails the async APPROVAL activity via the async activity handle."""
+    mock_handle = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_async_activity_handle.return_value = mock_handle
+
+    mock_service = MagicMock()
+    mock_service.temporal_client = mock_client
+
+    with patch(SYNC_SERVICE_PATH, return_value=mock_service):
+        await fail_detached_approval_activity("wf-123", "run-456", "approval_node")
+
+    mock_client.get_async_activity_handle.assert_called_once_with(
+        workflow_id="wf-123",
+        run_id="run-456",
+        activity_id="approval_node",
+    )
+    mock_handle.fail.assert_called_once()
+    assert mock_handle.fail.call_args.args[0].type == "ApprovalExpired"
+
+
+@pytest.mark.asyncio
+async def test_fail_detached_approval_activity_already_resolved_is_swallowed() -> None:
+    """Already-completed/not-found activities are treated as an idempotent no-op."""
+    mock_handle = AsyncMock()
+    mock_handle.fail.side_effect = RPCError("activity not found", RPCStatusCode.NOT_FOUND, b"")
+    mock_client = MagicMock()
+    mock_client.get_async_activity_handle.return_value = mock_handle
+
+    mock_service = MagicMock()
+    mock_service.temporal_client = mock_client
+
+    with patch(SYNC_SERVICE_PATH, return_value=mock_service):
+        await fail_detached_approval_activity("wf-123", "run-456", "approval_node")
+
+
+@pytest.mark.asyncio
+async def test_fail_detached_approval_activity_unexpected_error_propagates() -> None:
+    """Unexpected RPC errors are re-raised rather than swallowed."""
+    mock_handle = AsyncMock()
+    mock_handle.fail.side_effect = RPCError("internal server error", RPCStatusCode.INTERNAL, b"")
+    mock_client = MagicMock()
+    mock_client.get_async_activity_handle.return_value = mock_handle
+
+    mock_service = MagicMock()
+    mock_service.temporal_client = mock_client
+
+    with patch(SYNC_SERVICE_PATH, return_value=mock_service), pytest.raises(RPCError, match="internal server error"):
+        await fail_detached_approval_activity("wf-123", "run-456", "approval_node")
+
+
+@pytest.mark.asyncio
+async def test_fail_detached_approval_activity_no_sync_service_is_noop() -> None:
+    """No-op (does not raise) when the activity sync service is unavailable."""
+    with patch(SYNC_SERVICE_PATH, return_value=None):
+        await fail_detached_approval_activity("wf-123", "run-456", "approval_node")

--- a/backend/tests/unit/workflows/activities/test_expire_approval_activity.py
+++ b/backend/tests/unit/workflows/activities/test_expire_approval_activity.py
@@ -132,6 +132,67 @@ async def test_expire_api_error_returns_gracefully(execution_id: str, node_id: s
 
 
 @pytest.mark.asyncio
+async def test_expire_all_pending_when_node_id_none(execution_id: str) -> None:
+    """When node_id is omitted, pending approvals across all nodes are expired."""
+    approvals = [
+        {"id": str(uuid4()), "approval_node_id": "approval_1", "status": "pending"},
+        {"id": str(uuid4()), "approval_node_id": "approval_2", "status": "pending"},
+    ]
+
+    mock_client = AsyncMock()
+    mock_client.list_approvals_by_execution = AsyncMock(return_value=approvals)
+    mock_client.batch_expire = AsyncMock(return_value={"total_success": 2, "total_failed": 0})
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "syntara.workflows.workflow_engine.activities.approval_activity.ApprovalsApiClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "syntara.workflows.workflow_engine.activities.approval_activity.AuditEventDispatcher",
+        ) as mock_dispatcher,
+    ):
+        result = await expire_approval_requests_activity(execution_id)
+
+    assert result["expired_count"] == 2
+    expired_ids = mock_client.batch_expire.call_args[0][0]
+    assert len(expired_ids) == 2
+    dispatched_node_ids = {call.args[0].approval_node_id for call in mock_dispatcher.dispatch.call_args_list}
+    assert dispatched_node_ids == {"approval_1", "approval_2"}
+
+
+@pytest.mark.asyncio
+async def test_expire_fails_before_mutating_on_malformed_record(execution_id: str) -> None:
+    """A record missing approval_node_id fails before batch_expire runs.
+
+    Guards against silently reporting "0 expired" while the mutation actually
+    succeeded: validation of the audit-record shape must happen before the
+    mutating API call, not after. Uses node_id=None (execution-wide expiry) since
+    the per-node filter path would otherwise drop the malformed record before
+    it's ever validated.
+    """
+    malformed_approval = {"id": str(uuid4()), "status": "pending"}  # missing approval_node_id
+
+    mock_client = AsyncMock()
+    mock_client.list_approvals_by_execution = AsyncMock(return_value=[malformed_approval])
+    mock_client.batch_expire = AsyncMock(return_value={"total_success": 1, "total_failed": 0})
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "syntara.workflows.workflow_engine.activities.approval_activity.ApprovalsApiClient",
+        return_value=mock_client,
+    ):
+        result = await expire_approval_requests_activity(execution_id)
+
+    assert result["expired_count"] == 0
+    assert "error" in result
+    mock_client.batch_expire.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_expire_unexpected_error_returns_gracefully(execution_id: str, node_id: str) -> None:
     """Unexpected errors are caught and returned as error info, not raised."""
     mock_client = AsyncMock()

--- a/backend/tests/unit/workflows/workflow_engine/test_dynamic_workflow_approval.py
+++ b/backend/tests/unit/workflows/workflow_engine/test_dynamic_workflow_approval.py
@@ -512,6 +512,75 @@ class TestDispatchApprovalNode:
 
         assert result["control"] == {"next_port": "rejected"}
 
+
+class TestExpireRemainingApprovals:
+    """Tests for _expire_remaining_approvals (called when a workflow run ends)."""
+
+    @pytest.mark.asyncio
+    async def test_expires_all_pending_approvals_for_execution(self) -> None:
+        """Calls EXPIRE_APPROVAL with no node_id filter, scoped to the execution."""
+        wf = _make_workflow(execution_id="exec-789")
+        graph = WorkflowGraph(InMemoryGraphBackend())
+        mock_activity = AsyncMock(return_value={"expired_count": 1})
+
+        with patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_activity):
+            await wf._expire_remaining_approvals(graph)
+
+        mock_activity.assert_called_once()
+        assert mock_activity.call_args.args[0] == ActivityName.EXPIRE_APPROVAL
+        assert mock_activity.call_args.kwargs["args"] == ["exec-789", None]
+
+    @pytest.mark.asyncio
+    async def test_swallows_activity_failure(self) -> None:
+        """Failures are best-effort and must not propagate to the caller."""
+        wf = _make_workflow()
+        graph = WorkflowGraph(InMemoryGraphBackend())
+        mock_activity = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_activity):
+            await wf._expire_remaining_approvals(graph)
+
+    @pytest.mark.asyncio
+    async def test_fails_temporal_activity_for_detached_approval_node(self) -> None:
+        """A detached approval node's Temporal activity is failed via local activity."""
+        wf = _make_workflow(execution_id="exec-789")
+        graph = _build_approval_graph(with_predecessor=False, with_successor=False)
+        wf._detached_nodes = {"approval"}
+        mock_execute_activity = AsyncMock(return_value={"expired_count": 1})
+        mock_execute_local_activity = AsyncMock(return_value=None)
+
+        with (
+            patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_execute_activity),
+            patch(
+                "syntara.workflows.workflow_engine.approval_mixin.workflow.execute_local_activity",
+                mock_execute_local_activity,
+            ),
+        ):
+            await wf._expire_remaining_approvals(graph)
+
+        mock_execute_local_activity.assert_called_once()
+        assert mock_execute_local_activity.call_args.kwargs["args"][2] == "approval"
+
+    @pytest.mark.asyncio
+    async def test_skips_non_approval_detached_nodes(self) -> None:
+        """Detached nodes that aren't approval-type are not passed to the fail-activity call."""
+        wf = _make_workflow(execution_id="exec-789")
+        graph = _build_approval_graph(with_predecessor=True, with_successor=False)
+        wf._detached_nodes = {"scan"}  # a "script" typed node, not an approval
+        mock_execute_activity = AsyncMock(return_value={"expired_count": 0})
+        mock_execute_local_activity = AsyncMock(return_value=None)
+
+        with (
+            patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_execute_activity),
+            patch(
+                "syntara.workflows.workflow_engine.approval_mixin.workflow.execute_local_activity",
+                mock_execute_local_activity,
+            ),
+        ):
+            await wf._expire_remaining_approvals(graph)
+
+        mock_execute_local_activity.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_dispatch_raises_on_unexpected_decision(self) -> None:
         """Verify unexpected approval decision raises ApplicationError with output in details."""

--- a/backend/tests/unit/workflows/workflow_engine/test_dynamic_workflow_approval.py
+++ b/backend/tests/unit/workflows/workflow_engine/test_dynamic_workflow_approval.py
@@ -520,10 +520,18 @@ class TestExpireRemainingApprovals:
     async def test_expires_all_pending_approvals_for_execution(self) -> None:
         """Calls EXPIRE_APPROVAL with no node_id filter, scoped to the execution."""
         wf = _make_workflow(execution_id="exec-789")
-        graph = WorkflowGraph(InMemoryGraphBackend())
+        graph = _build_approval_graph(with_predecessor=False, with_successor=False)
+        wf._detached_nodes = {"approval"}
         mock_activity = AsyncMock(return_value={"expired_count": 1})
+        mock_local_activity = AsyncMock(return_value=None)
 
-        with patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_activity):
+        with (
+            patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_activity),
+            patch(
+                "syntara.workflows.workflow_engine.approval_mixin.workflow.execute_local_activity",
+                mock_local_activity,
+            ),
+        ):
             await wf._expire_remaining_approvals(graph)
 
         mock_activity.assert_called_once()
@@ -531,13 +539,38 @@ class TestExpireRemainingApprovals:
         assert mock_activity.call_args.kwargs["args"] == ["exec-789", None]
 
     @pytest.mark.asyncio
+    async def test_no_op_when_nothing_detached(self) -> None:
+        """No EXPIRE_APPROVAL call at all when no node was detached.
+
+        This is the case for an approval that already resolved via its own
+        timeout or a normal decision — it must not trigger a redundant
+        execution-wide expire sweep.
+        """
+        wf = _make_workflow(execution_id="exec-789")
+        graph = _build_approval_graph(with_predecessor=False, with_successor=False)
+        mock_activity = AsyncMock(return_value={"expired_count": 0})
+
+        with patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_activity):
+            await wf._expire_remaining_approvals(graph)
+
+        mock_activity.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_swallows_activity_failure(self) -> None:
         """Failures are best-effort and must not propagate to the caller."""
         wf = _make_workflow()
-        graph = WorkflowGraph(InMemoryGraphBackend())
+        graph = _build_approval_graph(with_predecessor=False, with_successor=False)
+        wf._detached_nodes = {"approval"}
         mock_activity = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_local_activity = AsyncMock(return_value=None)
 
-        with patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_activity):
+        with (
+            patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_activity),
+            patch(
+                "syntara.workflows.workflow_engine.approval_mixin.workflow.execute_local_activity",
+                mock_local_activity,
+            ),
+        ):
             await wf._expire_remaining_approvals(graph)
 
     @pytest.mark.asyncio
@@ -580,6 +613,7 @@ class TestExpireRemainingApprovals:
             await wf._expire_remaining_approvals(graph)
 
         mock_execute_local_activity.assert_not_called()
+        mock_execute_activity.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_dispatch_raises_on_unexpected_decision(self) -> None:


### PR DESCRIPTION
## Summary
- When a workflow has multiple approval nodes and only some are decided before the run reaches a terminal state (e.g. an ANY-strategy converge satisfied by one branch), the other approval nodes were detached from orchestration and left in `pending` forever instead of being marked `expired`.
- On completion, the orchestrator now expires any still-pending approvals for the execution and fails their underlying Temporal activities so they resolve immediately instead of lingering until their own decision-window timeout (previously up to 24h by default).
- Fixed a secondary issue found during review: the audit-record shape is now validated before the mutating expire/cancel call, so a malformed record fails clean instead of misreporting a successful mutation as `0 expired`.

## Test plan
- [x] `ruff check` / `mypy` clean on all touched files
- [x] Unit tests: `approval_activity`, `approval_mixin`, `dynamic_workflow` (new coverage for execution-wide expiry, detached-node Temporal cleanup, and the fail-before-mutate ordering)
- [x] New Temporal integration test reproducing the exact reported scenario (two approval nodes converging via `ANY`, only one decided) — asserts the workflow completes and the other approval is expired
- [x] Manually verified in a live cluster: approval status shows `Expired` after workflow completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)