### PR TITLE
chore(ci): stop Renovate from bumping the CI Python version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,12 @@
       "enabled": false
     },
     {
+      "description": "Do not let the bot bump the CI Python version.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["actions/python-versions", "python"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "groupName": "npm dependencies",
       "matchFileNames": ["frontend/**"],


### PR DESCRIPTION
Prevents PRs like https://github.com/syntara-orchestration/syntara/pull/153
python version is something we want to handle on demand. 