### PR TITLE
chore(ci): bump ao-api-tests Tekton bundles to latest

### DIFF
--- a/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:e9dff52d3b10939e74f7c0c4b35f1b783e8cdea938f1ea3f152704c44beb0b0c
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:09b63f7777b9d3244a7de072a66c827fc1410bd3c038fe9829e190f9ffb44796
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-api-tests-early-access-pull-request.yaml
+++ b/.tekton/automation-orchestrator-api-tests-early-access-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:e9dff52d3b10939e74f7c0c4b35f1b783e8cdea938f1ea3f152704c44beb0b0c
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:09b63f7777b9d3244a7de072a66c827fc1410bd3c038fe9829e190f9ffb44796
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
See https://github.com/ansible-automation-platform/aap-konflux-pipelines/pull/3378

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
