### PR TITLE
  fix: resolve AAP proxy from a visible enabled integration without query IDs

### DIFF
--- a/backend/docs/integrations.md
+++ b/backend/docs/integrations.md
@@ -147,7 +147,7 @@ Integrations use two distinct credential roles with different scopes:
 
 The system does not reference the management credential during **workflow execution** of MCP or LLM calls, or fall back to it there. Execution credentials are independently selected by the workflow designer from credentials available in the workflow's project. A user may choose the same credential object for both roles, but the system treats them as separate references — there is no implicit fallback for those types. If no execution credential is configured for an MCP/LLM integration, tool calls are made unauthenticated.
 
-**AAP proxy exception:** `GET /api/v1/proxies/aap/*` falls back to the integration's management credential when `credential_id` is omitted, so a validated AAP integration is enough to list controller resources. With one visible AAP integration, both query params may be omitted. With more than one, pass `integration_id` to select which gateway to use.
+**AAP proxy exception:** `GET /api/v1/proxies/aap/*` falls back to the integration's management credential when `credential_id` is omitted, so a unique visible enabled AAP integration is enough to list controller resources. With one visible AAP integration, both query params may be omitted. With more than one, pass `integration_id` to select which gateway to use.
 
 Credential requirements vary by integration type. LLM providers and AAP instances always require a management credential — health checks and discovery cannot run without one. MCP servers support unauthenticated connections, so a management credential is only needed when the server itself requires authentication.
 
@@ -205,7 +205,7 @@ The LLM adapter delegates to provider-specific implementations via `LLMProviderB
 
 ### Ansible Automation Platform
 
-The AAP integration stores the API URL and TLS configuration. It does not discover sub-resources — AAP objects (job templates, inventories, organizations) are browsed at workflow-design time through `GET /api/v1/proxies/aap/*`. The proxy uses the integration's management credential when the caller does not pass an execution `credential_id`, so a validated AAP integration is sufficient to list controller resources. If more than one AAP integration is visible, pass `integration_id`; `credential_id` is still optional.
+The AAP integration stores the API URL and TLS configuration. It does not discover sub-resources — AAP objects (job templates, inventories, organizations) are browsed at workflow-design time through `GET /api/v1/proxies/aap/*`. The proxy uses the integration's management credential when the caller does not pass an execution `credential_id`, so a unique visible enabled AAP integration is sufficient to list controller resources. If more than one AAP integration is visible, pass `integration_id`; `credential_id` is still optional.
 
 **Design Decisions:**
 - **Static credential authentication.** The adapter uses `aap_oauth_token` (Bearer) if present, falling back to `aap_username` + `aap_password` (Basic Auth). No support for short-lived tokens, token refresh, or OIDC — this is a known limitation.

--- a/backend/docs/integrations.md
+++ b/backend/docs/integrations.md
@@ -142,10 +142,12 @@ Integrations use two distinct credential roles with different scopes:
 
 | Credential | Stored on | Used for |
 |---|---|---|
-| **Management credential** | `Integration.management_credential_id` | Health checks (`validate`, `refresh`), tool/model discovery only |
-| **Execution credential** | `IntegrationConnectionConfig` (per workflow node) | MCP tool calls and LLM invocations during workflow execution |
+| **Management credential** | `Integration.management_credential_id` | Health checks (`validate`, `refresh`), tool/model discovery, and AAP proxy browsing when no execution `credential_id` is passed |
+| **Execution credential** | `IntegrationConnectionConfig` (per workflow node) or AAP node `credential_id` | MCP tool calls, LLM invocations, and AAP job launches during workflow execution |
 
-The system does not reference the management credential during workflow execution or fall back to it. Execution credentials are independently selected by the workflow designer from credentials available in the workflow's project. A user may choose the same credential object for both roles, but the system treats them as separate references — there is no implicit fallback. If no execution credential is configured for an integration, tool calls are made unauthenticated.
+The system does not reference the management credential during **workflow execution** of MCP or LLM calls, or fall back to it there. Execution credentials are independently selected by the workflow designer from credentials available in the workflow's project. A user may choose the same credential object for both roles, but the system treats them as separate references — there is no implicit fallback for those types. If no execution credential is configured for an MCP/LLM integration, tool calls are made unauthenticated.
+
+**AAP proxy exception:** `GET /api/v1/proxies/aap/*` falls back to the integration's management credential when `credential_id` is omitted, so a validated AAP integration is enough to list controller resources. With one visible AAP integration, both query params may be omitted. With more than one, pass `integration_id` to select which gateway to use.
 
 Credential requirements vary by integration type. LLM providers and AAP instances always require a management credential — health checks and discovery cannot run without one. MCP servers support unauthenticated connections, so a management credential is only needed when the server itself requires authentication.
 
@@ -203,7 +205,7 @@ The LLM adapter delegates to provider-specific implementations via `LLMProviderB
 
 ### Ansible Automation Platform
 
-The AAP integration stores the API URL and TLS configuration. It does not discover sub-resources — AAP objects (job templates, inventories, organizations) are browsed at workflow-design time through separate proxy endpoints using execution credentials.
+The AAP integration stores the API URL and TLS configuration. It does not discover sub-resources — AAP objects (job templates, inventories, organizations) are browsed at workflow-design time through `GET /api/v1/proxies/aap/*`. The proxy uses the integration's management credential when the caller does not pass an execution `credential_id`, so a validated AAP integration is sufficient to list controller resources. If more than one AAP integration is visible, pass `integration_id`; `credential_id` is still optional.
 
 **Design Decisions:**
 - **Static credential authentication.** The adapter uses `aap_oauth_token` (Bearer) if present, falling back to `aap_username` + `aap_password` (Basic Auth). No support for short-lived tokens, token refresh, or OIDC — this is a known limitation.

--- a/backend/docs/standards/api-response-format.md
+++ b/backend/docs/standards/api-response-format.md
@@ -613,7 +613,7 @@ Endpoints under `/api/v1/proxies/aap/` are pure HTTP proxies to AAP Controller A
 |---|---|---|
 | Pagination | Cursor-based keyset (N+1) | Offset-based (`page_size`) |
 | Response type | `ResourcesResponse[T]` (`resources`, `next`, `prev`, `total`) | `AAPListResponse[T]` (`count`, `results`) |
-| Query params | `BaseListParams` (`limit`, `cursor`, `sort`, `include_total`) | `AAPBaseQuery` (`search`, `page_size`, `credential_id`) |
+| Query params | `BaseListParams` (`limit`, `cursor`, `sort`, `include_total`) | `AAPBaseQuery` (`search`, `page_size`, `credential_id`, `integration_id`) |
 | Filtering | Bracket notation with 7 operators + label filters | `search` string only |
 | Sorting | `-field` prefix notation with ID tiebreaker | None (upstream order) |
 | Default page size | 20 (max 100) | 50 (max 200) |

--- a/backend/docs/workflow-engine/aap-nodes.md
+++ b/backend/docs/workflow-engine/aap-nodes.md
@@ -81,7 +81,9 @@ All config fields support template expressions (e.g., `${trigger.host}`), resolv
 
 ## Authentication
 
-AAP nodes require an **AAP integration** (`integration_id` on the node config) for URL and TLS settings, and a **Syntara credential** (`credential_id`) for auth headers/token. Without an integration, the node fails with `ConfigError: "AAP integration not configured. Attach an AAP integration to this node."`
+AAP **execution** nodes require an **AAP integration** (`integration_id` on the node config) for URL and TLS settings, and a **Syntara credential** (`credential_id`) for auth headers/token. Without an integration, the node fails with `ConfigError: "AAP integration not configured. Attach an AAP integration to this node."`
+
+**Design-time browsing** (cascading dropdowns in the builder) uses `GET /api/v1/proxies/aap/*`, not these node fields. That proxy resolves the Gateway from the AAP integration and authenticates with the integration's management credential when `credential_id` is omitted. With one visible AAP integration, both query params may be omitted. With more than one, pass `integration_id`.
 
 ## Cancellation Propagation
 

--- a/backend/src/cli/orchestrator_cli/openapi.yaml
+++ b/backend/src/cli/orchestrator_cli/openapi.yaml
@@ -106,7 +106,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -119,7 +119,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -267,7 +268,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -280,7 +281,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -444,7 +446,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -457,7 +459,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -605,7 +608,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -618,7 +621,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -782,7 +786,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -795,7 +799,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -943,7 +948,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -956,7 +961,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -1113,7 +1119,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1126,7 +1132,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -1283,7 +1290,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1296,7 +1303,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -1444,7 +1452,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1457,7 +1465,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -1604,7 +1613,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1617,7 +1626,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response

--- a/backend/src/syntara/aap/__init__.py
+++ b/backend/src/syntara/aap/__init__.py
@@ -2,4 +2,9 @@
 
 Provides BFF proxy endpoints for browsing AAP Controller resources
 (organizations, job templates, inventories) via the Syntara backend.
+
+Auth is resolved from the AAP Gateway integration (URL/TLS) and a Syntara
+credential. When ``integration_id`` and ``credential_id`` are omitted, the
+unique visible enabled AAP integration and its management credential are used.
+With more than one AAP integration, pass ``integration_id`` to select one.
 """

--- a/backend/src/syntara/aap/__init__.py
+++ b/backend/src/syntara/aap/__init__.py
@@ -3,7 +3,7 @@
 Provides BFF proxy endpoints for browsing AAP Controller resources
 (organizations, job templates, inventories) via the Syntara backend.
 
-Auth is resolved from the AAP Gateway integration (URL/TLS) and a Syntara
+Auth is resolved from the AAP Gateway integration (URL/TLS) and an Orchestrator
 credential. When ``integration_id`` and ``credential_id`` are omitted, the
 unique visible enabled AAP integration and its management credential are used.
 With more than one AAP integration, pass ``integration_id`` to select one.

--- a/backend/src/syntara/aap/audit/aap_resource_access.py
+++ b/backend/src/syntara/aap/audit/aap_resource_access.py
@@ -56,7 +56,9 @@ class AAPResourceAccessEvent:
     """Domain event emitted when a user accesses AAP resources via the proxy.
 
     Captures the resource type, action (list/get), result metadata, and
-    whether a per-user credential was used (vs. environment-level auth).
+    whether a Syntara credential authenticated the request (explicit
+    ``credential_id`` or the integration's management credential). Env-var
+    auth is not used by the AAP proxy.
     """
 
     resource_type: AAPResourceType

--- a/backend/src/syntara/aap/audit/aap_resource_access.py
+++ b/backend/src/syntara/aap/audit/aap_resource_access.py
@@ -56,7 +56,7 @@ class AAPResourceAccessEvent:
     """Domain event emitted when a user accesses AAP resources via the proxy.
 
     Captures the resource type, action (list/get), result metadata, and
-    whether a Syntara credential authenticated the request (explicit
+    whether an Orchestrator credential authenticated the request (explicit
     ``credential_id`` or the integration's management credential). Env-var
     auth is not used by the AAP proxy.
     """

--- a/backend/src/syntara/aap/audit/aap_resource_access.py
+++ b/backend/src/syntara/aap/audit/aap_resource_access.py
@@ -57,8 +57,8 @@ class AAPResourceAccessEvent:
 
     Captures the resource type, action (list/get), result metadata, and
     whether an Orchestrator credential authenticated the request (explicit
-    ``credential_id`` or the integration's management credential). Env-var
-    auth is not used by the AAP proxy.
+    ``credential_id`` or the integration's management credential). False when
+    the request failed before decrypt. Env-var auth is not used by the AAP proxy.
     """
 
     resource_type: AAPResourceType

--- a/backend/src/syntara/aap/auth.py
+++ b/backend/src/syntara/aap/auth.py
@@ -1,10 +1,14 @@
-"""Shared AAP Controller authentication resolution.
+"""Shared AAP Controller connection types and env-var auth resolution.
 
-Resolves AAP auth from environment variables:
-  APP_AAP_BASE_URL, APP_AAP_TOKEN, APP_AAP_USERNAME, APP_AAP_PASSWORD, APP_AAP_VERIFY_SSL
+``AAPConnection`` is the resolved connection used by the AAP proxy and by
+AAP job-template activities.
 
-Used by both the AAP proxy service (BFF endpoints) and the AAP job template
-activity (workflow execution) when no credential is injected at runtime.
+``resolve_aap_connection`` reads environment variables
+(``APP_AAP_BASE_URL``, ``APP_AAP_TOKEN``, ``APP_AAP_USERNAME``,
+``APP_AAP_PASSWORD``, ``APP_AAP_VERIFY_SSL``). The BFF proxy no longer uses
+this path — it resolves URL and auth from the AAP integration and credential.
+Env-var resolution remains for workflow execution when no credential is
+injected at runtime.
 """
 
 from __future__ import annotations
@@ -62,6 +66,10 @@ def _get_basic_auth_from_settings(settings: Settings) -> httpx.BasicAuth | None:
 
 def resolve_aap_connection(settings: Settings) -> AAPConnection:
     """Resolve AAP connection from environment settings.
+
+    Used by workflow execution when no Syntara credential is injected.
+    The BFF proxy (``/proxies/aap/*``) does not call this — it resolves
+    from the AAP integration and credential instead.
 
     Args:
         settings: Application settings.

--- a/backend/src/syntara/aap/auth.py
+++ b/backend/src/syntara/aap/auth.py
@@ -67,7 +67,7 @@ def _get_basic_auth_from_settings(settings: Settings) -> httpx.BasicAuth | None:
 def resolve_aap_connection(settings: Settings) -> AAPConnection:
     """Resolve AAP connection from environment settings.
 
-    Used by workflow execution when no Syntara credential is injected.
+    Used by workflow execution when no Orchestrator credential is injected.
     The BFF proxy (``/proxies/aap/*``) does not call this — it resolves
     from the AAP integration and credential instead.
 

--- a/backend/src/syntara/aap/credential_resolver.py
+++ b/backend/src/syntara/aap/credential_resolver.py
@@ -217,6 +217,8 @@ async def resolve_aap_connection_from_credential(
     session: AsyncSession,
     credential_id: UUID | str,
     user_id: UUID,
+    *,
+    skip_ownership_check: bool = False,
 ) -> AAPConnection:
     """Resolve AAP auth from a Syntara credential.
 
@@ -227,7 +229,11 @@ async def resolve_aap_connection_from_credential(
     Args:
         session: Async database session.
         credential_id: UUID of the credential (accepts UUID or str for conversion).
-        user_id: User ID (UUID) for authorization check (required - credential owner must match).
+        user_id: User ID (UUID) for authorization check (required unless
+            ``skip_ownership_check`` is True).
+        skip_ownership_check: When True, skip the owner match. Use only for
+            an integration's management credential, which is authorized by
+            integration visibility rather than personal ownership.
 
     Returns:
         AAPConnection with decrypted auth. ``base_url`` is empty and
@@ -241,6 +247,7 @@ async def resolve_aap_connection_from_credential(
     Security:
         - credential_id is validated as UUID format to prevent SQL injection vectors
         - user_id is required (not optional) to prevent accidental bypass of authorization
+          unless ``skip_ownership_check`` is explicitly set by a trusted caller
 
     """
     # Validate and convert credential_id to UUID
@@ -252,7 +259,8 @@ async def resolve_aap_connection_from_credential(
     # Validate credential type, enabled status, and ownership
     _validate_credential_type(credential)
     _validate_credential_enabled(credential)
-    _validate_credential_ownership(credential, user_id)
+    if not skip_ownership_check:
+        _validate_credential_ownership(credential, user_id)
 
     # Decrypt credential fields
     secret_service: SecretService = create_secret_service(session)

--- a/backend/src/syntara/aap/credential_resolver.py
+++ b/backend/src/syntara/aap/credential_resolver.py
@@ -18,6 +18,7 @@ from syntara.core.lib.encryption import EncryptionError
 from syntara.core.services.secret_service import SecretService, create_secret_service
 from syntara.credentials.lib.injector_resolver import InjectorResolver
 from syntara.credentials.models.credential import Credential
+from syntara.integrations.models.integration import Integration
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -213,14 +214,33 @@ def _extract_auth_from_extra_vars(
     return auth_headers, basic_auth
 
 
+async def _connection_from_validated_credential(session: AsyncSession, credential: Credential) -> AAPConnection:
+    """Decrypt a type-checked AAP credential. Does not check ownership."""
+    secret_service: SecretService = create_secret_service(session)
+    decrypted_inputs = await _decrypt_credential_inputs(credential, secret_service)
+    extra_vars = _resolve_credential_injectors(credential, decrypted_inputs)
+    auth_headers, basic_auth = _extract_auth_from_extra_vars(extra_vars)
+
+    logger.info(
+        "AAP auth details resolved from credential",
+        credential_id=str(credential.id),
+        credential_name=credential.name,
+        auth_method="oauth" if basic_auth is None else "basic",
+    )
+
+    return AAPConnection(
+        base_url="",
+        headers=dict(auth_headers),
+        basic_auth=basic_auth,
+    )
+
+
 async def resolve_aap_connection_from_credential(
     session: AsyncSession,
     credential_id: UUID | str,
     user_id: UUID,
-    *,
-    skip_ownership_check: bool = False,
 ) -> AAPConnection:
-    """Resolve AAP auth from a Syntara credential.
+    """Resolve AAP auth from a Syntara credential the caller owns.
 
     Returns an AAPConnection with authentication fields populated.
     The caller must supply ``base_url`` and ``verify_ssl`` from the
@@ -229,11 +249,7 @@ async def resolve_aap_connection_from_credential(
     Args:
         session: Async database session.
         credential_id: UUID of the credential (accepts UUID or str for conversion).
-        user_id: User ID (UUID) for authorization check (required unless
-            ``skip_ownership_check`` is True).
-        skip_ownership_check: When True, skip the owner match. Use only for
-            an integration's management credential, which is authorized by
-            integration visibility rather than personal ownership.
+        user_id: User ID (UUID) for the owner check. Required.
 
     Returns:
         AAPConnection with decrypted auth. ``base_url`` is empty and
@@ -247,42 +263,33 @@ async def resolve_aap_connection_from_credential(
     Security:
         - credential_id is validated as UUID format to prevent SQL injection vectors
         - user_id is required (not optional) to prevent accidental bypass of authorization
-          unless ``skip_ownership_check`` is explicitly set by a trusted caller
 
     """
-    # Validate and convert credential_id to UUID
     validated_credential_id = _validate_credential_id(credential_id)
-
-    # Fetch credential from database
     credential = await _fetch_credential(session, validated_credential_id)
-
-    # Validate credential type, enabled status, and ownership
     _validate_credential_type(credential)
     _validate_credential_enabled(credential)
-    if not skip_ownership_check:
-        _validate_credential_ownership(credential, user_id)
+    _validate_credential_ownership(credential, user_id)
+    return await _connection_from_validated_credential(session, credential)
 
-    # Decrypt credential fields
-    secret_service: SecretService = create_secret_service(session)
-    decrypted_inputs = await _decrypt_credential_inputs(credential, secret_service)
 
-    # Resolve injector templates to get mapped field names
-    extra_vars = _resolve_credential_injectors(credential, decrypted_inputs)
+async def resolve_aap_connection_from_management_credential(
+    session: AsyncSession,
+    integration: Integration,
+) -> AAPConnection:
+    """Decrypt the integration's management credential. No owner check.
 
-    # Extract AAP auth from resolved extra_vars
-    auth_headers, basic_auth = _extract_auth_from_extra_vars(extra_vars)
+    Call only after integration visibility has been enforced. Loads
+    ``integration.management_credential_id`` only — not an arbitrary credential ID.
+    """
+    if integration.management_credential_id is None:
+        msg = (
+            f"Integration '{integration.name}' has no management credential; "
+            "pass credential_id or configure a management credential on the integration"
+        )
+        raise AAPNotConfiguredError(msg)
 
-    # Log credential auth resolution
-    # Security: Log at INFO level to prevent infrastructure leakage
-    logger.info(
-        "AAP auth details resolved from credential",
-        credential_id=str(validated_credential_id),
-        credential_name=credential.name,
-        auth_method="oauth" if basic_auth is None else "basic",
-    )
-
-    return AAPConnection(
-        base_url="",
-        headers=dict(auth_headers),
-        basic_auth=basic_auth,
-    )
+    credential = await _fetch_credential(session, integration.management_credential_id)
+    _validate_credential_type(credential)
+    _validate_credential_enabled(credential)
+    return await _connection_from_validated_credential(session, credential)

--- a/backend/src/syntara/aap/exceptions.py
+++ b/backend/src/syntara/aap/exceptions.py
@@ -6,7 +6,7 @@ from syntara.core.exceptions import SyntaraError
 
 @fastapi_exception(handler="syntara.aap.error_handlers.aap_not_configured_handler")
 class AAPNotConfiguredError(SyntaraError):
-    """AAP Controller not configured (no env vars)."""
+    """AAP Controller integration is missing, disabled, or not resolvable."""
 
 
 @fastapi_exception(handler="syntara.aap.error_handlers.aap_connection_error_handler")

--- a/backend/src/syntara/aap/models/queries.py
+++ b/backend/src/syntara/aap/models/queries.py
@@ -9,21 +9,28 @@ _MAX_SEARCH_LENGTH = 200
 
 
 class AAPBaseQuery(BaseModel):
-    """Common query params for all AAP proxy endpoints."""
+    """Common query params for all AAP proxy endpoints.
+
+    ``integration_id`` and ``credential_id`` are optional. Omit both when a
+    single visible AAP integration exists; with multiple integrations, pass
+    ``integration_id`` (``credential_id`` still defaults to that integration's
+    management credential).
+    """
 
     search: str | None = Field(default=None, max_length=_MAX_SEARCH_LENGTH, description="Search filter")
     page_size: int = Field(default=50, ge=1, le=200, description="Max results to return")
     credential_id: UUID | None = Field(
         default=None,
         description="Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication. "
-        "If provided, the credential is decrypted and used instead of environment variables. "
+        "If omitted, the selected integration's management credential is used. "
         'Credential must be of type "Ansible Automation Platform". '
         "Must be a valid UUID format.",
     )
     integration_id: UUID | None = Field(
         default=None,
         description="Optional Ansible Automation Platform Gateway integration ID for connection URL resolution. "
-        "When provided, the integration's configured URL is used instead of environment variables. "
+        "If omitted, the unique visible enabled AAP integration is used. "
+        "Required when more than one AAP integration is visible. "
         "Must be a valid UUID format.",
     )
 

--- a/backend/src/syntara/aap/router.py
+++ b/backend/src/syntara/aap/router.py
@@ -3,11 +3,15 @@
 Thin layer that validates query params, resolves dependencies,
 and delegates to AAPProxyService.
 
-Authentication: Endpoints support optional per-user credential forwarding
-via the ``credential_id`` query parameter. If provided, the specified Syntara
-credential (type: "Ansible Automation Platform") is decrypted and used to
-authenticate against the AAP Controller. If not provided, falls back to
-environment variables (APP_AAP_TOKEN or APP_AAP_USERNAME/PASSWORD).
+Authentication: Endpoints accept optional ``credential_id`` and
+``integration_id`` query parameters. When both are omitted, the proxy uses
+the unique visible enabled AAP integration and its management credential
+(the same pair that integration validation already proved works). When more
+than one AAP integration is visible, pass ``integration_id`` to select one;
+``credential_id`` may still be omitted (management credential is used).
+When ``credential_id`` is provided, the specified Syntara credential (type:
+"Ansible Automation Platform") is decrypted and used instead; callers may
+only use credentials they own.
 
 Authorization: The ``current_user`` dependency ensures only authenticated
 Syntara users can call these endpoints. When using credential_id, users can

--- a/backend/src/syntara/aap/router.py
+++ b/backend/src/syntara/aap/router.py
@@ -60,9 +60,15 @@ router = APIRouter(prefix="/proxies/aap", tags=["Ansible Automation Platform Pro
 
 _integration_scope = ProjectScopeFilter("integration", "read")
 
-# The proxy always authenticates with an Orchestrator credential: query.credential_id
-# or the integration's management credential. Env-var auth is not used here.
-_PROXY_USES_SYNTARA_CREDENTIAL = True
+
+def _credential_used_for_audit(error_type: str | None) -> bool:
+    """Whether an Orchestrator credential was resolved for this proxy request.
+
+    True on success and after decrypt (auth/upstream errors). False when the
+    request failed before decrypt (no/ambiguous integration, missing
+    management credential). Env-var auth is not used on this path.
+    """
+    return error_type != "AAPNotConfiguredError"
 
 
 # ============================================================================
@@ -111,7 +117,7 @@ async def list_organizations(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
+                credential_used=_credential_used_for_audit(error_type),
                 search_filter=query.search,
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),
@@ -143,7 +149,7 @@ async def list_job_templates(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
+                credential_used=_credential_used_for_audit(error_type),
                 search_filter=query.search,
                 organization_filter=query.organization,
                 error_type=error_type,
@@ -185,7 +191,7 @@ async def get_job_template(
                 username=current_user.username,
                 resource_id=job_template_id,
                 resource_name=resource_name,
-                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
+                credential_used=_credential_used_for_audit(error_type),
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),
             )
@@ -218,7 +224,7 @@ async def list_workflow_job_templates(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
+                credential_used=_credential_used_for_audit(error_type),
                 search_filter=query.search,
                 organization_filter=query.organization,
                 error_type=error_type,
@@ -264,7 +270,7 @@ async def get_workflow_job_template(
                 username=current_user.username,
                 resource_id=workflow_job_template_id,
                 resource_name=resource_name,
-                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
+                credential_used=_credential_used_for_audit(error_type),
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),
             )
@@ -295,7 +301,7 @@ async def list_inventories(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
+                credential_used=_credential_used_for_audit(error_type),
                 search_filter=query.search,
                 organization_filter=query.organization,
                 error_type=error_type,
@@ -330,7 +336,7 @@ async def list_execution_environments(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
+                credential_used=_credential_used_for_audit(error_type),
                 search_filter=query.search,
                 organization_filter=query.organization,
                 error_type=error_type,
@@ -363,7 +369,7 @@ async def list_credentials(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
+                credential_used=_credential_used_for_audit(error_type),
                 search_filter=query.search,
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),
@@ -395,7 +401,7 @@ async def list_instance_groups(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
+                credential_used=_credential_used_for_audit(error_type),
                 search_filter=query.search,
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),
@@ -427,7 +433,7 @@ async def list_labels(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
+                credential_used=_credential_used_for_audit(error_type),
                 search_filter=query.search,
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),

--- a/backend/src/syntara/aap/router.py
+++ b/backend/src/syntara/aap/router.py
@@ -5,13 +5,12 @@ and delegates to AAPProxyService.
 
 Authentication: Endpoints accept optional ``credential_id`` and
 ``integration_id`` query parameters. When both are omitted, the proxy uses
-the unique visible enabled AAP integration and its management credential
-(the same pair that integration validation already proved works). When more
-than one AAP integration is visible, pass ``integration_id`` to select one;
-``credential_id`` may still be omitted (management credential is used).
-When ``credential_id`` is provided, the specified Syntara credential (type:
-"Ansible Automation Platform") is decrypted and used instead; callers may
-only use credentials they own.
+the unique visible enabled AAP integration and its management credential.
+When more than one AAP integration is visible, pass ``integration_id`` to
+select one; ``credential_id`` may still be omitted (management credential is
+used). When ``credential_id`` is provided, the specified Syntara credential
+(type: "Ansible Automation Platform") is decrypted and used instead; callers
+may only use credentials they own.
 
 Authorization: The ``current_user`` dependency ensures only authenticated
 Syntara users can call these endpoints. When using credential_id, users can

--- a/backend/src/syntara/aap/router.py
+++ b/backend/src/syntara/aap/router.py
@@ -61,6 +61,10 @@ router = APIRouter(prefix="/proxies/aap", tags=["Ansible Automation Platform Pro
 
 _integration_scope = ProjectScopeFilter("integration", "read")
 
+# The proxy always authenticates with a Syntara credential: query.credential_id
+# or the integration's management credential. Env-var auth is not used here.
+_PROXY_USES_SYNTARA_CREDENTIAL = True
+
 
 # ============================================================================
 # Dependency Injection
@@ -108,7 +112,7 @@ async def list_organizations(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=query.credential_id is not None,
+                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
                 search_filter=query.search,
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),
@@ -140,7 +144,7 @@ async def list_job_templates(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=query.credential_id is not None,
+                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
                 search_filter=query.search,
                 organization_filter=query.organization,
                 error_type=error_type,
@@ -182,7 +186,7 @@ async def get_job_template(
                 username=current_user.username,
                 resource_id=job_template_id,
                 resource_name=resource_name,
-                credential_used=query.credential_id is not None,
+                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),
             )
@@ -215,7 +219,7 @@ async def list_workflow_job_templates(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=query.credential_id is not None,
+                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
                 search_filter=query.search,
                 organization_filter=query.organization,
                 error_type=error_type,
@@ -261,7 +265,7 @@ async def get_workflow_job_template(
                 username=current_user.username,
                 resource_id=workflow_job_template_id,
                 resource_name=resource_name,
-                credential_used=query.credential_id is not None,
+                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),
             )
@@ -292,7 +296,7 @@ async def list_inventories(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=query.credential_id is not None,
+                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
                 search_filter=query.search,
                 organization_filter=query.organization,
                 error_type=error_type,
@@ -327,7 +331,7 @@ async def list_execution_environments(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=query.credential_id is not None,
+                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
                 search_filter=query.search,
                 organization_filter=query.organization,
                 error_type=error_type,
@@ -360,7 +364,7 @@ async def list_credentials(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=query.credential_id is not None,
+                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
                 search_filter=query.search,
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),
@@ -392,7 +396,7 @@ async def list_instance_groups(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=query.credential_id is not None,
+                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
                 search_filter=query.search,
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),
@@ -424,7 +428,7 @@ async def list_labels(
                 user_id=current_user.id,
                 username=current_user.username,
                 result_count=result_count,
-                credential_used=query.credential_id is not None,
+                credential_used=_PROXY_USES_SYNTARA_CREDENTIAL,
                 search_filter=query.search,
                 error_type=error_type,
                 principal_type=current_user.__dict__.get("__principal_type__"),

--- a/backend/src/syntara/aap/router.py
+++ b/backend/src/syntara/aap/router.py
@@ -60,7 +60,7 @@ router = APIRouter(prefix="/proxies/aap", tags=["Ansible Automation Platform Pro
 
 _integration_scope = ProjectScopeFilter("integration", "read")
 
-# The proxy always authenticates with a Syntara credential: query.credential_id
+# The proxy always authenticates with an Orchestrator credential: query.credential_id
 # or the integration's management credential. Env-var auth is not used here.
 _PROXY_USES_SYNTARA_CREDENTIAL = True
 

--- a/backend/src/syntara/aap/services/aap_proxy_service.py
+++ b/backend/src/syntara/aap/services/aap_proxy_service.py
@@ -356,8 +356,7 @@ class AAPProxyService:
 
         ``integration_id`` and ``credential_id`` are optional. When omitted, the
         proxy uses the unique visible enabled AAP integration and its
-        management credential — the same pair that successful
-        ``POST /integrations/{id}/validate`` already proved works.
+        management credential. ``validation_status`` is not considered.
 
         When the caller supplies ``credential_id``, that credential's owner
         must match ``user_id``. Omitted ``credential_id`` uses the integration's

--- a/backend/src/syntara/aap/services/aap_proxy_service.py
+++ b/backend/src/syntara/aap/services/aap_proxy_service.py
@@ -2,6 +2,13 @@
 
 Handles auth resolution, request forwarding, and response shaping for
 the UI's cascading resource dropdowns.
+
+Connection resolution:
+- ``integration_id`` selects the AAP Gateway (URL/TLS). If omitted, the unique
+  visible enabled AAP integration is used. If more than one is visible, the
+  caller must pass ``integration_id``.
+- ``credential_id`` selects a Syntara AAP credential (owner check). If omitted,
+  the selected integration's management credential is used.
 """
 
 from __future__ import annotations
@@ -12,7 +19,7 @@ from uuid import UUID
 import httpx
 import structlog
 from pydantic import BaseModel
-from sqlmodel import select
+from sqlmodel import col, select
 
 from syntara.aap.auth import AAPConnection
 from syntara.aap.credential_resolver import resolve_aap_connection_from_credential
@@ -36,6 +43,7 @@ from syntara.integrations.models.integration import (
     Integration,
     IntegrationProjectAssignment,
     IntegrationScope,
+    IntegrationStatus,
     IntegrationType,
 )
 from syntara.integrations.models.integration_configuration import AAPConfiguration
@@ -348,8 +356,14 @@ class AAPProxyService:
     ) -> AAPConnection:
         """Resolve AAP connection from an integration and credential.
 
-        Both integration_id and credential_id are required. The integration
-        provides the AAP Gateway URL while the credential supplies authentication.
+        ``integration_id`` and ``credential_id`` are optional. When omitted, the
+        proxy uses the unique visible enabled AAP integration and its
+        management credential — the same pair that successful
+        ``POST /integrations/{id}/validate`` already proved works.
+
+        When the caller supplies ``credential_id``, that credential's owner
+        must match ``user_id``. Management-credential fallback is authorized
+        by integration visibility instead of personal ownership.
 
         Args:
             credential_id: Syntara credential ID for AAP authentication.
@@ -362,20 +376,22 @@ class AAPProxyService:
         Raises:
             AAPNotConfiguredError: Integration/credential not found, disabled, or IDs missing.
             AAPAuthenticationError: Credential decryption failed or user not authorized.
-            ValueError: user_id not provided.
+            ValueError: user_id not provided for connection resolution.
 
         """
-        if not integration_id:
-            msg = "integration_id is required for AAP connection resolution"
-            raise AAPNotConfiguredError(msg)
-        if not credential_id:
-            msg = "credential_id is required for AAP connection resolution"
-            raise AAPNotConfiguredError(msg)
-        if user_id is None:
+        if credential_id is not None and user_id is None:
             msg = "user_id is required when credential_id is provided (authorization check cannot be bypassed)"
             raise ValueError(msg)
+        integration = await self._resolve_aap_integration(integration_id)
+        resolved_credential_id, skip_ownership = self._resolve_aap_credential_id(credential_id, integration)
+        if user_id is None:
+            msg = "user_id is required for AAP proxy connection resolution"
+            raise ValueError(msg)
         return await self._resolve_connection_from_integration(
-            integration_id=integration_id, credential_id=credential_id, user_id=user_id
+            integration=integration,
+            credential_id=resolved_credential_id,
+            user_id=user_id,
+            skip_ownership_check=skip_ownership,
         )
 
     async def _enforce_integration_visibility(self, integration: Integration) -> None:
@@ -398,13 +414,95 @@ class AAPProxyService:
             msg = f"Integration {integration.id} not found"
             raise AAPNotConfiguredError(msg)
 
-    async def _resolve_connection_from_integration(
-        self,
-        integration_id: UUID | str,
-        credential_id: UUID | str,
-        user_id: UUID,
-    ) -> AAPConnection:
-        """Resolve AAP connection URL from an integration, with auth from a credential."""
+    async def _list_visible_aap_integrations(self) -> list[Integration]:
+        """Return enabled AAP integrations the caller is allowed to see."""
+        stmt = select(Integration).where(
+            Integration.integration_type == IntegrationType.ANSIBLE_AUTOMATION_PLATFORM,
+            col(Integration.enabled).is_(True),
+        )
+        result = await self._session.exec(stmt)
+        integrations = list(result.all())
+        if self._allowed_projects is None or self._allowed_projects.all_projects:
+            return integrations
+
+        user_project_ids = set(self._allowed_projects.project_ids)
+        visible: list[Integration] = []
+        project_scoped: list[Integration] = []
+        for integration in integrations:
+            if integration.scope == IntegrationScope.GLOBAL:
+                visible.append(integration)
+            else:
+                project_scoped.append(integration)
+
+        if not project_scoped:
+            return visible
+
+        scoped_ids = [integration.id for integration in project_scoped]
+        assign_stmt = select(IntegrationProjectAssignment).where(
+            col(IntegrationProjectAssignment.integration_id).in_(scoped_ids),
+        )
+        assign_result = await self._session.exec(assign_stmt)
+        allowed_ids = {
+            assignment.integration_id for assignment in assign_result.all() if assignment.project_id in user_project_ids
+        }
+        visible.extend(integration for integration in project_scoped if integration.id in allowed_ids)
+        return visible
+
+    @staticmethod
+    def _select_default_aap_integration(integrations: list[Integration]) -> Integration:
+        """Pick the unique AAP integration to use when integration_id is omitted.
+
+        Prefers ``validation_status=available``. Raises if none exist or more
+        than one equally eligible integration is visible.
+        """
+        if not integrations:
+            msg = "No enabled AAP Controller integration is configured"
+            raise AAPNotConfiguredError(msg)
+
+        available = [item for item in integrations if item.validation_status == IntegrationStatus.AVAILABLE]
+        candidates = available or integrations
+        if len(candidates) > 1:
+            msg = "Multiple AAP Controller integrations are configured; pass integration_id to select one"
+            raise AAPNotConfiguredError(msg)
+        return candidates[0]
+
+    async def _resolve_aap_integration(self, integration_id: UUID | str | None) -> Integration:
+        """Load the requested AAP integration, or the unique visible default."""
+        if integration_id:
+            return await self._load_aap_integration(integration_id)
+        candidates = await self._list_visible_aap_integrations()
+        integration = self._select_default_aap_integration(candidates)
+        logger.info(
+            "AAP proxy using default integration",
+            integration_id=str(integration.id),
+            integration_name=integration.name,
+        )
+        return integration
+
+    @staticmethod
+    def _resolve_aap_credential_id(
+        credential_id: UUID | str | None,
+        integration: Integration,
+    ) -> tuple[UUID | str, bool]:
+        """Return (credential_id, skip_ownership) for the proxy request.
+
+        An explicit credential_id keeps the owner check. Omitting it uses the
+        integration's management credential, authorized via integration visibility.
+        """
+        if credential_id:
+            return credential_id, False
+        if integration.management_credential_id:
+            logger.info(
+                "AAP proxy using integration management credential",
+                integration_id=str(integration.id),
+                credential_id=str(integration.management_credential_id),
+            )
+            return integration.management_credential_id, True
+        msg = "credential_id is required for AAP connection resolution"
+        raise AAPNotConfiguredError(msg)
+
+    async def _load_aap_integration(self, integration_id: UUID | str) -> Integration:
+        """Fetch an AAP integration by ID and enforce type, enabled, and visibility."""
         parsed_id: UUID
         if isinstance(integration_id, str):
             try:
@@ -434,12 +532,22 @@ class AAPProxyService:
             msg = f"Integration '{integration.name}' is disabled"
             raise AAPNotConfiguredError(msg)
 
+        await self._enforce_integration_visibility(integration)
+        return integration
+
+    async def _resolve_connection_from_integration(
+        self,
+        integration: Integration,
+        credential_id: UUID | str,
+        user_id: UUID,
+        *,
+        skip_ownership_check: bool = False,
+    ) -> AAPConnection:
+        """Resolve AAP connection URL from an integration, with auth from a credential."""
         config = integration.configuration
         if not isinstance(config, AAPConfiguration):
-            msg = f"Integration {parsed_id} has invalid configuration type"
+            msg = f"Integration {integration.id} has invalid configuration type"
             raise AAPNotConfiguredError(msg)
-
-        await self._enforce_integration_visibility(integration)
 
         # Re-run the integration SSRF policy at request time: the stored base_url may have
         # been re-pointed to a private/metadata address (DNS rebinding) since write time.
@@ -454,11 +562,15 @@ class AAPProxyService:
 
         logger.debug(
             "Resolving AAP auth from credential with integration URL",
-            integration_id=str(parsed_id),
+            integration_id=str(integration.id),
             credential_id=str(credential_id),
+            skip_ownership_check=skip_ownership_check,
         )
         cred_connection = await resolve_aap_connection_from_credential(
-            session=self._session, credential_id=credential_id, user_id=user_id
+            session=self._session,
+            credential_id=credential_id,
+            user_id=user_id,
+            skip_ownership_check=skip_ownership_check,
         )
         return AAPConnection(
             base_url=base_url,

--- a/backend/src/syntara/aap/services/aap_proxy_service.py
+++ b/backend/src/syntara/aap/services/aap_proxy_service.py
@@ -22,7 +22,10 @@ from pydantic import BaseModel
 from sqlmodel import col, select
 
 from syntara.aap.auth import AAPConnection
-from syntara.aap.credential_resolver import resolve_aap_connection_from_credential
+from syntara.aap.credential_resolver import (
+    resolve_aap_connection_from_credential,
+    resolve_aap_connection_from_management_credential,
+)
 from syntara.aap.exceptions import AAPAuthenticationError, AAPConnectionError, AAPNotConfiguredError, AAPUpstreamError
 from syntara.aap.models.responses import (
     AAPCredential,
@@ -39,14 +42,9 @@ from syntara.aap.models.responses import (
 )
 from syntara.core.lib.tls_utils import build_integration_httpx_verify
 from syntara.integrations.lib.url_validation import validate_integration_configuration_no_ssrf
-from syntara.integrations.models.integration import (
-    Integration,
-    IntegrationProjectAssignment,
-    IntegrationScope,
-    IntegrationStatus,
-    IntegrationType,
-)
+from syntara.integrations.models.integration import Integration, IntegrationType
 from syntara.integrations.models.integration_configuration import AAPConfiguration
+from syntara.integrations.services.integration_service import IntegrationService
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -362,8 +360,8 @@ class AAPProxyService:
         ``POST /integrations/{id}/validate`` already proved works.
 
         When the caller supplies ``credential_id``, that credential's owner
-        must match ``user_id``. Management-credential fallback is authorized
-        by integration visibility instead of personal ownership.
+        must match ``user_id``. Omitted ``credential_id`` uses the integration's
+        management credential after visibility has been enforced.
 
         Args:
             credential_id: Syntara credential ID for AAP authentication.
@@ -383,34 +381,26 @@ class AAPProxyService:
             msg = "user_id is required when credential_id is provided (authorization check cannot be bypassed)"
             raise ValueError(msg)
         integration = await self._resolve_aap_integration(integration_id)
-        resolved_credential_id, skip_ownership = self._resolve_aap_credential_id(credential_id, integration)
         if user_id is None:
             msg = "user_id is required for AAP proxy connection resolution"
             raise ValueError(msg)
         return await self._resolve_connection_from_integration(
             integration=integration,
-            credential_id=resolved_credential_id,
+            credential_id=credential_id,
             user_id=user_id,
-            skip_ownership_check=skip_ownership,
         )
 
     async def _enforce_integration_visibility(self, integration: Integration) -> None:
         """Raise AAPNotConfiguredError if the caller cannot see the integration.
 
-        GLOBAL integrations are visible to everyone. PROJECT-scoped integrations
-        require the caller to have access to at least one assigned project.
+        Delegates to ``IntegrationService.resolve_visible_integration_ids`` so
+        proxy defaulting and ``GET /integrations`` share the same GLOBAL /
+        project-assignment rules.
         """
-        if self._allowed_projects is None or self._allowed_projects.all_projects:
+        if self._allowed_projects is None:
             return
-        if integration.scope == IntegrationScope.GLOBAL:
-            return
-        stmt = select(IntegrationProjectAssignment.project_id).where(
-            IntegrationProjectAssignment.integration_id == integration.id,
-        )
-        result = await self._session.exec(stmt)
-        assigned_project_ids = set(result.all())
-        user_project_ids = set(self._allowed_projects.project_ids)
-        if not assigned_project_ids & user_project_ids:
+        visible_ids = await IntegrationService.resolve_visible_integration_ids(self._session, self._allowed_projects)
+        if visible_ids is not None and integration.id not in set(visible_ids):
             msg = f"Integration {integration.id} not found"
             raise AAPNotConfiguredError(msg)
 
@@ -420,51 +410,31 @@ class AAPProxyService:
             Integration.integration_type == IntegrationType.ANSIBLE_AUTOMATION_PLATFORM,
             col(Integration.enabled).is_(True),
         )
+        if self._allowed_projects is not None:
+            visible_ids = await IntegrationService.resolve_visible_integration_ids(
+                self._session, self._allowed_projects
+            )
+            if visible_ids is not None:
+                if not visible_ids:
+                    return []
+                stmt = stmt.where(col(Integration.id).in_(visible_ids))
         result = await self._session.exec(stmt)
-        integrations = list(result.all())
-        if self._allowed_projects is None or self._allowed_projects.all_projects:
-            return integrations
-
-        user_project_ids = set(self._allowed_projects.project_ids)
-        visible: list[Integration] = []
-        project_scoped: list[Integration] = []
-        for integration in integrations:
-            if integration.scope == IntegrationScope.GLOBAL:
-                visible.append(integration)
-            else:
-                project_scoped.append(integration)
-
-        if not project_scoped:
-            return visible
-
-        scoped_ids = [integration.id for integration in project_scoped]
-        assign_stmt = select(IntegrationProjectAssignment).where(
-            col(IntegrationProjectAssignment.integration_id).in_(scoped_ids),
-        )
-        assign_result = await self._session.exec(assign_stmt)
-        allowed_ids = {
-            assignment.integration_id for assignment in assign_result.all() if assignment.project_id in user_project_ids
-        }
-        visible.extend(integration for integration in project_scoped if integration.id in allowed_ids)
-        return visible
+        return list(result.all())
 
     @staticmethod
     def _select_default_aap_integration(integrations: list[Integration]) -> Integration:
-        """Pick the unique AAP integration to use when integration_id is omitted.
+        """Pick the unique visible enabled AAP integration when integration_id is omitted.
 
-        Prefers ``validation_status=available``. Raises if none exist or more
-        than one equally eligible integration is visible.
+        Uniqueness is exactly one visible enabled integration, matching the
+        public API contract. ``validation_status`` is not a tie-break.
         """
         if not integrations:
             msg = "No enabled AAP Controller integration is configured"
             raise AAPNotConfiguredError(msg)
-
-        available = [item for item in integrations if item.validation_status == IntegrationStatus.AVAILABLE]
-        candidates = available or integrations
-        if len(candidates) > 1:
+        if len(integrations) > 1:
             msg = "Multiple AAP Controller integrations are configured; pass integration_id to select one"
             raise AAPNotConfiguredError(msg)
-        return candidates[0]
+        return integrations[0]
 
     async def _resolve_aap_integration(self, integration_id: UUID | str | None) -> Integration:
         """Load the requested AAP integration, or the unique visible default."""
@@ -478,28 +448,6 @@ class AAPProxyService:
             integration_name=integration.name,
         )
         return integration
-
-    @staticmethod
-    def _resolve_aap_credential_id(
-        credential_id: UUID | str | None,
-        integration: Integration,
-    ) -> tuple[UUID | str, bool]:
-        """Return (credential_id, skip_ownership) for the proxy request.
-
-        An explicit credential_id keeps the owner check. Omitting it uses the
-        integration's management credential, authorized via integration visibility.
-        """
-        if credential_id:
-            return credential_id, False
-        if integration.management_credential_id:
-            logger.info(
-                "AAP proxy using integration management credential",
-                integration_id=str(integration.id),
-                credential_id=str(integration.management_credential_id),
-            )
-            return integration.management_credential_id, True
-        msg = "credential_id is required for AAP connection resolution"
-        raise AAPNotConfiguredError(msg)
 
     async def _load_aap_integration(self, integration_id: UUID | str) -> Integration:
         """Fetch an AAP integration by ID and enforce type, enabled, and visibility."""
@@ -538,10 +486,8 @@ class AAPProxyService:
     async def _resolve_connection_from_integration(
         self,
         integration: Integration,
-        credential_id: UUID | str,
+        credential_id: UUID | str | None,
         user_id: UUID,
-        *,
-        skip_ownership_check: bool = False,
     ) -> AAPConnection:
         """Resolve AAP connection URL from an integration, with auth from a credential."""
         config = integration.configuration
@@ -560,18 +506,29 @@ class AAPProxyService:
         base_url = config.base_url.rstrip("/")
         verify_ssl = not config.insecure_skip_tls_verify
 
-        logger.debug(
-            "Resolving AAP auth from credential with integration URL",
-            integration_id=str(integration.id),
-            credential_id=str(credential_id),
-            skip_ownership_check=skip_ownership_check,
-        )
-        cred_connection = await resolve_aap_connection_from_credential(
-            session=self._session,
-            credential_id=credential_id,
-            user_id=user_id,
-            skip_ownership_check=skip_ownership_check,
-        )
+        if credential_id:
+            logger.debug(
+                "Resolving AAP auth from credential with integration URL",
+                integration_id=str(integration.id),
+                credential_id=str(credential_id),
+            )
+            cred_connection = await resolve_aap_connection_from_credential(
+                session=self._session,
+                credential_id=credential_id,
+                user_id=user_id,
+            )
+        else:
+            logger.info(
+                "AAP proxy using integration management credential",
+                integration_id=str(integration.id),
+                credential_id=str(integration.management_credential_id)
+                if integration.management_credential_id
+                else None,
+            )
+            cred_connection = await resolve_aap_connection_from_management_credential(
+                session=self._session,
+                integration=integration,
+            )
         return AAPConnection(
             base_url=base_url,
             headers=cred_connection.headers,

--- a/backend/src/syntara/aap/services/aap_proxy_service.py
+++ b/backend/src/syntara/aap/services/aap_proxy_service.py
@@ -7,7 +7,7 @@ Connection resolution:
 - ``integration_id`` selects the AAP Gateway (URL/TLS). If omitted, the unique
   visible enabled AAP integration is used. If more than one is visible, the
   caller must pass ``integration_id``.
-- ``credential_id`` selects a Syntara AAP credential (owner check). If omitted,
+- ``credential_id`` selects an Orchestrator AAP credential (owner check). If omitted,
   the selected integration's management credential is used.
 """
 

--- a/backend/src/syntara/schemas/aap/openapi.yaml
+++ b/backend/src/syntara/schemas/aap/openapi.yaml
@@ -11,8 +11,13 @@ info:
     (organizations, job templates, inventories) via cascading dropdowns
     without direct Ansible Automation Platform Controller access.
 
-    Authentication to the Ansible Automation Platform Controller is resolved server-side from
-    environment variables (`APP_AAP_BASE_URL`, `APP_AAP_TOKEN`).
+    Authentication to the Ansible Automation Platform Controller is resolved
+    server-side from the AAP Gateway integration (URL and TLS) and a Syntara
+    credential (token or username/password). When integration_id and
+    credential_id are omitted, the unique visible enabled AAP integration
+    and its management credential are used. When more than one AAP integration
+    is visible, pass integration_id to select one. credential_id remains
+    optional and defaults to that integration's management credential.
 
     Note: This API intentionally diverges from standard Orchestrator response conventions.
     As a BFF proxy, it mirrors the upstream Ansible Automation Platform API shape (count/results, page_size)
@@ -1260,7 +1265,7 @@ components:
         title: Credential Id
       description: |
         Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-        If provided, the credential is decrypted and used instead of environment variables.
+        If omitted, the selected integration's management credential is used.
         Credential must be of type "Ansible Automation Platform".
     integrationId:
       in: query
@@ -1274,7 +1279,8 @@ components:
         title: Integration Id
       description: |
         Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-        When provided, the integration's configured URL is used instead of environment variables.
+        If omitted, the unique visible enabled AAP integration is used.
+        Required when more than one AAP integration is visible.
 
   securitySchemes:
     bearerAuth:

--- a/backend/src/syntara/schemas/aap/openapi.yaml
+++ b/backend/src/syntara/schemas/aap/openapi.yaml
@@ -12,7 +12,7 @@ info:
     without direct Ansible Automation Platform Controller access.
 
     Authentication to the Ansible Automation Platform Controller is resolved
-    server-side from the AAP Gateway integration (URL and TLS) and a Syntara
+    server-side from the AAP Gateway integration (URL and TLS) and an Orchestrator
     credential (token or username/password). When integration_id and
     credential_id are omitted, the unique visible enabled AAP integration
     and its management credential are used. When more than one AAP integration

--- a/backend/src/syntara/schemas/openapi-public.json
+++ b/backend/src/syntara/schemas/openapi-public.json
@@ -164,7 +164,7 @@
               ],
               "title": "Credential Id"
             },
-            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf provided, the credential is decrypted and used instead of environment variables.\nCredential must be of type \"Ansible Automation Platform\".\n"
+            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf omitted, the selected integration's management credential is used.\nCredential must be of type \"Ansible Automation Platform\".\n"
           },
           {
             "in": "query",
@@ -182,7 +182,7 @@
               ],
               "title": "Integration Id"
             },
-            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nWhen provided, the integration's configured URL is used instead of environment variables.\n"
+            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nIf omitted, the unique visible enabled AAP integration is used.\nRequired when more than one AAP integration is visible.\n"
           }
         ],
         "responses": {
@@ -400,7 +400,7 @@
               ],
               "title": "Credential Id"
             },
-            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf provided, the credential is decrypted and used instead of environment variables.\nCredential must be of type \"Ansible Automation Platform\".\n"
+            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf omitted, the selected integration's management credential is used.\nCredential must be of type \"Ansible Automation Platform\".\n"
           },
           {
             "in": "query",
@@ -418,7 +418,7 @@
               ],
               "title": "Integration Id"
             },
-            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nWhen provided, the integration's configured URL is used instead of environment variables.\n"
+            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nIf omitted, the unique visible enabled AAP integration is used.\nRequired when more than one AAP integration is visible.\n"
           },
           {
             "in": "query",
@@ -663,7 +663,7 @@
               ],
               "title": "Credential Id"
             },
-            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf provided, the credential is decrypted and used instead of environment variables.\nCredential must be of type \"Ansible Automation Platform\".\n"
+            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf omitted, the selected integration's management credential is used.\nCredential must be of type \"Ansible Automation Platform\".\n"
           },
           {
             "in": "query",
@@ -681,7 +681,7 @@
               ],
               "title": "Integration Id"
             },
-            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nWhen provided, the integration's configured URL is used instead of environment variables.\n"
+            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nIf omitted, the unique visible enabled AAP integration is used.\nRequired when more than one AAP integration is visible.\n"
           }
         ],
         "responses": {
@@ -899,7 +899,7 @@
               ],
               "title": "Credential Id"
             },
-            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf provided, the credential is decrypted and used instead of environment variables.\nCredential must be of type \"Ansible Automation Platform\".\n"
+            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf omitted, the selected integration's management credential is used.\nCredential must be of type \"Ansible Automation Platform\".\n"
           },
           {
             "in": "query",
@@ -917,7 +917,7 @@
               ],
               "title": "Integration Id"
             },
-            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nWhen provided, the integration's configured URL is used instead of environment variables.\n"
+            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nIf omitted, the unique visible enabled AAP integration is used.\nRequired when more than one AAP integration is visible.\n"
           },
           {
             "in": "query",
@@ -1162,7 +1162,7 @@
               ],
               "title": "Credential Id"
             },
-            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf provided, the credential is decrypted and used instead of environment variables.\nCredential must be of type \"Ansible Automation Platform\".\n"
+            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf omitted, the selected integration's management credential is used.\nCredential must be of type \"Ansible Automation Platform\".\n"
           },
           {
             "in": "query",
@@ -1180,7 +1180,7 @@
               ],
               "title": "Integration Id"
             },
-            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nWhen provided, the integration's configured URL is used instead of environment variables.\n"
+            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nIf omitted, the unique visible enabled AAP integration is used.\nRequired when more than one AAP integration is visible.\n"
           }
         ],
         "responses": {
@@ -1398,7 +1398,7 @@
               ],
               "title": "Credential Id"
             },
-            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf provided, the credential is decrypted and used instead of environment variables.\nCredential must be of type \"Ansible Automation Platform\".\n"
+            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf omitted, the selected integration's management credential is used.\nCredential must be of type \"Ansible Automation Platform\".\n"
           },
           {
             "in": "query",
@@ -1416,7 +1416,7 @@
               ],
               "title": "Integration Id"
             },
-            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nWhen provided, the integration's configured URL is used instead of environment variables.\n"
+            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nIf omitted, the unique visible enabled AAP integration is used.\nRequired when more than one AAP integration is visible.\n"
           },
           {
             "in": "query",
@@ -1651,7 +1651,7 @@
               ],
               "title": "Credential Id"
             },
-            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf provided, the credential is decrypted and used instead of environment variables.\nCredential must be of type \"Ansible Automation Platform\".\n"
+            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf omitted, the selected integration's management credential is used.\nCredential must be of type \"Ansible Automation Platform\".\n"
           },
           {
             "in": "query",
@@ -1669,7 +1669,7 @@
               ],
               "title": "Integration Id"
             },
-            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nWhen provided, the integration's configured URL is used instead of environment variables.\n"
+            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nIf omitted, the unique visible enabled AAP integration is used.\nRequired when more than one AAP integration is visible.\n"
           },
           {
             "in": "query",
@@ -1904,7 +1904,7 @@
               ],
               "title": "Credential Id"
             },
-            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf provided, the credential is decrypted and used instead of environment variables.\nCredential must be of type \"Ansible Automation Platform\".\n"
+            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf omitted, the selected integration's management credential is used.\nCredential must be of type \"Ansible Automation Platform\".\n"
           },
           {
             "in": "query",
@@ -1922,7 +1922,7 @@
               ],
               "title": "Integration Id"
             },
-            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nWhen provided, the integration's configured URL is used instead of environment variables.\n"
+            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nIf omitted, the unique visible enabled AAP integration is used.\nRequired when more than one AAP integration is visible.\n"
           }
         ],
         "responses": {
@@ -2140,7 +2140,7 @@
               ],
               "title": "Credential Id"
             },
-            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf provided, the credential is decrypted and used instead of environment variables.\nCredential must be of type \"Ansible Automation Platform\".\n"
+            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf omitted, the selected integration's management credential is used.\nCredential must be of type \"Ansible Automation Platform\".\n"
           },
           {
             "in": "query",
@@ -2158,7 +2158,7 @@
               ],
               "title": "Integration Id"
             },
-            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nWhen provided, the integration's configured URL is used instead of environment variables.\n"
+            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nIf omitted, the unique visible enabled AAP integration is used.\nRequired when more than one AAP integration is visible.\n"
           }
         ],
         "responses": {
@@ -2377,7 +2377,7 @@
               ],
               "title": "Credential Id"
             },
-            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf provided, the credential is decrypted and used instead of environment variables.\nCredential must be of type \"Ansible Automation Platform\".\n"
+            "description": "Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.\nIf omitted, the selected integration's management credential is used.\nCredential must be of type \"Ansible Automation Platform\".\n"
           },
           {
             "in": "query",
@@ -2395,7 +2395,7 @@
               ],
               "title": "Integration Id"
             },
-            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nWhen provided, the integration's configured URL is used instead of environment variables.\n"
+            "description": "Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.\nIf omitted, the unique visible enabled AAP integration is used.\nRequired when more than one AAP integration is visible.\n"
           }
         ],
         "responses": {

--- a/backend/src/syntara/schemas/openapi-public.yaml
+++ b/backend/src/syntara/schemas/openapi-public.yaml
@@ -107,7 +107,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -120,7 +120,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -268,7 +269,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -281,7 +282,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -445,7 +447,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -458,7 +460,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -606,7 +609,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -619,7 +622,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -783,7 +787,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -796,7 +800,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -944,7 +949,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -957,7 +962,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -1114,7 +1120,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1127,7 +1133,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -1284,7 +1291,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1297,7 +1304,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -1445,7 +1453,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1458,7 +1466,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -1605,7 +1614,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1618,7 +1627,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response

--- a/backend/src/syntara/schemas/openapi.yaml
+++ b/backend/src/syntara/schemas/openapi.yaml
@@ -106,7 +106,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -119,7 +119,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -267,7 +268,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -280,7 +281,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -444,7 +446,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -457,7 +459,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -605,7 +608,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -618,7 +621,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -782,7 +786,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -795,7 +799,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -943,7 +948,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -956,7 +961,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -1113,7 +1119,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1126,7 +1132,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
         - in: query
           name: organization
           required: false
@@ -1283,7 +1290,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1296,7 +1303,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -1444,7 +1452,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1457,7 +1465,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response
@@ -1604,7 +1613,7 @@ paths:
             title: Credential Id
           description: |
             Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-            If provided, the credential is decrypted and used instead of environment variables.
+            If omitted, the selected integration's management credential is used.
             Credential must be of type "Ansible Automation Platform".
         - in: query
           name: integration_id
@@ -1617,7 +1626,8 @@ paths:
             title: Integration Id
           description: |
             Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-            When provided, the integration's configured URL is used instead of environment variables.
+            If omitted, the unique visible enabled AAP integration is used.
+            Required when more than one AAP integration is visible.
       responses:
         '200':
           description: Successful Response

--- a/backend/tests/unit/aap/audit/test_aap_resource_access_audit.py
+++ b/backend/tests/unit/aap/audit/test_aap_resource_access_audit.py
@@ -152,7 +152,7 @@ class TestAAPResourceAccessHandler:
         assert result.structured_data.credential_used is True
 
     def test_credential_not_used_tracking(self) -> None:
-        """credential_used=False (env-level auth) is captured."""
+        """credential_used=False is captured when the event records no Syntara credential."""
         event = AAPResourceAccessEvent(
             resource_type=AAPResourceType.LABELS,
             action=AAPAccessAction.LIST,

--- a/backend/tests/unit/aap/audit/test_aap_resource_access_audit.py
+++ b/backend/tests/unit/aap/audit/test_aap_resource_access_audit.py
@@ -152,7 +152,7 @@ class TestAAPResourceAccessHandler:
         assert result.structured_data.credential_used is True
 
     def test_credential_not_used_tracking(self) -> None:
-        """credential_used=False is captured when the event records no Syntara credential."""
+        """credential_used=False is captured when the event records no Orchestrator credential."""
         event = AAPResourceAccessEvent(
             resource_type=AAPResourceType.LABELS,
             action=AAPAccessAction.LIST,

--- a/backend/tests/unit/aap/services/test_service.py
+++ b/backend/tests/unit/aap/services/test_service.py
@@ -995,10 +995,10 @@ def _mock_session_with_integration(integration: MagicMock | None) -> AsyncMock:
 
 def _bound_uuids_from_statement(stmt: object) -> set[UUID]:
     """Collect UUID bind params from a SQLAlchemy select (e.g. ``id IN (...)``)."""
-    compiled = stmt.compile()  # type: ignore[union-attr]
+    compiled = stmt.compile()  # type: ignore[attr-defined]
     bound: set[UUID] = set()
     for value in compiled.params.values():
-        items: tuple[object, ...] = value if isinstance(value, (list, tuple)) else (value,)
+        items = value if isinstance(value, (list, tuple)) else (value,)
         for item in items:
             if isinstance(item, UUID):
                 bound.add(item)

--- a/backend/tests/unit/aap/services/test_service.py
+++ b/backend/tests/unit/aap/services/test_service.py
@@ -993,6 +993,23 @@ def _mock_session_with_integration(integration: MagicMock | None) -> AsyncMock:
     return mock_session
 
 
+def _bound_uuids_from_statement(stmt: object) -> set[UUID]:
+    """Collect UUID bind params from a SQLAlchemy select (e.g. ``id IN (...)``)."""
+    compiled = stmt.compile()  # type: ignore[union-attr]
+    bound: set[UUID] = set()
+    for value in compiled.params.values():
+        items: tuple[object, ...] = value if isinstance(value, (list, tuple)) else (value,)
+        for item in items:
+            if isinstance(item, UUID):
+                bound.add(item)
+            elif isinstance(item, str):
+                try:
+                    bound.add(UUID(item))
+                except ValueError:
+                    continue
+    return bound
+
+
 class TestResolveConnectionFromIntegration:
     """Tests for _resolve_connection_from_integration."""
 
@@ -1297,7 +1314,7 @@ class TestDefaultAAPIntegrationResolution:
 
     @pytest.mark.asyncio
     async def test_omitted_ids_use_unique_available_integration_and_management_credential(self) -> None:
-        """GET /proxies/aap/* without query params uses the validated AAP integration."""
+        """GET /proxies/aap/* without query params uses the unique visible enabled AAP integration."""
         management_credential_id = uuid4()
         integration = _mock_integration(
             base_url="https://aap-gw.example.com/",
@@ -1432,6 +1449,68 @@ class TestDefaultAAPIntegrationResolution:
             pytest.raises(AAPNotConfiguredError, match="pass integration_id"),
         ):
             await service._resolve_connection(user_id=uuid4())
+
+    @pytest.mark.asyncio
+    async def test_omitted_ids_use_only_the_visible_enabled_integration(self) -> None:
+        """Two enabled AAP rows: auto-default uses the one visibility returns.
+
+        ``session.exec`` returns both rows unless the statement binds the
+        visible id (the ``id IN (...)`` filter). Dropping that filter would
+        auto-select a hidden tenant integration.
+        """
+        from syntara.authz.engine import AllowedProjectsResult
+
+        visible = _mock_integration(
+            name="Visible AAP",
+            base_url="https://visible-aap.example.com",
+            management_credential_id=uuid4(),
+        )
+        hidden = _mock_integration(
+            name="Hidden AAP",
+            base_url="https://hidden-aap.example.com",
+            management_credential_id=uuid4(),
+        )
+        catalog = [hidden, visible]
+        catalog_ids = {hidden.id, visible.id}
+
+        async def fake_exec(stmt: object) -> MagicMock:
+            matched = _bound_uuids_from_statement(stmt) & catalog_ids
+            rows = [row for row in catalog if row.id in matched] if matched else catalog
+            result = MagicMock()
+            result.all.return_value = rows
+            return result
+
+        mock_session = AsyncMock()
+        mock_session.exec = AsyncMock(side_effect=fake_exec)
+        service = AAPProxyService(
+            settings=get_settings(),
+            session=mock_session,
+            allowed_projects=AllowedProjectsResult(all_projects=False, project_ids=[uuid4()]),
+        )
+        cred_connection = AAPConnection(
+            base_url="",
+            headers={"Authorization": "Bearer visible-mgmt-token"},
+            verify_ssl=True,
+            timeout=30.0,
+        )
+
+        with (
+            patch(
+                "syntara.aap.services.aap_proxy_service.IntegrationService.resolve_visible_integration_ids",
+                new_callable=AsyncMock,
+                return_value=[visible.id],
+            ),
+            patch(
+                "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_management_credential",
+                new_callable=AsyncMock,
+                return_value=cred_connection,
+            ) as mock_mgmt_resolver,
+        ):
+            result = await service._resolve_connection(user_id=uuid4())
+
+        assert result.base_url == "https://visible-aap.example.com"
+        assert result.headers == {"Authorization": "Bearer visible-mgmt-token"}
+        mock_mgmt_resolver.assert_called_once_with(session=mock_session, integration=visible)
 
 
 class TestSelectDefaultAAPIntegration:

--- a/backend/tests/unit/aap/services/test_service.py
+++ b/backend/tests/unit/aap/services/test_service.py
@@ -883,22 +883,26 @@ class TestCredentialAuthorization:
 
     @pytest.mark.asyncio
     async def test_missing_integration_id_raises_not_configured(self) -> None:
-        """Calling _resolve_connection without integration_id must raise AAPNotConfiguredError."""
+        """Calling _resolve_connection without integration_id must raise when none are configured."""
         service = _service()
         user_id = uuid4()
 
-        with pytest.raises(AAPNotConfiguredError, match="integration_id is required"):
+        with (
+            patch.object(service, "_list_visible_aap_integrations", new_callable=AsyncMock, return_value=[]),
+            pytest.raises(AAPNotConfiguredError, match="No enabled AAP Controller integration"),
+        ):
             await service._resolve_connection(credential_id="550e8400-e29b-41d4-a716-446655440000", user_id=user_id)
 
     @pytest.mark.asyncio
     async def test_missing_credential_id_raises_not_configured(self) -> None:
-        """Calling _resolve_connection without credential_id must raise AAPNotConfiguredError."""
-        service = _service()
-        integration_id = uuid4()
+        """Raise when credential_id is omitted and the integration has no management credential."""
+        integration = _mock_integration(management_credential_id=None)
+        mock_session = _mock_session_with_integration(integration)
+        service = AAPProxyService(settings=get_settings(), session=mock_session)
         user_id = uuid4()
 
         with pytest.raises(AAPNotConfiguredError, match="credential_id is required"):
-            await service._resolve_connection(integration_id=integration_id, user_id=user_id)
+            await service._resolve_connection(integration_id=integration.id, user_id=user_id)
 
     @pytest.mark.asyncio
     async def test_credential_id_without_user_id_raises_value_error(self) -> None:
@@ -912,6 +916,18 @@ class TestCredentialAuthorization:
                 integration_id=integration_id,
                 user_id=None,
             )
+
+    @pytest.mark.asyncio
+    async def test_omitted_credential_id_without_user_id_raises_value_error(self) -> None:
+        """Auto-resolved management credential still requires a caller user_id."""
+        integration = _mock_integration(management_credential_id=uuid4())
+        service = _service()
+
+        with (
+            patch.object(service, "_list_visible_aap_integrations", new_callable=AsyncMock, return_value=[integration]),
+            pytest.raises(ValueError, match="user_id is required for AAP proxy connection resolution"),
+        ):
+            await service._resolve_connection(credential_id=None, user_id=None)
 
     @pytest.mark.asyncio
     async def test_invalid_credential_id_format_raises_authentication_error(self) -> None:
@@ -938,15 +954,20 @@ def _mock_integration(
     base_url: str = "https://aap-integration.example.com",
     insecure_skip_tls_verify: bool = False,
     config_valid: bool = True,
+    management_credential_id: UUID | None = None,
+    validation_status: str = "available",
 ) -> MagicMock:
     """Build a mock Integration with AAPConfiguration."""
-    from syntara.integrations.models.integration import IntegrationType
+    from syntara.integrations.models.integration import IntegrationScope, IntegrationStatus, IntegrationType
 
     integration = MagicMock()
     integration.id = integration_id or uuid4()
     integration.name = name
     integration.enabled = enabled
     integration.integration_type = IntegrationType(integration_type)
+    integration.management_credential_id = management_credential_id
+    integration.validation_status = IntegrationStatus(validation_status)
+    integration.scope = IntegrationScope.GLOBAL
 
     if config_valid:
         config = MagicMock()
@@ -1014,7 +1035,12 @@ class TestResolveConnectionFromIntegration:
         # verify_ssl from integration config (insecure_skip_tls_verify=False -> verify_ssl=True)
         assert result.verify_ssl is True
         # Credential resolver was called
-        mock_cred_resolver.assert_called_once_with(session=mock_session, credential_id=credential_id, user_id=user_id)
+        mock_cred_resolver.assert_called_once_with(
+            session=mock_session,
+            credential_id=credential_id,
+            user_id=user_id,
+            skip_ownership_check=False,
+        )
 
     @pytest.mark.asyncio
     async def test_integration_not_found_raises_not_configured(self) -> None:
@@ -1256,3 +1282,266 @@ class TestEnforceIntegrationVisibility:
                 credential_id=credential_id,
                 user_id=user_id,
             )
+
+
+class TestDefaultAAPIntegrationResolution:
+    """Auto-resolve a unique visible AAP integration and its management credential."""
+
+    @pytest.mark.asyncio
+    async def test_omitted_ids_use_unique_available_integration_and_management_credential(self) -> None:
+        """GET /proxies/aap/* without query params uses the validated AAP integration."""
+        management_credential_id = uuid4()
+        integration = _mock_integration(
+            base_url="https://aap-gw.example.com/",
+            management_credential_id=management_credential_id,
+        )
+        service = _service()
+        user_id = uuid4()
+        cred_connection = AAPConnection(
+            base_url="",
+            headers={"Authorization": "Bearer mgmt-token"},
+            verify_ssl=True,
+            timeout=30.0,
+        )
+
+        with (
+            patch.object(service, "_list_visible_aap_integrations", new_callable=AsyncMock, return_value=[integration]),
+            patch(
+                "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_credential",
+                new_callable=AsyncMock,
+                return_value=cred_connection,
+            ) as mock_cred_resolver,
+        ):
+            result = await service._resolve_connection(user_id=user_id)
+
+        assert result.base_url == "https://aap-gw.example.com"
+        assert result.headers == {"Authorization": "Bearer mgmt-token"}
+        mock_cred_resolver.assert_called_once_with(
+            session=service._session,
+            credential_id=management_credential_id,
+            user_id=user_id,
+            skip_ownership_check=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_omitted_credential_id_uses_management_credential_of_explicit_integration(self) -> None:
+        """UI may pass only integration_id before an execution credential is chosen."""
+        management_credential_id = uuid4()
+        integration = _mock_integration(
+            base_url="https://aap-gw.example.com",
+            management_credential_id=management_credential_id,
+        )
+        mock_session = _mock_session_with_integration(integration)
+        service = AAPProxyService(settings=get_settings(), session=mock_session)
+        user_id = uuid4()
+        cred_connection = AAPConnection(
+            base_url="",
+            headers={"Authorization": "Bearer mgmt-token"},
+            verify_ssl=True,
+            timeout=30.0,
+        )
+
+        with patch(
+            "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_credential",
+            new_callable=AsyncMock,
+            return_value=cred_connection,
+        ) as mock_cred_resolver:
+            result = await service._resolve_connection(integration_id=integration.id, user_id=user_id)
+
+        assert result.base_url == "https://aap-gw.example.com"
+        mock_cred_resolver.assert_called_once_with(
+            session=mock_session,
+            credential_id=management_credential_id,
+            user_id=user_id,
+            skip_ownership_check=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_explicit_credential_id_keeps_ownership_check(self) -> None:
+        """Caller-supplied credentials must still belong to the requesting user."""
+        integration = _mock_integration(
+            base_url="https://aap-gw.example.com",
+            management_credential_id=uuid4(),
+        )
+        mock_session = _mock_session_with_integration(integration)
+        service = AAPProxyService(settings=get_settings(), session=mock_session)
+        credential_id = uuid4()
+        user_id = uuid4()
+        cred_connection = AAPConnection(
+            base_url="",
+            headers={"Authorization": "Bearer user-token"},
+            verify_ssl=True,
+            timeout=30.0,
+        )
+
+        with patch(
+            "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_credential",
+            new_callable=AsyncMock,
+            return_value=cred_connection,
+        ) as mock_cred_resolver:
+            await service._resolve_connection(
+                integration_id=integration.id,
+                credential_id=credential_id,
+                user_id=user_id,
+            )
+
+        mock_cred_resolver.assert_called_once_with(
+            session=mock_session,
+            credential_id=credential_id,
+            user_id=user_id,
+            skip_ownership_check=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_multiple_available_integrations_require_explicit_id(self) -> None:
+        """Ambiguous AAP integrations must not be auto-selected."""
+        service = _service()
+        integrations = [
+            _mock_integration(name="AAP One"),
+            _mock_integration(name="AAP Two"),
+        ]
+
+        with (
+            patch.object(service, "_list_visible_aap_integrations", new_callable=AsyncMock, return_value=integrations),
+            pytest.raises(AAPNotConfiguredError, match="pass integration_id"),
+        ):
+            await service._resolve_connection(user_id=uuid4())
+
+    @pytest.mark.asyncio
+    async def test_prefers_available_integration_when_others_are_unvalidated(self) -> None:
+        """A single validated integration wins over unvalidated siblings."""
+        available = _mock_integration(
+            name="Healthy AAP",
+            base_url="https://healthy.example.com",
+            management_credential_id=uuid4(),
+            validation_status="available",
+        )
+        unknown = _mock_integration(name="Unvalidated AAP", validation_status="unknown")
+        service = _service()
+        cred_connection = AAPConnection(
+            base_url="",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=True,
+            timeout=30.0,
+        )
+
+        with (
+            patch.object(
+                service,
+                "_list_visible_aap_integrations",
+                new_callable=AsyncMock,
+                return_value=[unknown, available],
+            ),
+            patch(
+                "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_credential",
+                new_callable=AsyncMock,
+                return_value=cred_connection,
+            ),
+        ):
+            result = await service._resolve_connection(user_id=uuid4())
+
+        assert result.base_url == "https://healthy.example.com"
+
+
+class TestSelectDefaultAAPIntegration:
+    """Unit tests for default-integration selection without I/O."""
+
+    def test_empty_list_raises(self) -> None:
+        with pytest.raises(AAPNotConfiguredError, match="No enabled AAP Controller integration"):
+            AAPProxyService._select_default_aap_integration([])
+
+    def test_single_integration_returned(self) -> None:
+        integration = _mock_integration()
+        assert AAPProxyService._select_default_aap_integration([integration]) is integration
+
+
+class TestListVisibleAAPIntegrations:
+    """Tests for visibility filtering when auto-resolving the AAP integration."""
+
+    @pytest.mark.asyncio
+    async def test_unrestricted_caller_sees_all_enabled_integrations(self) -> None:
+        integration = _mock_integration()
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = [integration]
+        mock_session.exec.return_value = mock_result
+        service = AAPProxyService(settings=get_settings(), session=mock_session)
+
+        result = await service._list_visible_aap_integrations()
+
+        assert result == [integration]
+
+    @pytest.mark.asyncio
+    async def test_project_scoped_integration_hidden_without_assignment(self) -> None:
+        from syntara.authz.engine import AllowedProjectsResult
+        from syntara.integrations.models.integration import IntegrationScope
+
+        integration = _mock_integration()
+        integration.scope = IntegrationScope.PROJECT
+        mock_session = AsyncMock()
+        mock_integrations = MagicMock()
+        mock_integrations.all.return_value = [integration]
+        mock_assignments = MagicMock()
+        mock_assignments.all.return_value = []
+        mock_session.exec = AsyncMock(side_effect=[mock_integrations, mock_assignments])
+
+        service = AAPProxyService(
+            settings=get_settings(),
+            session=mock_session,
+            allowed_projects=AllowedProjectsResult(all_projects=False, project_ids=[uuid4()]),
+        )
+
+        result = await service._list_visible_aap_integrations()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_global_integration_visible_to_project_restricted_caller(self) -> None:
+        from syntara.authz.engine import AllowedProjectsResult
+        from syntara.integrations.models.integration import IntegrationScope
+
+        integration = _mock_integration()
+        integration.scope = IntegrationScope.GLOBAL
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = [integration]
+        mock_session.exec.return_value = mock_result
+
+        service = AAPProxyService(
+            settings=get_settings(),
+            session=mock_session,
+            allowed_projects=AllowedProjectsResult(all_projects=False, project_ids=[uuid4()]),
+        )
+
+        result = await service._list_visible_aap_integrations()
+
+        assert result == [integration]
+
+    @pytest.mark.asyncio
+    async def test_project_scoped_integration_visible_with_matching_assignment(self) -> None:
+        from syntara.authz.engine import AllowedProjectsResult
+        from syntara.integrations.models.integration import IntegrationScope
+
+        project_id = uuid4()
+        integration = _mock_integration()
+        integration.scope = IntegrationScope.PROJECT
+        assignment = MagicMock()
+        assignment.integration_id = integration.id
+        assignment.project_id = project_id
+
+        mock_session = AsyncMock()
+        mock_integrations = MagicMock()
+        mock_integrations.all.return_value = [integration]
+        mock_assignments = MagicMock()
+        mock_assignments.all.return_value = [assignment]
+        mock_session.exec = AsyncMock(side_effect=[mock_integrations, mock_assignments])
+
+        service = AAPProxyService(
+            settings=get_settings(),
+            session=mock_session,
+            allowed_projects=AllowedProjectsResult(all_projects=False, project_ids=[project_id]),
+        )
+
+        result = await service._list_visible_aap_integrations()
+
+        assert result == [integration]

--- a/backend/tests/unit/aap/services/test_service.py
+++ b/backend/tests/unit/aap/services/test_service.py
@@ -901,7 +901,7 @@ class TestCredentialAuthorization:
         service = AAPProxyService(settings=get_settings(), session=mock_session)
         user_id = uuid4()
 
-        with pytest.raises(AAPNotConfiguredError, match="credential_id is required"):
+        with pytest.raises(AAPNotConfiguredError, match="no management credential"):
             await service._resolve_connection(integration_id=integration.id, user_id=user_id)
 
     @pytest.mark.asyncio
@@ -1039,7 +1039,6 @@ class TestResolveConnectionFromIntegration:
             session=mock_session,
             credential_id=credential_id,
             user_id=user_id,
-            skip_ownership_check=False,
         )
 
     @pytest.mark.asyncio
@@ -1240,10 +1239,17 @@ class TestEnforceIntegrationVisibility:
             timeout=30.0,
         )
 
-        with patch(
-            "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_credential",
-            new_callable=AsyncMock,
-            return_value=cred_connection,
+        with (
+            patch(
+                "syntara.aap.services.aap_proxy_service.IntegrationService.resolve_visible_integration_ids",
+                new_callable=AsyncMock,
+                return_value=[integration.id],
+            ),
+            patch(
+                "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_credential",
+                new_callable=AsyncMock,
+                return_value=cred_connection,
+            ),
         ):
             result = await service._resolve_connection(
                 integration_id=integration.id,
@@ -1262,12 +1268,7 @@ class TestEnforceIntegrationVisibility:
         integration = _mock_integration(base_url="https://aap-project.example.com")
         integration.scope = IntegrationScope.PROJECT
 
-        mock_session = AsyncMock()
-        mock_result_integration = MagicMock()
-        mock_result_integration.one_or_none.return_value = integration
-        mock_result_projects = MagicMock()
-        mock_result_projects.all.return_value = [uuid4()]
-        mock_session.exec = AsyncMock(side_effect=[mock_result_integration, mock_result_projects])
+        mock_session = _mock_session_with_integration(integration)
 
         unrelated_project = uuid4()
         restricted_projects = AllowedProjectsResult(all_projects=False, project_ids=[unrelated_project])
@@ -1276,7 +1277,14 @@ class TestEnforceIntegrationVisibility:
         credential_id = uuid4()
         user_id = uuid4()
 
-        with pytest.raises(AAPNotConfiguredError, match="not found"):
+        with (
+            patch(
+                "syntara.aap.services.aap_proxy_service.IntegrationService.resolve_visible_integration_ids",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            pytest.raises(AAPNotConfiguredError, match="not found"),
+        ):
             await service._resolve_connection(
                 integration_id=integration.id,
                 credential_id=credential_id,
@@ -1307,20 +1315,18 @@ class TestDefaultAAPIntegrationResolution:
         with (
             patch.object(service, "_list_visible_aap_integrations", new_callable=AsyncMock, return_value=[integration]),
             patch(
-                "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_credential",
+                "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_management_credential",
                 new_callable=AsyncMock,
                 return_value=cred_connection,
-            ) as mock_cred_resolver,
+            ) as mock_mgmt_resolver,
         ):
             result = await service._resolve_connection(user_id=user_id)
 
         assert result.base_url == "https://aap-gw.example.com"
         assert result.headers == {"Authorization": "Bearer mgmt-token"}
-        mock_cred_resolver.assert_called_once_with(
+        mock_mgmt_resolver.assert_called_once_with(
             session=service._session,
-            credential_id=management_credential_id,
-            user_id=user_id,
-            skip_ownership_check=True,
+            integration=integration,
         )
 
     @pytest.mark.asyncio
@@ -1342,18 +1348,16 @@ class TestDefaultAAPIntegrationResolution:
         )
 
         with patch(
-            "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_credential",
+            "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_management_credential",
             new_callable=AsyncMock,
             return_value=cred_connection,
-        ) as mock_cred_resolver:
+        ) as mock_mgmt_resolver:
             result = await service._resolve_connection(integration_id=integration.id, user_id=user_id)
 
         assert result.base_url == "https://aap-gw.example.com"
-        mock_cred_resolver.assert_called_once_with(
+        mock_mgmt_resolver.assert_called_once_with(
             session=mock_session,
-            credential_id=management_credential_id,
-            user_id=user_id,
-            skip_ownership_check=True,
+            integration=integration,
         )
 
     @pytest.mark.asyncio
@@ -1389,7 +1393,6 @@ class TestDefaultAAPIntegrationResolution:
             session=mock_session,
             credential_id=credential_id,
             user_id=user_id,
-            skip_ownership_check=False,
         )
 
     @pytest.mark.asyncio
@@ -1408,8 +1411,8 @@ class TestDefaultAAPIntegrationResolution:
             await service._resolve_connection(user_id=uuid4())
 
     @pytest.mark.asyncio
-    async def test_prefers_available_integration_when_others_are_unvalidated(self) -> None:
-        """A single validated integration wins over unvalidated siblings."""
+    async def test_multiple_enabled_integrations_require_explicit_id_even_if_one_is_available(self) -> None:
+        """Uniqueness is visible-enabled, not validation_status=available."""
         available = _mock_integration(
             name="Healthy AAP",
             base_url="https://healthy.example.com",
@@ -1418,12 +1421,6 @@ class TestDefaultAAPIntegrationResolution:
         )
         unknown = _mock_integration(name="Unvalidated AAP", validation_status="unknown")
         service = _service()
-        cred_connection = AAPConnection(
-            base_url="",
-            headers={"Authorization": "Bearer tok"},
-            verify_ssl=True,
-            timeout=30.0,
-        )
 
         with (
             patch.object(
@@ -1432,15 +1429,9 @@ class TestDefaultAAPIntegrationResolution:
                 new_callable=AsyncMock,
                 return_value=[unknown, available],
             ),
-            patch(
-                "syntara.aap.services.aap_proxy_service.resolve_aap_connection_from_credential",
-                new_callable=AsyncMock,
-                return_value=cred_connection,
-            ),
+            pytest.raises(AAPNotConfiguredError, match="pass integration_id"),
         ):
-            result = await service._resolve_connection(user_id=uuid4())
-
-        assert result.base_url == "https://healthy.example.com"
+            await service._resolve_connection(user_id=uuid4())
 
 
 class TestSelectDefaultAAPIntegration:
@@ -1453,6 +1444,12 @@ class TestSelectDefaultAAPIntegration:
     def test_single_integration_returned(self) -> None:
         integration = _mock_integration()
         assert AAPProxyService._select_default_aap_integration([integration]) is integration
+
+    def test_two_enabled_integrations_raise(self) -> None:
+        with pytest.raises(AAPNotConfiguredError, match="pass integration_id"):
+            AAPProxyService._select_default_aap_integration(
+                [_mock_integration(name="one"), _mock_integration(name="two")]
+            )
 
 
 class TestListVisibleAAPIntegrations:
@@ -1472,36 +1469,31 @@ class TestListVisibleAAPIntegrations:
         assert result == [integration]
 
     @pytest.mark.asyncio
-    async def test_project_scoped_integration_hidden_without_assignment(self) -> None:
+    async def test_empty_visible_ids_returns_empty(self) -> None:
         from syntara.authz.engine import AllowedProjectsResult
-        from syntara.integrations.models.integration import IntegrationScope
 
-        integration = _mock_integration()
-        integration.scope = IntegrationScope.PROJECT
         mock_session = AsyncMock()
-        mock_integrations = MagicMock()
-        mock_integrations.all.return_value = [integration]
-        mock_assignments = MagicMock()
-        mock_assignments.all.return_value = []
-        mock_session.exec = AsyncMock(side_effect=[mock_integrations, mock_assignments])
-
         service = AAPProxyService(
             settings=get_settings(),
             session=mock_session,
             allowed_projects=AllowedProjectsResult(all_projects=False, project_ids=[uuid4()]),
         )
 
-        result = await service._list_visible_aap_integrations()
+        with patch(
+            "syntara.aap.services.aap_proxy_service.IntegrationService.resolve_visible_integration_ids",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await service._list_visible_aap_integrations()
 
         assert result == []
+        mock_session.exec.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_global_integration_visible_to_project_restricted_caller(self) -> None:
+    async def test_restricts_query_to_visible_ids(self) -> None:
         from syntara.authz.engine import AllowedProjectsResult
-        from syntara.integrations.models.integration import IntegrationScope
 
         integration = _mock_integration()
-        integration.scope = IntegrationScope.GLOBAL
         mock_session = AsyncMock()
         mock_result = MagicMock()
         mock_result.all.return_value = [integration]
@@ -1513,35 +1505,36 @@ class TestListVisibleAAPIntegrations:
             allowed_projects=AllowedProjectsResult(all_projects=False, project_ids=[uuid4()]),
         )
 
-        result = await service._list_visible_aap_integrations()
+        with patch(
+            "syntara.aap.services.aap_proxy_service.IntegrationService.resolve_visible_integration_ids",
+            new_callable=AsyncMock,
+            return_value=[integration.id],
+        ):
+            result = await service._list_visible_aap_integrations()
 
         assert result == [integration]
 
     @pytest.mark.asyncio
-    async def test_project_scoped_integration_visible_with_matching_assignment(self) -> None:
+    async def test_unrestricted_all_projects_does_not_filter_ids(self) -> None:
         from syntara.authz.engine import AllowedProjectsResult
-        from syntara.integrations.models.integration import IntegrationScope
 
-        project_id = uuid4()
         integration = _mock_integration()
-        integration.scope = IntegrationScope.PROJECT
-        assignment = MagicMock()
-        assignment.integration_id = integration.id
-        assignment.project_id = project_id
-
         mock_session = AsyncMock()
-        mock_integrations = MagicMock()
-        mock_integrations.all.return_value = [integration]
-        mock_assignments = MagicMock()
-        mock_assignments.all.return_value = [assignment]
-        mock_session.exec = AsyncMock(side_effect=[mock_integrations, mock_assignments])
-
+        mock_result = MagicMock()
+        mock_result.all.return_value = [integration]
+        mock_session.exec.return_value = mock_result
         service = AAPProxyService(
             settings=get_settings(),
             session=mock_session,
-            allowed_projects=AllowedProjectsResult(all_projects=False, project_ids=[project_id]),
+            allowed_projects=AllowedProjectsResult(all_projects=True, project_ids=[]),
         )
 
-        result = await service._list_visible_aap_integrations()
+        with patch(
+            "syntara.aap.services.aap_proxy_service.IntegrationService.resolve_visible_integration_ids",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_resolve:
+            result = await service._list_visible_aap_integrations()
 
         assert result == [integration]
+        mock_resolve.assert_called_once()

--- a/backend/tests/unit/aap/services/test_service.py
+++ b/backend/tests/unit/aap/services/test_service.py
@@ -1525,10 +1525,10 @@ class TestSelectDefaultAAPIntegration:
         assert AAPProxyService._select_default_aap_integration([integration]) is integration
 
     def test_two_enabled_integrations_raise(self) -> None:
+        one = _mock_integration(name="one")
+        two = _mock_integration(name="two")
         with pytest.raises(AAPNotConfiguredError, match="pass integration_id"):
-            AAPProxyService._select_default_aap_integration(
-                [_mock_integration(name="one"), _mock_integration(name="two")]
-            )
+            AAPProxyService._select_default_aap_integration([one, two])
 
 
 class TestListVisibleAAPIntegrations:

--- a/backend/tests/unit/aap/test_credential_resolver.py
+++ b/backend/tests/unit/aap/test_credential_resolver.py
@@ -569,3 +569,39 @@ class TestResolveAAPConnectionFromCredential:
 
         with pytest.raises(AAPAuthenticationError, match="is not authorized"):
             await resolve_aap_connection_from_credential(mock_session, credential_id, user_id)
+
+    @pytest.mark.asyncio
+    async def test_skip_ownership_check_allows_non_owner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Management-credential fallback may use a credential the caller does not own."""
+        from typing import cast
+
+        credential_id = uuid4()
+        caller_id = uuid4()
+        owner_id = uuid4()
+        credential = _mock_credential(credential_id=credential_id, created_by=owner_id)
+        cast("MagicMock", credential.is_owned_by).return_value = False
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = credential
+        mock_session = AsyncMock()
+        mock_session.exec.return_value = mock_result
+
+        mock_secret_service = AsyncMock()
+        mock_secret_service.retrieve_secret.return_value = {"oauth_token": "secret-token"}
+        monkeypatch.setattr(
+            "syntara.aap.credential_resolver.create_secret_service",
+            MagicMock(return_value=mock_secret_service),
+        )
+
+        mock_resolved = MagicMock()
+        mock_resolved.extra_vars = {"aap_oauth_token": "secret-token"}
+        mock_injector_resolver = MagicMock()
+        mock_injector_resolver.resolve.return_value = mock_resolved
+        monkeypatch.setattr("syntara.aap.credential_resolver.InjectorResolver", mock_injector_resolver)
+
+        result = await resolve_aap_connection_from_credential(
+            mock_session, credential_id, caller_id, skip_ownership_check=True
+        )
+
+        assert result.headers == {"authorization": "Bearer secret-token"}
+        cast("MagicMock", credential.is_owned_by).assert_not_called()

--- a/backend/tests/unit/aap/test_credential_resolver.py
+++ b/backend/tests/unit/aap/test_credential_resolver.py
@@ -24,6 +24,7 @@ from syntara.aap.credential_resolver import (
     _validate_credential_ownership,
     _validate_credential_type,
     resolve_aap_connection_from_credential,
+    resolve_aap_connection_from_management_credential,
 )
 from syntara.aap.exceptions import AAPAuthenticationError, AAPNotConfiguredError
 from syntara.core.lib.encryption import EncryptionError
@@ -571,12 +572,11 @@ class TestResolveAAPConnectionFromCredential:
             await resolve_aap_connection_from_credential(mock_session, credential_id, user_id)
 
     @pytest.mark.asyncio
-    async def test_skip_ownership_check_allows_non_owner(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Management-credential fallback may use a credential the caller does not own."""
+    async def test_management_credential_allows_non_owner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Management-credential helper decrypts without an owner check."""
         from typing import cast
 
         credential_id = uuid4()
-        caller_id = uuid4()
         owner_id = uuid4()
         credential = _mock_credential(credential_id=credential_id, created_by=owner_id)
         cast("MagicMock", credential.is_owned_by).return_value = False
@@ -599,9 +599,20 @@ class TestResolveAAPConnectionFromCredential:
         mock_injector_resolver.resolve.return_value = mock_resolved
         monkeypatch.setattr("syntara.aap.credential_resolver.InjectorResolver", mock_injector_resolver)
 
-        result = await resolve_aap_connection_from_credential(
-            mock_session, credential_id, caller_id, skip_ownership_check=True
-        )
+        integration = MagicMock()
+        integration.name = "AAP Gateway"
+        integration.management_credential_id = credential_id
+
+        result = await resolve_aap_connection_from_management_credential(mock_session, integration)
 
         assert result.headers == {"authorization": "Bearer secret-token"}
         cast("MagicMock", credential.is_owned_by).assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_management_credential_missing_raises(self) -> None:
+        integration = MagicMock()
+        integration.name = "AAP Gateway"
+        integration.management_credential_id = None
+
+        with pytest.raises(AAPNotConfiguredError, match="no management credential"):
+            await resolve_aap_connection_from_management_credential(AsyncMock(), integration)

--- a/backend/tests/unit/aap/test_credential_resolver.py
+++ b/backend/tests/unit/aap/test_credential_resolver.py
@@ -613,6 +613,7 @@ class TestResolveAAPConnectionFromCredential:
         integration = MagicMock()
         integration.name = "AAP Gateway"
         integration.management_credential_id = None
+        session = AsyncMock()
 
         with pytest.raises(AAPNotConfiguredError, match="no management credential"):
-            await resolve_aap_connection_from_management_credential(AsyncMock(), integration)
+            await resolve_aap_connection_from_management_credential(session, integration)

--- a/backend/tests/unit/aap/test_router.py
+++ b/backend/tests/unit/aap/test_router.py
@@ -8,6 +8,8 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from syntara.aap.audit.aap_resource_access import AAPResourceAccessEvent
+from syntara.aap.exceptions import AAPNotConfiguredError
 from syntara.aap.models.responses import (
     AAPCredential,
     AAPExecutionEnvironment,
@@ -238,3 +240,48 @@ class TestListLabels:
         assert data["results"][0]["organization"] == 1
         assert data["results"][1]["name"] == "staging"
         assert data["results"][1]["organization"] is None
+
+
+class TestCredentialUsedForAudit:
+    """Audit credential_used is true only after a credential was resolved."""
+
+    def test_success_is_true(self) -> None:
+        from syntara.aap.router import _credential_used_for_audit
+
+        assert _credential_used_for_audit(None) is True
+
+    def test_not_configured_is_false(self) -> None:
+        from syntara.aap.router import _credential_used_for_audit
+
+        assert _credential_used_for_audit("AAPNotConfiguredError") is False
+
+    def test_auth_and_upstream_errors_are_true(self) -> None:
+        from syntara.aap.router import _credential_used_for_audit
+
+        assert _credential_used_for_audit("AAPAuthenticationError") is True
+        assert _credential_used_for_audit("AAPConnectionError") is True
+        assert _credential_used_for_audit("AAPUpstreamError") is True
+
+    @pytest.mark.asyncio
+    async def test_endpoint_records_false_when_not_configured(
+        self, app: FastAPI, mock_service: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """503-before-decrypt must not look credential-backed in audit."""
+        captured: list[AAPResourceAccessEvent] = []
+        monkeypatch.setattr(
+            "syntara.aap.router.AuditEventDispatcher.dispatch",
+            captured.append,
+        )
+        mock_service.list_organizations.side_effect = AAPNotConfiguredError(
+            "Multiple AAP Controller integrations are configured; pass integration_id to select one"
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            with pytest.raises(AAPNotConfiguredError):
+                await client.get("/api/v1/proxies/aap/organizations")
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert isinstance(event, AAPResourceAccessEvent)
+        assert event.credential_used is False
+        assert event.error_type == "AAPNotConfiguredError"

--- a/frontend/packages/syntara-contracts/src/aap-api.ts
+++ b/frontend/packages/syntara-contracts/src/aap-api.ts
@@ -857,13 +857,14 @@ export interface components {
   parameters: {
     /**
      * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-     *     If provided, the credential is decrypted and used instead of environment variables.
+     *     If omitted, the selected integration's management credential is used.
      *     Credential must be of type "Ansible Automation Platform".
      */
     credentialId: string | null
     /**
      * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-     *     When provided, the integration's configured URL is used instead of environment variables.
+     *     If omitted, the unique visible enabled AAP integration is used.
+     *     Required when more than one AAP integration is visible.
      */
     integrationId: string | null
   }
@@ -880,13 +881,14 @@ export interface operations {
         page_size?: number
         /**
          * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-         *     If provided, the credential is decrypted and used instead of environment variables.
+         *     If omitted, the selected integration's management credential is used.
          *     Credential must be of type "Ansible Automation Platform".
          */
         credential_id?: components['parameters']['credentialId']
         /**
          * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-         *     When provided, the integration's configured URL is used instead of environment variables.
+         *     If omitted, the unique visible enabled AAP integration is used.
+         *     Required when more than one AAP integration is visible.
          */
         integration_id?: components['parameters']['integrationId']
       }
@@ -922,13 +924,14 @@ export interface operations {
         page_size?: number
         /**
          * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-         *     If provided, the credential is decrypted and used instead of environment variables.
+         *     If omitted, the selected integration's management credential is used.
          *     Credential must be of type "Ansible Automation Platform".
          */
         credential_id?: components['parameters']['credentialId']
         /**
          * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-         *     When provided, the integration's configured URL is used instead of environment variables.
+         *     If omitted, the unique visible enabled AAP integration is used.
+         *     Required when more than one AAP integration is visible.
          */
         integration_id?: components['parameters']['integrationId']
         organization?: string | null
@@ -965,13 +968,14 @@ export interface operations {
         page_size?: number
         /**
          * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-         *     If provided, the credential is decrypted and used instead of environment variables.
+         *     If omitted, the selected integration's management credential is used.
          *     Credential must be of type "Ansible Automation Platform".
          */
         credential_id?: components['parameters']['credentialId']
         /**
          * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-         *     When provided, the integration's configured URL is used instead of environment variables.
+         *     If omitted, the unique visible enabled AAP integration is used.
+         *     Required when more than one AAP integration is visible.
          */
         integration_id?: components['parameters']['integrationId']
       }
@@ -1009,13 +1013,14 @@ export interface operations {
         page_size?: number
         /**
          * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-         *     If provided, the credential is decrypted and used instead of environment variables.
+         *     If omitted, the selected integration's management credential is used.
          *     Credential must be of type "Ansible Automation Platform".
          */
         credential_id?: components['parameters']['credentialId']
         /**
          * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-         *     When provided, the integration's configured URL is used instead of environment variables.
+         *     If omitted, the unique visible enabled AAP integration is used.
+         *     Required when more than one AAP integration is visible.
          */
         integration_id?: components['parameters']['integrationId']
         organization?: string | null
@@ -1052,13 +1057,14 @@ export interface operations {
         page_size?: number
         /**
          * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-         *     If provided, the credential is decrypted and used instead of environment variables.
+         *     If omitted, the selected integration's management credential is used.
          *     Credential must be of type "Ansible Automation Platform".
          */
         credential_id?: components['parameters']['credentialId']
         /**
          * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-         *     When provided, the integration's configured URL is used instead of environment variables.
+         *     If omitted, the unique visible enabled AAP integration is used.
+         *     Required when more than one AAP integration is visible.
          */
         integration_id?: components['parameters']['integrationId']
       }
@@ -1096,13 +1102,14 @@ export interface operations {
         page_size?: number
         /**
          * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-         *     If provided, the credential is decrypted and used instead of environment variables.
+         *     If omitted, the selected integration's management credential is used.
          *     Credential must be of type "Ansible Automation Platform".
          */
         credential_id?: components['parameters']['credentialId']
         /**
          * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-         *     When provided, the integration's configured URL is used instead of environment variables.
+         *     If omitted, the unique visible enabled AAP integration is used.
+         *     Required when more than one AAP integration is visible.
          */
         integration_id?: components['parameters']['integrationId']
         organization?: string | null
@@ -1139,13 +1146,14 @@ export interface operations {
         page_size?: number
         /**
          * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-         *     If provided, the credential is decrypted and used instead of environment variables.
+         *     If omitted, the selected integration's management credential is used.
          *     Credential must be of type "Ansible Automation Platform".
          */
         credential_id?: components['parameters']['credentialId']
         /**
          * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-         *     When provided, the integration's configured URL is used instead of environment variables.
+         *     If omitted, the unique visible enabled AAP integration is used.
+         *     Required when more than one AAP integration is visible.
          */
         integration_id?: components['parameters']['integrationId']
         organization?: string | null
@@ -1182,13 +1190,14 @@ export interface operations {
         page_size?: number
         /**
          * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-         *     If provided, the credential is decrypted and used instead of environment variables.
+         *     If omitted, the selected integration's management credential is used.
          *     Credential must be of type "Ansible Automation Platform".
          */
         credential_id?: components['parameters']['credentialId']
         /**
          * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-         *     When provided, the integration's configured URL is used instead of environment variables.
+         *     If omitted, the unique visible enabled AAP integration is used.
+         *     Required when more than one AAP integration is visible.
          */
         integration_id?: components['parameters']['integrationId']
       }
@@ -1224,13 +1233,14 @@ export interface operations {
         page_size?: number
         /**
          * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-         *     If provided, the credential is decrypted and used instead of environment variables.
+         *     If omitted, the selected integration's management credential is used.
          *     Credential must be of type "Ansible Automation Platform".
          */
         credential_id?: components['parameters']['credentialId']
         /**
          * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-         *     When provided, the integration's configured URL is used instead of environment variables.
+         *     If omitted, the unique visible enabled AAP integration is used.
+         *     Required when more than one AAP integration is visible.
          */
         integration_id?: components['parameters']['integrationId']
       }
@@ -1266,13 +1276,14 @@ export interface operations {
         page_size?: number
         /**
          * @description Optional Orchestrator credential ID for Ansible Automation Platform Controller authentication.
-         *     If provided, the credential is decrypted and used instead of environment variables.
+         *     If omitted, the selected integration's management credential is used.
          *     Credential must be of type "Ansible Automation Platform".
          */
         credential_id?: components['parameters']['credentialId']
         /**
          * @description Optional Ansible Automation Platform Gateway integration ID for connection URL resolution.
-         *     When provided, the integration's configured URL is used instead of environment variables.
+         *     If omitted, the unique visible enabled AAP integration is used.
+         *     Required when more than one AAP integration is visible.
          */
         integration_id?: components['parameters']['integrationId']
       }

--- a/frontend/packages/syntara-ui/src/hooks/useAAPBrowser.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useAAPBrowser.ts
@@ -324,7 +324,7 @@ function useAAPBrowserResults(
  * Hook to browse AAP resources (organizations, job/workflow templates, inventories,
  * execution environments, credentials, instance groups) via the Syntara backend proxy.
  *
- * @param credentialId - Optional Syntara AAP credential ID for authentication.
+ * @param credentialId - Optional Orchestrator AAP credential ID for authentication.
  *   If omitted, the backend uses the selected integration's management credential.
  * @param initialState - Initial organization and template selection
  * @param templateType - 'job' for job templates (default) or 'workflow' for workflow templates

--- a/frontend/packages/syntara-ui/src/hooks/useAAPBrowser.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useAAPBrowser.ts
@@ -324,13 +324,16 @@ function useAAPBrowserResults(
  * Hook to browse AAP resources (organizations, job/workflow templates, inventories,
  * execution environments, credentials, instance groups) via the Syntara backend proxy.
  *
- * @param credentialId - AAP credential ID to use for authentication
+ * @param credentialId - Optional Syntara AAP credential ID for authentication.
+ *   If omitted, the backend uses the selected integration's management credential.
  * @param initialState - Initial organization and template selection
  * @param templateType - 'job' for job templates (default) or 'workflow' for workflow templates
+ * @param integrationId - Optional AAP Gateway integration ID. If omitted and only
+ *   one AAP integration is visible, the backend uses that integration. Required
+ *   when more than one AAP integration is configured.
  *
- * When credentialId is provided, the hook fetches organizations
- * on mount. When an organization is selected, it re-fetches
- * resources filtered by that org.
+ * Fetching starts when `credentialId` or `integrationId` is provided. When an
+ * organization is selected, the hook re-fetches resources filtered by that org.
  */
 export function useAAPBrowser(
   credentialId: string | undefined,


### PR DESCRIPTION
## Description

A reachable AAP Controller behind a visible enabled integration still returned HTTP 503 `AAP_NOT_CONFIGURED` on `GET /api/v1/proxies/aap/*` (ticket path abbreviated as `/api/v1/aap/*`). The BFF required both `integration_id` and `credential_id` and no longer fell back to `APP_AAP_*` env vars, so a reporter curl with no query params — and the builder after picking an integration but before an execution credential — always failed.

When those query params are omitted, the proxy now uses the unique **visible enabled** AAP integration and that integration's management credential. `validation_status` is not a tie-break. With more than one visible AAP integration, pass `integration_id`. `credential_id` remains optional.

Implicit default-integration and management-credential choices are logged at **info** so admins can see which gateway and credential were used.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

- [x] `AAPProxyService` auto-resolves the unique visible enabled AAP integration when `integration_id` is omitted; 503 if none or more than one is visible
- [x] Visibility for omit-`integration_id` and explicit-id uses `IntegrationService.resolve_visible_integration_ids` (same GLOBAL / project-assignment rules as `GET /integrations`)
- [x] Omitted `credential_id` uses `resolve_aap_connection_from_management_credential`, which only loads `integration.management_credential_id` after visibility is enforced. Explicit `credential_id` still requires `user_id` and owner match
- [x] Audit `credential_used=True` on all `/proxies/aap/*` handlers (query or management fallback; env-var auth is unused on this path)
- [x] OpenAPI (`aap` + bundled + CLI), generated `aap-api.ts`, docs (`integrations.md`, `aap-nodes.md`, `api-response-format.md`), and `useAAPBrowser` JSDoc
- [x] Unit tests for unique-enabled default, management-credential fallback, owner check, ambiguity, and omit-both visibility (`id IN visible_ids`)

## Out of Scope

- AAP **job / workflow launch** still requires an owned execution `credential_id`. This PR does **not** reuse the management credential at execution time.
- Refresh `422 INTEGRATION_REFRESH_NOT_SUPPORTED` for AAP is expected (no tool discovery). Unchanged.
- Ambiguous multi-integration case still returns `503 AAP_NOT_CONFIGURED` (not a new `AAP_INTEGRATION_AMBIGUOUS` 400).
- No HTTP-level proxy integration test; coverage is unit tests plus manual curl.

## Why 503 for “pass integration_id” (intentional, not a bug)

Do not treat this as a merge blocker or an incomplete fix for AAP-87713. HTTP 400 vs 503 for the multi-integration case is a **deferred API-shape follow-up**, already classified as Out of Scope. The ticket is: a *unique visible enabled* integration must browse successfully. That path is 200.

## How to Test

Prereq: at least one **enabled** AAP integration the user can see, with a management credential, controller reachable, Bearer token.

**One AAP integration — omit both query params**

```bash
curl -k https://localhost:8000/api/v1/proxies/aap/job_templates \
  -H "Authorization: Bearer $TOKEN"
```

Expect `200` with `count` / `results` (not `503 AAP_NOT_CONFIGURED`). Restart `make -C backend dev` so this branch is loaded (`server_reload` defaults to false).

**Two or more AAP integrations — `integration_id` is enough**

```bash
curl -k "https://localhost:8000/api/v1/proxies/aap/job_templates?integration_id=<AAP_INTEGRATION_UUID>" \
  -H "Authorization: Bearer $TOKEN"
```

Expect `200`. Omitting `integration_id` here should 503 and tell you to pass `integration_id`.

**Optional explicit execution credential** (owner check)

```bash
curl -k "https://localhost:8000/api/v1/proxies/aap/job_templates?integration_id=<UUID>&credential_id=<UUID>" \
  -H "Authorization: Bearer $TOKEN"
```

**UI:** open a workflow, add “Launch AAP job template”, pick a visible enabled AAP integration. Organizations / job templates should load without a 503 before an execution credential is chosen.

**Logs:** default integration / management credential fallback should appear at info (`AAP proxy using default integration`, `AAP proxy using integration management credential`).

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [x] Database migrations are included if schema changed (N/A)
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality (N/A — JSDoc + generated contracts only)
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation) (N/A — no UI change)
- [x] Screenshots or screen recordings are attached for UI changes (N/A)

## Visual Regression

- [x] If this PR intentionally changes covered UI: N/A
- [x] If this PR adds a new page/route: N/A

## General Checklist

- [x] Code follows the project's coding conventions
- [x] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps (N/A — query params were already optional in the schema; behavior now matches)

## Additional Notes

Anyone who can **see** the AAP integration can browse controller resources as the **management credential** (often broader AAP perms than a personal execution cred). Proxy remains GET-only.

Env-var resolution (`APP_AAP_*` / `resolve_aap_connection`) is unchanged for workflow execution when no credential is injected. The BFF proxy does not use that path.
