### PR TITLE
chore(deps): update ao-api-tests and ao-ui-tests bundle digests

### DIFF
--- a/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:e9dff52d3b10939e74f7c0c4b35f1b783e8cdea938f1ea3f152704c44beb0b0c
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:49b2f917b06da9814d7b878e87f7de81ce92e7bb009f5bcaff31235dedf65e4a
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-api-tests-early-access-pull-request.yaml
+++ b/.tekton/automation-orchestrator-api-tests-early-access-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:e9dff52d3b10939e74f7c0c4b35f1b783e8cdea938f1ea3f152704c44beb0b0c
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:49b2f917b06da9814d7b878e87f7de81ce92e7bb009f5bcaff31235dedf65e4a
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:3c666a8f77c6e29c428ed6d31400ca9b76a56ceaebd3e402457560ec20ff2506
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:8490d57cc4f9f03ec4102621462426ae32214d76373d061045a4a45857cfcf50
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-ui-tests-early-access-pull-request.yaml
+++ b/.tekton/automation-orchestrator-ui-tests-early-access-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:3c666a8f77c6e29c428ed6d31400ca9b76a56ceaebd3e402457560ec20ff2506
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:8490d57cc4f9f03ec4102621462426ae32214d76373d061045a4a45857cfcf50
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
Pick up the kernel log collection added in
https://github.com/ansible-automation-platform/aap-konflux-pipelines/pull/3343

The collect-kubernetes-logs-on-failure task now also captures host VM
dmesg output (OOM killer events). This gives us definitive evidence
when pod crashes are caused by memory exhaustion on the 32 GiB Kind
cluster nodes, instead of having to infer OOM from indirect signals.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
