### PR TITLE
fix(ci): skip merge queue monitoring workflows when webhook not set

### DIFF
--- a/.github/workflows/merge-queue-dequeue-alert.yml
+++ b/.github/workflows/merge-queue-dequeue-alert.yml
@@ -9,31 +9,35 @@ on:
 jobs:
   dequeue-burst-detection:
     runs-on: ubuntu-latest
-    if: vars.SLACK_CI_MONITORING_WEBHOOK_URL != ''
     permissions:
       contents: read
       actions: read
+    env:
+      SLACK_CI_MONITORING_WEBHOOK_URL: ${{ secrets.SLACK_CI_MONITORING_WEBHOOK_URL }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        if: env.SLACK_CI_MONITORING_WEBHOOK_URL != ''
         with:
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        if: env.SLACK_CI_MONITORING_WEBHOOK_URL != ''
         with:
           node-version: '22.13.0'
           cache: 'npm'
           cache-dependency-path: .github/scripts/package-lock.json
 
       - name: Install dependencies
+        if: env.SLACK_CI_MONITORING_WEBHOOK_URL != ''
         run: npm ci
         working-directory: .github/scripts
 
       - name: Check for dequeue burst and notify
+        if: env.SLACK_CI_MONITORING_WEBHOOK_URL != ''
         run: npm run check-dequeue-burst
         working-directory: .github/scripts
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          SLACK_CI_MONITORING_WEBHOOK_URL: ${{ vars.SLACK_CI_MONITORING_WEBHOOK_URL || secrets.SLACK_CI_MONITORING_WEBHOOK_URL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/merge-queue-dequeue-alert.yml
+++ b/.github/workflows/merge-queue-dequeue-alert.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   dequeue-burst-detection:
     runs-on: ubuntu-latest
-    if: vars.SLACK_CI_MONITORING_WEBHOOK_URL != '' || secrets.SLACK_CI_MONITORING_WEBHOOK_URL != ''
+    if: vars.SLACK_CI_MONITORING_WEBHOOK_URL != ''
     permissions:
       contents: read
       actions: read
@@ -34,6 +34,6 @@ jobs:
         working-directory: .github/scripts
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          SLACK_CI_MONITORING_WEBHOOK_URL: ${{ secrets.SLACK_CI_MONITORING_WEBHOOK_URL }}
+          SLACK_CI_MONITORING_WEBHOOK_URL: ${{ vars.SLACK_CI_MONITORING_WEBHOOK_URL || secrets.SLACK_CI_MONITORING_WEBHOOK_URL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/merge-queue-health-poll.yml
+++ b/.github/workflows/merge-queue-health-poll.yml
@@ -9,31 +9,35 @@ on:
 jobs:
   queue-health-check:
     runs-on: ubuntu-latest
-    if: vars.SLACK_CI_MONITORING_WEBHOOK_URL != ''
     permissions:
       contents: read
       actions: read
+    env:
+      SLACK_CI_MONITORING_WEBHOOK_URL: ${{ secrets.SLACK_CI_MONITORING_WEBHOOK_URL }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        if: env.SLACK_CI_MONITORING_WEBHOOK_URL != ''
         with:
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        if: env.SLACK_CI_MONITORING_WEBHOOK_URL != ''
         with:
           node-version: '22.13.0'
           cache: 'npm'
           cache-dependency-path: .github/scripts/package-lock.json
 
       - name: Install dependencies
+        if: env.SLACK_CI_MONITORING_WEBHOOK_URL != ''
         run: npm ci
         working-directory: .github/scripts
 
       - name: Check queue health and notify
+        if: env.SLACK_CI_MONITORING_WEBHOOK_URL != ''
         run: npm run check-queue-health
         working-directory: .github/scripts
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          SLACK_CI_MONITORING_WEBHOOK_URL: ${{ vars.SLACK_CI_MONITORING_WEBHOOK_URL || secrets.SLACK_CI_MONITORING_WEBHOOK_URL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/merge-queue-health-poll.yml
+++ b/.github/workflows/merge-queue-health-poll.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   queue-health-check:
     runs-on: ubuntu-latest
-    if: vars.SLACK_CI_MONITORING_WEBHOOK_URL != '' || secrets.SLACK_CI_MONITORING_WEBHOOK_URL != ''
+    if: vars.SLACK_CI_MONITORING_WEBHOOK_URL != ''
     permissions:
       contents: read
       actions: read
@@ -34,6 +34,6 @@ jobs:
         working-directory: .github/scripts
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          SLACK_CI_MONITORING_WEBHOOK_URL: ${{ secrets.SLACK_CI_MONITORING_WEBHOOK_URL }}
+          SLACK_CI_MONITORING_WEBHOOK_URL: ${{ vars.SLACK_CI_MONITORING_WEBHOOK_URL || secrets.SLACK_CI_MONITORING_WEBHOOK_URL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}


### PR DESCRIPTION
## Description

Two scheduled workflows were failing on every run because they referenced secrets in a job-level conditional, which GitHub Actions does not allow. The workflows now skip entirely when the Slack webhook is not configured as a repository variable.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- Use repository variable in job conditional to skip when not configured
- Add fallback to secret in environment for backward compatibility

## Out of Scope

Configuring the actual Slack webhook URL for the repository.

## How to Test

Set `SLACK_CI_MONITORING_WEBHOOK_URL` as a repository variable (Settings → Secrets and variables → Actions → Variables) and verify the workflows run on schedule or manual trigger. Without the variable set, the workflows should be skipped.

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [ ] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [ ] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

N/A — workflow configuration change only

## Additional Notes

The workflows monitor merge queue health and dequeue activity. They send Slack alerts when the queue is stalled or experiencing rapid dequeue bursts.

> 🤖 PR description AI-assisted