### PR TITLE
chore(ci): cancel orphaned CI when kicked from merge queue

### DIFF
--- a/.github/workflows/cancel-orphaned-merge-queue-runs.yml
+++ b/.github/workflows/cancel-orphaned-merge-queue-runs.yml
@@ -1,0 +1,43 @@
+---
+name: Cancel orphaned merge-queue runs
+
+# GitHub's merge queue creates temporary `gh-readonly-queue/<base>/pr-<n>-<sha>`
+# branches and deletes them when an entry leaves the queue (kick, reshuffle, or
+# successful merge). merge_group CI runs against those branches do not auto-cancel
+# on deletion, so orphaned runs keep consuming runner minutes. This workflow
+# cancels them as soon as the queue branch is deleted.
+#
+# Uses the `delete` event (fully supported by actionlint) rather than the
+# undocumented-in-Actions-schema `merge_group` `destroyed` type.
+
+on:
+  delete:
+
+permissions:
+  actions: write
+
+jobs:
+  cancel-orphans:
+    name: Cancel orphaned runs
+    if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'gh-readonly-queue/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Cancel active runs against deleted queue branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DELETED_REF: ${{ github.event.ref }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          echo "Deleted merge-queue branch: ${DELETED_REF}"
+          encoded_ref=$(jq -rn --arg b "${DELETED_REF}" '$b|@uri')
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${encoded_ref}&per_page=100" \
+            --jq '.workflow_runs[] | select(.status != "completed") | .id' \
+          | while IFS= read -r id; do
+              [ -z "${id}" ] && continue
+              [ "${id}" = "${CURRENT_RUN_ID}" ] && continue
+              echo "Cancelling orphaned run ${id}"
+              gh run cancel "${id}" -R "${GITHUB_REPOSITORY}" || true
+            done


### PR DESCRIPTION
## Description

CI jobs for merge-queue entries keep running after the entry leaves the queue. This wastes runner time. This change cancels those orphaned runs when the temporary queue branch is deleted.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] Cancel in-progress Actions runs when a merge-queue branch is deleted
- [x] Limit the cancel job to merge-queue temporary branches only

## Out of Scope

Does not change concurrency settings on existing CI workflows. Does not cancel runs for successful merges that already finished their checks.

## Related Issues

None.

## How to Test

1. Add a PR to the merge queue and confirm CI starts.
2. Remove the PR from the queue (or cause a reshuffle that deletes the queue branch).
3. Confirm in-progress Actions runs for that queue branch are cancelled.

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

N/A

## Additional Notes

Validated locally with pre-commit (including yamlfmt), actionlint, and zizmor.

### Validation evidence

We could not eject a live merge-queue entry in this org (review rules block self-enqueue). We tested the same delete signal on a personal fork: start a 2-minute job on a `gh-readonly-queue/*` branch, delete the branch, confirm the cancel workflow runs and the job is cancelled.

- Harness: https://github.com/nicklemmon/mq-orphan-cancel-test
- Cancel run (success): https://github.com/nicklemmon/mq-orphan-cancel-test/actions/runs/32416697631
- Sleep run (cancelled): https://github.com/nicklemmon/mq-orphan-cancel-test/actions/runs/32416658729

> 🤖 PR description AI-assisted