### PR TITLE
DO NOT MERGE: chore(ci): hide outdated Konflux PR comments

### DIFF
--- a/.github/workflows/check-contract-drift.yml
+++ b/.github/workflows/check-contract-drift.yml
@@ -6,15 +6,6 @@ on:
   push:
     branches: [devel, early-access]
   workflow_dispatch:
-    inputs:
-      # TEMPORARY validation input — remove before merging
-      # chore/hide-outdated-konflux-comments. Leave empty for a normal drift check.
-      pr_number:
-        description: >-
-          DO NOT MERGE scaffold. PR number whose outdated Konflux Test Results
-          comments should be hidden. Empty = normal contract-drift check.
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -25,7 +16,6 @@ env:
 jobs:
   check-drift:
     name: Check Contract Drift
-    if: github.event_name != 'workflow_dispatch' || inputs.pr_number == ''
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -56,155 +46,3 @@ jobs:
             git diff frontend/packages/syntara-contracts/src/
             exit 1
           fi
-
-  # -------------------------------------------------------------------------
-  # TEMPORARY — DO NOT MERGE this job.
-  # Validation scaffold: Check Contract Drift already exists on devel with
-  # workflow_dispatch, so we can run THIS BRANCH's copy with GITHUB_TOKEN:
-  #
-  #   gh workflow run check-contract-drift.yml \
-  #     --ref chore/hide-outdated-konflux-comments \
-  #     -f pr_number=284
-  #
-  # Same GraphQL minimizeComment logic as hide-outdated-konflux-comments.yml.
-  # Delete this job and the pr_number input before merge.
-  # -------------------------------------------------------------------------
-  hide-outdated-konflux-comments:
-    name: TEMPORARY Hide outdated Konflux comments
-    if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Minimize older Konflux Test Results comments
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
-        env:
-          PR_NUMBER: ${{ inputs.pr_number }}
-        with:
-          script: |
-            const KONFLUX_BOT = 'orchestrator-konflux-ci';
-            const LIST_QUERY = `
-              query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
-                repository(owner: $owner, name: $name) {
-                  pullRequest(number: $number) {
-                    comments(first: 100, after: $cursor) {
-                      nodes {
-                        id
-                        author { login }
-                        body
-                        isMinimized
-                        createdAt
-                      }
-                      pageInfo { hasNextPage endCursor }
-                    }
-                  }
-                }
-              }
-            `;
-            const MINIMIZE_MUTATION = `
-              mutation($id: ID!) {
-                minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
-                  minimizedComment { isMinimized }
-                }
-              }
-            `;
-
-            function normalizeLogin(login) {
-              return (login || '').replace(/\[bot\]$/i, '');
-            }
-
-            function classifySuite(body) {
-              if (!body || !body.includes('Test Results')) {
-                return 'unknown';
-              }
-              if (/\.spec\.ts\b/.test(body)) {
-                return 'ui';
-              }
-              if (/\btests\.[A-Za-z0-9_.]+/.test(body)) {
-                return 'api';
-              }
-              const match = body.match(/\|\s*Total Tests\s*\|\s*(\d+)\s*\|/);
-              if (!match) {
-                return 'unknown';
-              }
-              const total = Number(match[1]);
-              if (total <= 550) {
-                return 'api';
-              }
-              if (total >= 650) {
-                return 'ui';
-              }
-              return 'unknown';
-            }
-
-            async function listComments(owner, name, number) {
-              const comments = [];
-              let cursor = null;
-              for (;;) {
-                const data = await github.graphql(LIST_QUERY, {
-                  owner,
-                  name,
-                  number,
-                  cursor,
-                });
-                const pr = data.repository && data.repository.pullRequest;
-                if (!pr) {
-                  throw new Error(`Pull request #${number} not found`);
-                }
-                comments.push(...pr.comments.nodes);
-                if (!pr.comments.pageInfo.hasNextPage) {
-                  return comments;
-                }
-                cursor = pr.comments.pageInfo.endCursor;
-              }
-            }
-
-            const prNumber = parseInt(process.env.PR_NUMBER, 10);
-            if (!Number.isInteger(prNumber) || prNumber < 1) {
-              core.setFailed(`Invalid PR number: ${process.env.PR_NUMBER}`);
-              return;
-            }
-
-            const { owner, repo } = context.repo;
-            const comments = await listComments(owner, repo, prNumber);
-            const bySuite = { api: [], ui: [] };
-
-            for (const comment of comments) {
-              const login = comment.author && comment.author.login;
-              if (normalizeLogin(login) !== KONFLUX_BOT) {
-                continue;
-              }
-              const suite = classifySuite(comment.body);
-              if (suite !== 'api' && suite !== 'ui') {
-                continue;
-              }
-              bySuite[suite].push(comment);
-            }
-
-            let minimized = 0;
-            for (const [suite, suiteComments] of Object.entries(bySuite)) {
-              suiteComments.sort(
-                (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
-              );
-              const [latest, ...older] = suiteComments;
-              if (latest) {
-                console.log(
-                  `Keeping latest ${suite} comment ${latest.id} (${latest.createdAt})`,
-                );
-              }
-              for (const comment of older) {
-                if (comment.isMinimized) {
-                  console.log(`Already minimized ${suite} comment ${comment.id}`);
-                  continue;
-                }
-                console.log(
-                  `Minimizing outdated ${suite} comment ${comment.id} (${comment.createdAt})`,
-                );
-                await github.graphql(MINIMIZE_MUTATION, { id: comment.id });
-                minimized += 1;
-              }
-            }
-
-            console.log(
-              `Minimized ${minimized} outdated Konflux comment(s) on PR #${prNumber}`,
-            );

--- a/.github/workflows/hide-outdated-konflux-comments.yml
+++ b/.github/workflows/hide-outdated-konflux-comments.yml
@@ -1,85 +1,47 @@
----
-name: Check Contract Drift
+# Collapse older Konflux Test Results PR comments, keeping the latest API
+# result and the latest UI result visible.
+#
+# orchestrator-konflux-ci[bot] posts a new comment on every Konflux test run
+# (from report-trusted-artifact-tests-as-comment-in-pr). This workflow does
+# not check out PR code; it only calls the GraphQL minimizeComment mutation.
+#
+# issue_comment workflows always run from the default branch. Use
+# workflow_dispatch to backfill a PR after this lands on devel.
+name: Hide Outdated Konflux Comments
 
 on:
-  pull_request:
-  push:
-    branches: [devel, early-access]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
-      # TEMPORARY validation input — remove before merging
-      # chore/hide-outdated-konflux-comments. Leave empty for a normal drift check.
       pr_number:
-        description: >-
-          DO NOT MERGE scaffold. PR number whose outdated Konflux Test Results
-          comments should be hidden. Empty = normal contract-drift check.
-        required: false
+        description: Pull request number to backfill
+        required: true
         type: string
 
 permissions:
-  contents: read
+  pull-requests: write
 
-env:
-  NODE_VERSION: '22.13.0'
+concurrency:
+  group: hide-konflux-comments-${{ github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: false
 
 jobs:
-  check-drift:
-    name: Check Contract Drift
-    if: github.event_name != 'workflow_dispatch' || inputs.pr_number == ''
+  hide:
+    name: Hide outdated comments
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.issue.pull_request &&
+        github.event.comment.user.login == 'orchestrator-konflux-ci[bot]' &&
+        contains(github.event.comment.body, 'Test Results')
+      )
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        working-directory: frontend
-        run: npm ci
-
-      - name: Regenerate contracts
-        working-directory: frontend
-        run: npm run gen
-        timeout-minutes: 10
-
-      - name: Check for drift
-        run: |
-          if git diff --quiet frontend/packages/syntara-contracts/src/; then
-            echo "No contract drift detected."
-          else
-            echo "::error::Generated contracts are out of date. Run 'make gen-contracts' and commit the result."
-            git diff --stat frontend/packages/syntara-contracts/src/
-            git diff frontend/packages/syntara-contracts/src/
-            exit 1
-          fi
-
-  # -------------------------------------------------------------------------
-  # TEMPORARY — DO NOT MERGE this job.
-  # Validation scaffold: Check Contract Drift already exists on devel with
-  # workflow_dispatch, so we can run THIS BRANCH's copy with GITHUB_TOKEN:
-  #
-  #   gh workflow run check-contract-drift.yml \
-  #     --ref chore/hide-outdated-konflux-comments \
-  #     -f pr_number=284
-  #
-  # Same GraphQL minimizeComment logic as hide-outdated-konflux-comments.yml.
-  # Delete this job and the pr_number input before merge.
-  # -------------------------------------------------------------------------
-  hide-outdated-konflux-comments:
-    name: TEMPORARY Hide outdated Konflux comments
-    if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Minimize older Konflux Test Results comments
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
         with:
           script: |
             const KONFLUX_BOT = 'orchestrator-konflux-ci';

--- a/.github/workflows/hide-outdated-konflux-comments.yml
+++ b/.github/workflows/hide-outdated-konflux-comments.yml
@@ -1,3 +1,4 @@
+---
 # Collapse older Konflux Test Results PR comments, keeping the latest API
 # result and the latest UI result visible.
 #


### PR DESCRIPTION
## DO NOT MERGE

**Never merge this PR.** It was a validation vehicle for hiding outdated Konflux Test Results comments. The Check Contract Drift scaffold has been removed after a successful live run.

## Validation (done)

Dispatched this branch’s hide job via Check Contract Drift (before the scaffold was deleted):

https://github.com/syntara-orchestration/syntara/actions/runs/32505001779

Against https://github.com/syntara-orchestration/syntara/pull/284:

| Check | Result |
| --- | --- |
| Before | 20 Konflux Test Results comments, 0 minimized |
| After | 18 minimized as Outdated; 2 left visible |
| Latest API | still expanded (470 tests, 2026-08-21T14:47:26Z) |
| Latest UI | still expanded (711 tests, 2026-08-21T15:00:20Z) |
| Other comments | SonarCloud comments not minimized |
| Token | Actions `GITHUB_TOKEN` + `pull-requests: write` can `minimizeComment` on `orchestrator-konflux-ci[bot]` |

## Remaining file (not for merge here)

- `.github/workflows/hide-outdated-konflux-comments.yml` — `issue_comment` (bot + `Test Results`) and `workflow_dispatch` (`pr_number`)

`issue_comment` workflows only run from `devel`. A follow-up PR that *is* intended for merge would add that file alone.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Out of Scope

- Merging this PR
- Changing `aap-konflux-pipelines` / the reporter to add HTML suite markers

## How to Test

Do not re-run the Check Contract Drift piggyback; it is gone. After a *different* PR merges the standalone workflow to `devel`:

```bash
gh workflow run hide-outdated-konflux-comments.yml \
  --repo syntara-orchestration/syntara \
  -f pr_number=<n>
```

## Additional Notes

yamlfmt failed on the first commit (`---` document start missing). Fixed in `3166948e0`. Pre-commit is green on that SHA.