### PR TITLE
fix(AAP-84620): Fix and stabilize workflows-project-actions E2E tests

### DIFF
--- a/frontend/packages/syntara-ui/e2e/utils/api-core.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api-core.ts
@@ -97,3 +97,29 @@ export async function ensureProject(app: Page, name = 'default'): Promise<{ id: 
     return null
   }
 }
+
+/** Create a project via the API. Returns the project ID. */
+export async function createProjectViaApi(app: Page, name: string, description?: string): Promise<{ id: string }> {
+  const token = await getAuthToken(app)
+  if (!token) throw new Error('createProjectViaApi: could not obtain auth token')
+  const resp = await apiRequest(app, 'post', '/projects', {
+    token,
+    data: { name, description: description ?? `E2E test project: ${name}` },
+  })
+  if (!resp.ok()) {
+    const body = await resp.text().catch(() => '(unreadable)')
+    throw new Error(`POST /projects returned ${resp.status()}: ${body}`)
+  }
+  return (await resp.json()) as { id: string }
+}
+
+/** Delete a project by ID via the API (best-effort cleanup). */
+export async function deleteProjectViaApi(app: Page, projectId: string): Promise<void> {
+  if (app.isClosed()) return
+  try {
+    const token = await getAuthToken(app)
+    if (token) await apiRequest(app, 'delete', `/projects/${projectId}`, { token })
+  } catch {
+    // Best-effort cleanup
+  }
+}

--- a/frontend/packages/syntara-ui/e2e/utils/api-workflows.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api-workflows.ts
@@ -85,8 +85,41 @@ export async function publishWorkflowViaApi(
 export async function createBasicWorkflowViaApi(
   app: Page,
   name: string,
-  actionName = 'Script'
+  actionName = 'Script',
+  options?: { projectId?: string }
 ): Promise<{ id: string; name: string; versionNumber: number }> {
+  if (options?.projectId) {
+    const token = await getAuthToken(app)
+    if (!token) throw new Error('createBasicWorkflowViaApi: could not obtain auth token')
+    const resp = await apiRequest(app, 'post', '/workflows', {
+      token,
+      data: {
+        name,
+        project_id: options.projectId,
+        workflow_definition: {
+          schema_version: '2.0.0',
+          name,
+          triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+          nodes: [
+            {
+              id: 'action_1',
+              type: 'script',
+              name: actionName,
+              parameters: { language: 'python', code: 'print("hello")' },
+            },
+          ],
+          edges: [{ from: 'trigger_1', to: 'action_1' }],
+        },
+      },
+    })
+    if (!resp.ok()) {
+      const body = await resp.text().catch(() => '(unreadable)')
+      throw new Error(`POST /workflows returned ${resp.status()}: ${body}`)
+    }
+    const body = (await resp.json()) as { id: string; current_version: number }
+    return { id: body.id, name, versionNumber: body.current_version }
+  }
+
   const { id, versionNumber } = await createWorkflowViaApi(
     app,
     name,

--- a/frontend/packages/syntara-ui/e2e/utils/api.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api.ts
@@ -5,7 +5,7 @@
  * etc.). This file re-exports everything so existing spec files can continue to
  * import from './utils/api' without changes.
  */
-export { apiUrl, getAuthToken, apiRequest, ensureProject } from './api-core'
+export { apiUrl, getAuthToken, apiRequest, ensureProject, createProjectViaApi, deleteProjectViaApi } from './api-core'
 export { createCredentialViaApi, deleteCredentialViaApi, listCredentialsByName } from './api-credentials'
 export {
   createWorkflowViaApi,

--- a/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
@@ -8,42 +8,81 @@
  * - Delete project shows confirmation dialog with cascade warnings
  * - Permission gating for project actions
  */
-import { test, expect, toAppUrl } from './fixtures'
-import { buildUniqueName, createBasicWorkflow, deleteWorkflow, deleteProject } from './helpers/workflows'
+import { test, expect, toAppUrl, type Page } from './fixtures'
+import { buildUniqueName } from './helpers/workflows'
+import { apiRequest, getAuthToken, deleteWorkflowViaApi } from './utils/api'
+
+async function deleteProjectViaApi(app: Page, projectName: string): Promise<void> {
+  if (app.isClosed()) return
+  try {
+    const token = await getAuthToken(app)
+    if (!token) return
+    const listResp = await apiRequest(app, 'get', '/projects', { token })
+    if (!listResp.ok()) return
+    const body = (await listResp.json()) as { resources: Array<{ id: string; name: string }> }
+    const project = body.resources.find((p) => p.name === projectName)
+    if (project) {
+      await apiRequest(app, 'delete', `/projects/${project.id}`, { token })
+    }
+  } catch {
+    // Best-effort cleanup
+  }
+}
+
+async function createProjectAndWorkflowViaApi(
+  app: Page,
+  projectName: string,
+  workflowName: string
+): Promise<{ projectId: string; workflowId: string }> {
+  const token = await getAuthToken(app)
+  if (!token) throw new Error('Could not obtain auth token')
+
+  const projResp = await apiRequest(app, 'post', '/projects', {
+    token,
+    data: { name: projectName, description: `E2E test project: ${projectName}` },
+  })
+  if (!projResp.ok()) throw new Error(`Failed to create project: ${projResp.status()}`)
+  const project = (await projResp.json()) as { id: string }
+
+  const wfResp = await apiRequest(app, 'post', '/workflows', {
+    token,
+    data: {
+      name: workflowName,
+      project_id: project.id,
+      workflow_definition: {
+        schema_version: '2.0.0',
+        name: workflowName,
+        triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+        nodes: [],
+        edges: [],
+      },
+    },
+  })
+  if (!wfResp.ok()) throw new Error(`Failed to create workflow: ${wfResp.status()}`)
+  const workflow = (await wfResp.json()) as { id: string }
+
+  return { projectId: project.id, workflowId: workflow.id }
+}
 
 test.describe('Workflows Page - Project Actions in All Projects View', () => {
   test('project group header shows kebab menu with edit and delete actions', async ({ app }) => {
-    test.setTimeout(60_000)
-
     const projectName = buildUniqueName('e2e-project')
     const workflowName = buildUniqueName('e2e-workflow')
+    let workflowId: string | undefined
 
     try {
-      // Create a project with a workflow so it appears in the grouped view
-      await app.goto(toAppUrl('/workflows'))
+      const result = await createProjectAndWorkflowViaApi(app, projectName, workflowName)
+      workflowId = result.workflowId
 
-      // Create project via project selector
+      // Navigate to All projects view
+      await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
-      await projectSelector.click()
-      await app.getByRole('option', { name: 'Create project' }).click()
-
-      const createDialog = app.getByRole('dialog', { name: /Create project/i })
-      await expect(createDialog).toBeVisible()
-      await createDialog.getByRole('textbox', { name: 'Project name' }).fill(projectName)
-      await createDialog.getByRole('button', { name: 'Create project' }).click()
-      await expect(createDialog).not.toBeVisible({ timeout: 15_000 })
-
-      // Create a workflow in this project
-      await createBasicWorkflow(app, workflowName, 'Test workflow')
-
-      // Go back to All projects view
-      await app.goto(toAppUrl('/workflows'))
       await projectSelector.click()
       await app.getByRole('option', { name: 'All projects' }).click()
 
       // Find the project group header row
       const projectRow = app.getByRole('row').filter({ hasText: projectName })
-      await expect(projectRow).toBeVisible()
+      await expect(projectRow).toBeVisible({ timeout: 15_000 })
 
       // Find and click the kebab menu for this project
       const projectKebab = projectRow.getByRole('button', { name: /Actions for.*project/i })
@@ -54,40 +93,30 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
       await expect(app.getByRole('menuitem', { name: /Edit project/i })).toBeVisible()
       await expect(app.getByRole('menuitem', { name: /Delete project/i })).toBeVisible()
     } finally {
-      await deleteWorkflow(app, workflowName)
-      await deleteProject(app, projectName)
+      if (workflowId) await deleteWorkflowViaApi(app, workflowId)
+      await deleteProjectViaApi(app, projectName)
     }
   })
 
   test('edit project from group header updates name immediately', async ({ app }) => {
-    test.setTimeout(60_000)
-
     const originalName = buildUniqueName('e2e-project-original')
     const updatedName = buildUniqueName('e2e-project-updated')
     const workflowName = buildUniqueName('e2e-workflow')
+    let workflowId: string | undefined
 
     try {
-      // Create project
-      await app.goto(toAppUrl('/workflows'))
-      const projectSelector = app.getByRole('textbox', { name: 'Project' })
-      await projectSelector.click()
-      await app.getByRole('option', { name: 'Create project' }).click()
-
-      const createDialog = app.getByRole('dialog', { name: /Create project/i })
-      await createDialog.getByRole('textbox', { name: 'Project name' }).fill(originalName)
-      await createDialog.getByRole('button', { name: 'Create project' }).click()
-      await expect(createDialog).not.toBeVisible({ timeout: 15_000 })
-
-      // Create workflow
-      await createBasicWorkflow(app, workflowName, 'Test')
+      const result = await createProjectAndWorkflowViaApi(app, originalName, workflowName)
+      workflowId = result.workflowId
 
       // Navigate to All projects view
       await app.goto(toAppUrl('/workflows'))
+      const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
       await app.getByRole('option', { name: 'All projects' }).click()
 
       // Open project kebab menu
       const projectRow = app.getByRole('row').filter({ hasText: originalName })
+      await expect(projectRow).toBeVisible({ timeout: 15_000 })
       const projectKebab = projectRow.getByRole('button', { name: /Actions for.*project/i })
       await projectKebab.click()
       await app.getByRole('menuitem', { name: /Edit project/i }).click()
@@ -105,38 +134,29 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
       await expect(app.getByRole('row').filter({ hasText: updatedName })).toBeVisible({ timeout: 10_000 })
       await expect(app.getByRole('row').filter({ hasText: originalName })).not.toBeVisible()
     } finally {
-      await deleteWorkflow(app, workflowName)
-      await deleteProject(app, updatedName) // Use updated name since project was renamed
+      if (workflowId) await deleteWorkflowViaApi(app, workflowId)
+      await deleteProjectViaApi(app, updatedName)
     }
   })
 
-  test.skip('delete project shows confirmation dialog with cascade warnings', async ({ app }) => {
-    test.setTimeout(60_000)
-
+  test('delete project shows confirmation dialog with cascade warnings', async ({ app }) => {
     const projectName = buildUniqueName('e2e-project-delete')
     const workflowName = buildUniqueName('e2e-workflow')
+    let workflowId: string | undefined
 
     try {
-      // Create project and workflow
-      await app.goto(toAppUrl('/workflows'))
-      const projectSelector = app.getByRole('textbox', { name: 'Project' })
-      await projectSelector.click()
-      await app.getByRole('option', { name: 'Create project' }).click()
-
-      const createDialog = app.getByRole('dialog', { name: /Create project/i })
-      await createDialog.getByRole('textbox', { name: 'Project name' }).fill(projectName)
-      await createDialog.getByRole('button', { name: 'Create project' }).click()
-      await expect(createDialog).not.toBeVisible({ timeout: 15_000 })
-
-      await createBasicWorkflow(app, workflowName, 'Test')
+      const result = await createProjectAndWorkflowViaApi(app, projectName, workflowName)
+      workflowId = result.workflowId
 
       // Navigate to All projects view
       await app.goto(toAppUrl('/workflows'))
+      const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
       await app.getByRole('option', { name: 'All projects' }).click()
 
       // Open delete from project kebab
       const projectRow = app.getByRole('row').filter({ hasText: projectName })
+      await expect(projectRow).toBeVisible({ timeout: 15_000 })
       const projectKebab = projectRow.getByRole('button', { name: /Actions for.*project/i })
       await projectKebab.click()
       await app.getByRole('menuitem', { name: /Delete project/i }).click()
@@ -160,21 +180,17 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
       await deleteDialog.getByRole('button', { name: 'Cancel' }).click()
       await expect(deleteDialog).not.toBeVisible()
     } finally {
-      await deleteWorkflow(app, workflowName)
-      await deleteProject(app, projectName)
+      if (workflowId) await deleteWorkflowViaApi(app, workflowId)
+      await deleteProjectViaApi(app, projectName)
     }
   })
 })
 
 test.describe('Workflows Page - Project Actions in Selected Project View', () => {
-  test.skip('page header shows project kebab menu when specific project selected', async ({ app }) => {
-    test.setTimeout(60_000)
-
+  test('page header shows project kebab menu when specific project selected', async ({ app }) => {
     const projectName = buildUniqueName('e2e-project-header')
-    const workflowName = buildUniqueName('e2e-workflow')
 
     try {
-      // Create project and workflow
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
@@ -185,36 +201,24 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       await createDialog.getByRole('button', { name: 'Create project' }).click()
       await expect(createDialog).not.toBeVisible({ timeout: 15_000 })
 
-      await createBasicWorkflow(app, workflowName, 'Test')
-
-      // Ensure we're viewing this specific project
-      await app.goto(toAppUrl('/workflows'))
-      await projectSelector.click()
-      await app.getByRole('option', { name: projectName }).click()
-
-      // Find and click the kebab menu in the page header
+      // Project is now selected — kebab should be visible in header
       const headerKebab = app.getByRole('button', { name: 'Project actions' })
-      await expect(headerKebab).toBeVisible()
+      await expect(headerKebab).toBeVisible({ timeout: 15_000 })
       await headerKebab.click()
 
-      // Verify Edit and Delete actions are present
       await expect(app.getByRole('menuitem', { name: /Edit project/i })).toBeVisible()
       await expect(app.getByRole('menuitem', { name: /Delete project/i })).toBeVisible()
     } finally {
-      await deleteWorkflow(app, workflowName)
-      await deleteProject(app, projectName)
+      await deleteProjectViaApi(app, projectName)
     }
   })
 
-  test.skip('edit project from header updates name in project selector', async ({ app }) => {
-    test.setTimeout(60_000)
-
+  test('edit project from header updates name in project selector', async ({ app }) => {
     const originalName = buildUniqueName('e2e-project-orig')
     const updatedName = buildUniqueName('e2e-project-upd')
-    const workflowName = buildUniqueName('e2e-workflow')
 
     try {
-      // Create project and workflow
+      // Create project via UI — it becomes the selected project
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
@@ -225,15 +229,9 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       await createDialog.getByRole('button', { name: 'Create project' }).click()
       await expect(createDialog).not.toBeVisible({ timeout: 15_000 })
 
-      await createBasicWorkflow(app, workflowName, 'Test')
-
-      // Select the project
-      await app.goto(toAppUrl('/workflows'))
-      await projectSelector.click()
-      await app.getByRole('option', { name: originalName }).click()
-
       // Edit via header kebab
       const headerKebab = app.getByRole('button', { name: 'Project actions' })
+      await expect(headerKebab).toBeVisible({ timeout: 15_000 })
       await headerKebab.click()
       await app.getByRole('menuitem', { name: /Edit project/i }).click()
 
@@ -247,8 +245,7 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       // Verify the project selector shows the updated name
       await expect(projectSelector).toHaveValue(updatedName)
     } finally {
-      await deleteWorkflow(app, workflowName)
-      await deleteProject(app, updatedName) // Use updated name since project was renamed
+      await deleteProjectViaApi(app, updatedName)
     }
   })
 })

--- a/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
@@ -161,7 +161,6 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
-      await projectSelector.fill(projectName)
       await app.getByRole('option', { name: projectName, exact: true }).waitFor({ state: 'visible', timeout: 10_000 })
       await app.getByRole('option', { name: projectName, exact: true }).click()
 
@@ -189,7 +188,6 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
-      await projectSelector.fill(originalName)
       await app.getByRole('option', { name: originalName, exact: true }).waitFor({ state: 'visible', timeout: 10_000 })
       await app.getByRole('option', { name: originalName, exact: true }).click()
 

--- a/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
@@ -9,8 +9,8 @@
  * - Permission gating for project actions
  */
 import { test, expect, toAppUrl } from './fixtures'
-import { buildUniqueName } from './helpers/workflows'
-import { createProjectViaApi, createWorkflowViaApi, deleteProjectViaApi, deleteWorkflowViaApi } from './utils/api'
+import { buildUniqueName, createBasicWorkflowViaApi } from './helpers/workflows'
+import { createProjectViaApi, deleteProjectViaApi, deleteWorkflowViaApi } from './utils/api'
 
 test.describe('Workflows Page - Project Actions in All Projects View', () => {
   test('project group header shows kebab menu with edit and delete actions', async ({ app }) => {
@@ -22,21 +22,16 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
     try {
       const project = await createProjectViaApi(app, projectName)
       projectId = project.id
-      const workflow = await createWorkflowViaApi(
-        app,
-        workflowName,
-        [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-        [],
-        [],
-        { projectId }
-      )
+      const workflow = await createBasicWorkflowViaApi(app, workflowName, undefined, { projectId })
       workflowId = workflow.id
 
-      // Navigate to All projects view
+      // Navigate to All projects view and filter to isolate our workflow
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
       await app.getByRole('option', { name: 'All projects' }).click()
+      await app.getByPlaceholder('Filter by name').fill(workflowName)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
 
       // Find the project group header row
       const projectRow = app.getByRole('row').filter({ hasText: projectName })
@@ -66,21 +61,16 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
     try {
       const project = await createProjectViaApi(app, originalName)
       projectId = project.id
-      const workflow = await createWorkflowViaApi(
-        app,
-        workflowName,
-        [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-        [],
-        [],
-        { projectId }
-      )
+      const workflow = await createBasicWorkflowViaApi(app, workflowName, undefined, { projectId })
       workflowId = workflow.id
 
-      // Navigate to All projects view
+      // Navigate to All projects view and filter to isolate our workflow
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
       await app.getByRole('option', { name: 'All projects' }).click()
+      await app.getByPlaceholder('Filter by name').fill(workflowName)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
 
       // Open project kebab menu
       const projectRow = app.getByRole('row').filter({ hasText: originalName })
@@ -116,21 +106,16 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
     try {
       const project = await createProjectViaApi(app, projectName)
       projectId = project.id
-      const workflow = await createWorkflowViaApi(
-        app,
-        workflowName,
-        [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-        [],
-        [],
-        { projectId }
-      )
+      const workflow = await createBasicWorkflowViaApi(app, workflowName, undefined, { projectId })
       workflowId = workflow.id
 
-      // Navigate to All projects view
+      // Navigate to All projects view and filter to isolate our workflow
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
       await app.getByRole('option', { name: 'All projects' }).click()
+      await app.getByPlaceholder('Filter by name').fill(workflowName)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
 
       // Open delete from project kebab
       const projectRow = app.getByRole('row').filter({ hasText: projectName })
@@ -176,7 +161,8 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
-      await app.getByRole('option', { name: projectName }).click()
+      await projectSelector.fill(projectName)
+      await app.getByRole('option', { name: projectName, exact: true }).click()
 
       // Project is now selected — kebab should be visible in header
       const headerKebab = app.getByRole('button', { name: 'Project actions' })
@@ -202,7 +188,8 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
-      await app.getByRole('option', { name: originalName }).click()
+      await projectSelector.fill(originalName)
+      await app.getByRole('option', { name: originalName, exact: true }).click()
 
       // Edit via header kebab
       const headerKebab = app.getByRole('button', { name: 'Project actions' })

--- a/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
@@ -162,6 +162,7 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
       await projectSelector.fill(projectName)
+      await app.getByRole('option', { name: projectName, exact: true }).waitFor({ state: 'visible', timeout: 10_000 })
       await app.getByRole('option', { name: projectName, exact: true }).click()
 
       // Project is now selected — kebab should be visible in header
@@ -189,6 +190,7 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
       await projectSelector.fill(originalName)
+      await app.getByRole('option', { name: originalName, exact: true }).waitFor({ state: 'visible', timeout: 10_000 })
       await app.getByRole('option', { name: originalName, exact: true }).click()
 
       // Edit via header kebab

--- a/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
@@ -8,71 +8,29 @@
  * - Delete project shows confirmation dialog with cascade warnings
  * - Permission gating for project actions
  */
-import { test, expect, toAppUrl, type Page } from './fixtures'
+import { test, expect, toAppUrl } from './fixtures'
 import { buildUniqueName } from './helpers/workflows'
-import { apiRequest, getAuthToken, deleteWorkflowViaApi } from './utils/api'
-
-async function deleteProjectViaApi(app: Page, projectName: string): Promise<void> {
-  if (app.isClosed()) return
-  try {
-    const token = await getAuthToken(app)
-    if (!token) return
-    const listResp = await apiRequest(app, 'get', '/projects', { token })
-    if (!listResp.ok()) return
-    const body = (await listResp.json()) as { resources: Array<{ id: string; name: string }> }
-    const project = body.resources.find((p) => p.name === projectName)
-    if (project) {
-      await apiRequest(app, 'delete', `/projects/${project.id}`, { token })
-    }
-  } catch {
-    // Best-effort cleanup
-  }
-}
-
-async function createProjectAndWorkflowViaApi(
-  app: Page,
-  projectName: string,
-  workflowName: string
-): Promise<{ projectId: string; workflowId: string }> {
-  const token = await getAuthToken(app)
-  if (!token) throw new Error('Could not obtain auth token')
-
-  const projResp = await apiRequest(app, 'post', '/projects', {
-    token,
-    data: { name: projectName, description: `E2E test project: ${projectName}` },
-  })
-  if (!projResp.ok()) throw new Error(`Failed to create project: ${projResp.status()}`)
-  const project = (await projResp.json()) as { id: string }
-
-  const wfResp = await apiRequest(app, 'post', '/workflows', {
-    token,
-    data: {
-      name: workflowName,
-      project_id: project.id,
-      workflow_definition: {
-        schema_version: '2.0.0',
-        name: workflowName,
-        triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-        nodes: [],
-        edges: [],
-      },
-    },
-  })
-  if (!wfResp.ok()) throw new Error(`Failed to create workflow: ${wfResp.status()}`)
-  const workflow = (await wfResp.json()) as { id: string }
-
-  return { projectId: project.id, workflowId: workflow.id }
-}
+import { createProjectViaApi, createWorkflowViaApi, deleteProjectViaApi, deleteWorkflowViaApi } from './utils/api'
 
 test.describe('Workflows Page - Project Actions in All Projects View', () => {
   test('project group header shows kebab menu with edit and delete actions', async ({ app }) => {
     const projectName = buildUniqueName('e2e-project')
     const workflowName = buildUniqueName('e2e-workflow')
+    let projectId: string | undefined
     let workflowId: string | undefined
 
     try {
-      const result = await createProjectAndWorkflowViaApi(app, projectName, workflowName)
-      workflowId = result.workflowId
+      const project = await createProjectViaApi(app, projectName)
+      projectId = project.id
+      const workflow = await createWorkflowViaApi(
+        app,
+        workflowName,
+        [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+        [],
+        [],
+        { projectId }
+      )
+      workflowId = workflow.id
 
       // Navigate to All projects view
       await app.goto(toAppUrl('/workflows'))
@@ -94,7 +52,7 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
       await expect(app.getByRole('menuitem', { name: /Delete project/i })).toBeVisible()
     } finally {
       if (workflowId) await deleteWorkflowViaApi(app, workflowId)
-      await deleteProjectViaApi(app, projectName)
+      if (projectId) await deleteProjectViaApi(app, projectId)
     }
   })
 
@@ -102,11 +60,21 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
     const originalName = buildUniqueName('e2e-project-original')
     const updatedName = buildUniqueName('e2e-project-updated')
     const workflowName = buildUniqueName('e2e-workflow')
+    let projectId: string | undefined
     let workflowId: string | undefined
 
     try {
-      const result = await createProjectAndWorkflowViaApi(app, originalName, workflowName)
-      workflowId = result.workflowId
+      const project = await createProjectViaApi(app, originalName)
+      projectId = project.id
+      const workflow = await createWorkflowViaApi(
+        app,
+        workflowName,
+        [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+        [],
+        [],
+        { projectId }
+      )
+      workflowId = workflow.id
 
       // Navigate to All projects view
       await app.goto(toAppUrl('/workflows'))
@@ -135,18 +103,28 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
       await expect(app.getByRole('row').filter({ hasText: originalName })).not.toBeVisible()
     } finally {
       if (workflowId) await deleteWorkflowViaApi(app, workflowId)
-      await deleteProjectViaApi(app, updatedName)
+      if (projectId) await deleteProjectViaApi(app, projectId)
     }
   })
 
   test('delete project shows confirmation dialog with cascade warnings', async ({ app }) => {
     const projectName = buildUniqueName('e2e-project-delete')
     const workflowName = buildUniqueName('e2e-workflow')
+    let projectId: string | undefined
     let workflowId: string | undefined
 
     try {
-      const result = await createProjectAndWorkflowViaApi(app, projectName, workflowName)
-      workflowId = result.workflowId
+      const project = await createProjectViaApi(app, projectName)
+      projectId = project.id
+      const workflow = await createWorkflowViaApi(
+        app,
+        workflowName,
+        [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+        [],
+        [],
+        { projectId }
+      )
+      workflowId = workflow.id
 
       // Navigate to All projects view
       await app.goto(toAppUrl('/workflows'))
@@ -181,7 +159,7 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
       await expect(deleteDialog).not.toBeVisible()
     } finally {
       if (workflowId) await deleteWorkflowViaApi(app, workflowId)
-      await deleteProjectViaApi(app, projectName)
+      if (projectId) await deleteProjectViaApi(app, projectId)
     }
   })
 })
@@ -189,17 +167,16 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
 test.describe('Workflows Page - Project Actions in Selected Project View', () => {
   test('page header shows project kebab menu when specific project selected', async ({ app }) => {
     const projectName = buildUniqueName('e2e-project-header')
+    let projectId: string | undefined
 
     try {
+      const project = await createProjectViaApi(app, projectName)
+      projectId = project.id
+
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
-      await app.getByRole('option', { name: 'Create project' }).click()
-
-      const createDialog = app.getByRole('dialog', { name: /Create project/i })
-      await createDialog.getByRole('textbox', { name: 'Project name' }).fill(projectName)
-      await createDialog.getByRole('button', { name: 'Create project' }).click()
-      await expect(createDialog).not.toBeVisible({ timeout: 15_000 })
+      await app.getByRole('option', { name: projectName }).click()
 
       // Project is now selected — kebab should be visible in header
       const headerKebab = app.getByRole('button', { name: 'Project actions' })
@@ -209,25 +186,23 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       await expect(app.getByRole('menuitem', { name: /Edit project/i })).toBeVisible()
       await expect(app.getByRole('menuitem', { name: /Delete project/i })).toBeVisible()
     } finally {
-      await deleteProjectViaApi(app, projectName)
+      if (projectId) await deleteProjectViaApi(app, projectId)
     }
   })
 
   test('edit project from header updates name in project selector', async ({ app }) => {
     const originalName = buildUniqueName('e2e-project-orig')
     const updatedName = buildUniqueName('e2e-project-upd')
+    let projectId: string | undefined
 
     try {
-      // Create project via UI — it becomes the selected project
+      const project = await createProjectViaApi(app, originalName)
+      projectId = project.id
+
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
-      await app.getByRole('option', { name: 'Create project' }).click()
-
-      const createDialog = app.getByRole('dialog', { name: /Create project/i })
-      await createDialog.getByRole('textbox', { name: 'Project name' }).fill(originalName)
-      await createDialog.getByRole('button', { name: 'Create project' }).click()
-      await expect(createDialog).not.toBeVisible({ timeout: 15_000 })
+      await app.getByRole('option', { name: originalName }).click()
 
       // Edit via header kebab
       const headerKebab = app.getByRole('button', { name: 'Project actions' })
@@ -245,7 +220,7 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       // Verify the project selector shows the updated name
       await expect(projectSelector).toHaveValue(updatedName)
     } finally {
-      await deleteProjectViaApi(app, updatedName)
+      if (projectId) await deleteProjectViaApi(app, projectId)
     }
   })
 })

--- a/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
@@ -161,8 +161,9 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
-      await app.getByRole('option', { name: projectName, exact: true }).waitFor({ state: 'visible', timeout: 10_000 })
-      await app.getByRole('option', { name: projectName, exact: true }).click()
+      await projectSelector.fill(projectName)
+      await app.getByRole('option', { name: projectName }).waitFor({ state: 'visible', timeout: 10_000 })
+      await app.getByRole('option', { name: projectName }).click()
 
       // Project is now selected — kebab should be visible in header
       const headerKebab = app.getByRole('button', { name: 'Project actions' })
@@ -188,8 +189,9 @@ test.describe('Workflows Page - Project Actions in Selected Project View', () =>
       await app.goto(toAppUrl('/workflows'))
       const projectSelector = app.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
-      await app.getByRole('option', { name: originalName, exact: true }).waitFor({ state: 'visible', timeout: 10_000 })
-      await app.getByRole('option', { name: originalName, exact: true }).click()
+      await projectSelector.fill(originalName)
+      await app.getByRole('option', { name: originalName }).waitFor({ state: 'visible', timeout: 10_000 })
+      await app.getByRole('option', { name: originalName }).click()
 
       // Edit via header kebab
       const headerKebab = app.getByRole('button', { name: 'Project actions' })


### PR DESCRIPTION
## Description

Un-skip 3 flaky E2E tests in `workflows-project-actions.spec.ts` and stabilize the entire suite by switching to API-based setup/teardown, matching the convention used across the E2E codebase.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Changes Made

- [x] Un-skipped 3 tests: `delete project shows confirmation dialog`, `page header shows project kebab menu`, `edit project from header updates name`
- [x] Replaced `createBasicWorkflow` (UI-based) with `createProjectAndWorkflowViaApi` for "All Projects View" tests — `createBasicWorkflow` was placing workflows in the wrong project ("default" via `ensureProject`) so group headers never appeared
- [x] Removed unnecessary workflow creation from "Selected Project View" tests — these only test header kebab/edit actions and don't need a workflow
- [x] Replaced UI-based `deleteProject`/`deleteWorkflow` cleanup with API-based `deleteProjectViaApi`/`deleteWorkflowViaApi` — UI cleanup was consuming ~57s per test through dropdown navigation and dialog interactions
- [x] Fixed strict mode violations in delete dialog assertions by anchoring regexes (`/^All workflows.../`, `/^All project role.../`)
- [x] Added destructive acknowledgement checkbox verification (checkbox → enable Delete button → Cancel flow)

## Related Issues

Resolves AAP-84620

## How to Test
1. Run locally against a running backend
2. All 5 tests should pass consistently in ~20 seconds
3. Verify on CI with full E2E suite

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)

## General Checklist

- [x] Code follows the project's coding conventions
- [x] No secrets or credentials are included in this PR

## Additional Notes

In addition to removing the skips and getting tests to pass, suite runtime dropped from 60s+ (with timeouts/failures) to ~20s for all 5 tests. The root causes were: (1) `createBasicWorkflow` creating workflows in the wrong project, and (2) UI-based cleanup in `finally` blocks consuming the entire test timeout budget.
