### PR TITLE
fix(AAP-89065): Add duplicate workflow action to builder toolbar

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, toAppUrl } from './fixtures'
 import { APP_TITLE } from './helpers/appTitle'
-import { buildUniqueName, createBasicWorkflowViaApi, deleteWorkflow } from './helpers/workflows'
+import { buildUniqueName, createBasicWorkflowViaApi, deleteWorkflow, openWorkflowInBuilder } from './helpers/workflows'
 
 test.skip('workflows page toolbar shows Import workflow before Create workflow', async ({ app }) => {
   await app.goto(toAppUrl('/workflows'))
@@ -73,6 +73,58 @@ test.skip('user searches, views, and deletes a workflow', async ({ app }) => {
   } finally {
     for (const name of [otherWorkflowName, workflowName]) {
       await deleteWorkflow(app, name)
+    }
+  }
+})
+
+test('duplicates workflow from builder toolbar kebab menu', async ({ app }) => {
+  const workflowName = buildUniqueName('duplicate-source')
+  let duplicatedWorkflowName: string | undefined
+
+  try {
+    // Create a workflow with a descriptive step
+    const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Original Step')
+
+    // Open in builder
+    await openWorkflowInBuilder(app, workflowName, id)
+
+    // Open kebab menu and click Duplicate
+    await app.getByLabel('Workflow actions').click()
+    await app.getByRole('menuitem', { name: /Duplicate workflow/i }).click()
+
+    // Verify success alert appears
+    const successAlert = app.getByText('Workflow duplicated')
+    await expect(successAlert).toBeVisible({ timeout: 10_000 })
+
+    // Extract duplicated workflow name from the alert (format: "Created \"<name>\"")
+    const alertDescription = app.getByText(/Created ".*"/)
+    await expect(alertDescription).toBeVisible()
+    const alertText = await alertDescription.textContent()
+    const match = alertText?.match(/Created "(.+)"/)
+    expect(match).toBeTruthy()
+    duplicatedWorkflowName = match?.[1]
+    expect(duplicatedWorkflowName).toMatch(new RegExp(`${workflowName} - duplicate-[a-z0-9]+`))
+
+    // Click "Open workflow" link in alert
+    const openWorkflowLink = app.getByRole('button', { name: 'Open workflow' })
+    await expect(openWorkflowLink).toBeVisible()
+    await openWorkflowLink.click()
+
+    // Verify duplicated workflow opens in builder with correct name
+    await expect(app.getByPlaceholder('Workflow name')).toHaveValue(duplicatedWorkflowName!, { timeout: 15_000 })
+
+    // Verify the step was duplicated (ReactFlow canvas node)
+    await expect(app.getByText('Original Step')).toBeVisible()
+
+    // Verify duplicated workflow appears in workflows list
+    await app.goto(toAppUrl('/workflows'))
+    await app.getByPlaceholder('Filter by name').fill(duplicatedWorkflowName!)
+    await app.getByRole('button', { name: 'Apply filter' }).click()
+    await expect(app.getByRole('link', { name: duplicatedWorkflowName, exact: true })).toBeVisible()
+  } finally {
+    await deleteWorkflow(app, workflowName)
+    if (duplicatedWorkflowName) {
+      await deleteWorkflow(app, duplicatedWorkflowName)
     }
   }
 })

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
@@ -421,7 +421,10 @@ export function BuilderContent(props: BuilderContentProps) {
   )
 
   const handleDuplicateWorkflow = useCallback(() => {
-    if (!currentWorkflow) return
+    if (!currentWorkflow) {
+      showError({ title: 'Cannot duplicate workflow', description: 'Save the workflow before duplicating.' })
+      return
+    }
     const { edges, nodePositions } = useWorkflowStore.getState()
     const activities = currentWorkflow.workflow.activities ?? []
     const triggers = currentWorkflow.triggers ?? []
@@ -430,7 +433,7 @@ export function BuilderContent(props: BuilderContentProps) {
       nodePositions,
     })
     executeDuplicateWorkflow(definition)
-  }, [currentWorkflow, workflowName, workflowDescription, executeDuplicateWorkflow])
+  }, [currentWorkflow, workflowName, workflowDescription, executeDuplicateWorkflow, showError])
 
   const versionPanel = useBuilderVersionPanel({
     workflowId,

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
@@ -57,6 +57,7 @@ import { NodeActionsContext } from './NodeActionsContext'
 import type { BuilderContentProps } from './types/builderContent'
 import { useBuilderPermissions } from './useBuilderPermissions'
 import { createAddStepHandler } from './utils/panelActions'
+import { buildWorkflowDefinition } from './utils/workflowDefinitionBuilder'
 import { ValidationBanner } from './ValidationBanner'
 import { VersionInfoCard } from './VersionInfoCard'
 import { VersionViewProvider } from './VersionViewContext'
@@ -357,14 +358,10 @@ export function BuilderContent(props: BuilderContentProps) {
   )
 
   const { mutate: duplicateWorkflow, isPending: isDuplicating } = workflowClient.useMutation('post', '/workflows')
-  const handleDuplicateVersion = useCallback(
-    (version: WorkflowVersion) => {
+
+  const executeDuplicateWorkflow = useCallback(
+    (definition: Record<string, unknown>) => {
       if (isDuplicating || !workflow?.name || !workflow.project_id) return
-      const definition = version.workflow_definition
-      if (!definition) {
-        showError({ title: 'Failed to duplicate workflow', description: 'Version has no definition to duplicate' })
-        return
-      }
       const timestamp = Date.now().toString(36)
       const suffix = ` - duplicate-${timestamp}`
       const maxBaseLength = 255 - suffix.length
@@ -410,6 +407,30 @@ export function BuilderContent(props: BuilderContentProps) {
     },
     [isDuplicating, workflow, duplicateWorkflow, queryClient, showAlert, showError, setLocation]
   )
+
+  const handleDuplicateVersion = useCallback(
+    (version: WorkflowVersion) => {
+      const definition = version.workflow_definition
+      if (!definition) {
+        showError({ title: 'Failed to duplicate workflow', description: 'Version has no definition to duplicate' })
+        return
+      }
+      executeDuplicateWorkflow(definition)
+    },
+    [executeDuplicateWorkflow, showError]
+  )
+
+  const handleDuplicateWorkflow = useCallback(() => {
+    if (!currentWorkflow) return
+    const { edges, nodePositions } = useWorkflowStore.getState()
+    const activities = currentWorkflow.workflow.activities ?? []
+    const triggers = currentWorkflow.triggers ?? []
+    const definition = buildWorkflowDefinition(workflowName, workflowDescription, activities, triggers, {
+      edges,
+      nodePositions,
+    })
+    executeDuplicateWorkflow(definition)
+  }, [currentWorkflow, workflowName, workflowDescription, executeDuplicateWorkflow])
 
   const versionPanel = useBuilderVersionPanel({
     workflowId,
@@ -523,6 +544,7 @@ export function BuilderContent(props: BuilderContentProps) {
                   handleSaveWorkflow={guardedSaveWorkflow}
                   onPublish={onPublish}
                   onUnpublish={onUnpublish}
+                  onDuplicate={handleDuplicateWorkflow}
                   onPendingImport={setPendingImport}
                   isLiveRunActive={isLiveRunActive}
                   executionId={mostRecentExecutionId}

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderEditorToolbar.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderEditorToolbar.test.tsx
@@ -690,10 +690,16 @@ describe('BuilderEditorToolbar', () => {
   })
 
   describe('Duplicate workflow action', () => {
-    it('renders Duplicate workflow in kebab menu', () => {
+    it('renders Duplicate workflow in kebab menu for existing workflows', () => {
       render(<BuilderEditorToolbar {...defaultProps} isKebabOpen />)
 
       expect(screen.getByRole('menuitem', { name: /Duplicate workflow/i })).toBeInTheDocument()
+    })
+
+    it('does not render Duplicate for new workflows', () => {
+      render(<BuilderEditorToolbar {...defaultProps} isNew workflow={undefined} isKebabOpen />)
+
+      expect(screen.queryByRole('menuitem', { name: /Duplicate workflow/i })).not.toBeInTheDocument()
     })
 
     it('positions Duplicate between Verify and Export', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderEditorToolbar.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderEditorToolbar.test.tsx
@@ -56,6 +56,7 @@ describe('BuilderEditorToolbar', () => {
     handleSaveWorkflow: vi.fn().mockResolvedValue(true),
     onPublishClick: vi.fn(),
     onUnpublish: vi.fn(),
+    onDuplicate: vi.fn(),
     onPendingImport: vi.fn(),
     builderPermissions: {
       canEdit: true,
@@ -686,6 +687,89 @@ describe('BuilderEditorToolbar', () => {
     await user.hover(screen.getByRole('button', { name: /^Save$/i }))
 
     expect(await screen.findByText('No save permission')).toBeInTheDocument()
+  })
+
+  describe('Duplicate workflow action', () => {
+    it('renders Duplicate workflow in kebab menu', () => {
+      render(<BuilderEditorToolbar {...defaultProps} isKebabOpen />)
+
+      expect(screen.getByRole('menuitem', { name: /Duplicate workflow/i })).toBeInTheDocument()
+    })
+
+    it('positions Duplicate between Verify and Export', () => {
+      render(<BuilderEditorToolbar {...defaultProps} isKebabOpen />)
+
+      const menuItems = screen.getAllByRole('menuitem')
+      const verifyIndex = menuItems.findIndex((item) => item.textContent?.includes('Verify'))
+      const duplicateIndex = menuItems.findIndex((item) => item.textContent?.includes('Duplicate'))
+      const exportIndex = menuItems.findIndex((item) => item.textContent?.includes('Export'))
+
+      expect(duplicateIndex).toBeGreaterThan(verifyIndex)
+      expect(duplicateIndex).toBeLessThan(exportIndex)
+    })
+
+    it('fires onDuplicate handler when clicked', async () => {
+      const user = userEvent.setup()
+      const dispatch = vi.fn()
+      const onDuplicate = vi.fn()
+
+      render(<BuilderEditorToolbar {...defaultProps} isKebabOpen dispatch={dispatch} onDuplicate={onDuplicate} />)
+
+      await user.click(screen.getByRole('menuitem', { name: /Duplicate workflow/i }))
+
+      expect(onDuplicate).toHaveBeenCalledTimes(1)
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_KEBAB_OPEN', payload: false })
+    })
+
+    it('disables Duplicate when canEdit is false', () => {
+      render(
+        <BuilderEditorToolbar
+          {...defaultProps}
+          isKebabOpen
+          builderPermissions={{ ...defaultProps.builderPermissions, canEdit: false }}
+        />
+      )
+
+      expect(screen.getByRole('menuitem', { name: /Duplicate workflow/i })).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('does not fire onDuplicate when canEdit is false', async () => {
+      const user = userEvent.setup()
+      const onDuplicate = vi.fn()
+
+      render(
+        <BuilderEditorToolbar
+          {...defaultProps}
+          isKebabOpen
+          onDuplicate={onDuplicate}
+          builderPermissions={{ ...defaultProps.builderPermissions, canEdit: false }}
+        />
+      )
+
+      await user.click(screen.getByRole('menuitem', { name: /Duplicate workflow/i }))
+
+      expect(onDuplicate).not.toHaveBeenCalled()
+    })
+
+    it('shows permission tooltip when canEdit is false', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <BuilderEditorToolbar
+          {...defaultProps}
+          isKebabOpen
+          builderPermissions={{
+            ...defaultProps.builderPermissions,
+            canEdit: false,
+            tooltips: { ...defaultProps.builderPermissions.tooltips, edit: 'No edit permission' },
+          }}
+        />
+      )
+
+      await user.hover(screen.getByRole('menuitem', { name: /Duplicate workflow/i }))
+
+      expect(await screen.findByText('No edit permission')).toBeInTheDocument()
+    })
   })
 
   it('has no accessibility violations', async () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderEditorToolbar.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderEditorToolbar.tsx
@@ -1,33 +1,12 @@
-import {
-  Button,
-  Divider,
-  Dropdown,
-  DropdownGroup,
-  DropdownItem,
-  DropdownList,
-  Icon,
-  MenuToggle,
-  type MenuToggleElement,
-} from '@patternfly/react-core'
-import {
-  RhUiCodeIcon,
-  RhUiCheckCircleIcon,
-  RhUiExportIcon,
-  RhUiClockIcon,
-  RhUiHistoryIcon,
-  RhUiImportIcon,
-  RhUiTrashIcon,
-  RhUiEllipsisVerticalFillIcon,
-  RhUiAddSquareIcon,
-  RhUiMinusCircleFillIcon,
-} from '@patternfly/react-icons'
+import { Button, Divider, Dropdown, Icon, MenuToggle, type MenuToggleElement } from '@patternfly/react-core'
+import { RhUiEllipsisVerticalFillIcon, RhUiAddSquareIcon } from '@patternfly/react-icons'
 import { useCallback, type Dispatch, type Ref } from 'react'
 
 import { DisabledWithTooltip } from '../../components/DisabledWithTooltip'
 import { useWorkflowStore } from '../../stores/useWorkflowStore'
 
-import toolbarStyles from './BuilderEditorToolbar.module.css'
 import type { BuilderAction } from './builderReducer'
+import { KebabMenuViewsGroup, KebabMenuActionsGroup } from './kebabMenuItems'
 import { PublishWorkflowButton } from './PublishWorkflowButton'
 import { RunWorkflowSection } from './RunWorkflowSection'
 import { SaveWorkflowButton } from './SaveWorkflowButton'
@@ -70,6 +49,7 @@ type WorkflowKebabMenuProps = Readonly<{
   handleImportFile: (event: React.ChangeEvent<HTMLInputElement>) => void
   handleExport: () => void
   handleVerify: (onValid?: () => void) => void
+  handleDuplicate: () => void
 }>
 
 function WorkflowKebabMenu({
@@ -88,6 +68,7 @@ function WorkflowKebabMenu({
   handleImportFile,
   handleExport,
   handleVerify,
+  handleDuplicate,
 }: WorkflowKebabMenuProps) {
   const renderKebabMenuToggle = useCallback(
     (toggleRef: Ref<MenuToggleElement>) => (
@@ -96,8 +77,6 @@ function WorkflowKebabMenu({
     [dispatch, isKebabOpen]
   )
   const showExistingWorkflowItems = !isNew && !!workflow?.id
-  const canEdit = builderPermissions.canEdit
-  const canDelete = builderPermissions.canDelete
   const closeKebab = () => dispatch({ type: 'SET_KEBAB_OPEN', payload: false })
 
   return (
@@ -108,121 +87,29 @@ function WorkflowKebabMenu({
         popperProps={{ position: 'right' }}
         toggle={renderKebabMenuToggle}
       >
-        <DropdownGroup label="Views">
-          <DropdownList>
-            {showExistingWorkflowItems && (
-              <DropdownItem
-                onClick={() => {
-                  handleToggleHistory()
-                  closeKebab()
-                }}
-              >
-                <Icon isInline className={toolbarStyles.menuIcon}>
-                  <RhUiHistoryIcon />
-                </Icon>
-                Run history
-              </DropdownItem>
-            )}
-            {showExistingWorkflowItems && (
-              <DropdownItem
-                onClick={() => {
-                  handleToggleVersionHistory()
-                  closeKebab()
-                }}
-              >
-                <Icon isInline className={toolbarStyles.menuIcon}>
-                  <RhUiClockIcon />
-                </Icon>
-                Version history
-              </DropdownItem>
-            )}
-            <DropdownItem
-              onClick={() => {
-                handleToggleDetails()
-                closeKebab()
-              }}
-            >
-              <Icon isInline className={toolbarStyles.menuIcon}>
-                <RhUiCodeIcon />
-              </Icon>
-              Workflow details
-            </DropdownItem>
-          </DropdownList>
-        </DropdownGroup>
+        <KebabMenuViewsGroup
+          showExistingWorkflowItems={showExistingWorkflowItems}
+          handleToggleHistory={handleToggleHistory}
+          handleToggleVersionHistory={handleToggleVersionHistory}
+          handleToggleDetails={handleToggleDetails}
+          closeKebab={closeKebab}
+        />
         {!isBuiltin && <Divider />}
         {!isBuiltin && (
-          <DropdownGroup label="Actions">
-            <DropdownList>
-              <DropdownItem onClick={() => handleVerify()}>
-                <Icon isInline className={toolbarStyles.menuIcon}>
-                  <RhUiCheckCircleIcon />
-                </Icon>
-                Verify workflow
-              </DropdownItem>
-              <DropdownItem onClick={handleExport}>
-                <Icon isInline className={toolbarStyles.menuIcon}>
-                  <RhUiExportIcon />
-                </Icon>
-                Export workflow
-              </DropdownItem>
-              <DropdownItem
-                isAriaDisabled={!canEdit}
-                tooltipProps={canEdit ? undefined : { content: builderPermissions.tooltips.edit }}
-                onClick={
-                  canEdit
-                    ? () => {
-                        importFileRef.current?.click()
-                        closeKebab()
-                      }
-                    : undefined
-                }
-              >
-                <Icon isInline className={toolbarStyles.menuIcon}>
-                  <RhUiImportIcon />
-                </Icon>
-                Import workflow
-              </DropdownItem>
-              {showExistingWorkflowItems && publishedVersionId != null && (
-                <DropdownItem
-                  isAriaDisabled={!canEdit}
-                  tooltipProps={canEdit ? undefined : { content: builderPermissions.tooltips.unpublish }}
-                  onClick={
-                    canEdit
-                      ? () => {
-                          onUnpublish()
-                          closeKebab()
-                        }
-                      : undefined
-                  }
-                >
-                  <Icon isInline className={toolbarStyles.menuIcon}>
-                    <RhUiMinusCircleFillIcon />
-                  </Icon>
-                  Unpublish workflow
-                </DropdownItem>
-              )}
-              {showExistingWorkflowItems && (
-                <DropdownItem
-                  isAriaDisabled={!canDelete}
-                  tooltipProps={canDelete ? undefined : { content: builderPermissions.tooltips.delete }}
-                  onClick={
-                    canDelete
-                      ? () => {
-                          dispatch({ type: 'SET_DELETE_DIALOG', payload: true })
-                          closeKebab()
-                        }
-                      : undefined
-                  }
-                  isDanger={canDelete}
-                >
-                  <Icon isInline className={toolbarStyles.menuIcon}>
-                    <RhUiTrashIcon />
-                  </Icon>
-                  Delete workflow
-                </DropdownItem>
-              )}
-            </DropdownList>
-          </DropdownGroup>
+          <KebabMenuActionsGroup
+            showExistingWorkflowItems={showExistingWorkflowItems}
+            publishedVersionId={publishedVersionId}
+            canEdit={builderPermissions.canEdit}
+            canDelete={builderPermissions.canDelete}
+            tooltips={builderPermissions.tooltips}
+            handleVerify={handleVerify}
+            handleDuplicate={handleDuplicate}
+            handleExport={handleExport}
+            importFileRef={importFileRef}
+            onUnpublish={onUnpublish}
+            dispatch={dispatch}
+            closeKebab={closeKebab}
+          />
         )}
       </Dropdown>
       <input ref={importFileRef} type="file" accept=".json" onChange={handleImportFile} style={{ display: 'none' }} />
@@ -252,6 +139,7 @@ type BuilderEditorToolbarProps = Readonly<{
   handleSaveWorkflow: () => Promise<boolean>
   onPublishClick: () => void
   onUnpublish: () => void
+  onDuplicate: () => void
   onPendingImport: (data: PendingImportData) => void
   triggers?: { id: string; name?: string }[]
   builderPermissions: BuilderPermissions
@@ -280,6 +168,7 @@ export function BuilderEditorToolbar({
   handleSaveWorkflow,
   onPublishClick,
   onUnpublish,
+  onDuplicate,
   onPendingImport,
   triggers,
   builderPermissions,
@@ -323,6 +212,7 @@ export function BuilderEditorToolbar({
         handleImportFile={handleImportFile}
         handleExport={handleExport}
         handleVerify={handleVerify}
+        handleDuplicate={onDuplicate}
       />
     )
   }
@@ -423,6 +313,7 @@ export function BuilderEditorToolbar({
         handleImportFile={handleImportFile}
         handleExport={handleExport}
         handleVerify={handleVerify}
+        handleDuplicate={onDuplicate}
       />
     </>
   )

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderWorkflowPageHeader.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderWorkflowPageHeader.test.tsx
@@ -89,6 +89,7 @@ describe('BuilderWorkflowPageHeader', () => {
     handleSaveWorkflow: vi.fn().mockResolvedValue(true),
     onPublish: vi.fn(),
     onUnpublish: vi.fn(),
+    onDuplicate: vi.fn(),
     onPendingImport: vi.fn(),
     builderPermissions: {
       canEdit: true,

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderWorkflowPageHeader.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderWorkflowPageHeader.tsx
@@ -47,6 +47,7 @@ type BuilderToolbarContentProps = Readonly<{
   handleSaveWorkflow: () => Promise<boolean>
   onPublishClick: () => void
   onUnpublish: () => void
+  onDuplicate: () => void
   onPendingImport: (data: PendingImportData) => void
   triggers?: { id: string; name?: string }[]
   isBuiltin: boolean
@@ -96,6 +97,7 @@ function BuilderToolbarContent({
   handleSaveWorkflow,
   onPublishClick,
   onUnpublish,
+  onDuplicate,
   onPendingImport,
   triggers,
   isAddNodePanelOpen,
@@ -194,6 +196,7 @@ function BuilderToolbarContent({
       handleSaveWorkflow={handleSaveWorkflow}
       onPublishClick={onPublishClick}
       onUnpublish={onUnpublish}
+      onDuplicate={onDuplicate}
       onPendingImport={onPendingImport}
       triggers={triggers}
       isAddNodePanelOpen={isAddNodePanelOpen}
@@ -318,6 +321,7 @@ export type BuilderWorkflowPageHeaderProps = Readonly<{
   handleSaveWorkflow: () => Promise<boolean>
   onPublish: (publishName?: string, description?: string, onSettled?: () => void) => void
   onUnpublish: () => void
+  onDuplicate: () => void
   isViewingVersion?: boolean
   versionHistoryOpen?: boolean
   viewedVersionDate?: string | null
@@ -366,6 +370,7 @@ export function BuilderWorkflowPageHeader({
   handleSaveWorkflow,
   onPublish,
   onUnpublish,
+  onDuplicate,
   isViewingVersion,
   versionHistoryOpen,
   viewedVersionDate,
@@ -406,6 +411,7 @@ export function BuilderWorkflowPageHeader({
       handleSaveWorkflow={handleSaveWorkflow}
       onPublishClick={() => publishDialog.open(true)}
       onUnpublish={onUnpublish}
+      onDuplicate={onDuplicate}
       onPendingImport={onPendingImport}
       triggers={triggers}
       isAddNodePanelOpen={isAddNodePanelOpen}

--- a/frontend/packages/syntara-ui/src/routes/builder/kebabMenuItems.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/kebabMenuItems.test.tsx
@@ -236,15 +236,7 @@ describe('DeleteMenuItem', () => {
   it('disables delete when canDelete is false', () => {
     render(<DeleteMenuItem canDelete={false} deleteTooltip="No permission" dispatch={vi.fn()} closeKebab={vi.fn()} />)
 
-    const item = screen.getByRole('menuitem', { name: /Delete workflow/i })
-    expect(item).toHaveAttribute('aria-disabled', 'true')
-    expect(item).not.toHaveClass('pf-m-danger')
-  })
-
-  it('shows danger styling when canDelete is true', () => {
-    render(<DeleteMenuItem canDelete deleteTooltip="No permission" dispatch={vi.fn()} closeKebab={vi.fn()} />)
-
-    expect(screen.getByRole('menuitem', { name: /Delete workflow/i })).toHaveClass('pf-m-danger')
+    expect(screen.getByRole('menuitem', { name: /Delete workflow/i })).toHaveAttribute('aria-disabled', 'true')
   })
 
   it('dispatches delete dialog action when clicked', async () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/kebabMenuItems.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/kebabMenuItems.test.tsx
@@ -276,13 +276,19 @@ describe('KebabMenuActionsGroup', () => {
     closeKebab: vi.fn(),
   }
 
-  it('renders all basic actions', () => {
+  it('renders all basic actions for new workflows', () => {
     render(<KebabMenuActionsGroup {...defaultProps} />)
 
     expect(screen.getByRole('menuitem', { name: /Verify workflow/i })).toBeInTheDocument()
-    expect(screen.getByRole('menuitem', { name: /Duplicate workflow/i })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /Duplicate workflow/i })).not.toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /Export workflow/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /Import workflow/i })).toBeInTheDocument()
+  })
+
+  it('renders duplicate for existing workflows', () => {
+    render(<KebabMenuActionsGroup {...defaultProps} showExistingWorkflowItems />)
+
+    expect(screen.getByRole('menuitem', { name: /Duplicate workflow/i })).toBeInTheDocument()
   })
 
   it('renders unpublish for published workflows', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/kebabMenuItems.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/kebabMenuItems.test.tsx
@@ -1,0 +1,349 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import {
+  KebabMenuViewsGroup,
+  DuplicateMenuItem,
+  ImportMenuItem,
+  UnpublishMenuItem,
+  DeleteMenuItem,
+  KebabMenuActionsGroup,
+} from './kebabMenuItems'
+
+describe('KebabMenuViewsGroup', () => {
+  it('renders workflow details for all workflow types', () => {
+    render(
+      <KebabMenuViewsGroup
+        showExistingWorkflowItems={false}
+        handleToggleHistory={vi.fn()}
+        handleToggleVersionHistory={vi.fn()}
+        handleToggleDetails={vi.fn()}
+        closeKebab={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('menuitem', { name: /Workflow details/i })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /Run history/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /Version history/i })).not.toBeInTheDocument()
+  })
+
+  it('renders run and version history for existing workflows', () => {
+    render(
+      <KebabMenuViewsGroup
+        showExistingWorkflowItems
+        handleToggleHistory={vi.fn()}
+        handleToggleVersionHistory={vi.fn()}
+        handleToggleDetails={vi.fn()}
+        closeKebab={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('menuitem', { name: /Run history/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Version history/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Workflow details/i })).toBeInTheDocument()
+  })
+
+  it('calls handlers and closes kebab when items clicked', async () => {
+    const user = userEvent.setup()
+    const handleToggleHistory = vi.fn()
+    const handleToggleVersionHistory = vi.fn()
+    const handleToggleDetails = vi.fn()
+    const closeKebab = vi.fn()
+
+    render(
+      <KebabMenuViewsGroup
+        showExistingWorkflowItems
+        handleToggleHistory={handleToggleHistory}
+        handleToggleVersionHistory={handleToggleVersionHistory}
+        handleToggleDetails={handleToggleDetails}
+        closeKebab={closeKebab}
+      />
+    )
+
+    await user.click(screen.getByRole('menuitem', { name: /Run history/i }))
+    expect(handleToggleHistory).toHaveBeenCalledTimes(1)
+    expect(closeKebab).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole('menuitem', { name: /Version history/i }))
+    expect(handleToggleVersionHistory).toHaveBeenCalledTimes(1)
+    expect(closeKebab).toHaveBeenCalledTimes(2)
+
+    await user.click(screen.getByRole('menuitem', { name: /Workflow details/i }))
+    expect(handleToggleDetails).toHaveBeenCalledTimes(1)
+    expect(closeKebab).toHaveBeenCalledTimes(3)
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <KebabMenuViewsGroup
+        showExistingWorkflowItems
+        handleToggleHistory={vi.fn()}
+        handleToggleVersionHistory={vi.fn()}
+        handleToggleDetails={vi.fn()}
+        closeKebab={vi.fn()}
+      />
+    )
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('DuplicateMenuItem', () => {
+  it('renders duplicate menu item when enabled', () => {
+    render(<DuplicateMenuItem canEdit editTooltip="No permission" handleDuplicate={vi.fn()} closeKebab={vi.fn()} />)
+
+    const item = screen.getByRole('menuitem', { name: /Duplicate workflow/i })
+    expect(item).toBeInTheDocument()
+    expect(item).not.toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('disables duplicate when canEdit is false', () => {
+    render(
+      <DuplicateMenuItem canEdit={false} editTooltip="No permission" handleDuplicate={vi.fn()} closeKebab={vi.fn()} />
+    )
+
+    expect(screen.getByRole('menuitem', { name: /Duplicate workflow/i })).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('calls handlers when enabled and clicked', async () => {
+    const user = userEvent.setup()
+    const handleDuplicate = vi.fn()
+    const closeKebab = vi.fn()
+
+    render(
+      <DuplicateMenuItem
+        canEdit
+        editTooltip="No permission"
+        handleDuplicate={handleDuplicate}
+        closeKebab={closeKebab}
+      />
+    )
+
+    await user.click(screen.getByRole('menuitem', { name: /Duplicate workflow/i }))
+
+    expect(handleDuplicate).toHaveBeenCalledTimes(1)
+    expect(closeKebab).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call handlers when disabled', async () => {
+    const user = userEvent.setup()
+    const handleDuplicate = vi.fn()
+    const closeKebab = vi.fn()
+
+    render(
+      <DuplicateMenuItem
+        canEdit={false}
+        editTooltip="No permission"
+        handleDuplicate={handleDuplicate}
+        closeKebab={closeKebab}
+      />
+    )
+
+    await user.click(screen.getByRole('menuitem', { name: /Duplicate workflow/i }))
+
+    expect(handleDuplicate).not.toHaveBeenCalled()
+    expect(closeKebab).not.toHaveBeenCalled()
+  })
+
+  it('shows tooltip when disabled', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DuplicateMenuItem
+        canEdit={false}
+        editTooltip="No edit permission"
+        handleDuplicate={vi.fn()}
+        closeKebab={vi.fn()}
+      />
+    )
+
+    await user.hover(screen.getByRole('menuitem', { name: /Duplicate workflow/i }))
+
+    expect(await screen.findByText('No edit permission')).toBeInTheDocument()
+  })
+})
+
+describe('ImportMenuItem', () => {
+  it('renders import menu item', () => {
+    const ref = { current: null }
+    render(<ImportMenuItem canEdit editTooltip="No permission" importFileRef={ref} closeKebab={vi.fn()} />)
+
+    expect(screen.getByRole('menuitem', { name: /Import workflow/i })).toBeInTheDocument()
+  })
+
+  it('disables import when canEdit is false', () => {
+    const ref = { current: null }
+    render(<ImportMenuItem canEdit={false} editTooltip="No permission" importFileRef={ref} closeKebab={vi.fn()} />)
+
+    expect(screen.getByRole('menuitem', { name: /Import workflow/i })).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('triggers file input click when enabled', async () => {
+    const user = userEvent.setup()
+    const mockClick = vi.fn()
+    const ref = { current: { click: mockClick } as unknown as HTMLInputElement }
+    const closeKebab = vi.fn()
+
+    render(<ImportMenuItem canEdit editTooltip="No permission" importFileRef={ref} closeKebab={closeKebab} />)
+
+    await user.click(screen.getByRole('menuitem', { name: /Import workflow/i }))
+
+    expect(mockClick).toHaveBeenCalledTimes(1)
+    expect(closeKebab).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('UnpublishMenuItem', () => {
+  it('renders unpublish menu item', () => {
+    render(<UnpublishMenuItem canEdit unpublishTooltip="No permission" onUnpublish={vi.fn()} closeKebab={vi.fn()} />)
+
+    expect(screen.getByRole('menuitem', { name: /Unpublish workflow/i })).toBeInTheDocument()
+  })
+
+  it('disables unpublish when canEdit is false', () => {
+    render(
+      <UnpublishMenuItem canEdit={false} unpublishTooltip="No permission" onUnpublish={vi.fn()} closeKebab={vi.fn()} />
+    )
+
+    expect(screen.getByRole('menuitem', { name: /Unpublish workflow/i })).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('calls handlers when clicked', async () => {
+    const user = userEvent.setup()
+    const onUnpublish = vi.fn()
+    const closeKebab = vi.fn()
+
+    render(
+      <UnpublishMenuItem canEdit unpublishTooltip="No permission" onUnpublish={onUnpublish} closeKebab={closeKebab} />
+    )
+
+    await user.click(screen.getByRole('menuitem', { name: /Unpublish workflow/i }))
+
+    expect(onUnpublish).toHaveBeenCalledTimes(1)
+    expect(closeKebab).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('DeleteMenuItem', () => {
+  it('renders delete menu item', () => {
+    render(<DeleteMenuItem canDelete deleteTooltip="No permission" dispatch={vi.fn()} closeKebab={vi.fn()} />)
+
+    expect(screen.getByRole('menuitem', { name: /Delete workflow/i })).toBeInTheDocument()
+  })
+
+  it('disables delete when canDelete is false', () => {
+    render(<DeleteMenuItem canDelete={false} deleteTooltip="No permission" dispatch={vi.fn()} closeKebab={vi.fn()} />)
+
+    const item = screen.getByRole('menuitem', { name: /Delete workflow/i })
+    expect(item).toHaveAttribute('aria-disabled', 'true')
+    expect(item).not.toHaveClass('pf-m-danger')
+  })
+
+  it('shows danger styling when canDelete is true', () => {
+    render(<DeleteMenuItem canDelete deleteTooltip="No permission" dispatch={vi.fn()} closeKebab={vi.fn()} />)
+
+    expect(screen.getByRole('menuitem', { name: /Delete workflow/i })).toHaveClass('pf-m-danger')
+  })
+
+  it('dispatches delete dialog action when clicked', async () => {
+    const user = userEvent.setup()
+    const dispatch = vi.fn()
+    const closeKebab = vi.fn()
+
+    render(<DeleteMenuItem canDelete deleteTooltip="No permission" dispatch={dispatch} closeKebab={closeKebab} />)
+
+    await user.click(screen.getByRole('menuitem', { name: /Delete workflow/i }))
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_DELETE_DIALOG', payload: true })
+    expect(closeKebab).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('KebabMenuActionsGroup', () => {
+  const defaultProps = {
+    showExistingWorkflowItems: false,
+    publishedVersionId: null as string | null,
+    canEdit: true,
+    canDelete: true,
+    tooltips: {
+      edit: 'No edit',
+      save: 'No save',
+      publish: 'No publish',
+      unpublish: 'No unpublish',
+      run: 'No run',
+      delete: 'No delete',
+    },
+    handleVerify: vi.fn(),
+    handleDuplicate: vi.fn(),
+    handleExport: vi.fn(),
+    importFileRef: { current: null },
+    onUnpublish: vi.fn(),
+    dispatch: vi.fn(),
+    closeKebab: vi.fn(),
+  }
+
+  it('renders all basic actions', () => {
+    render(<KebabMenuActionsGroup {...defaultProps} />)
+
+    expect(screen.getByRole('menuitem', { name: /Verify workflow/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Duplicate workflow/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Export workflow/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Import workflow/i })).toBeInTheDocument()
+  })
+
+  it('renders unpublish for published workflows', () => {
+    render(<KebabMenuActionsGroup {...defaultProps} showExistingWorkflowItems publishedVersionId="ver-1" />)
+
+    expect(screen.getByRole('menuitem', { name: /Unpublish workflow/i })).toBeInTheDocument()
+  })
+
+  it('renders delete for existing workflows', () => {
+    render(<KebabMenuActionsGroup {...defaultProps} showExistingWorkflowItems />)
+
+    expect(screen.getByRole('menuitem', { name: /Delete workflow/i })).toBeInTheDocument()
+  })
+
+  it('does not render unpublish when not published', () => {
+    render(<KebabMenuActionsGroup {...defaultProps} showExistingWorkflowItems publishedVersionId={null} />)
+
+    expect(screen.queryByRole('menuitem', { name: /Unpublish workflow/i })).not.toBeInTheDocument()
+  })
+
+  it('does not render delete for new workflows', () => {
+    render(<KebabMenuActionsGroup {...defaultProps} showExistingWorkflowItems={false} />)
+
+    expect(screen.queryByRole('menuitem', { name: /Delete workflow/i })).not.toBeInTheDocument()
+  })
+
+  it('calls verify handler', async () => {
+    const user = userEvent.setup()
+    const handleVerify = vi.fn()
+
+    render(<KebabMenuActionsGroup {...defaultProps} handleVerify={handleVerify} />)
+
+    await user.click(screen.getByRole('menuitem', { name: /Verify workflow/i }))
+
+    expect(handleVerify).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls export handler', async () => {
+    const user = userEvent.setup()
+    const handleExport = vi.fn()
+
+    render(<KebabMenuActionsGroup {...defaultProps} handleExport={handleExport} />)
+
+    await user.click(screen.getByRole('menuitem', { name: /Export workflow/i }))
+
+    expect(handleExport).toHaveBeenCalledTimes(1)
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <KebabMenuActionsGroup {...defaultProps} showExistingWorkflowItems publishedVersionId="ver-1" />
+    )
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/builder/kebabMenuItems.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/kebabMenuItems.tsx
@@ -231,12 +231,14 @@ export function KebabMenuActionsGroup({
           </Icon>
           Verify workflow
         </DropdownItem>
-        <DuplicateMenuItem
-          canEdit={canEdit}
-          editTooltip={tooltips.edit}
-          handleDuplicate={handleDuplicate}
-          closeKebab={closeKebab}
-        />
+        {showExistingWorkflowItems && (
+          <DuplicateMenuItem
+            canEdit={canEdit}
+            editTooltip={tooltips.edit}
+            handleDuplicate={handleDuplicate}
+            closeKebab={closeKebab}
+          />
+        )}
         <DropdownItem onClick={handleExport}>
           <Icon isInline className={toolbarStyles.menuIcon}>
             <RhUiExportIcon />

--- a/frontend/packages/syntara-ui/src/routes/builder/kebabMenuItems.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/kebabMenuItems.tsx
@@ -1,0 +1,271 @@
+import { DropdownGroup, DropdownItem, DropdownList, Icon } from '@patternfly/react-core'
+import {
+  RhUiCodeIcon,
+  RhUiCheckCircleIcon,
+  RhUiExportIcon,
+  RhUiClockIcon,
+  RhUiHistoryIcon,
+  RhUiImportIcon,
+  RhUiTrashIcon,
+  RhUiMinusCircleFillIcon,
+  RhUiDuplicateIcon,
+} from '@patternfly/react-icons'
+import type { Dispatch } from 'react'
+
+import toolbarStyles from './BuilderEditorToolbar.module.css'
+import type { BuilderAction } from './builderReducer'
+import type { BuilderPermissions } from './useBuilderPermissions'
+
+export type KebabMenuViewsGroupProps = Readonly<{
+  showExistingWorkflowItems: boolean
+  handleToggleHistory: () => void
+  handleToggleVersionHistory: () => void
+  handleToggleDetails: () => void
+  closeKebab: () => void
+}>
+
+export function KebabMenuViewsGroup({
+  showExistingWorkflowItems,
+  handleToggleHistory,
+  handleToggleVersionHistory,
+  handleToggleDetails,
+  closeKebab,
+}: KebabMenuViewsGroupProps) {
+  return (
+    <DropdownGroup label="Views">
+      <DropdownList>
+        {showExistingWorkflowItems && (
+          <DropdownItem
+            onClick={() => {
+              handleToggleHistory()
+              closeKebab()
+            }}
+          >
+            <Icon isInline className={toolbarStyles.menuIcon}>
+              <RhUiHistoryIcon />
+            </Icon>
+            Run history
+          </DropdownItem>
+        )}
+        {showExistingWorkflowItems && (
+          <DropdownItem
+            onClick={() => {
+              handleToggleVersionHistory()
+              closeKebab()
+            }}
+          >
+            <Icon isInline className={toolbarStyles.menuIcon}>
+              <RhUiClockIcon />
+            </Icon>
+            Version history
+          </DropdownItem>
+        )}
+        <DropdownItem
+          onClick={() => {
+            handleToggleDetails()
+            closeKebab()
+          }}
+        >
+          <Icon isInline className={toolbarStyles.menuIcon}>
+            <RhUiCodeIcon />
+          </Icon>
+          Workflow details
+        </DropdownItem>
+      </DropdownList>
+    </DropdownGroup>
+  )
+}
+
+export type DuplicateMenuItemProps = Readonly<{
+  canEdit: boolean
+  editTooltip: string
+  handleDuplicate: () => void
+  closeKebab: () => void
+}>
+
+export function DuplicateMenuItem({ canEdit, editTooltip, handleDuplicate, closeKebab }: DuplicateMenuItemProps) {
+  return (
+    <DropdownItem
+      isAriaDisabled={!canEdit}
+      tooltipProps={canEdit ? undefined : { content: editTooltip }}
+      onClick={
+        canEdit
+          ? () => {
+              handleDuplicate()
+              closeKebab()
+            }
+          : undefined
+      }
+    >
+      <Icon isInline className={toolbarStyles.menuIcon}>
+        <RhUiDuplicateIcon />
+      </Icon>
+      Duplicate workflow
+    </DropdownItem>
+  )
+}
+
+export type ImportMenuItemProps = Readonly<{
+  canEdit: boolean
+  editTooltip: string
+  importFileRef: React.RefObject<HTMLInputElement | null>
+  closeKebab: () => void
+}>
+
+export function ImportMenuItem({ canEdit, editTooltip, importFileRef, closeKebab }: ImportMenuItemProps) {
+  return (
+    <DropdownItem
+      isAriaDisabled={!canEdit}
+      tooltipProps={canEdit ? undefined : { content: editTooltip }}
+      onClick={
+        canEdit
+          ? () => {
+              importFileRef.current?.click()
+              closeKebab()
+            }
+          : undefined
+      }
+    >
+      <Icon isInline className={toolbarStyles.menuIcon}>
+        <RhUiImportIcon />
+      </Icon>
+      Import workflow
+    </DropdownItem>
+  )
+}
+
+export type UnpublishMenuItemProps = Readonly<{
+  canEdit: boolean
+  unpublishTooltip: string
+  onUnpublish: () => void
+  closeKebab: () => void
+}>
+
+export function UnpublishMenuItem({ canEdit, unpublishTooltip, onUnpublish, closeKebab }: UnpublishMenuItemProps) {
+  return (
+    <DropdownItem
+      isAriaDisabled={!canEdit}
+      tooltipProps={canEdit ? undefined : { content: unpublishTooltip }}
+      onClick={
+        canEdit
+          ? () => {
+              onUnpublish()
+              closeKebab()
+            }
+          : undefined
+      }
+    >
+      <Icon isInline className={toolbarStyles.menuIcon}>
+        <RhUiMinusCircleFillIcon />
+      </Icon>
+      Unpublish workflow
+    </DropdownItem>
+  )
+}
+
+export type DeleteMenuItemProps = Readonly<{
+  canDelete: boolean
+  deleteTooltip: string
+  dispatch: Dispatch<BuilderAction>
+  closeKebab: () => void
+}>
+
+export function DeleteMenuItem({ canDelete, deleteTooltip, dispatch, closeKebab }: DeleteMenuItemProps) {
+  return (
+    <DropdownItem
+      isAriaDisabled={!canDelete}
+      tooltipProps={canDelete ? undefined : { content: deleteTooltip }}
+      onClick={
+        canDelete
+          ? () => {
+              dispatch({ type: 'SET_DELETE_DIALOG', payload: true })
+              closeKebab()
+            }
+          : undefined
+      }
+      isDanger={canDelete}
+    >
+      <Icon isInline className={toolbarStyles.menuIcon}>
+        <RhUiTrashIcon />
+      </Icon>
+      Delete workflow
+    </DropdownItem>
+  )
+}
+
+export type KebabMenuActionsGroupProps = Readonly<{
+  showExistingWorkflowItems: boolean
+  publishedVersionId: string | null
+  canEdit: boolean
+  canDelete: boolean
+  tooltips: BuilderPermissions['tooltips']
+  handleVerify: (onValid?: () => void) => void
+  handleDuplicate: () => void
+  handleExport: () => void
+  importFileRef: React.RefObject<HTMLInputElement | null>
+  onUnpublish: () => void
+  dispatch: Dispatch<BuilderAction>
+  closeKebab: () => void
+}>
+
+export function KebabMenuActionsGroup({
+  showExistingWorkflowItems,
+  publishedVersionId,
+  canEdit,
+  canDelete,
+  tooltips,
+  handleVerify,
+  handleDuplicate,
+  handleExport,
+  importFileRef,
+  onUnpublish,
+  dispatch,
+  closeKebab,
+}: KebabMenuActionsGroupProps) {
+  return (
+    <DropdownGroup label="Actions">
+      <DropdownList>
+        <DropdownItem onClick={() => handleVerify()}>
+          <Icon isInline className={toolbarStyles.menuIcon}>
+            <RhUiCheckCircleIcon />
+          </Icon>
+          Verify workflow
+        </DropdownItem>
+        <DuplicateMenuItem
+          canEdit={canEdit}
+          editTooltip={tooltips.edit}
+          handleDuplicate={handleDuplicate}
+          closeKebab={closeKebab}
+        />
+        <DropdownItem onClick={handleExport}>
+          <Icon isInline className={toolbarStyles.menuIcon}>
+            <RhUiExportIcon />
+          </Icon>
+          Export workflow
+        </DropdownItem>
+        <ImportMenuItem
+          canEdit={canEdit}
+          editTooltip={tooltips.edit}
+          importFileRef={importFileRef}
+          closeKebab={closeKebab}
+        />
+        {showExistingWorkflowItems && publishedVersionId != null && (
+          <UnpublishMenuItem
+            canEdit={canEdit}
+            unpublishTooltip={tooltips.unpublish}
+            onUnpublish={onUnpublish}
+            closeKebab={closeKebab}
+          />
+        )}
+        {showExistingWorkflowItems && (
+          <DeleteMenuItem
+            canDelete={canDelete}
+            deleteTooltip={tooltips.delete}
+            dispatch={dispatch}
+            closeKebab={closeKebab}
+          />
+        )}
+      </DropdownList>
+    </DropdownGroup>
+  )
+}


### PR DESCRIPTION
## Summary
Adds "Duplicate workflow" action to the toolbar kebab menu between "Verify" and "Export".

Fixes AAP-89065

## Changes
- Added `RhUiDuplicateIcon` menu item to kebab Actions group
- Extracted shared duplication logic into `executeDuplicateWorkflow` helper
- Permission-gated with `canEdit` + tooltip
- Reuses existing mutation and alert patterns

## Screenshots
[Add 5 screenshots here]

1. Kebab menu showing Duplicate position
2. Action enabled (editor role)
3. Action disabled with tooltip (viewer role)
4. Success alert with "Open workflow" link
5. Duplicated workflow with timestamped name

## Testing
- [ ] Unit tests added for menu item (6 test cases)
- [ ] Manually tested duplicate action
- [ ] Verified permission gating
- [ ] Confirmed accessibility (inherits from PatternFly DropdownItem)

## Checklist
- [x] No unsafe type casts
- [x] Permission gating with tooltip
- [x] Shared logic extracted (no duplication)
- [x] Uses RhUi icon
- [x] TanStack Query mutation
- [ ] Screenshots included
- [ ] Tests added