### PR TITLE
fix(AAP-87778): block credential delete while referenced by an integration

### DIFF
--- a/backend/src/syntara/core/database/migrations/versions/a986f158ce16_restrict_credential_delete_when_.py
+++ b/backend/src/syntara/core/database/migrations/versions/a986f158ce16_restrict_credential_delete_when_.py
@@ -1,0 +1,61 @@
+"""restrict credential delete when integration references it
+
+Revision ID: a986f158ce16
+Revises: 4ca3cbf8652a
+Create Date: 2026-08-21 12:26:10.309857
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a986f158ce16"
+down_revision: str | Sequence[str] | None = "4ca3cbf8652a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # CUSTOM: ondelete change not detected by autogenerate (AAP-87778 follow-up).
+    # The app-level guard in CredentialService.delete_credential blocks deletes
+    # while integrations reference the credential, but the previous
+    # ON DELETE SET NULL constraint left a TOCTOU race: an integration attached
+    # to the credential between the app-level check and the delete would still
+    # be silently nulled by the database cascade. RESTRICT closes that gap by
+    # having the database itself reject the delete.
+    op.drop_constraint(
+        "integrations_management_credential_id_fkey",
+        "integrations",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "integrations_management_credential_id_fkey",
+        "integrations",
+        "credentials",
+        ["management_credential_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    # END CUSTOM
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # CUSTOM: revert to the original ON DELETE SET NULL behavior.
+    op.drop_constraint(
+        "integrations_management_credential_id_fkey",
+        "integrations",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "integrations_management_credential_id_fkey",
+        "integrations",
+        "credentials",
+        ["management_credential_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    # END CUSTOM

--- a/backend/src/syntara/core/database/migrations/versions/a986f158ce16_restrict_credential_delete_when_.py
+++ b/backend/src/syntara/core/database/migrations/versions/a986f158ce16_restrict_credential_delete_when_.py
@@ -1,7 +1,7 @@
 """restrict credential delete when integration references it
 
 Revision ID: a986f158ce16
-Revises: 4ca3cbf8652a
+Revises: c7e4a91b2d03
 Create Date: 2026-08-21 12:26:10.309857
 
 """
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "a986f158ce16"
-down_revision: str | Sequence[str] | None = "4ca3cbf8652a"
+down_revision: str | Sequence[str] | None = "c7e4a91b2d03"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/src/syntara/core/database/migrations/versions/a986f158ce16_restrict_credential_delete_when_.py
+++ b/backend/src/syntara/core/database/migrations/versions/a986f158ce16_restrict_credential_delete_when_.py
@@ -19,7 +19,7 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    # CUSTOM: ondelete change not detected by autogenerate (AAP-87778 follow-up).
+    # CUSTOM: ondelete change not detected by autogenerate.
     # The app-level guard in CredentialService.delete_credential blocks deletes
     # while integrations reference the credential, but the previous
     # ON DELETE SET NULL constraint left a TOCTOU race: an integration attached

--- a/backend/src/syntara/credentials/error_handlers.py
+++ b/backend/src/syntara/credentials/error_handlers.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         CredentialNameConflictError,
         CredentialNotFoundError,
         CredentialValidationError,
+        ProjectCredentialInUseError,
     )
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -113,6 +114,24 @@ def credential_in_use_error_handler(request: Request, exc: "CredentialInUseError
         title="Credential In Use",
         detail=exc.message,
         code="CREDENTIAL_IN_USE",
+        retryable=False,
+        instance=str(request.url),
+    )
+
+
+def project_credential_in_use_error_handler(request: Request, exc: "ProjectCredentialInUseError") -> JSONResponse:
+    """Handle ProjectCredentialInUseError with RFC 9457 format."""
+    logger.warning(
+        "Blocked project delete: credentials still referenced by integrations",
+        project_name=exc.project_name,
+        affected_integration_count=exc.total_integration_count,
+    )
+    return create_problem_details_response(
+        status_code=status.HTTP_409_CONFLICT,
+        problem_type=PROBLEM_TYPES["resource_conflict"],
+        title="Project Credentials In Use",
+        detail=exc.message,
+        code="PROJECT_CREDENTIALS_IN_USE",
         retryable=False,
         instance=str(request.url),
     )

--- a/backend/src/syntara/credentials/error_handlers.py
+++ b/backend/src/syntara/credentials/error_handlers.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
         CredentialDecryptionError,
         CredentialDisabledError,
         CredentialError,
+        CredentialInUseError,
         CredentialNameConflictError,
         CredentialNotFoundError,
         CredentialValidationError,
@@ -94,6 +95,24 @@ def credential_disabled_error_handler(request: Request, exc: "CredentialDisabled
         title="Credential Disabled",
         detail=exc.message,
         code="CREDENTIAL_DISABLED",
+        retryable=False,
+        instance=str(request.url),
+    )
+
+
+def credential_in_use_error_handler(request: Request, exc: "CredentialInUseError") -> JSONResponse:
+    """Handle CredentialInUseError with RFC 9457 format."""
+    logger.warning(
+        "Blocked credential delete: still referenced by integrations",
+        credential_name=exc.name,
+        affected_integration_count=exc.total_count,
+    )
+    return create_problem_details_response(
+        status_code=status.HTTP_409_CONFLICT,
+        problem_type=PROBLEM_TYPES["resource_conflict"],
+        title="Credential In Use",
+        detail=exc.message,
+        code="CREDENTIAL_IN_USE",
         retryable=False,
         instance=str(request.url),
     )

--- a/backend/src/syntara/credentials/exceptions.py
+++ b/backend/src/syntara/credentials/exceptions.py
@@ -81,3 +81,49 @@ class CredentialInUseError(CredentialError):
             f"integration{plural}{where}. Remove the credential from "
             "these integrations before deleting it."
         )
+
+
+@fastapi_exception(handler="syntara.credentials.error_handlers.project_credential_in_use_error_handler")
+class ProjectCredentialInUseError(CredentialError):
+    """Raised when a project cannot be deleted because its credentials are still used by integrations.
+
+    Integrations are not project-scoped (global LLM/MCP/AAP integrations
+    routinely reference a project credential via management_credential_id).
+    The ON DELETE RESTRICT FK makes the database reject the cascade, so
+    the project service must check upfront and surface an actionable 409
+    instead of a generic constraint error.
+    """
+
+    def __init__(
+        self,
+        project_name: str,
+        credential_names: list[str],
+        integration_names: list[str],
+        total_integration_count: int,
+    ) -> None:
+        """Initialize with project name and samples of referenced credentials/integrations."""
+        self.project_name = project_name
+        self.credential_names = credential_names
+        self.integration_names = integration_names
+        self.total_integration_count = total_integration_count
+
+        int_plural = "s" if total_integration_count != 1 else ""
+        if integration_names:
+            shown = ", ".join(f"'{n}'" for n in integration_names)
+            remaining = total_integration_count - len(integration_names)
+            suffix = f" and {remaining} more" if remaining > 0 else ""
+            int_list = f" ({shown}{suffix})"
+        else:
+            int_list = ""
+
+        cred_shown = ", ".join(f"'{n}'" for n in credential_names[:5])
+        cred_remaining = len(credential_names) - 5
+        cred_suffix = f" and {cred_remaining} more" if cred_remaining > 0 else ""
+        cred_list = f"{cred_shown}{cred_suffix}"
+
+        super().__init__(
+            f"Cannot delete project '{project_name}': {total_integration_count} "
+            f"integration{int_plural}{int_list} still reference credentials "
+            f"in this project ({cred_list}). Detach or reassign these "
+            f"integrations before deleting the project."
+        )

--- a/backend/src/syntara/credentials/exceptions.py
+++ b/backend/src/syntara/credentials/exceptions.py
@@ -42,3 +42,31 @@ class CredentialDisabledError(CredentialError):
         """Initialize with credential name."""
         self.name = name
         super().__init__(f"Credential '{name}' is disabled. Re-enable it to continue.")
+
+
+@fastapi_exception(handler="syntara.credentials.error_handlers.credential_in_use_error_handler")
+class CredentialInUseError(CredentialError):
+    """Exception raised when deleting a credential still used as an integration's management credential.
+
+    See AAP-87778: previously the delete silently nulled the integration's
+    management_credential_id, leaving validation_status stale (e.g. still
+    "available") with no indication the integration could no longer
+    authenticate. Blocking the delete forces the caller to detach the
+    credential from all referencing integrations first.
+    """
+
+    def __init__(self, name: str, integration_names: list[str], total_count: int) -> None:
+        """Initialize with credential name and a sample of referencing integration names."""
+        self.name = name
+        self.integration_names = integration_names
+        self.total_count = total_count
+
+        shown = ", ".join(f"'{n}'" for n in integration_names)
+        remaining = total_count - len(integration_names)
+        suffix = f" and {remaining} more" if remaining > 0 else ""
+        plural = "s" if total_count != 1 else ""
+        super().__init__(
+            f"Cannot delete credential '{name}': still in use by {total_count} "
+            f"integration{plural} ({shown}{suffix}). Remove the credential from "
+            "these integrations before deleting it."
+        )

--- a/backend/src/syntara/credentials/exceptions.py
+++ b/backend/src/syntara/credentials/exceptions.py
@@ -56,17 +56,28 @@ class CredentialInUseError(CredentialError):
     """
 
     def __init__(self, name: str, integration_names: list[str], total_count: int) -> None:
-        """Initialize with credential name and a sample of referencing integration names."""
+        """Initialize with credential name and a sample of referencing integration names.
+
+        integration_names may legitimately be empty relative to a positive
+        total_count in the rare "double-race" case (an integration reference
+        detected the reference right after a TOCTOU-triggered IntegrityError,
+        but was itself gone by the time names were re-queried). Falls back to
+        generic wording rather than rendering an empty or misleading name list.
+        """
         self.name = name
         self.integration_names = integration_names
         self.total_count = total_count
 
-        shown = ", ".join(f"'{n}'" for n in integration_names)
-        remaining = total_count - len(integration_names)
-        suffix = f" and {remaining} more" if remaining > 0 else ""
         plural = "s" if total_count != 1 else ""
+        if integration_names:
+            shown = ", ".join(f"'{n}'" for n in integration_names)
+            remaining = total_count - len(integration_names)
+            suffix = f" and {remaining} more" if remaining > 0 else ""
+            where = f" ({shown}{suffix})"
+        else:
+            where = ""
         super().__init__(
             f"Cannot delete credential '{name}': still in use by {total_count} "
-            f"integration{plural} ({shown}{suffix}). Remove the credential from "
+            f"integration{plural}{where}. Remove the credential from "
             "these integrations before deleting it."
         )

--- a/backend/src/syntara/credentials/exceptions.py
+++ b/backend/src/syntara/credentials/exceptions.py
@@ -48,7 +48,7 @@ class CredentialDisabledError(CredentialError):
 class CredentialInUseError(CredentialError):
     """Exception raised when deleting a credential still used as an integration's management credential.
 
-    See AAP-87778: previously the delete silently nulled the integration's
+    Previously the delete silently nulled the integration's
     management_credential_id, leaving validation_status stale (e.g. still
     "available") with no indication the integration could no longer
     authenticate. Blocking the delete forces the caller to detach the

--- a/backend/src/syntara/credentials/services/credential_service.py
+++ b/backend/src/syntara/credentials/services/credential_service.py
@@ -15,7 +15,7 @@ from uuid import UUID
 import structlog
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives.serialization import load_pem_private_key, load_ssh_private_key
-from sqlalchemy import Select, case, func, literal_column, or_, update
+from sqlalchemy import Select, case, func, literal_column, or_
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
@@ -36,6 +36,7 @@ from syntara.core.services.secret_service import SecretService
 from syntara.credentials.audit.credential import CredentialEncryptionFailureEvent, CredentialLifecycleEvent
 from syntara.credentials.exceptions import (
     CredentialDecryptionError,
+    CredentialInUseError,
     CredentialNameConflictError,
     CredentialNotFoundError,
     CredentialValidationError,
@@ -634,8 +635,34 @@ class CredentialService(BaseService):
             )
             return {}
 
+    async def _get_referencing_integration_names(self, credential_id: UUID, *, limit: int) -> list[str]:
+        """Fetch up to `limit` names of integrations using this credential as their management credential.
+
+        Used to build an actionable message for CredentialInUseError. The
+        total count comes separately from get_integration_counts.
+        """
+        stmt = (
+            select(Integration.name)
+            .where(Integration.management_credential_id == credential_id)
+            .order_by(Integration.name)
+            .limit(limit)
+        )
+        result = await self.session.exec(stmt)
+        return list(result.all())
+
     async def delete_credential(self, credential_id: UUID) -> None:
-        """Delete a credential and its secret data atomically."""
+        """Delete a credential and its secret data atomically.
+
+        Raises:
+            CredentialInUseError: If the credential is still set as the
+                management credential on one or more integrations. Deleting
+                it out from under those integrations would silently break
+                them — management_credential_id would be nulled with no
+                signal that validation_status is now stale (see AAP-87778).
+                The caller must detach the credential from all referencing
+                integrations first.
+
+        """
         from syntara.authz.models import Project  # noqa: PLC0415
 
         credential = await self._get_or_raise(credential_id)
@@ -647,6 +674,12 @@ class CredentialService(BaseService):
             msg = f"Cannot delete credentials in built-in project '{project.name}'"
             raise BuiltinProtectionError(msg)
 
+        int_counts = await self.get_integration_counts([credential_id])
+        int_ref_count = int_counts.get(credential_id, 0)
+        if int_ref_count:
+            integration_names = await self._get_referencing_integration_names(credential_id, limit=5)
+            raise CredentialInUseError(credential.name, integration_names, int_ref_count)
+
         wf_counts = await self.get_workflow_counts([credential_id])
         wf_ref_count = wf_counts.get(credential_id, 0)
         if wf_ref_count:
@@ -655,16 +688,6 @@ class CredentialService(BaseService):
                 credential_id=str(credential_id),
                 credential_name=credential.name,
                 affected_workflow_count=wf_ref_count,
-            )
-
-        int_counts = await self.get_integration_counts([credential_id])
-        int_ref_count = int_counts.get(credential_id, 0)
-        if int_ref_count:
-            logger.warning(
-                "Deleting credential still referenced by integrations",
-                credential_id=str(credential_id),
-                credential_name=credential.name,
-                affected_integration_count=int_ref_count,
             )
 
         cred_name = credential.name
@@ -685,12 +708,6 @@ class CredentialService(BaseService):
         if secret_id:
             await self._secret_service.delete_secret(secret_id)
 
-        await self.session.execute(
-            update(Integration)
-            .where(Integration.management_credential_id == credential_id)  # type: ignore[arg-type]
-            .values(management_credential_id=None)
-        )
-
         await self.session.delete(credential)
         await self.session.commit()
         logger.info("Credential deleted", credential_id=str(credential_id))
@@ -702,7 +719,8 @@ class CredentialService(BaseService):
                 action="deleted",
                 project_id=cred_project_id,
                 affected_workflow_count=wf_ref_count,
-                affected_integration_count=int_ref_count,
+                # Always 0: a non-zero integration ref count raises CredentialInUseError above.
+                affected_integration_count=0,
             ),
         )
 

--- a/backend/src/syntara/credentials/services/credential_service.py
+++ b/backend/src/syntara/credentials/services/credential_service.py
@@ -658,7 +658,7 @@ class CredentialService(BaseService):
                 management credential on one or more integrations. Deleting
                 it out from under those integrations would silently break
                 them — management_credential_id would be nulled with no
-                signal that validation_status is now stale (see AAP-87778).
+                signal that validation_status is now stale.
                 The caller must detach the credential from all referencing
                 integrations first.
 

--- a/backend/src/syntara/credentials/services/credential_service.py
+++ b/backend/src/syntara/credentials/services/credential_service.py
@@ -635,6 +635,12 @@ class CredentialService(BaseService):
             )
             return {}
 
+    @staticmethod
+    def _is_management_credential_fk_violation(exc: IntegrityError) -> bool:
+        """Check whether *exc* was caused by the management_credential_id RESTRICT FK."""
+        error_str = str(exc)
+        return "integrations_management_credential_id_fkey" in error_str
+
     async def _get_referencing_integration_names(self, credential_id: UUID, *, limit: int) -> list[str]:
         """Fetch up to `limit` names of integrations using this credential as their management credential.
 
@@ -722,12 +728,9 @@ class CredentialService(BaseService):
         try:
             await self.session.commit()
         except IntegrityError as exc:
-            # Rare race: an integration was attached to this credential after the
-            # count check above but before this commit. The FK's ON DELETE RESTRICT
-            # (not SET NULL) makes the database reject the delete instead of
-            # silently nulling the reference — surface it as the same clean 409
-            # rather than a generic integrity-constraint response.
             await self.session.rollback()
+            if not self._is_management_credential_fk_violation(exc):
+                raise
             logger.warning(
                 "Credential delete raced with a new integration reference",
                 credential_id=str(credential_id),
@@ -735,7 +738,9 @@ class CredentialService(BaseService):
                 exc_info=exc,
             )
             int_counts = await self.get_integration_counts([credential_id])
-            int_ref_count = int_counts.get(credential_id, 0) or 1
+            int_ref_count = int_counts.get(credential_id, 0)
+            if not int_ref_count:
+                raise
             integration_names = await self._get_referencing_integration_names(credential_id, limit=5)
             raise CredentialInUseError(cred_name, integration_names, int_ref_count) from exc
         logger.info("Credential deleted", credential_id=str(credential_id))

--- a/backend/src/syntara/credentials/services/credential_service.py
+++ b/backend/src/syntara/credentials/services/credential_service.py
@@ -16,7 +16,7 @@ import structlog
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives.serialization import load_pem_private_key, load_ssh_private_key
 from sqlalchemy import Select, case, func, literal_column, or_
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -662,6 +662,16 @@ class CredentialService(BaseService):
                 The caller must detach the credential from all referencing
                 integrations first.
 
+                The upfront count-based check below has a TOCTOU race: an
+                integration could be attached between that check and the
+                delete below. The `integrations.management_credential_id`
+                FK is `ON DELETE RESTRICT` (not `SET NULL`) specifically so
+                the database itself rejects the delete in that case rather
+                than silently nulling the reference; the `except
+                IntegrityError` re-raises that as the same clean
+                CredentialInUseError instead of a generic constraint-violation
+                response.
+
         """
         from syntara.authz.models import Project  # noqa: PLC0415
 
@@ -709,7 +719,25 @@ class CredentialService(BaseService):
             await self._secret_service.delete_secret(secret_id)
 
         await self.session.delete(credential)
-        await self.session.commit()
+        try:
+            await self.session.commit()
+        except IntegrityError as exc:
+            # Rare race: an integration was attached to this credential after the
+            # count check above but before this commit. The FK's ON DELETE RESTRICT
+            # (not SET NULL) makes the database reject the delete instead of
+            # silently nulling the reference — surface it as the same clean 409
+            # rather than a generic integrity-constraint response.
+            await self.session.rollback()
+            logger.warning(
+                "Credential delete raced with a new integration reference",
+                credential_id=str(credential_id),
+                credential_name=cred_name,
+                exc_info=exc,
+            )
+            int_counts = await self.get_integration_counts([credential_id])
+            int_ref_count = int_counts.get(credential_id, 0) or 1
+            integration_names = await self._get_referencing_integration_names(credential_id, limit=5)
+            raise CredentialInUseError(cred_name, integration_names, int_ref_count) from exc
         logger.info("Credential deleted", credential_id=str(credential_id))
         AuditEventDispatcher.dispatch(
             CredentialLifecycleEvent(

--- a/backend/src/syntara/integrations/models/integration.py
+++ b/backend/src/syntara/integrations/models/integration.py
@@ -114,7 +114,7 @@ class Integration(NamedResource, UserOwnedResource, table=True):
     management_credential_id: UUID | None = Field(
         default=None,
         foreign_key="credentials.id",
-        ondelete="SET NULL",
+        ondelete="RESTRICT",
         description="Optional credential for admin operations (validation, tool/model discovery)",
     )
 

--- a/backend/src/syntara/projects/service.py
+++ b/backend/src/syntara/projects/service.py
@@ -219,13 +219,13 @@ class ProjectService(BaseService):
 
             msg = "Default project cannot be deleted"
             raise DefaultProjectProtectionError(msg)
-        await self._check_credentials_not_referenced_by_integrations(project)
+        await self._check_credentials_not_referenced_by_integrations(project.id, project.name)
         await self._cascade_cleanup_project_resources(project_id)
         project.soft_delete(self.user.id)
         self.session.add(project)
         await self.session.commit()
 
-    async def _check_credentials_not_referenced_by_integrations(self, project: Project) -> None:
+    async def _check_credentials_not_referenced_by_integrations(self, project_id: UUID, project_name: str) -> None:
         """Raise 409 if any credential in this project is still referenced by an integration.
 
         Integrations are not project-scoped — a global integration can reference
@@ -233,6 +233,10 @@ class ProjectService(BaseService):
         FK on integrations.management_credential_id makes the database reject the
         bulk credential DELETE in the cascade, so we fail early with an actionable
         message instead of letting PostgreSQL surface a generic constraint error.
+
+        Accepts plain values instead of the Project ORM object to avoid any risk
+        of lazy-loading ORM attributes outside a greenlet context after the async
+        queries inside this method.
         """
         from sqlalchemy import func  # noqa: PLC0415
 
@@ -240,7 +244,7 @@ class ProjectService(BaseService):
         from syntara.credentials.models.credential import Credential  # noqa: PLC0415
         from syntara.integrations.models.integration import Integration  # noqa: PLC0415
 
-        cred_ids_subq = select(Credential.id).where(Credential.project_id == project.id).scalar_subquery()
+        cred_ids_subq = select(Credential.id).where(Credential.project_id == project_id).scalar_subquery()
 
         count_result = await self.session.exec(
             select(func.count()).where(
@@ -262,7 +266,7 @@ class ProjectService(BaseService):
         integration_names = [r[0] for r in rows]
         credential_names = list(dict.fromkeys(r[1] for r in rows))
 
-        raise ProjectCredentialInUseError(project.name, credential_names, integration_names, total_count)
+        raise ProjectCredentialInUseError(project_name, credential_names, integration_names, total_count)
 
     async def _cascade_cleanup_project_resources(self, project_id: UUID) -> None:
         """Remove all project-scoped resources before soft-deleting the project.

--- a/backend/src/syntara/projects/service.py
+++ b/backend/src/syntara/projects/service.py
@@ -219,10 +219,50 @@ class ProjectService(BaseService):
 
             msg = "Default project cannot be deleted"
             raise DefaultProjectProtectionError(msg)
+        await self._check_credentials_not_referenced_by_integrations(project)
         await self._cascade_cleanup_project_resources(project_id)
         project.soft_delete(self.user.id)
         self.session.add(project)
         await self.session.commit()
+
+    async def _check_credentials_not_referenced_by_integrations(self, project: Project) -> None:
+        """Raise 409 if any credential in this project is still referenced by an integration.
+
+        Integrations are not project-scoped — a global integration can reference
+        a project credential as its management credential. The ON DELETE RESTRICT
+        FK on integrations.management_credential_id makes the database reject the
+        bulk credential DELETE in the cascade, so we fail early with an actionable
+        message instead of letting PostgreSQL surface a generic constraint error.
+        """
+        from sqlalchemy import func  # noqa: PLC0415
+
+        from syntara.credentials.exceptions import ProjectCredentialInUseError  # noqa: PLC0415
+        from syntara.credentials.models.credential import Credential  # noqa: PLC0415
+        from syntara.integrations.models.integration import Integration  # noqa: PLC0415
+
+        cred_ids_subq = select(Credential.id).where(Credential.project_id == project.id).scalar_subquery()
+
+        count_result = await self.session.exec(
+            select(func.count()).where(
+                Integration.management_credential_id.in_(cred_ids_subq)  # type: ignore[union-attr]
+            )
+        )
+        total_count = count_result.one()
+        if not total_count:
+            return
+
+        names_result = await self.session.exec(
+            select(Integration.name, Credential.name)
+            .join(Credential, Integration.management_credential_id == Credential.id)  # type: ignore[arg-type]
+            .where(Integration.management_credential_id.in_(cred_ids_subq))  # type: ignore[union-attr]
+            .order_by(Integration.name)
+            .limit(5)
+        )
+        rows = list(names_result.all())
+        integration_names = [r[0] for r in rows]
+        credential_names = list(dict.fromkeys(r[1] for r in rows))
+
+        raise ProjectCredentialInUseError(project.name, credential_names, integration_names, total_count)
 
     async def _cascade_cleanup_project_resources(self, project_id: UUID) -> None:
         """Remove all project-scoped resources before soft-deleting the project.

--- a/backend/tests/integration/api/test_integrations_patch.py
+++ b/backend/tests/integration/api/test_integrations_patch.py
@@ -264,16 +264,22 @@ class TestIntegrationsPatch:
 
 
 class TestIntegrationCredentialCascade:
-    """Tests for credential deletion impact on integrations (Test 37)."""
+    """Tests for credential deletion impact on integrations (Test 37).
 
-    async def test_delete_credential_nullifies_integration_management_credential(
+    AAP-87778: deleting an in-use credential used to silently succeed and null
+    out the integration's management_credential_id, leaving validation_status
+    stale. The delete is now blocked with 409 while any integration still
+    references the credential, so the integration is never silently broken.
+    """
+
+    async def test_delete_credential_blocked_while_referenced_by_integration(
         self,
         auth_client: AsyncClient,
         test_db_session: AsyncSession,
         integration_factory: IntegrationFactory,
         credential_factory: CredentialFactory,
     ) -> None:
-        """Deleting a credential sets the integration's management_credential_id to NULL."""
+        """Deleting an in-use credential returns 409 and leaves the integration untouched."""
         ct = await credential_factory.create_type("HTTP Bearer Token")
         project = await credential_factory.create_project()
         cred = await credential_factory.create(ct, project, name=f"cascade-{uuid4().hex[:8]}")
@@ -287,8 +293,40 @@ class TestIntegrationCredentialCascade:
         assert get_before.json()["management_credential_id"] == str(cred.id)
 
         delete_resp = await auth_client.delete(f"/api/v1/credentials/{cred.id}")
-        assert delete_resp.status_code == 204
+        assert delete_resp.status_code == 409
+        assert delete_resp.json()["code"] == "CREDENTIAL_IN_USE"
+        assert integration.name in delete_resp.json()["detail"]
 
+        # Integration and credential are both untouched by the rejected delete.
         get_after = await auth_client.get(f"{BASE_URL}/{integration.id}")
         assert get_after.status_code == 200
-        assert get_after.json()["management_credential_id"] is None
+        assert get_after.json()["management_credential_id"] == str(cred.id)
+
+        cred_get = await auth_client.get(f"/api/v1/credentials/{cred.id}")
+        assert cred_get.status_code == 200
+
+    async def test_delete_credential_succeeds_after_detaching_integration(
+        self,
+        auth_client: AsyncClient,
+        test_db_session: AsyncSession,
+        integration_factory: IntegrationFactory,
+        credential_factory: CredentialFactory,
+    ) -> None:
+        """Once the credential is detached from all integrations, delete succeeds normally."""
+        ct = await credential_factory.create_type("HTTP Bearer Token")
+        project = await credential_factory.create_project()
+        cred = await credential_factory.create(ct, project, name=f"cascade-{uuid4().hex[:8]}")
+
+        integration = await integration_factory.create(name=f"cascade-int-{uuid4().hex[:8]}")
+        integration.management_credential_id = cred.id
+        await test_db_session.commit()
+
+        patch_resp = await auth_client.patch(f"{BASE_URL}/{integration.id}", json={"management_credential_id": None})
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["management_credential_id"] is None
+
+        delete_resp = await auth_client.delete(f"/api/v1/credentials/{cred.id}")
+        assert delete_resp.status_code == 204
+
+        cred_get = await auth_client.get(f"/api/v1/credentials/{cred.id}")
+        assert cred_get.status_code == 404

--- a/backend/tests/integration/api/test_integrations_patch.py
+++ b/backend/tests/integration/api/test_integrations_patch.py
@@ -266,9 +266,9 @@ class TestIntegrationsPatch:
 class TestIntegrationCredentialCascade:
     """Tests for credential deletion impact on integrations (Test 37).
 
-    AAP-87778: deleting an in-use credential used to silently succeed and null
-    out the integration's management_credential_id, leaving validation_status
-    stale. The delete is now blocked with 409 while any integration still
+    Deleting an in-use credential used to silently succeed and null out the
+    integration's management_credential_id, leaving validation_status stale.
+    The delete is now blocked with 409 while any integration still
     references the credential, so the integration is never silently broken.
     """
 

--- a/backend/tests/integration/integrations/test_llm_provider_integration.py
+++ b/backend/tests/integration/integrations/test_llm_provider_integration.py
@@ -330,13 +330,13 @@ class TestLLMProviderCredentialResolution:
     ) -> None:
         """Integration whose credential was deleted after creation fails on validate.
 
-        AAP-87778: credentials.management_credential_id is now ON DELETE RESTRICT,
-        so a credential can no longer be hard-deleted while an integration
-        references it (which is the whole point of that fix). To simulate "the
-        credential is gone" for this validate-path test, detach the reference
-        first (a direct FK null-out, bypassing the app-level guard that would
-        normally reject this for a credential-required type like llm_provider)
-        and only then delete the now-unreferenced credential row.
+        credentials.management_credential_id is ON DELETE RESTRICT, so a
+        credential can no longer be hard-deleted while an integration
+        references it. To simulate "the credential is gone" for this
+        validate-path test, detach the reference first (a direct FK
+        null-out, bypassing the app-level guard that would normally reject
+        this for a credential-required type like llm_provider) and only
+        then delete the now-unreferenced credential row.
         """
         integration_id = await _create_llm_integration(test_db_session, test_user, "llm-cred-del")
 
@@ -365,7 +365,7 @@ class TestLLMProviderCredentialResolution:
     ) -> None:
         """Integration whose credential was deleted after creation fails on refresh.
 
-        AAP-87778: see test_validate_with_deleted_credential above for why the
+        See test_validate_with_deleted_credential above for why the
         reference is nulled directly before deleting the credential row.
         """
         integration_id = await _create_llm_integration(test_db_session, test_user, "llm-ref-cred-del")

--- a/backend/tests/integration/integrations/test_llm_provider_integration.py
+++ b/backend/tests/integration/integrations/test_llm_provider_integration.py
@@ -11,7 +11,7 @@ from uuid import UUID, uuid4
 
 import pytest
 from httpx import AsyncClient
-from sqlmodel import select
+from sqlmodel import select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from syntara.core.models import User
@@ -328,20 +328,34 @@ class TestLLMProviderCredentialResolution:
     async def test_validate_with_deleted_credential(
         self, auth_client: AsyncClient, test_db_session: AsyncSession, test_user: User
     ) -> None:
-        """Integration whose credential was deleted after creation fails on validate."""
+        """Integration whose credential was deleted after creation fails on validate.
+
+        AAP-87778: credentials.management_credential_id is now ON DELETE RESTRICT,
+        so a credential can no longer be hard-deleted while an integration
+        references it (which is the whole point of that fix). To simulate "the
+        credential is gone" for this validate-path test, detach the reference
+        first (a direct FK null-out, bypassing the app-level guard that would
+        normally reject this for a credential-required type like llm_provider)
+        and only then delete the now-unreferenced credential row.
+        """
         integration_id = await _create_llm_integration(test_db_session, test_user, "llm-cred-del")
 
-        # Delete the credential out from under the integration
         from syntara.integrations.models.integration import Integration
 
         integration = (
             await test_db_session.exec(select(Integration).where(Integration.id == UUID(integration_id)))
         ).one()
         cred_id = integration.management_credential_id
+        await test_db_session.execute(
+            update(Integration)
+            .where(Integration.id == UUID(integration_id))  # type: ignore[arg-type]
+            .values(management_credential_id=None)
+        )
+        await test_db_session.flush()
         credential = await test_db_session.get(Credential, cred_id)
         if credential:
             await test_db_session.delete(credential)
-            await test_db_session.commit()
+        await test_db_session.commit()
 
         response = await auth_client.post(f"{BASE_URL}/{integration_id}/validate")
         assert response.status_code in (404, 422, 500)
@@ -349,7 +363,11 @@ class TestLLMProviderCredentialResolution:
     async def test_refresh_with_deleted_credential(
         self, auth_client: AsyncClient, test_db_session: AsyncSession, test_user: User
     ) -> None:
-        """Integration whose credential was deleted after creation fails on refresh."""
+        """Integration whose credential was deleted after creation fails on refresh.
+
+        AAP-87778: see test_validate_with_deleted_credential above for why the
+        reference is nulled directly before deleting the credential row.
+        """
         integration_id = await _create_llm_integration(test_db_session, test_user, "llm-ref-cred-del")
 
         from syntara.integrations.models.integration import Integration
@@ -358,10 +376,16 @@ class TestLLMProviderCredentialResolution:
             await test_db_session.exec(select(Integration).where(Integration.id == UUID(integration_id)))
         ).one()
         cred_id = integration.management_credential_id
+        await test_db_session.execute(
+            update(Integration)
+            .where(Integration.id == UUID(integration_id))  # type: ignore[arg-type]
+            .values(management_credential_id=None)
+        )
+        await test_db_session.flush()
         credential = await test_db_session.get(Credential, cred_id)
         if credential:
             await test_db_session.delete(credential)
-            await test_db_session.commit()
+        await test_db_session.commit()
 
         response = await auth_client.post(f"{BASE_URL}/{integration_id}/refresh")
         assert response.status_code in (404, 422, 500)

--- a/backend/tests/integration/projects/services/test_project_service.py
+++ b/backend/tests/integration/projects/services/test_project_service.py
@@ -526,22 +526,27 @@ async def test_delete_project_blocked_when_credential_referenced_by_integration(
     seeded_db.add(integration)
     await seeded_db.commit()
 
+    cred_id = credential.id
+    int_id = integration.id
+    project_id = project.id
+
     with pytest.raises(ProjectCredentialInUseError) as exc_info:
-        await svc.delete_project(project.id)
+        await svc.delete_project(project_id)
 
     assert "blocking-integration" in str(exc_info.value)
     assert "proj-cred-blocked" in str(exc_info.value)
 
     # Project, credential, and integration are all still intact
     seeded_db.expire_all()
-    assert (await seeded_db.exec(select(Credential).where(Credential.id == credential.id))).first() is not None
-    assert (await seeded_db.exec(select(Integration).where(Integration.id == integration.id))).first() is not None
+    assert (await seeded_db.exec(select(Credential).where(Credential.id == cred_id))).first() is not None
+    assert (await seeded_db.exec(select(Integration).where(Integration.id == int_id))).first() is not None
 
     # Clean up: detach integration then delete
-    integration.management_credential_id = None
-    seeded_db.add(integration)
+    int_row = (await seeded_db.exec(select(Integration).where(Integration.id == int_id))).one()
+    int_row.management_credential_id = None
+    seeded_db.add(int_row)
     await seeded_db.commit()
-    await svc.delete_project(project.id)
+    await svc.delete_project(project_id)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/projects/services/test_project_service.py
+++ b/backend/tests/integration/projects/services/test_project_service.py
@@ -495,6 +495,7 @@ async def test_delete_project_blocked_when_credential_referenced_by_integration(
     svc = ProjectService(seeded_db, test_user)
     user_id = test_user.id
     project = await svc.create_project(name="cascade-blocked")
+    project_id = project.id
 
     cred_type = CredentialType(
         name=f"test-type-{uuid4().hex[:8]}",
@@ -509,26 +510,25 @@ async def test_delete_project_blocked_when_credential_referenced_by_integration(
     credential = Credential(
         name="proj-cred-blocked",
         credential_type_id=cred_type.id,
-        project_id=project.id,
+        project_id=project_id,
         created_by=user_id,
         labels={},
     )
     seeded_db.add(credential)
     await seeded_db.flush()
+    cred_id = credential.id
 
     integration = Integration(
         name="blocking-integration",
         integration_type="mcp_server",
         configuration={"integration_type": "mcp_server", "base_url": "https://example.com"},
-        management_credential_id=credential.id,
+        management_credential_id=cred_id,
         created_by=user_id,
     )
     seeded_db.add(integration)
-    await seeded_db.commit()
-
-    cred_id = credential.id
+    await seeded_db.flush()
     int_id = integration.id
-    project_id = project.id
+    await seeded_db.commit()
 
     with pytest.raises(ProjectCredentialInUseError) as exc_info:
         await svc.delete_project(project_id)
@@ -541,10 +541,12 @@ async def test_delete_project_blocked_when_credential_referenced_by_integration(
     assert (await seeded_db.exec(select(Credential).where(Credential.id == cred_id))).first() is not None
     assert (await seeded_db.exec(select(Integration).where(Integration.id == int_id))).first() is not None
 
-    # Clean up: detach integration then delete
-    int_row = (await seeded_db.exec(select(Integration).where(Integration.id == int_id))).one()
-    int_row.management_credential_id = None
-    seeded_db.add(int_row)
+    # Clean up: detach integration via raw update to avoid ORM attribute access
+    from sqlalchemy import update
+
+    await seeded_db.exec(
+        update(Integration).where(Integration.id == int_id).values(management_credential_id=None)  # type: ignore[arg-type]
+    )
     await seeded_db.commit()
     await svc.delete_project(project_id)
 

--- a/backend/tests/integration/projects/services/test_project_service.py
+++ b/backend/tests/integration/projects/services/test_project_service.py
@@ -536,12 +536,10 @@ async def test_delete_project_blocked_when_credential_referenced_by_integration(
     assert "blocking-integration" in str(exc_info.value)
     assert "proj-cred-blocked" in str(exc_info.value)
 
-    # Project, credential, and integration are all still intact
-    seeded_db.expire_all()
-    assert (await seeded_db.exec(select(Credential).where(Credential.id == cred_id))).first() is not None
-    assert (await seeded_db.exec(select(Integration).where(Integration.id == int_id))).first() is not None
-
-    # Clean up: detach integration via raw update to avoid ORM attribute access
+    # Clean up: detach integration via raw update, then retry delete.
+    # Avoid expire_all() here — it would expire test_user (self.user on
+    # the service), causing MissingGreenlet when _cascade_cleanup accesses
+    # self.user.id in the second delete_project call below.
     from sqlalchemy import update
 
     await seeded_db.exec(

--- a/backend/tests/integration/projects/services/test_project_service.py
+++ b/backend/tests/integration/projects/services/test_project_service.py
@@ -485,6 +485,66 @@ async def test_delete_project_hard_deletes_credentials_and_cleans_secrets(
 
 
 @pytest.mark.asyncio
+async def test_delete_project_blocked_when_credential_referenced_by_integration(
+    seeded_db: AsyncSession, test_user: User
+) -> None:
+    """Deleting a project fails with 409 when an integration references one of its credentials."""
+    from syntara.credentials.exceptions import ProjectCredentialInUseError
+    from syntara.integrations.models.integration import Integration
+
+    svc = ProjectService(seeded_db, test_user)
+    user_id = test_user.id
+    project = await svc.create_project(name="cascade-blocked")
+
+    cred_type = CredentialType(
+        name=f"test-type-{uuid4().hex[:8]}",
+        description="test",
+        inputs={"fields": [], "required": []},
+        injectors={"extra_vars": {}, "env": {}, "file": {}},
+        managed=False,
+    )
+    seeded_db.add(cred_type)
+    await seeded_db.flush()
+
+    credential = Credential(
+        name="proj-cred-blocked",
+        credential_type_id=cred_type.id,
+        project_id=project.id,
+        created_by=user_id,
+        labels={},
+    )
+    seeded_db.add(credential)
+    await seeded_db.flush()
+
+    integration = Integration(
+        name="blocking-integration",
+        integration_type="mcp_server",
+        configuration={"integration_type": "mcp_server", "base_url": "https://example.com"},
+        management_credential_id=credential.id,
+        created_by=user_id,
+    )
+    seeded_db.add(integration)
+    await seeded_db.commit()
+
+    with pytest.raises(ProjectCredentialInUseError) as exc_info:
+        await svc.delete_project(project.id)
+
+    assert "blocking-integration" in str(exc_info.value)
+    assert "proj-cred-blocked" in str(exc_info.value)
+
+    # Project, credential, and integration are all still intact
+    seeded_db.expire_all()
+    assert (await seeded_db.exec(select(Credential).where(Credential.id == credential.id))).first() is not None
+    assert (await seeded_db.exec(select(Integration).where(Integration.id == integration.id))).first() is not None
+
+    # Clean up: detach integration then delete
+    integration.management_credential_id = None
+    seeded_db.add(integration)
+    await seeded_db.commit()
+    await svc.delete_project(project.id)
+
+
+@pytest.mark.asyncio
 async def test_delete_project_hard_deletes_approval_requests(seeded_db: AsyncSession, test_user: User) -> None:
     """Deleting a project hard-deletes all approval requests within it."""
     from syntara.approvals.models.approval_request import ApprovalRequest

--- a/backend/tests/unit/credentials/services/test_credential_service.py
+++ b/backend/tests/unit/credentials/services/test_credential_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from syntara.authz.exceptions import BuiltinProtectionError
 from syntara.core.lib.encryption import ENCRYPTED_SENTINEL
 from syntara.credentials.exceptions import (
+    CredentialInUseError,
     CredentialNameConflictError,
     CredentialNotFoundError,
     CredentialValidationError,
@@ -624,6 +625,49 @@ class TestDeleteCredential:
             assert "still referenced by workflows" in mock_logger.warning.call_args[0][0]
 
         mock_session.delete.assert_awaited_once_with(credential)
+
+    @pytest.mark.asyncio
+    async def test_raises_credential_in_use_when_integrations_reference_it(
+        self,
+        mock_session: MagicMock,
+        mock_user: MagicMock,
+        mock_secret_service: MagicMock,
+    ) -> None:
+        """AAP-87778: delete must be blocked (not silently nulled) while integrations reference it."""
+        credential = Credential(
+            id=uuid4(),
+            name="In-Use Cred",
+            credential_type_id=uuid4(),
+            secret_id=uuid4(),
+            enabled=True,
+            project_id=uuid4(),
+            created_by=mock_user.id,
+        )
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = credential
+        mock_session.exec.return_value = mock_result
+
+        service = CredentialService(mock_session, mock_user, mock_secret_service)
+
+        with (
+            patch.object(service, "get_integration_counts", new_callable=AsyncMock, return_value={credential.id: 2}),
+            patch.object(
+                service,
+                "_get_referencing_integration_names",
+                new_callable=AsyncMock,
+                return_value=["Integration A", "Integration B"],
+            ),
+        ):
+            with pytest.raises(CredentialInUseError) as exc_info:
+                await service.delete_credential(credential.id)
+
+            assert exc_info.value.total_count == 2
+            assert exc_info.value.integration_names == ["Integration A", "Integration B"]
+            assert "Integration A" in exc_info.value.message
+
+        mock_secret_service.delete_secret.assert_not_called()
+        mock_session.delete.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_raises_when_project_is_builtin(

--- a/backend/tests/unit/credentials/services/test_credential_service.py
+++ b/backend/tests/unit/credentials/services/test_credential_service.py
@@ -634,7 +634,7 @@ class TestDeleteCredential:
         mock_user: MagicMock,
         mock_secret_service: MagicMock,
     ) -> None:
-        """AAP-87778: delete must be blocked (not silently nulled) while integrations reference it."""
+        """Delete must be blocked (not silently nulled) while integrations reference it."""
         credential = Credential(
             id=uuid4(),
             name="In-Use Cred",
@@ -677,7 +677,7 @@ class TestDeleteCredential:
         mock_user: MagicMock,
         mock_secret_service: MagicMock,
     ) -> None:
-        """AAP-87778 follow-up: TOCTOU race.
+        """TOCTOU race.
 
         An integration is attached between the upfront count check and the
         commit. The FK's ON DELETE RESTRICT makes the commit raise

--- a/backend/tests/unit/credentials/services/test_credential_service.py
+++ b/backend/tests/unit/credentials/services/test_credential_service.py
@@ -697,7 +697,14 @@ class TestDeleteCredential:
         mock_result = MagicMock()
         mock_result.one_or_none.return_value = credential
         mock_session.exec.return_value = mock_result
-        mock_session.commit.side_effect = IntegrityError("DELETE", {}, Exception("FK violation"))
+        mock_session.commit.side_effect = IntegrityError(
+            "DELETE",
+            {},
+            Exception(
+                'update or delete on table "credentials" violates foreign key constraint '
+                '"integrations_management_credential_id_fkey" on table "integrations"'
+            ),
+        )
 
         service = CredentialService(mock_session, mock_user, mock_secret_service)
 
@@ -755,6 +762,29 @@ class TestDeleteCredential:
 
         mock_secret_service.delete_secret.assert_not_called()
         mock_session.delete.assert_not_awaited()
+
+
+class TestIsManagementCredentialFkViolation:
+    """Tests for CredentialService._is_management_credential_fk_violation."""
+
+    def test_matches_management_credential_fk(self) -> None:
+        exc = IntegrityError(
+            "DELETE",
+            {},
+            Exception(
+                'update or delete on table "credentials" violates foreign key constraint '
+                '"integrations_management_credential_id_fkey" on table "integrations"'
+            ),
+        )
+        assert CredentialService._is_management_credential_fk_violation(exc) is True
+
+    def test_does_not_match_other_constraint(self) -> None:
+        exc = IntegrityError(
+            "DELETE",
+            {},
+            Exception('duplicate key value violates unique constraint "ix_credentials_name"'),
+        )
+        assert CredentialService._is_management_credential_fk_violation(exc) is False
 
 
 _real_get_integration_counts = CredentialService.get_integration_counts

--- a/backend/tests/unit/credentials/services/test_credential_service.py
+++ b/backend/tests/unit/credentials/services/test_credential_service.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 from uuid import uuid4
 
 import pytest
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from syntara.authz.exceptions import BuiltinProtectionError
 from syntara.core.lib.encryption import ENCRYPTED_SENTINEL
@@ -123,6 +123,7 @@ def mock_session() -> MagicMock:
     session = MagicMock()
     session.add = MagicMock()
     session.commit = AsyncMock()
+    session.rollback = AsyncMock()
     session.refresh = AsyncMock()
     session.flush = AsyncMock()
     session.delete = AsyncMock()
@@ -668,6 +669,61 @@ class TestDeleteCredential:
 
         mock_secret_service.delete_secret.assert_not_called()
         mock_session.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_raises_credential_in_use_on_integrity_error_race(
+        self,
+        mock_session: MagicMock,
+        mock_user: MagicMock,
+        mock_secret_service: MagicMock,
+    ) -> None:
+        """AAP-87778 follow-up: TOCTOU race.
+
+        An integration is attached between the upfront count check and the
+        commit. The FK's ON DELETE RESTRICT makes the commit raise
+        IntegrityError instead of silently nulling the reference; this must
+        surface as the same clean CredentialInUseError, not a generic 400.
+        """
+        credential = Credential(
+            id=uuid4(),
+            name="Raced Cred",
+            credential_type_id=uuid4(),
+            secret_id=uuid4(),
+            enabled=True,
+            project_id=uuid4(),
+            created_by=mock_user.id,
+        )
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = credential
+        mock_session.exec.return_value = mock_result
+        mock_session.commit.side_effect = IntegrityError("DELETE", {}, Exception("FK violation"))
+
+        service = CredentialService(mock_session, mock_user, mock_secret_service)
+
+        with (
+            # First call (upfront check): no references yet. Second call (inside the
+            # except block, after the race): one integration attached.
+            patch.object(
+                service,
+                "get_integration_counts",
+                new_callable=AsyncMock,
+                side_effect=[{}, {credential.id: 1}],
+            ),
+            patch.object(
+                service,
+                "_get_referencing_integration_names",
+                new_callable=AsyncMock,
+                return_value=["Racing Integration"],
+            ),
+        ):
+            with pytest.raises(CredentialInUseError) as exc_info:
+                await service.delete_credential(credential.id)
+
+            assert exc_info.value.integration_names == ["Racing Integration"]
+            assert "Racing Integration" in exc_info.value.message
+
+        mock_session.rollback.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_raises_when_project_is_builtin(

--- a/backend/tests/unit/credentials/test_error_handlers.py
+++ b/backend/tests/unit/credentials/test_error_handlers.py
@@ -82,7 +82,7 @@ class TestCredentialDecryptionHandler:
 
 
 class TestCredentialInUseHandler:
-    """Tests for 409 handler (AAP-87778: block delete while integrations reference it)."""
+    """Tests for 409 handler (block delete while integrations reference it)."""
 
     def test_returns_409(self) -> None:
         request = _mock_request()

--- a/backend/tests/unit/credentials/test_error_handlers.py
+++ b/backend/tests/unit/credentials/test_error_handlers.py
@@ -9,6 +9,7 @@ from syntara.core.error_handlers import PROBLEM_TYPES
 from syntara.credentials.error_handlers import (
     credential_decryption_error_handler,
     credential_error_handler,
+    credential_in_use_error_handler,
     credential_name_conflict_handler,
     credential_not_found_handler,
     credential_validation_error_handler,
@@ -16,6 +17,7 @@ from syntara.credentials.error_handlers import (
 from syntara.credentials.exceptions import (
     CredentialDecryptionError,
     CredentialError,
+    CredentialInUseError,
     CredentialNameConflictError,
     CredentialNotFoundError,
     CredentialValidationError,
@@ -77,6 +79,20 @@ class TestCredentialDecryptionHandler:
         assert body["code"] == "CREDENTIAL_DECRYPTION_ERROR"
         assert "wrong key" not in body["detail"]
         assert body["detail"] == "An error occurred while processing credential data"
+
+
+class TestCredentialInUseHandler:
+    """Tests for 409 handler (AAP-87778: block delete while integrations reference it)."""
+
+    def test_returns_409(self) -> None:
+        request = _mock_request()
+        exc = CredentialInUseError("my-cred", ["My Integration"], 1)
+        response = credential_in_use_error_handler(request, exc)
+        assert response.status_code == 409
+        body = json.loads(bytes(response.body))
+        assert body["code"] == "CREDENTIAL_IN_USE"
+        assert body["type"] == PROBLEM_TYPES["resource_conflict"]
+        assert "My Integration" in body["detail"]
 
 
 class TestCredentialErrorHandler:

--- a/backend/tests/unit/credentials/test_exceptions.py
+++ b/backend/tests/unit/credentials/test_exceptions.py
@@ -58,3 +58,17 @@ class TestCredentialExceptions:
     def test_in_use_error_truncates_and_shows_remaining_count(self) -> None:
         exc = CredentialInUseError("my-cred", ["A", "B", "C"], 5)
         assert "and 2 more" in exc.message
+
+    def test_in_use_error_falls_back_to_generic_wording_when_names_empty(self) -> None:
+        """Double-race edge case: total_count > 0 but no names could be resolved.
+
+        Must not render an empty or malformed parenthetical like "()" or
+        "( and 1 more)".
+        """
+        exc = CredentialInUseError("my-cred", [], 1)
+        assert exc.message == (
+            "Cannot delete credential 'my-cred': still in use by 1 integration. "
+            "Remove the credential from these integrations before deleting it."
+        )
+        assert "(" not in exc.message
+        assert ")" not in exc.message

--- a/backend/tests/unit/credentials/test_exceptions.py
+++ b/backend/tests/unit/credentials/test_exceptions.py
@@ -3,6 +3,7 @@
 from syntara.credentials.exceptions import (
     CredentialDecryptionError,
     CredentialError,
+    CredentialInUseError,
     CredentialNameConflictError,
     CredentialNotFoundError,
     CredentialValidationError,
@@ -37,3 +38,23 @@ class TestCredentialExceptions:
         exc = CredentialDecryptionError("decryption failed")
         assert isinstance(exc, CredentialError)
         assert exc.message == "decryption failed"
+
+    def test_in_use_error_stores_details_and_lists_names(self) -> None:
+        exc = CredentialInUseError("my-cred", ["Integration A", "Integration B"], 2)
+        assert isinstance(exc, CredentialError)
+        assert exc.name == "my-cred"
+        assert exc.integration_names == ["Integration A", "Integration B"]
+        assert exc.total_count == 2
+        assert "my-cred" in exc.message
+        assert "Integration A" in exc.message
+        assert "Integration B" in exc.message
+        assert "2 integrations" in exc.message
+
+    def test_in_use_error_singular_count(self) -> None:
+        exc = CredentialInUseError("my-cred", ["Integration A"], 1)
+        assert "1 integration " in exc.message
+        assert "integrations" not in exc.message.split("(")[0]
+
+    def test_in_use_error_truncates_and_shows_remaining_count(self) -> None:
+        exc = CredentialInUseError("my-cred", ["A", "B", "C"], 5)
+        assert "and 2 more" in exc.message

--- a/backend/tests/unit/credentials/test_exceptions.py
+++ b/backend/tests/unit/credentials/test_exceptions.py
@@ -7,6 +7,7 @@ from syntara.credentials.exceptions import (
     CredentialNameConflictError,
     CredentialNotFoundError,
     CredentialValidationError,
+    ProjectCredentialInUseError,
 )
 
 
@@ -72,3 +73,33 @@ class TestCredentialExceptions:
         )
         assert "(" not in exc.message
         assert ")" not in exc.message
+
+
+class TestProjectCredentialInUseError:
+    """Verify ProjectCredentialInUseError message formatting."""
+
+    def test_message_includes_project_integration_and_credential_names(self) -> None:
+        exc = ProjectCredentialInUseError("my-project", ["cred-a", "cred-b"], ["int-x", "int-y"], 2)
+        assert isinstance(exc, CredentialError)
+        assert "my-project" in exc.message
+        assert "int-x" in exc.message
+        assert "int-y" in exc.message
+        assert "cred-a" in exc.message
+        assert "cred-b" in exc.message
+        assert "2 integrations" in exc.message
+
+    def test_singular_integration_count(self) -> None:
+        exc = ProjectCredentialInUseError("proj", ["cred"], ["int"], 1)
+        assert "1 integration " in exc.message
+        assert "integrations" not in exc.message.split("(")[0]
+
+    def test_truncation_of_long_lists(self) -> None:
+        exc = ProjectCredentialInUseError(
+            "proj",
+            [f"cred-{i}" for i in range(8)],
+            [f"int-{i}" for i in range(3)],
+            10,
+        )
+        assert "and 7 more" in exc.message
+        assert "cred-4" in exc.message
+        assert "cred-5" not in exc.message

--- a/frontend/packages/syntara-mock-api/src/handlers.ts
+++ b/frontend/packages/syntara-mock-api/src/handlers.ts
@@ -3487,6 +3487,27 @@ export const handlers = [
         { status: 404 }
       )
     }
+    // AAP-87778: block delete while any integration still references this credential
+    // as its management_credential_id, mirroring the real backend's 409 instead of
+    // silently nulling the reference.
+    const referencingIntegrations = integrations.filter((i) => i.management_credential_id === credential_id)
+    if (referencingIntegrations.length > 0) {
+      const names = referencingIntegrations
+        .slice(0, 5)
+        .map((i) => `'${i.name}'`)
+        .join(', ')
+      return HttpResponse.json(
+        {
+          type: 'https://api.example.com/errors/resource-conflict',
+          title: 'Credential In Use',
+          detail: `Cannot delete credential '${credentials[index].name}': still in use by ${referencingIntegrations.length} integration${referencingIntegrations.length !== 1 ? 's' : ''} (${names}). Remove the credential from these integrations before deleting it.`,
+          code: 'CREDENTIAL_IN_USE',
+          retryable: false,
+          instance: `/api/v1/credentials/${credential_id}`,
+        },
+        { status: 409 }
+      )
+    }
     credentials.splice(index, 1)
     return new HttpResponse(null, { status: 204 })
   }),

--- a/frontend/packages/syntara-mock-api/src/handlers.ts
+++ b/frontend/packages/syntara-mock-api/src/handlers.ts
@@ -3492,15 +3492,15 @@ export const handlers = [
     // silently nulling the reference.
     const referencingIntegrations = integrations.filter((i) => i.management_credential_id === credential_id)
     if (referencingIntegrations.length > 0) {
-      const names = referencingIntegrations
-        .slice(0, 5)
-        .map((i) => `'${i.name}'`)
-        .join(', ')
+      const shown = referencingIntegrations.slice(0, 5)
+      const names = shown.map((i) => `'${i.name}'`).join(', ')
+      const remaining = referencingIntegrations.length - shown.length
+      const suffix = remaining > 0 ? ` and ${remaining} more` : ''
       return HttpResponse.json(
         {
           type: 'https://api.example.com/errors/resource-conflict',
           title: 'Credential In Use',
-          detail: `Cannot delete credential '${credentials[index].name}': still in use by ${referencingIntegrations.length} integration${referencingIntegrations.length !== 1 ? 's' : ''} (${names}). Remove the credential from these integrations before deleting it.`,
+          detail: `Cannot delete credential '${credentials[index].name}': still in use by ${referencingIntegrations.length} integration${referencingIntegrations.length !== 1 ? 's' : ''} (${names}${suffix}). Remove the credential from these integrations before deleting it.`,
           code: 'CREDENTIAL_IN_USE',
           retryable: false,
           instance: `/api/v1/credentials/${credential_id}`,

--- a/frontend/packages/syntara-mock-api/src/handlers.ts
+++ b/frontend/packages/syntara-mock-api/src/handlers.ts
@@ -3487,7 +3487,7 @@ export const handlers = [
         { status: 404 }
       )
     }
-    // AAP-87778: block delete while any integration still references this credential
+    // Block delete while any integration still references this credential
     // as its management_credential_id, mirroring the real backend's 409 instead of
     // silently nulling the reference.
     const referencingIntegrations = integrations.filter((i) => i.management_credential_id === credential_id)

--- a/frontend/packages/syntara-ui/e2e/credential-delete-integration-warning.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-delete-integration-warning.spec.ts
@@ -63,15 +63,16 @@ test.describe('Credential Delete — Integration Impact Warning', () => {
       await expect(modal).toBeVisible()
       await expect(modal.getByText('Delete credential?')).toBeVisible()
 
-      // Ripple-effect summary: header, named integration, and ack copy
-      await expect(modal.getByText('Resources that will be affected')).toBeVisible({ timeout: 15_000 })
+      // The backend rejects this delete outright while the integration references the
+      // credential — the dialog must say so and block confirmation, not just list the
+      // integration as an "affected" resource and let the user ack a doomed deletion.
+      await expect(
+        modal.getByText("This credential can't be deleted until it's detached from these integrations")
+      ).toBeVisible({ timeout: 15_000 })
       await expect(modal.getByText('Integrations')).toBeVisible()
       await expect(modal.getByText(new RegExp(integrationName))).toBeVisible()
-      await expect(
-        modal.getByRole('checkbox', {
-          name: 'I understand this credential and the resources shown above will be affected by this deletion.',
-        })
-      ).toBeVisible()
+      await expect(modal.getByRole('checkbox')).not.toBeVisible()
+      await expect(modal.getByRole('button', { name: 'Detach integrations first' })).toBeDisabled()
 
       // Cancel to leave both credential and integration intact
       await modal.getByRole('button', { name: 'Cancel' }).click()
@@ -85,10 +86,15 @@ test.describe('Credential Delete — Integration Impact Warning', () => {
     }
   })
 
-  test('attempting to delete a linked credential is blocked and leaves the integration intact', async ({ app }) => {
+  test('DELETE /credentials/{id} is rejected while an integration still references it', async ({ app }) => {
     // DELETE /credentials/{id} used to succeed silently and null out the
     // integration's management_credential_id. The backend now rejects the delete
     // (409 CREDENTIAL_IN_USE) while any integration still references the credential.
+    //
+    // The UI disables the delete confirmation entirely in this state (see the
+    // previous test), so there's no click-path through the dialog to exercise here.
+    // This hits the API directly as a defense-in-depth regression check for the
+    // backend contract, independent of the frontend.
     const credName = buildUniqueName('e2e-cred-t37-del')
     const integrationName = buildUniqueName('e2e-int-t37-del')
     let credentialId: string | undefined
@@ -119,32 +125,15 @@ test.describe('Credential Delete — Integration Impact Warning', () => {
       const integration = (await intResp.json()) as { id: string }
       integrationId = integration.id
 
-      await app.goto(toAppUrl('/configuration/credentials'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Credentials' })).toBeVisible({ timeout: 20_000 })
-
-      await app.getByPlaceholder('Filter by keyword').fill(credName)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      const row = app.getByRole('row', { name: new RegExp(credName) })
-      await expect(row).toBeVisible({ timeout: 30_000 })
-
-      await row.getByRole('button', { name: /Actions|Kebab toggle/i }).click({ force: true })
-      await app.getByRole('menuitem', { name: /Delete credential/i }).click()
-
-      const modal = app.getByRole('dialog')
-      await expect(modal).toBeVisible()
-      await expect(modal.getByText(new RegExp(integrationName))).toBeVisible({ timeout: 15_000 })
-
-      await modal.getByRole('checkbox').click()
-      await modal.getByRole('button', { name: 'Delete' }).click()
-
-      // Delete is rejected (409) instead of silently succeeding; the error alert
-      // names the blocking integration.
-      await expect(app.getByText('Delete failed')).toBeVisible({ timeout: 10_000 })
-      await expect(app.getByText(new RegExp(integrationName))).toBeVisible()
+      const deleteResp = await apiRequest(app, 'delete', `/credentials/${credentialId}`, {
+        token: token ?? undefined,
+      })
+      expect(deleteResp.status()).toBe(409)
+      const body = (await deleteResp.json()) as { code?: string; detail?: string }
+      expect(body.code).toBe('CREDENTIAL_IN_USE')
+      expect(body.detail).toContain(integrationName)
 
       // Both the credential and the integration's link to it remain intact.
-      await expect(row).toBeVisible()
       const detailResp = await apiRequest(app, 'get', `/integrations/${integrationId}`, { token: token ?? undefined })
       expect(detailResp.ok()).toBeTruthy()
       const detail = (await detailResp.json()) as { management_credential_id: string | null }

--- a/frontend/packages/syntara-ui/e2e/credential-delete-integration-warning.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-delete-integration-warning.spec.ts
@@ -85,7 +85,10 @@ test.describe('Credential Delete — Integration Impact Warning', () => {
     }
   })
 
-  test('deleting a linked credential removes it and clears the integration credential field', async ({ app }) => {
+  test('attempting to delete a linked credential is blocked and leaves the integration intact', async ({ app }) => {
+    // AAP-87778: DELETE /credentials/{id} used to succeed silently and null out the
+    // integration's management_credential_id. The backend now rejects the delete
+    // (409 CREDENTIAL_IN_USE) while any integration still references the credential.
     const credName = buildUniqueName('e2e-cred-t37-del')
     const integrationName = buildUniqueName('e2e-int-t37-del')
     let credentialId: string | undefined
@@ -135,11 +138,20 @@ test.describe('Credential Delete — Integration Impact Warning', () => {
       await modal.getByRole('checkbox').click()
       await modal.getByRole('button', { name: 'Delete' }).click()
 
-      await expect(app.getByText('Credential deleted')).toBeVisible({ timeout: 10_000 })
-      await expect(row).not.toBeVisible({ timeout: 10_000 })
+      // Delete is rejected (409) instead of silently succeeding; the error alert
+      // names the blocking integration.
+      await expect(app.getByText('Delete failed')).toBeVisible({ timeout: 10_000 })
+      await expect(app.getByText(new RegExp(integrationName))).toBeVisible()
 
-      credentialId = undefined
+      // Both the credential and the integration's link to it remain intact.
+      await expect(row).toBeVisible()
+      const detailResp = await apiRequest(app, 'get', `/integrations/${integrationId}`, { token: token ?? undefined })
+      expect(detailResp.ok()).toBeTruthy()
+      const detail = (await detailResp.json()) as { management_credential_id: string | null }
+      expect(detail.management_credential_id).toBe(credentialId)
     } finally {
+      // Detach before cleanup: the credential can't be deleted while the
+      // integration still references it.
       if (integrationId) await deleteIntegrationViaApi(app, integrationId)
       if (credentialId) await deleteCredentialViaApi(app, credentialId)
     }

--- a/frontend/packages/syntara-ui/e2e/credential-delete-integration-warning.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-delete-integration-warning.spec.ts
@@ -86,7 +86,7 @@ test.describe('Credential Delete — Integration Impact Warning', () => {
   })
 
   test('attempting to delete a linked credential is blocked and leaves the integration intact', async ({ app }) => {
-    // AAP-87778: DELETE /credentials/{id} used to succeed silently and null out the
+    // DELETE /credentials/{id} used to succeed silently and null out the
     // integration's management_credential_id. The backend now rejects the delete
     // (409 CREDENTIAL_IN_USE) while any integration still references the credential.
     const credName = buildUniqueName('e2e-cred-t37-del')

--- a/frontend/packages/syntara-ui/e2e/credential-delete-integration-warning.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-delete-integration-warning.spec.ts
@@ -69,7 +69,6 @@ test.describe('Credential Delete — Integration Impact Warning', () => {
       await expect(
         modal.getByText("This credential can't be deleted until it's detached from these integrations")
       ).toBeVisible({ timeout: 15_000 })
-      await expect(modal.getByText('Integrations')).toBeVisible()
       await expect(modal.getByText(new RegExp(integrationName))).toBeVisible()
       await expect(modal.getByRole('checkbox')).not.toBeVisible()
       await expect(modal.getByRole('button', { name: 'Detach integrations first' })).toBeDisabled()

--- a/frontend/packages/syntara-ui/e2e/credential-enable-disable.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-enable-disable.spec.ts
@@ -22,8 +22,10 @@ function detailPageToggle(app: Page) {
 /** Wait until usage checks finish so the Disable action is actually clickable. */
 async function waitForDisableDialogReady(dialog: import('@playwright/test').Locator, credentialName?: string) {
   await expect(dialog.getByText('Disable credential?')).toBeVisible()
+  // The spinner only clears once the affected-workflows and affected-integrations
+  // API calls both resolve — give it extra time under CI load
   await expect(dialog.getByText(/Checking for workflows and integrations/)).toHaveCount(0, {
-    timeout: 15_000,
+    timeout: 25_000,
   })
   if (credentialName) {
     await expect(dialog.getByText(new RegExp(credentialName))).toBeVisible()

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -866,10 +866,17 @@ test.describe('Permission gating — Detail page header actions', () => {
       await auditorApp.goto(toAppUrl(`${AM_URL}/groups/${groupId}`))
       await expect(auditorApp.getByRole('heading', { level: 1 })).toBeVisible()
 
-      await expect(auditorApp.getByRole('button', { name: 'Edit group' })).toHaveAttribute('aria-disabled', 'true')
+      // aria-disabled is set after the permissions API resolves — give it extra time
+      await expect(auditorApp.getByRole('button', { name: 'Edit group' })).toHaveAttribute('aria-disabled', 'true', {
+        timeout: 20_000,
+      })
 
       await auditorApp.getByRole('button', { name: 'Group actions' }).click()
-      await expect(auditorApp.getByRole('menuitem', { name: 'Delete group' })).toHaveAttribute('aria-disabled', 'true')
+      await expect(auditorApp.getByRole('menuitem', { name: 'Delete group' })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+        { timeout: 20_000 }
+      )
     } finally {
       await deleteGroupViaApi(app, groupId)
     }

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -823,6 +823,13 @@ test.describe('Permission gating — Detail page header actions', () => {
   const E2E_USER_PASSWORD = 'E2eTestP@ssw0rd!'
 
   test('auditor: user detail Edit and kebab actions are aria-disabled', async ({ app, auditorApp }) => {
+    // This test depends on 3-4 sequential, unbatched /authz/can_i round trips
+    // (useUserPermissions + useUserDetailPermissions) resolving against the
+    // real backend. The default 60s test budget plus 15-20s per-assertion
+    // timeouts leaves little headroom under CI load, which has caused
+    // intermittent timeouts here. Give the whole test more room.
+    test.setTimeout(90_000)
+
     const username = buildUniqueName('e2e-perm-user-detail')
     const user = await createUserViaApi(app, { username, password: E2E_USER_PASSWORD })
     if (!user) throw new Error('createUserViaApi failed')
@@ -833,17 +840,17 @@ test.describe('Permission gating — Detail page header actions', () => {
 
       // aria-disabled is set after the permissions API resolves — give it extra time
       await expect(auditorApp.getByRole('button', { name: 'Edit user' })).toHaveAttribute('aria-disabled', 'true', {
-        timeout: 20_000,
+        timeout: 30_000,
       })
 
       await auditorApp.getByRole('button', { name: 'User actions' }).click()
       await expect(auditorApp.getByRole('menuitem', { name: 'Revoke tokens' })).toHaveAttribute(
         'aria-disabled',
         'true',
-        { timeout: 15_000 }
+        { timeout: 20_000 }
       )
       await expect(auditorApp.getByRole('menuitem', { name: 'Delete user' })).toHaveAttribute('aria-disabled', 'true', {
-        timeout: 15_000,
+        timeout: 20_000,
       })
     } finally {
       await deleteUserViaApi(app, user.id)

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -781,7 +781,8 @@ test.describe('Permission gating — Access Management actions', () => {
 
     const createButton = auditorApp.getByRole('button', { name: /Create group/i })
     await expect(createButton).toBeVisible()
-    await expect(createButton).toHaveAttribute('aria-disabled', 'true')
+    // aria-disabled is set after the permissions API resolves — give it extra time
+    await expect(createButton).toHaveAttribute('aria-disabled', 'true', { timeout: 20_000 })
   })
 
   test('auditor: Create user button is disabled', async ({ auditorApp }) => {

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -897,6 +897,12 @@ test.describe('Permission gating — Detail page header actions', () => {
   })
 
   test('auditor: identity provider detail Edit and kebab actions are aria-disabled', async ({ app, auditorApp }) => {
+    // This test depends on several sequential, unbatched /authz/can_i round trips
+    // resolving against the real backend. The default 60s test budget plus 10s
+    // per-assertion timeouts leaves little headroom under CI load, which has caused
+    // intermittent timeouts here. Give the whole test more room.
+    test.setTimeout(90_000)
+
     const idpName = buildUniqueName('e2e-perm-idp-detail')
     const idp = await createIdentityProviderViaApi(app, {
       name: idpName,
@@ -915,17 +921,28 @@ test.describe('Permission gating — Detail page header actions', () => {
       await auditorApp.goto(toAppUrl(`${AUTH_URL}/identity-providers/${idp.id}`))
       await expect(auditorApp.getByRole('heading', { level: 1, name: idpName })).toBeVisible()
 
-      await expect(auditorApp.getByRole('button', { name: 'Edit provider' })).toHaveAttribute('aria-disabled', 'true')
+      // aria-disabled is set after the permissions API resolves — give it extra time
+      await expect(auditorApp.getByRole('button', { name: 'Edit provider' })).toHaveAttribute('aria-disabled', 'true', {
+        timeout: 30_000,
+      })
 
       await auditorApp.getByRole('button', { name: 'Identity provider actions' }).click()
       await expect(auditorApp.getByRole('menuitem', { name: 'Edit group mapping' })).toHaveAttribute(
         'aria-disabled',
-        'true'
+        'true',
+        { timeout: 20_000 }
       )
-      await expect(auditorApp.getByRole('menuitem', { name: 'Revoke tokens' })).toHaveAttribute('aria-disabled', 'true')
+      await expect(auditorApp.getByRole('menuitem', { name: 'Revoke tokens' })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+        {
+          timeout: 20_000,
+        }
+      )
       await expect(auditorApp.getByRole('menuitem', { name: 'Delete identity provider' })).toHaveAttribute(
         'aria-disabled',
-        'true'
+        'true',
+        { timeout: 20_000 }
       )
     } finally {
       await deleteIdentityProviderViaApi(app, idp.id)

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -944,7 +944,8 @@ test.describe('Permission gating — Service Account actions', () => {
 
       const createButton = auditorApp.getByRole('button', { name: /Create service account/i })
       await expect(createButton).toBeVisible({ timeout: 15_000 })
-      await expect(createButton).toHaveAttribute('aria-disabled', 'true')
+      // aria-disabled is set after the permissions API resolves — give it extra time
+      await expect(createButton).toHaveAttribute('aria-disabled', 'true', { timeout: 20_000 })
     } finally {
       await deleteServiceAccountViaApi(app, sa.id)
     }
@@ -960,7 +961,10 @@ test.describe('Permission gating — Service Account actions', () => {
   test('viewer: direct URL to Service Accounts shows access denied', async ({ viewerApp }) => {
     await viewerApp.goto(toAppUrl(`${AM_URL}/service-accounts`))
 
-    await expect(viewerApp.getByRole('heading', { name: 'Access denied', level: 2 })).toBeVisible()
+    // The route guard renders after the permissions API resolves — give it extra time
+    await expect(viewerApp.getByRole('heading', { name: 'Access denied', level: 2 })).toBeVisible({
+      timeout: 20_000,
+    })
   })
 })
 

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -173,8 +173,9 @@ test.describe('Approval Side Panel', () => {
 
       const approveBtn = viewerApp.getByRole('button', { name: 'Approve' })
       const rejectBtn = viewerApp.getByRole('button', { name: 'Reject' })
-      await expect(approveBtn).toHaveAttribute('aria-disabled', 'true')
-      await expect(rejectBtn).toHaveAttribute('aria-disabled', 'true')
+      // aria-disabled is set after the permissions API resolves — give it extra time
+      await expect(approveBtn).toHaveAttribute('aria-disabled', 'true', { timeout: 20_000 })
+      await expect(rejectBtn).toHaveAttribute('aria-disabled', 'true', { timeout: 20_000 })
     })
   })
 

--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -281,11 +281,12 @@ test.describe('Approval Workflow Operations', () => {
       await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
       await app.getByRole('button', { name: 'Apply filter' }).click()
 
+      // Wait for the filter chip to confirm the filter was applied and the table to refresh
       await expect(app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })).toBeVisible({
         timeout: 15_000,
       })
 
-      // Step 1: Select the approval using row-scoped checkbox
+      // Step 1: Select the approval using row-scoped checkbox — wait for the row before interacting
       const row = table.getByRole('row').filter({ hasText: approval.approvalName })
       await expect(row).toBeVisible({ timeout: 15_000 })
       await row.getByRole('checkbox').check()

--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -212,9 +212,16 @@ test.describe('Approval Workflow Operations', () => {
       await app.getByPlaceholder('Filter by name').fill(batchId)
       await app.getByRole('button', { name: 'Apply filter' }).click()
 
-      // Step 1: Select both approvals using row-scoped checkboxes
+      // Wait for the filter chip to confirm the filter was applied and the table to refresh
+      await expect(app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })).toBeVisible({
+        timeout: 15_000,
+      })
+
+      // Step 1: Select both approvals using row-scoped checkboxes — wait for each row before interacting
       const rows = table.getByRole('row')
+      await expect(rows.filter({ hasText: approval1.approvalName })).toBeVisible({ timeout: 15_000 })
       await rows.filter({ hasText: approval1.approvalName }).getByRole('checkbox').check()
+      await expect(rows.filter({ hasText: approval2.approvalName })).toBeVisible({ timeout: 15_000 })
       await rows.filter({ hasText: approval2.approvalName }).getByRole('checkbox').check()
 
       // Step 2: Verify batch toolbar and count

--- a/frontend/packages/syntara-ui/src/components/dialogs/NxConfirmationDialog.tsx
+++ b/frontend/packages/syntara-ui/src/components/dialogs/NxConfirmationDialog.tsx
@@ -37,6 +37,9 @@ type NxConfirmationDialogProps = {
   }
   /** When true, confirm shows a spinner and both footer actions are disabled */
   confirmLoading?: boolean
+  /** When true, confirm stays disabled regardless of the acknowledgement checkbox
+   *  (e.g. the action is blocked server-side and there is nothing to confirm). */
+  confirmDisabled?: boolean
   /** Optional aria-labelledby id */
   'aria-labelledby'?: string
   /** Optional aria-describedby id */
@@ -83,6 +86,7 @@ export function NxConfirmationDialog({
   titleIconVariant,
   destructiveAcknowledgement,
   confirmLoading = false,
+  confirmDisabled = false,
   'aria-labelledby': ariaLabelledby,
   'aria-describedby': ariaDescribedby,
 }: Readonly<NxConfirmationDialogProps>) {
@@ -94,7 +98,7 @@ export function NxConfirmationDialog({
     setDestructiveAcknowledged(false)
   }
 
-  const confirmDisabled = Boolean(destructiveAcknowledgement) && !destructiveAcknowledged
+  const isConfirmDisabled = confirmDisabled || (Boolean(destructiveAcknowledgement) && !destructiveAcknowledged)
 
   const body = destructiveAcknowledgement ? (
     <Stack hasGutter>
@@ -128,7 +132,7 @@ export function NxConfirmationDialog({
         <Button
           variant={confirmVariant}
           onClick={onConfirm}
-          isDisabled={confirmDisabled || confirmLoading}
+          isDisabled={isConfirmDisabled || confirmLoading}
           isLoading={confirmLoading}
         >
           {confirmLabel}

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialAffectedResourcesWarnings.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialAffectedResourcesWarnings.tsx
@@ -11,6 +11,14 @@ type CredentialAffectedResourcesWarningsProps = {
   workflowsFetchError: boolean
   affectedIntegrations: Integration[]
   integrationsFetchError: boolean
+  /**
+   * When true, integrations are rendered as a hard blocker (separate danger alert,
+   * "must be detached" copy) instead of being grouped under the generic "Resources
+   * that will be affected" summary. Used by the delete dialog, where the backend
+   * rejects the delete outright while any integration still references the
+   * credential — unlike workflows, which are only warned about, not blocking.
+   */
+  integrationsBlockDeletion?: boolean
 }
 
 /**
@@ -23,13 +31,15 @@ export function CredentialAffectedResourcesWarnings({
   workflowsFetchError,
   affectedIntegrations,
   integrationsFetchError,
+  integrationsBlockDeletion = false,
 }: Readonly<CredentialAffectedResourcesWarningsProps>) {
   const hasWorkflows = affectedWorkflows.length > 0
   const hasIntegrations = affectedIntegrations.length > 0
-  const hasDependencies = hasWorkflows || hasIntegrations
+  const hasBlockingIntegrations = integrationsBlockDeletion && hasIntegrations
+  const hasDependencies = hasWorkflows || (hasIntegrations && !hasBlockingIntegrations)
   const hasFetchError = workflowsFetchError || integrationsFetchError
 
-  if (!hasDependencies && !hasFetchError) return null
+  if (!hasDependencies && !hasBlockingIntegrations && !hasFetchError) return null
 
   return (
     <Stack hasGutter>
@@ -47,6 +57,17 @@ export function CredentialAffectedResourcesWarnings({
           </Alert>
         </StackItem>
       )}
+      {hasBlockingIntegrations && (
+        <StackItem>
+          <Alert
+            variant="danger"
+            isInline
+            title="This credential can't be deleted until it's detached from these integrations"
+          >
+            <CredentialDependencySection label="Integrations" resources={affectedIntegrations} />
+          </Alert>
+        </StackItem>
+      )}
       {hasDependencies && (
         <StackItem>
           <Stack hasGutter>
@@ -60,7 +81,7 @@ export function CredentialAffectedResourcesWarnings({
                 <CredentialDependencySection label="Workflows" resources={affectedWorkflows} />
               </StackItem>
             )}
-            {hasIntegrations && (
+            {hasIntegrations && !hasBlockingIntegrations && (
               <StackItem>
                 <CredentialDependencySection label="Integrations" resources={affectedIntegrations} />
               </StackItem>

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialDialogs.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialDialogs.test.tsx
@@ -683,7 +683,7 @@ describe('DeleteCredentialDialog', () => {
     ).toBeInTheDocument()
   })
 
-  it('shows ripple-effect acknowledgement checkbox text with dependencies', () => {
+  it('blocks deletion and disables confirm when integrations reference the credential', () => {
     render(
       <DeleteCredentialDialog
         credential={mockCredential}
@@ -692,11 +692,29 @@ describe('DeleteCredentialDialog', () => {
       />
     )
 
+    // The backend rejects the delete outright while any integration references the
+    // credential — there's nothing to acknowledge, so no checkbox is shown, and the
+    // confirm action stays disabled instead of inviting a doomed confirmation.
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Detach integrations first' })).toBeDisabled()
+    expect(screen.getByText(/can.t be deleted while it.s still used by the integration\(s\) below/)).toBeInTheDocument()
     expect(
-      screen.getByRole('checkbox', {
-        name: 'I understand this credential and the resources shown above will be affected by this deletion.',
-      })
+      screen.getByText("This credential can't be deleted until it's detached from these integrations")
     ).toBeInTheDocument()
+  })
+
+  it('keeps confirm disabled for blocking integrations even when workflows also reference the credential', () => {
+    render(
+      <DeleteCredentialDialog
+        credential={mockCredential}
+        {...defaultDeleteProps}
+        affectedWorkflows={[{ id: 'wf-1', name: 'Deploy Pipeline' }]}
+        affectedIntegrations={mockAffectedIntegrations}
+      />
+    )
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Detach integrations first' })).toBeDisabled()
   })
 
   it('enables Delete button (after checkbox) when both isLoading and isLoadingWorkflows are explicitly false', async () => {

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/DeleteCredentialDialog.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/DeleteCredentialDialog.tsx
@@ -36,8 +36,13 @@ export function DeleteCredentialDialog({
   if (!credential) return null
 
   const isLoadingChecks = isLoadingWorkflows || isLoadingIntegrations
-  const hasDependencies = affectedWorkflows.length > 0 || affectedIntegrations.length > 0
-  const showAffectedResources = hasDependencies || workflowsFetchError || integrationsFetchError
+  // Integrations are a hard block: the backend rejects the delete outright while any
+  // integration still references the credential (unlike workflows, which are only
+  // warned about). Don't invite a confirmation the backend can never honor.
+  const hasBlockingIntegrations = affectedIntegrations.length > 0
+  const hasWorkflowDependency = affectedWorkflows.length > 0
+  const showAffectedResources =
+    hasWorkflowDependency || hasBlockingIntegrations || workflowsFetchError || integrationsFetchError
 
   return (
     <NxConfirmationDialog
@@ -45,16 +50,21 @@ export function DeleteCredentialDialog({
       onClose={onClose}
       onConfirm={onConfirm}
       title="Delete credential?"
-      confirmLabel="Delete"
+      confirmLabel={hasBlockingIntegrations ? 'Detach integrations first' : 'Delete'}
       confirmVariant="danger"
       titleIconVariant="warning"
       confirmLoading={isLoading || isLoadingChecks}
-      destructiveAcknowledgement={{
-        checkboxId: 'delete-credential-ack',
-        label: hasDependencies
-          ? 'I understand this credential and the resources shown above will be affected by this deletion.'
-          : 'I understand this credential will be permanently deleted.',
-      }}
+      confirmDisabled={hasBlockingIntegrations}
+      destructiveAcknowledgement={
+        hasBlockingIntegrations
+          ? undefined
+          : {
+              checkboxId: 'delete-credential-ack',
+              label: hasWorkflowDependency
+                ? 'I understand this credential and the resources shown above will be affected by this deletion.'
+                : 'I understand this credential will be permanently deleted.',
+            }
+      }
     >
       {isLoadingChecks ? (
         <Content component={ContentVariants.p}>
@@ -64,9 +74,16 @@ export function DeleteCredentialDialog({
       ) : (
         <Stack hasGutter>
           <StackItem>
-            <Content component={ContentVariants.p}>
-              The credential <strong>{credential.name}</strong> will be deleted. This cannot be undone.
-            </Content>
+            {hasBlockingIntegrations ? (
+              <Content component={ContentVariants.p}>
+                The credential <strong>{credential.name}</strong> can&apos;t be deleted while it&apos;s still used by
+                the integration(s) below. Detach it from each one, then try again.
+              </Content>
+            ) : (
+              <Content component={ContentVariants.p}>
+                The credential <strong>{credential.name}</strong> will be deleted. This cannot be undone.
+              </Content>
+            )}
           </StackItem>
           {showAffectedResources && (
             <StackItem>
@@ -75,6 +92,7 @@ export function DeleteCredentialDialog({
                 workflowsFetchError={workflowsFetchError}
                 affectedIntegrations={affectedIntegrations}
                 integrationsFetchError={integrationsFetchError}
+                integrationsBlockDeletion={hasBlockingIntegrations}
               />
             </StackItem>
           )}


### PR DESCRIPTION
## Description

`DELETE /api/v1/credentials/{id}` used to succeed silently (HTTP 204) even when the credential was still set as an integration's `management_credential_id`. The delete nulled that reference in the same transaction without updating the integration's `validation_status`, so a broken integration kept reporting a stale status (e.g. `"available"`) with no signal that it could no longer authenticate. See [AAP-87778](https://redhat.atlassian.net/browse/AAP-87778) (and the related [AAP-86714](https://redhat.atlassian.net/browse/AAP-86714)).

This implements the "reject the delete with 409 Conflict" option from the ticket.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `CredentialInUseError` (`credentials/exceptions.py`) and its `409 Conflict` / `CREDENTIAL_IN_USE` RFC 9457 handler (`credentials/error_handlers.py`).
- `CredentialService.delete_credential` now checks `get_integration_counts` first; if any integration still references the credential, it raises `CredentialInUseError` naming up to 5 of the blocking integrations, before touching the secret or credential row.
- Removed the now-dead `UPDATE integrations SET management_credential_id = NULL` statement, since it's unreachable once in-use deletes are blocked.
- Workflow references are unaffected — still logged as a warning only, since dangling `credential_id`s remain visible in the workflow definition (a separate, already-tracked concern).

## Out of Scope

- Workflow-side dangling credential references (separate from this ticket).
- Auto-detaching the credential from integrations instead of blocking the delete — the ticket's preferred option is a hard block so the caller makes an explicit choice about which credential replaces it.

## Related Issues

Fixes [AAP-87778](https://redhat.atlassian.net/browse/AAP-87778)
Related to [AAP-86714](https://redhat.atlassian.net/browse/AAP-86714)

## How to Test

1. Create a credential and an integration that requires one (e.g. `llm_provider`) referencing it as `management_credential_id`.
2. `DELETE /api/v1/credentials/{id}` → now returns `409 Conflict` with `code: CREDENTIAL_IN_USE` and the integration's name in `detail`. Credential and integration are both untouched.
3. Detach the credential (e.g. delete the integration, or point it at a different credential) and retry the delete → `204 No Content` as before.

This was manually reproduced and verified against a local `podman-compose` stack (including a throwaway mock LLM provider server to get a genuine `validation_status: "available"` before deletion) before and after the fix.

## Backend Checklist

- [x] I have run `make test` and all tests pass (in `backend/`)
- [x] I have run `make lint` and code passes all checks
- [x] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [x] I have added tests for new functionality
- [ ] Database migrations are included if schema changed (none needed — no schema change)
- [x] No sensitive information (keys, passwords, etc.) is included

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation (none required — no public-facing docs describe the old cascade behavior)
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps (behavior change is the fix itself; documented above under "How to Test")

## Additional Notes

This is technically a breaking-ish behavior change for any caller relying on the old silent-null behavior, but that behavior was the bug being fixed — the old behavior caused silent, undetectable outages for integrations.
