### PR TITLE
chore(ci): Gate E2E tests on frontend checks to reduce costs

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -406,10 +406,8 @@ jobs:
             }
             core.setFailed(`Timed out waiting for shared checks: ${required.join(', ')}`);
 
-  # Gate that E2E tests wait for to reduce costs by failing fast on lint/unit test failures.
-  # E2E tests (test-compose-e2e, konflux-frontend-gate, konflux-ui-tests-gate) are expensive
-  # (8-core runners, 90-120 min timeouts). By gating them on fast checks (~2-3 min total),
-  # we avoid burning runner time when basic validation fails.
+  # Gate for E2E tests to reduce costs. Expensive E2E jobs only start after
+  # fast checks pass, avoiding wasted resources when basic validation fails.
   frontend-checks-gate:
     name: (Frontend) Checks Gate
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -406,9 +406,21 @@ jobs:
             }
             core.setFailed(`Timed out waiting for shared checks: ${required.join(', ')}`);
 
+  # Gate that E2E tests wait for to reduce costs by failing fast on lint/unit test failures.
+  # E2E tests (test-compose-e2e, konflux-frontend-gate, konflux-ui-tests-gate) are expensive
+  # (8-core runners, 90-120 min timeouts). By gating them on fast checks (~2-3 min total),
+  # we avoid burning runner time when basic validation fails.
+  frontend-checks-gate:
+    name: (Frontend) Checks Gate
+    runs-on: ubuntu-latest
+    needs: [changes, checks, unit-tests]
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.contracts == 'true'
+    steps:
+      - run: echo "Frontend checks passed"
+
   test-compose-e2e:
     name: (Frontend) Test Podman Compose E2E
-    needs: changes
+    needs: [changes, frontend-checks-gate]
     if: needs.changes.outputs.code == 'true' && github.event_name != 'push'
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 120
@@ -604,6 +616,7 @@ jobs:
 
   konflux-frontend-gate:
     name: (Frontend) Konflux Gate
+    needs: [changes, frontend-checks-gate]
     # Tekton PAC only fires on pull_request events (not merge_group or push).
     if: github.event_name == 'pull_request'
     permissions:
@@ -620,6 +633,7 @@ jobs:
 
   konflux-ui-tests-gate:
     name: (Frontend) Konflux UI Tests Gate
+    needs: [changes, frontend-checks-gate]
     # Tekton PAC only fires on pull_request events (not merge_group or push).
     if: github.event_name == 'pull_request'
     permissions:
@@ -651,6 +665,7 @@ jobs:
       - coverage-report
       - storybook-build
       - test-build
+      - frontend-checks-gate
       - konflux-frontend-gate
       - konflux-ui-tests-gate
       - shared-checks-gate
@@ -664,7 +679,7 @@ jobs:
           fi
 
           ok="success|skipped"
-          for job in gen-contracts checks unit-tests coverage-report storybook-build test-build test-compose-e2e konflux-frontend-gate konflux-ui-tests-gate shared-checks-gate; do
+          for job in gen-contracts checks unit-tests coverage-report storybook-build test-build frontend-checks-gate test-compose-e2e konflux-frontend-gate konflux-ui-tests-gate shared-checks-gate; do
             case "$job" in
               gen-contracts)           result="${{ needs.gen-contracts.result }}" ;;
               checks)                  result="${{ needs.checks.result }}" ;;
@@ -672,6 +687,7 @@ jobs:
               coverage-report)         result="${{ needs.coverage-report.result }}" ;;
               storybook-build)         result="${{ needs.storybook-build.result }}" ;;
               test-build)              result="${{ needs.test-build.result }}" ;;
+              frontend-checks-gate)    result="${{ needs.frontend-checks-gate.result }}" ;;
               test-compose-e2e)        result="${{ needs.test-compose-e2e.result }}" ;;
               konflux-frontend-gate)   result="${{ needs.konflux-frontend-gate.result }}" ;;
               konflux-ui-tests-gate)   result="${{ needs.konflux-ui-tests-gate.result }}" ;;


### PR DESCRIPTION


## Summary
- Add `frontend-checks-gate` job that runs before expensive E2E tests
- E2E jobs now wait for lint and unit tests to pass before starting
- Fails fast and avoids 8-core runner costs when basic checks fail

## Changes
- **New job**: `frontend-checks-gate` depends on `checks` + `unit-tests`
- **Updated E2E jobs** to wait for gate:
  - `test-compose-e2e`
  - `konflux-frontend-gate`
  - `konflux-ui-tests-gate`
- Gate respects path filtering (skips when no frontend files changed)
- Other jobs (coverage, storybook, test-build) continue running in parallel with E2E

## Expected Impact
- **Cost savings**: Skip ~2 hours of 8-core runner time per failed lint/unit test
- **Time to failure**: Fail in ~2-3 min instead of waiting for full E2E suite
- **E2E start delay**: Adds ~2-3 min wait before E2E starts (only when checks pass)

## Test Plan
- [x] Verify job graph shows correct dependencies in Actions UI
- [ ] Confirm E2E jobs skip when lint/unit tests fail
- [ ] Confirm E2E jobs run when lint/unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)