### PR TITLE
fix(approvals): close race between execution cancellation and approval decisions

### DIFF
--- a/backend/src/syntara/approvals/services/approval_service.py
+++ b/backend/src/syntara/approvals/services/approval_service.py
@@ -757,8 +757,12 @@ class ApprovalService(BaseService):
 
         Callers that perform a further, potentially-failing step as part of the
         same logical cancel operation (e.g. asking Temporal to cancel the
-        workflow) should pass the returned approvals to ``reopen_cancelled()``
-        if that later step fails, since this call commits immediately.
+        workflow) should not treat this call as the end of the operation: this
+        commits immediately, but does NOT dispatch audit events. Call
+        ``dispatch_cancelled_events()`` once that later step succeeds, or
+        ``reopen_cancelled()`` if it fails — dispatching here, before the
+        outcome is known, would record a permanent "cancelled" audit event even
+        for a cancellation that gets reverted.
 
         Args:
             execution_id: Execution whose pending approvals should be cancelled
@@ -786,19 +790,36 @@ class ApprovalService(BaseService):
 
         await self.session.commit()
 
-        for approval in approvals:
-            self._dispatch_decided_event(approval, ApprovalRequestStatus.CANCELLED.value, decided_at, notes)
-
         return approvals
+
+    def dispatch_cancelled_events(self, approvals: Sequence[ApprovalRequest]) -> None:
+        """Dispatch audit events for approvals ``cancel_pending_for_execution()`` cancelled.
+
+        Call only once the caller's own later step (e.g. the Temporal RPC) has
+        actually succeeded, so the audit trail never records a cancellation
+        that was subsequently reverted via ``reopen_cancelled()``.
+
+        Args:
+            approvals: Approvals previously returned by cancel_pending_for_execution()
+
+        """
+        for approval in approvals:
+            assert approval.decided_at is not None  # noqa: S101 -- set by cancel_pending_for_execution
+            self._dispatch_decided_event(
+                approval, ApprovalRequestStatus.CANCELLED.value, approval.decided_at, approval.decision_notes
+            )
 
     async def reopen_cancelled(self, approvals: Sequence[ApprovalRequest]) -> None:
         """Revert approvals that ``cancel_pending_for_execution()`` just cancelled.
 
         Compensation for when a later step in the same logical cancel operation
         (the Temporal RPC) failed, so the execution was never actually
-        cancelled. Only reverts rows still exactly as that call left them; a
-        concurrent decision can't have landed in between since ``decide()``
-        requires status=PENDING, which was no longer true once cancelled.
+        cancelled. Only reverts rows matching the exact cancellation fingerprint
+        (status, decided_by, decided_at, decision_notes) that call left behind,
+        so an unrelated cancellation of the same row in between is never
+        clobbered. A concurrent decision can't have landed in between anyway,
+        since ``decide()`` requires status=PENDING, which was no longer true
+        once cancelled.
 
         Args:
             approvals: Approvals previously returned by cancel_pending_for_execution()
@@ -807,11 +828,15 @@ class ApprovalService(BaseService):
         if not approvals:
             return
 
+        fingerprint = approvals[0]
         approval_ids = [approval.id for approval in approvals]
         stmt = (
             update(ApprovalRequest)
             .where(ApprovalRequest.id.in_(approval_ids))  # type: ignore[attr-defined]
             .where(ApprovalRequest.status == ApprovalRequestStatus.CANCELLED)  # type: ignore[arg-type]
+            .where(ApprovalRequest.decided_by == fingerprint.decided_by)  # type: ignore[arg-type]
+            .where(ApprovalRequest.decided_at == fingerprint.decided_at)  # type: ignore[arg-type]
+            .where(ApprovalRequest.decision_notes == fingerprint.decision_notes)  # type: ignore[arg-type]
             .values(status=ApprovalRequestStatus.PENDING, decided_by=None, decided_at=None, decision_notes=None)
         )
         await self.session.exec(stmt)

--- a/backend/src/syntara/approvals/services/approval_service.py
+++ b/backend/src/syntara/approvals/services/approval_service.py
@@ -606,6 +606,30 @@ class ApprovalService(BaseService):
             deleted_by=self.user.id,
         )
 
+    def _dispatch_decided_event(
+        self,
+        approval: ApprovalRequest,
+        decision: str,
+        decided_at: datetime,
+        notes: str | None,
+    ) -> None:
+        """Dispatch the audit event for a decision (approve/reject/cancel) on an approval."""
+        decided = decided_at.replace(tzinfo=None)
+        created = approval.created_at.replace(tzinfo=None)
+        AuditEventDispatcher.dispatch(
+            ApprovalDecidedEvent(
+                approval_id=approval.id,
+                execution_id=approval.execution_id,
+                approval_node_id=approval.approval_node_id,
+                decision=decision,
+                decided_by=self.user.id,
+                decided_at=decided_at,
+                wait_time_ms=int((decided - created).total_seconds() * 1000),
+                decision_notes=notes,
+                principal_type=self.user.__dict__.get("__principal_type__"),
+            )
+        )
+
     async def decide(
         self,
         approval_id: UUID,
@@ -685,23 +709,7 @@ class ApprovalService(BaseService):
             decided_by=self.user.id,
         )
 
-        # Calculate wait time for audit event using the decided_at timestamp we set
-        decided = decided_at.replace(tzinfo=None)
-        created = approval.created_at.replace(tzinfo=None)
-        wait_time_ms = int((decided - created).total_seconds() * 1000)
-        AuditEventDispatcher.dispatch(
-            ApprovalDecidedEvent(
-                approval_id=approval_id,
-                execution_id=approval.execution_id,
-                approval_node_id=approval.approval_node_id,
-                decision=status_enum.value,
-                decided_by=self.user.id,
-                decided_at=decided_at,
-                wait_time_ms=wait_time_ms,
-                decision_notes=request.notes,
-                principal_type=self.user.__dict__.get("__principal_type__"),
-            )
-        )
+        self._dispatch_decided_event(approval, status_enum.value, decided_at, request.notes)
 
         # Send signal to workflow engine (best-effort, never blocks the response)
         signal_error: str | None = None
@@ -733,6 +741,86 @@ class ApprovalService(BaseService):
         response = cast("ApprovalRequestRead", self.convert_resource_mixin.convert_resource(approval))
         response.signal_delivery_error = signal_error
         return response
+
+    async def cancel_pending_for_execution(
+        self,
+        execution_id: UUID,
+        notes: str = "Workflow execution was cancelled",
+    ) -> Sequence[ApprovalRequest]:
+        """Atomically cancel every pending approval for an execution.
+
+        Row-locks pending approvals for this execution before updating, so a
+        decision that commits first always wins instead of being silently
+        overwritten by a slower, later cancellation (the race this method
+        exists to close: previously cancellation only happened asynchronously
+        via the workflow engine's best-effort activity).
+
+        Callers that perform a further, potentially-failing step as part of the
+        same logical cancel operation (e.g. asking Temporal to cancel the
+        workflow) should pass the returned approvals to ``reopen_cancelled()``
+        if that later step fails, since this call commits immediately.
+
+        Args:
+            execution_id: Execution whose pending approvals should be cancelled
+            notes: Decision note recorded on each cancelled approval
+
+        Returns:
+            The approvals that were cancelled
+
+        """
+        query = (
+            select(ApprovalRequest)
+            .where(ApprovalRequest.execution_id == execution_id)
+            .where(ApprovalRequest.status == ApprovalRequestStatus.PENDING)
+            .with_for_update()
+        )
+        result = await self.session.exec(query)
+        approvals = list(result.all())
+
+        decided_at = datetime.now(UTC)
+        for approval in approvals:
+            approval.status = ApprovalRequestStatus.CANCELLED
+            approval.decided_by = self.user.id
+            approval.decided_at = decided_at
+            approval.decision_notes = notes
+
+        await self.session.commit()
+
+        for approval in approvals:
+            self._dispatch_decided_event(approval, ApprovalRequestStatus.CANCELLED.value, decided_at, notes)
+
+        return approvals
+
+    async def reopen_cancelled(self, approvals: Sequence[ApprovalRequest]) -> None:
+        """Revert approvals that ``cancel_pending_for_execution()`` just cancelled.
+
+        Compensation for when a later step in the same logical cancel operation
+        (the Temporal RPC) failed, so the execution was never actually
+        cancelled. Only reverts rows still exactly as that call left them; a
+        concurrent decision can't have landed in between since ``decide()``
+        requires status=PENDING, which was no longer true once cancelled.
+
+        Args:
+            approvals: Approvals previously returned by cancel_pending_for_execution()
+
+        """
+        if not approvals:
+            return
+
+        approval_ids = [approval.id for approval in approvals]
+        stmt = (
+            update(ApprovalRequest)
+            .where(ApprovalRequest.id.in_(approval_ids))  # type: ignore[attr-defined]
+            .where(ApprovalRequest.status == ApprovalRequestStatus.CANCELLED)  # type: ignore[arg-type]
+            .values(status=ApprovalRequestStatus.PENDING, decided_by=None, decided_at=None, decision_notes=None)
+        )
+        await self.session.exec(stmt)
+        await self.session.commit()
+
+        logger.warning(
+            "Reverted approval cancellation after execution cancel failed to reach Temporal",
+            approval_ids=[str(approval_id) for approval_id in approval_ids],
+        )
 
     async def _process_single_decision(
         self,
@@ -807,22 +895,7 @@ class ApprovalService(BaseService):
             decided_by=self.user.id,
         )
 
-        decided = (approval.decided_at or datetime.now(UTC)).replace(tzinfo=None)
-        created = approval.created_at.replace(tzinfo=None)
-        wait_time_ms = int((decided - created).total_seconds() * 1000)
-        AuditEventDispatcher.dispatch(
-            ApprovalDecidedEvent(
-                approval_id=approval_id,
-                execution_id=approval.execution_id,
-                approval_node_id=approval.approval_node_id,
-                decision=status.value,
-                decided_by=self.user.id,
-                decided_at=approval.decided_at,
-                wait_time_ms=wait_time_ms,
-                decision_notes=notes,
-                principal_type=self.user.__dict__.get("__principal_type__"),
-            )
-        )
+        self._dispatch_decided_event(approval, status.value, approval.decided_at, notes)
 
         return BatchApprovalResult(
             approval_id=approval_id,

--- a/backend/src/syntara/workflows/services/execution_service.py
+++ b/backend/src/syntara/workflows/services/execution_service.py
@@ -18,6 +18,7 @@ from sqlmodel import and_, col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from temporalio.exceptions import ApplicationError
 
+from syntara.approvals.services.approval_service import ApprovalService
 from syntara.audit.dispatcher import AuditEventDispatcher
 from syntara.authz.engine import AllowedProjectsResult
 from syntara.core.config.base import get_settings
@@ -95,7 +96,7 @@ async def count_active_executions(session: "AsyncSession") -> int:
 class ExecutionsEnrichQueryMixin(EnrichQueryMixin):
     """Eager-load workflow and workflow_version relationships so list queries include the name and version number."""
 
-    def enrich(self, query: Select) -> Select:  # type: ignore[type-arg]
+    def enrich(self, query: Select) -> Select:
         """Add selectinload for workflow and workflow_version to the query.
 
         Only applies when the root entity is Execution (skips ActivityExecution queries).
@@ -1071,8 +1072,14 @@ class ExecutionService(BaseService):
     async def cancel_execution(self, execution_id: UUID) -> None:
         """Cancel a running workflow execution.
 
-        Requests Temporal to cancel the workflow. The actual status update
-        to CANCELLED happens asynchronously via activity_sync_service.
+        Requests Temporal to cancel the workflow; the execution's own status
+        update to CANCELLED happens asynchronously via activity_sync_service.
+        Any pending approval for this execution is cancelled synchronously,
+        before the Temporal RPC, so a decision request racing the cancellation
+        can't slip through: a decide() call from that point on either loses the
+        row lock race outright or finds the approval already cancelled. If the
+        Temporal RPC then fails, the cancellation is reverted so we don't leave
+        approvals cancelled for an execution that was never actually cancelled.
 
         Args:
             execution_id: Execution ID to cancel
@@ -1113,9 +1120,21 @@ class ExecutionService(BaseService):
             current_status=execution.status.value,
         )
 
+        approval_service = ApprovalService(self.session, self.user)
+        cancelled_approvals = await approval_service.cancel_pending_for_execution(execution_id)
+
         try:
             await self.temporal_service.cancel_workflow(temporal_workflow_id=execution.temporal_workflow_id)
         except Exception as exc:
+            try:
+                await approval_service.reopen_cancelled(cancelled_approvals)
+            except Exception:
+                logger.exception(
+                    "Failed to revert approval cancellation after failed Temporal cancel RPC; "
+                    "approvals may be incorrectly left cancelled",
+                    execution_id=execution_id,
+                    approval_ids=[str(approval.id) for approval in cancelled_approvals],
+                )
             self._emit_lifecycle_event(
                 execution_id=execution.id,
                 workflow_id=execution.workflow_id,

--- a/backend/src/syntara/workflows/services/execution_service.py
+++ b/backend/src/syntara/workflows/services/execution_service.py
@@ -96,7 +96,7 @@ async def count_active_executions(session: "AsyncSession") -> int:
 class ExecutionsEnrichQueryMixin(EnrichQueryMixin):
     """Eager-load workflow and workflow_version relationships so list queries include the name and version number."""
 
-    def enrich(self, query: Select) -> Select:
+    def enrich(self, query: Select) -> Select:  # type: ignore[type-arg]
         """Add selectinload for workflow and workflow_version to the query.
 
         Only applies when the root entity is Execution (skips ActivityExecution queries).
@@ -1081,6 +1081,16 @@ class ExecutionService(BaseService):
         Temporal RPC then fails, the cancellation is reverted so we don't leave
         approvals cancelled for an execution that was never actually cancelled.
 
+        This only closes the race for approvals still PENDING at the moment
+        cancellation is requested. If decide() already committed (e.g. the
+        execution was still RUNNING and got approved a moment before someone
+        requested cancellation), cancel_pending_for_execution() finds nothing
+        to cancel and the Temporal cancel proceeds regardless -- the execution
+        ends CANCELLED with an already-APPROVED approval. That's a distinct,
+        intentionally-allowed race (a decision made while genuinely running
+        stands even if the run is cancelled moments later), not the bug this
+        method fixes.
+
         Args:
             execution_id: Execution ID to cancel
 
@@ -1144,6 +1154,8 @@ class ExecutionService(BaseService):
                 error_type=type(exc).__name__,
             )
             raise
+
+        approval_service.dispatch_cancelled_events(cancelled_approvals)
 
         self._emit_lifecycle_event(
             execution_id=execution.id,

--- a/backend/tests/integration/approvals/test_approval_service.py
+++ b/backend/tests/integration/approvals/test_approval_service.py
@@ -848,6 +848,96 @@ class TestApprovalServiceDecide(TestApprovalServiceBase):
             assert approval.decided_by == test_user.id
 
 
+class TestApprovalServiceCancelPendingForExecution(TestApprovalServiceBase):
+    """Test ApprovalService.cancel_pending_for_execution method.
+
+    Regression coverage for AAP bug: a workflow execution could be cancelled
+    while its approval stayed pending long enough to still be approved/rejected,
+    leaving execution=cancelled and approval=approved permanently inconsistent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancels_only_pending_approvals_for_the_execution(
+        self,
+        test_db_session: AsyncSession,
+        test_user: User,
+        approvals_factory: ApprovalsFactory,
+        executions_factory: ExecutionsFactory,
+    ) -> None:
+        """Only PENDING approvals for the given execution are cancelled."""
+        service = self._create_test_service(test_db_session, test_user)
+
+        executions = await executions_factory.create_executions(count=1)
+        execution_id = executions[0].id
+
+        approvals = await approvals_factory.create_approvals(
+            count=3,
+            execution_id=execution_id,
+            statuses=[ApprovalRequestStatus.PENDING, ApprovalRequestStatus.APPROVED, ApprovalRequestStatus.PENDING],
+        )
+        pending_approval, already_approved, other_pending_approval = approvals
+
+        # Unrelated execution's pending approval must not be touched.
+        other_executions = await executions_factory.create_executions(count=1)
+        other_execution_approvals = await approvals_factory.create_pending_approvals(
+            count=1, execution_id=other_executions[0].id
+        )
+        unrelated_approval = other_execution_approvals[0]
+
+        cancelled = await service.cancel_pending_for_execution(execution_id)
+
+        assert len(cancelled) == 2
+
+        await test_db_session.refresh(pending_approval)
+        await test_db_session.refresh(other_pending_approval)
+        await test_db_session.refresh(already_approved)
+        await test_db_session.refresh(unrelated_approval)
+
+        assert pending_approval.status == ApprovalRequestStatus.CANCELLED
+        assert pending_approval.decided_by == test_user.id
+        assert pending_approval.decided_at is not None
+        assert pending_approval.decision_notes == "Workflow execution was cancelled"
+
+        assert other_pending_approval.status == ApprovalRequestStatus.CANCELLED
+
+        # Already-decided approval is left exactly as it was.
+        assert already_approved.status == ApprovalRequestStatus.APPROVED
+
+        # Pending approval on a different execution is untouched.
+        assert unrelated_approval.status == ApprovalRequestStatus.PENDING
+
+    @pytest.mark.asyncio
+    async def test_reopen_cancelled_reverts_to_pending(
+        self,
+        test_db_session: AsyncSession,
+        test_user: User,
+        approvals_factory: ApprovalsFactory,
+        executions_factory: ExecutionsFactory,
+    ) -> None:
+        """reopen_cancelled undoes cancel_pending_for_execution, restoring PENDING.
+
+        Used when a later step in the same logical cancel operation (the
+        Temporal RPC) fails, so the execution was never actually cancelled.
+        """
+        service = self._create_test_service(test_db_session, test_user)
+
+        executions = await executions_factory.create_executions(count=1)
+        execution_id = executions[0].id
+        approvals = await approvals_factory.create_pending_approvals(count=2, execution_id=execution_id)
+
+        cancelled = await service.cancel_pending_for_execution(execution_id)
+        assert len(cancelled) == 2
+
+        await service.reopen_cancelled(cancelled)
+
+        for approval in approvals:
+            await test_db_session.refresh(approval)
+            assert approval.status == ApprovalRequestStatus.PENDING
+            assert approval.decided_by is None
+            assert approval.decided_at is None
+            assert approval.decision_notes is None
+
+
 class TestApprovalServiceBatchDecide(TestApprovalServiceBase):
     """Test ApprovalService.batch_decide method."""
 

--- a/backend/tests/integration/approvals/test_approval_service.py
+++ b/backend/tests/integration/approvals/test_approval_service.py
@@ -9,6 +9,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
+from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from syntara.approvals.audit.approval import (
@@ -907,6 +908,56 @@ class TestApprovalServiceCancelPendingForExecution(TestApprovalServiceBase):
         assert unrelated_approval.status == ApprovalRequestStatus.PENDING
 
     @pytest.mark.asyncio
+    async def test_does_not_dispatch_audit_events(
+        self,
+        test_db_session: AsyncSession,
+        test_user: User,
+        approvals_factory: ApprovalsFactory,
+        executions_factory: ExecutionsFactory,
+    ) -> None:
+        """cancel_pending_for_execution() defers audit dispatch to the caller.
+
+        Dispatching immediately would record a permanent "cancelled" audit
+        event even if the caller's later step (the Temporal RPC) fails and the
+        cancellation is reverted via reopen_cancelled().
+        """
+        service = self._create_test_service(test_db_session, test_user)
+
+        executions = await executions_factory.create_executions(count=1)
+        execution_id = executions[0].id
+        await approvals_factory.create_pending_approvals(count=1, execution_id=execution_id)
+
+        with patch("syntara.approvals.services.approval_service.AuditEventDispatcher.dispatch") as mock_dispatch:
+            cancelled = await service.cancel_pending_for_execution(execution_id)
+
+        assert len(cancelled) == 1
+        mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_cancelled_events_records_audit_event(
+        self,
+        test_db_session: AsyncSession,
+        test_user: User,
+        approvals_factory: ApprovalsFactory,
+        executions_factory: ExecutionsFactory,
+    ) -> None:
+        """dispatch_cancelled_events() records the audit event cancel_pending_for_execution() withheld."""
+        service = self._create_test_service(test_db_session, test_user)
+
+        executions = await executions_factory.create_executions(count=1)
+        execution_id = executions[0].id
+        await approvals_factory.create_pending_approvals(count=2, execution_id=execution_id)
+
+        cancelled = await service.cancel_pending_for_execution(execution_id)
+
+        with patch("syntara.approvals.services.approval_service.AuditEventDispatcher.dispatch") as mock_dispatch:
+            service.dispatch_cancelled_events(cancelled)
+
+        assert mock_dispatch.call_count == 2
+        dispatched_decisions = {call.args[0].decision for call in mock_dispatch.call_args_list}
+        assert dispatched_decisions == {"cancelled"}
+
+    @pytest.mark.asyncio
     async def test_reopen_cancelled_reverts_to_pending(
         self,
         test_db_session: AsyncSession,
@@ -936,6 +987,59 @@ class TestApprovalServiceCancelPendingForExecution(TestApprovalServiceBase):
             assert approval.decided_by is None
             assert approval.decided_at is None
             assert approval.decision_notes is None
+
+    @pytest.mark.asyncio
+    async def test_reopen_cancelled_ignores_row_with_mismatched_fingerprint(
+        self,
+        test_db_session: AsyncSession,
+        test_user: User,
+        approvals_factory: ApprovalsFactory,
+        executions_factory: ExecutionsFactory,
+    ) -> None:
+        """reopen_cancelled() only reverts rows matching the exact cancel fingerprint.
+
+        If the row was re-cancelled by something else (different decided_by/
+        decided_at/notes) in between, a stale approvals list must not clobber
+        that unrelated cancellation.
+        """
+        service = self._create_test_service(test_db_session, test_user)
+
+        executions = await executions_factory.create_executions(count=1)
+        execution_id = executions[0].id
+        await approvals_factory.create_pending_approvals(count=1, execution_id=execution_id)
+
+        cancelled = await service.cancel_pending_for_execution(execution_id)
+        assert len(cancelled) == 1
+        approval = cancelled[0]
+
+        # Simulate another actor re-cancelling the same row with a different
+        # fingerprint via a raw, non-ORM UPDATE, so the `cancelled` list (still
+        # in the session identity map) keeps holding the original, now-stale
+        # fingerprint instead of getting auto-synced to the new values.
+        # decided_by is FK-constrained to an existing principal, so reuse
+        # test_user.id -- the differing decided_at/notes alone are enough to
+        # make the fingerprint not match.
+        other_decided_at = datetime.now(UTC) + timedelta(seconds=1)
+        await test_db_session.execute(
+            text(
+                "UPDATE approval_requests "
+                "SET decided_by = :decided_by, decided_at = :decided_at, decision_notes = :notes "
+                "WHERE id = :approval_id"
+            ),
+            {
+                "decided_by": str(test_user.id),
+                "decided_at": other_decided_at,
+                "notes": "Cancelled for a different reason",
+                "approval_id": str(approval.id),
+            },
+        )
+        await test_db_session.commit()
+
+        await service.reopen_cancelled(cancelled)
+
+        await test_db_session.refresh(approval)
+        assert approval.status == ApprovalRequestStatus.CANCELLED
+        assert approval.decision_notes == "Cancelled for a different reason"
 
 
 class TestApprovalServiceBatchDecide(TestApprovalServiceBase):

--- a/backend/tests/unit/approvals/test_approval_concurrency.py
+++ b/backend/tests/unit/approvals/test_approval_concurrency.py
@@ -112,10 +112,10 @@ def _make_user(prefix: str = "user") -> User:
     )
 
 
-def _make_approval(project_id: UUID, node_id: str = "test_node") -> ApprovalRequest:
+def _make_approval(project_id: UUID, node_id: str = "test_node", execution_id: UUID | None = None) -> ApprovalRequest:
     """Build a pending ApprovalRequest for committed setup sessions."""
     return ApprovalRequest(
-        execution_id=uuid4(),
+        execution_id=execution_id if execution_id is not None else uuid4(),
         approval_node_id=node_id,
         project_id=project_id,
         name=f"Test Approval {node_id}",
@@ -150,6 +150,7 @@ async def _concurrency_data(
     *,
     user_count: int = 2,
     approval_count: int = 1,
+    execution_id: UUID | None = None,
 ) -> AsyncIterator[tuple[list[UUID], list[UUID]]]:
     """Commit project/users/approvals visible across sessions; delete them on exit.
 
@@ -165,7 +166,9 @@ async def _concurrency_data(
         session.add_all(users)
         await session.flush()
 
-        approvals = [_make_approval(project.id, node_id=f"node_{i}") for i in range(approval_count)]
+        approvals = [
+            _make_approval(project.id, node_id=f"node_{i}", execution_id=execution_id) for i in range(approval_count)
+        ]
         session.add_all(approvals)
         await session.commit()
 
@@ -196,6 +199,19 @@ async def _decide_with_own_session(
         assert user is not None
         service = ApprovalService(session, user)
         return await service.decide(approval_id, decision)
+
+
+async def _cancel_pending_with_own_session(
+    session_factory: async_sessionmaker[AsyncSession],
+    user_id: UUID,
+    execution_id: UUID,
+) -> list[ApprovalRequest]:
+    """Run cancel_pending_for_execution() on a dedicated session."""
+    async with session_factory() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        service = ApprovalService(session, user)
+        return await service.cancel_pending_for_execution(execution_id)
 
 
 async def _batch_decide_with_own_session(
@@ -317,6 +333,56 @@ async def test_concurrent_decision_and_list_no_deadlock(
     assert len(results) == 2
     assert not isinstance(results[0], Exception), f"Decision failed: {results[0]}"
     assert not isinstance(results[1], Exception), f"List failed: {results[1]}"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_execution_cancel_and_decide_only_one_succeeds(
+    test_session_factory: async_sessionmaker[AsyncSession],
+    mock_workflow_client: AsyncMock,
+) -> None:
+    """Test that racing execution-cancel against decide() never leaves both applied.
+
+    Regression test for the bug where a cancelled execution could still end up
+    with an approved approval: cancel_pending_for_execution() and decide() must
+    contend for the same row so exactly one of them wins, never both.
+    """
+    execution_id = uuid4()
+    async with _concurrency_data(test_session_factory, user_count=2, approval_count=1, execution_id=execution_id) as (
+        user_ids,
+        approval_ids,
+    ):
+        approval_id = approval_ids[0]
+
+        results = await asyncio.gather(
+            _cancel_pending_with_own_session(test_session_factory, user_ids[0], execution_id),
+            _decide_with_own_session(
+                test_session_factory,
+                user_ids[1],
+                approval_id,
+                ApprovalDecisionRequest(status="approved", note="Racing the cancellation"),
+            ),
+            return_exceptions=True,
+        )
+        cancel_result, decide_result = results
+
+        assert not isinstance(cancel_result, Exception), f"Cancel should never raise: {cancel_result}"
+        cancel_won = len(cancel_result) == 1
+        decide_won = not isinstance(decide_result, Exception)
+        decide_lost = isinstance(decide_result, ApprovalAlreadyDecidedError)
+
+        assert cancel_won ^ decide_won, f"Exactly one path should decide the approval; got {results!r}"
+        if decide_won:
+            assert cancel_result == []
+        else:
+            assert decide_lost, f"Losing decide() should raise AlreadyDecided; got {decide_result!r}"
+
+        async with test_session_factory() as session:
+            approval = await session.get(ApprovalRequest, approval_id)
+            assert approval is not None
+            expected_status = ApprovalRequestStatus.CANCELLED if cancel_won else ApprovalRequestStatus.APPROVED
+            assert approval.status == expected_status
+            assert approval.decided_by is not None
+            assert approval.decided_at is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/approvals/test_approval_concurrency.py
+++ b/backend/tests/unit/approvals/test_approval_concurrency.py
@@ -37,7 +37,7 @@ from syntara.authz.models.project import Project
 from syntara.core.models import User
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Sequence
 
     from sqlalchemy.ext.asyncio import async_sessionmaker
     from sqlmodel.ext.asyncio.session import AsyncSession
@@ -205,7 +205,7 @@ async def _cancel_pending_with_own_session(
     session_factory: async_sessionmaker[AsyncSession],
     user_id: UUID,
     execution_id: UUID,
-) -> list[ApprovalRequest]:
+) -> Sequence[ApprovalRequest]:
     """Run cancel_pending_for_execution() on a dedicated session."""
     async with session_factory() as session:
         user = await session.get(User, user_id)
@@ -365,7 +365,7 @@ async def test_concurrent_execution_cancel_and_decide_only_one_succeeds(
         )
         cancel_result, decide_result = results
 
-        assert not isinstance(cancel_result, Exception), f"Cancel should never raise: {cancel_result}"
+        assert not isinstance(cancel_result, BaseException), f"Cancel should never raise: {cancel_result}"
         cancel_won = len(cancel_result) == 1
         decide_won = not isinstance(decide_result, Exception)
         decide_lost = isinstance(decide_result, ApprovalAlreadyDecidedError)

--- a/backend/tests/unit/workflows/services/test_execution_service_cancel.py
+++ b/backend/tests/unit/workflows/services/test_execution_service_cancel.py
@@ -1,6 +1,6 @@
 """Unit tests for ExecutionService.cancel_execution method."""
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
 import pytest
@@ -34,6 +34,20 @@ def _mock_session_returning(execution: Execution | None) -> AsyncSession:
     return mock_session
 
 
+def _patch_approval_service(cancelled: list[object] | None = None):  # noqa: ANN202
+    """Patch the ApprovalService used by cancel_execution to avoid a real DB call."""
+    mock_instance = Mock()
+    mock_instance.cancel_pending_for_execution = AsyncMock(return_value=cancelled if cancelled is not None else [])
+    mock_instance.reopen_cancelled = AsyncMock()
+    return (
+        patch(
+            "syntara.workflows.services.execution_service.ApprovalService",
+            return_value=mock_instance,
+        ),
+        mock_instance,
+    )
+
+
 class TestCancelExecution:
     """Test cancel_execution method."""
 
@@ -60,9 +74,13 @@ class TestCancelExecution:
             temporal_service=mock_temporal,
         )
 
-        await service.cancel_execution(execution.id)
+        patcher, mock_approval_service = _patch_approval_service()
+        with patcher:
+            await service.cancel_execution(execution.id)
 
         mock_temporal.cancel_workflow.assert_awaited_once_with(temporal_workflow_id=execution.temporal_workflow_id)
+        mock_approval_service.cancel_pending_for_execution.assert_awaited_once_with(execution.id)
+        mock_approval_service.reopen_cancelled.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cancel_execution_not_found(self) -> None:
@@ -148,5 +166,101 @@ class TestCancelExecution:
             temporal_service=mock_temporal,
         )
 
-        with pytest.raises(RPCError):
+        patcher, _mock_approval_service = _patch_approval_service()
+        with patcher, pytest.raises(RPCError):
             await service.cancel_execution(execution.id)
+
+    @pytest.mark.asyncio
+    async def test_cancel_execution_temporal_failure_reverts_approval_cancellation(self) -> None:
+        """A failed Temporal cancel RPC reverts the approvals that were just cancelled.
+
+        Guards against a partial state: leaving approvals cancelled for an
+        execution that Temporal never actually agreed to cancel.
+        """
+        execution = _make_execution(ExecutionStatus.RUNNING)
+        mock_session = _mock_session_returning(execution)
+        mock_user = Mock(spec=User)
+        mock_temporal = Mock(spec=TemporalExecutionService)
+        mock_temporal.cancel_workflow = AsyncMock(side_effect=RuntimeError("temporal unreachable"))
+
+        service = ExecutionService(
+            session=mock_session,
+            user=mock_user,
+            temporal_service=mock_temporal,
+        )
+
+        cancelled = [Mock()]
+        patcher, mock_approval_service = _patch_approval_service(cancelled=cancelled)
+        with patcher, pytest.raises(RuntimeError):
+            await service.cancel_execution(execution.id)
+
+        mock_approval_service.cancel_pending_for_execution.assert_awaited_once_with(execution.id)
+        mock_approval_service.reopen_cancelled.assert_awaited_once_with(cancelled)
+
+    @pytest.mark.asyncio
+    async def test_cancel_execution_original_error_survives_a_failed_revert(self) -> None:
+        """The original Temporal error propagates even if reopen_cancelled() itself fails.
+
+        If both the Temporal RPC and the compensating revert fail, the caller must
+        still see the Temporal failure (not the revert's), and approvals may be
+        left incorrectly cancelled -- but that's a logged, visible failure rather
+        than a silently swallowed one.
+        """
+        execution = _make_execution(ExecutionStatus.RUNNING)
+        mock_session = _mock_session_returning(execution)
+        mock_user = Mock(spec=User)
+        mock_temporal = Mock(spec=TemporalExecutionService)
+        mock_temporal.cancel_workflow = AsyncMock(side_effect=RuntimeError("temporal unreachable"))
+
+        service = ExecutionService(
+            session=mock_session,
+            user=mock_user,
+            temporal_service=mock_temporal,
+        )
+
+        patcher, mock_approval_service = _patch_approval_service(cancelled=[Mock()])
+        mock_approval_service.reopen_cancelled = AsyncMock(side_effect=RuntimeError("db unreachable during revert"))
+        with patcher, pytest.raises(RuntimeError, match="temporal unreachable"):
+            await service.cancel_execution(execution.id)
+
+    @pytest.mark.asyncio
+    async def test_cancel_execution_cancels_pending_approvals_before_temporal_rpc(self) -> None:
+        """cancel_execution cancels pending approvals before asking Temporal to cancel.
+
+        This closes the race window (AAP bug: cancelled execution + approved
+        approval) that previously existed while cancellation depended solely on
+        the workflow engine's async, best-effort cleanup activity, or on a
+        synchronous cancel issued only after the Temporal RPC returned.
+        """
+        execution = _make_execution(ExecutionStatus.RUNNING)
+        mock_session = _mock_session_returning(execution)
+        mock_user = Mock(spec=User)
+        mock_temporal = Mock(spec=TemporalExecutionService)
+
+        call_order: list[str] = []
+        cancelled = [Mock()]
+
+        async def _fake_cancel_pending_for_execution(_execution_id: object) -> list[object]:
+            call_order.append("cancel_approvals")
+            return cancelled
+
+        async def _fake_temporal_cancel(**_kwargs: object) -> None:
+            call_order.append("temporal_cancel")
+
+        mock_temporal.cancel_workflow = AsyncMock(side_effect=_fake_temporal_cancel)
+
+        service = ExecutionService(
+            session=mock_session,
+            user=mock_user,
+            temporal_service=mock_temporal,
+        )
+
+        patcher, mock_approval_service = _patch_approval_service(cancelled=cancelled)
+        mock_approval_service.cancel_pending_for_execution.side_effect = _fake_cancel_pending_for_execution
+        with patcher as mock_approval_service_cls:
+            await service.cancel_execution(execution.id)
+
+        mock_approval_service_cls.assert_called_once_with(mock_session, mock_user)
+        mock_approval_service.cancel_pending_for_execution.assert_awaited_once_with(execution.id)
+        mock_approval_service.reopen_cancelled.assert_not_awaited()
+        assert call_order == ["cancel_approvals", "temporal_cancel"]

--- a/backend/tests/unit/workflows/services/test_execution_service_cancel.py
+++ b/backend/tests/unit/workflows/services/test_execution_service_cancel.py
@@ -1,5 +1,6 @@
 """Unit tests for ExecutionService.cancel_execution method."""
 
+from collections.abc import Sequence
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
@@ -34,11 +35,12 @@ def _mock_session_returning(execution: Execution | None) -> AsyncSession:
     return mock_session
 
 
-def _patch_approval_service(cancelled: list[object] | None = None):  # noqa: ANN202
+def _patch_approval_service(cancelled: Sequence[object] | None = None):  # noqa: ANN202
     """Patch the ApprovalService used by cancel_execution to avoid a real DB call."""
     mock_instance = Mock()
     mock_instance.cancel_pending_for_execution = AsyncMock(return_value=cancelled if cancelled is not None else [])
     mock_instance.reopen_cancelled = AsyncMock()
+    mock_instance.dispatch_cancelled_events = Mock()
     return (
         patch(
             "syntara.workflows.services.execution_service.ApprovalService",
@@ -81,6 +83,7 @@ class TestCancelExecution:
         mock_temporal.cancel_workflow.assert_awaited_once_with(temporal_workflow_id=execution.temporal_workflow_id)
         mock_approval_service.cancel_pending_for_execution.assert_awaited_once_with(execution.id)
         mock_approval_service.reopen_cancelled.assert_not_awaited()
+        mock_approval_service.dispatch_cancelled_events.assert_called_once_with([])
 
     @pytest.mark.asyncio
     async def test_cancel_execution_not_found(self) -> None:
@@ -196,6 +199,7 @@ class TestCancelExecution:
 
         mock_approval_service.cancel_pending_for_execution.assert_awaited_once_with(execution.id)
         mock_approval_service.reopen_cancelled.assert_awaited_once_with(cancelled)
+        mock_approval_service.dispatch_cancelled_events.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_cancel_execution_original_error_survives_a_failed_revert(self) -> None:
@@ -223,6 +227,8 @@ class TestCancelExecution:
         with patcher, pytest.raises(RuntimeError, match="temporal unreachable"):
             await service.cancel_execution(execution.id)
 
+        mock_approval_service.dispatch_cancelled_events.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_cancel_execution_cancels_pending_approvals_before_temporal_rpc(self) -> None:
         """cancel_execution cancels pending approvals before asking Temporal to cancel.
@@ -238,7 +244,7 @@ class TestCancelExecution:
         mock_temporal = Mock(spec=TemporalExecutionService)
 
         call_order: list[str] = []
-        cancelled = [Mock()]
+        cancelled: list[object] = [Mock()]
 
         async def _fake_cancel_pending_for_execution(_execution_id: object) -> list[object]:
             call_order.append("cancel_approvals")
@@ -257,10 +263,14 @@ class TestCancelExecution:
 
         patcher, mock_approval_service = _patch_approval_service(cancelled=cancelled)
         mock_approval_service.cancel_pending_for_execution.side_effect = _fake_cancel_pending_for_execution
+        mock_approval_service.dispatch_cancelled_events = Mock(
+            side_effect=lambda *_: call_order.append("dispatch_events")
+        )
         with patcher as mock_approval_service_cls:
             await service.cancel_execution(execution.id)
 
         mock_approval_service_cls.assert_called_once_with(mock_session, mock_user)
         mock_approval_service.cancel_pending_for_execution.assert_awaited_once_with(execution.id)
         mock_approval_service.reopen_cancelled.assert_not_awaited()
-        assert call_order == ["cancel_approvals", "temporal_cancel"]
+        mock_approval_service.dispatch_cancelled_events.assert_called_once_with(cancelled)
+        assert call_order == ["cancel_approvals", "temporal_cancel", "dispatch_events"]


### PR DESCRIPTION
## Summary
- A cancelled workflow execution could still end up with an approved (or rejected) approval if the decision request raced the execution cancel — cancellation only marked the approval `CANCELLED` asynchronously via the workflow engine's best-effort cleanup activity, leaving a window where a decision could legitimately land against a still-`PENDING` row.
- `ExecutionService.cancel_execution()` now synchronously cancels pending approvals for the execution (row-locked, same `WHERE status=PENDING` guard `decide()` already uses) *before* asking Temporal to cancel the workflow, closing that window.
- If the Temporal RPC then fails, the cancellation is reverted (`reopen_cancelled`) so approvals aren't left cancelled for an execution that was never actually cancelled. If the revert itself fails, the original error still propagates and the partial state is logged rather than silently swallowed.
- Extracted a shared `_dispatch_decided_event` helper to remove duplication across `decide()`, `_process_single_decision()`, and the new `cancel_pending_for_execution()`.

## Test plan
- [x] New unit tests for `ExecutionService.cancel_execution` covering ordering (approvals cancelled before the Temporal RPC), the revert-on-failure path, and that the original error still propagates if the revert itself fails.
- [x] New concurrency regression test (`test_approval_concurrency.py`) that races `cancel_pending_for_execution()` against `decide()` on the same approval and asserts exactly one wins, never both.
- [x] New direct correctness tests for `cancel_pending_for_execution()` / `reopen_cancelled()` (only-pending approvals touched, other approvals/executions untouched, revert restores `PENDING`).
- [x] Verified live against a deployed cluster: repeated concurrent cancel-vs-approve requests (6 trials) all correctly return 409 with consistent `execution=cancelled` / `approval=cancelled` state; a normal non-racing approve still completes the workflow successfully.
- [x] `ruff check`, `ruff format`, and `mypy` all clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)