### PR TITLE
fix(workflows): prevent secret leak in truncated approval prompts

### DIFF
--- a/backend/src/syntara/workflows/workflow_engine/approval_mixin.py
+++ b/backend/src/syntara/workflows/workflow_engine/approval_mixin.py
@@ -6,6 +6,7 @@ timeout expiration, cancellation cleanup, and previous-step context building.
 
 import asyncio
 import json
+from collections.abc import Callable
 from datetime import timedelta
 from typing import Any, ClassVar, cast
 
@@ -36,6 +37,13 @@ from syntara.workflows.workflow_engine.graph import ActivityNode, WorkflowGraph
 _APPROVAL_COMMENTS_MAX_LENGTH = FieldLimits.DESCRIPTION_MAX_LENGTH
 _APPROVAL_PROMPT_PATCH = "persist-approval-prompt"
 
+# Truncation must respect the narrower of the DB column width and the
+# ApprovalCreateRequest.prompt max_length — they are the same today, and this
+# constant is the place to change if either moves. Widening the column without
+# widening the request model would make an over-length prompt a 422 from
+# POST /approvals rather than a clipped message.
+_APPROVAL_PROMPT_MAX_LENGTH = FieldLimits.DESCRIPTION_MAX_LENGTH
+
 
 def _warn_approval_prompt(message: str) -> None:
     """Log prompt-coercion issues without crashing outside a workflow."""
@@ -43,50 +51,71 @@ def _warn_approval_prompt(message: str) -> None:
         workflow.logger.warning(message)
 
 
-def _resolved_approval_prompt(resolved_parameters: dict[str, Any]) -> str | None:
-    """Return the resolved approval-node prompt, or None if absent/blank.
+def _approval_prompt_value(resolved_parameters: dict[str, Any]) -> Any | None:  # noqa: ANN401
+    """Select the approval-node prompt, or None if it is not storable guidance.
 
     ``NamespaceResolver.resolve_value`` keeps the original type when the whole
-    field is a single ``${...}``. Store numbers as decimal text so a Message of
-    ``${trigger.amount}`` is kept. Skip booleans and empty containers — those
-    are not human-readable guidance. Serialize objects with ``json.dumps``;
-    if that fails or the JSON exceeds the column limit, store None rather than
-    a broken fragment. Oversized plain text is truncated to the column limit
-    with a trailing ellipsis so approvers can see it was clipped.
+    field is a single ``${...}``, so the prompt can arrive as any JSON value.
+    Booleans, empty containers and blank strings are not human-readable guidance
+    and are dropped here.
+
+    The ``json.dumps`` probe doubles as a **cycle guard**: ``scrub_credentials``
+    and ``scrub_credential_values`` recurse through dicts and lists with no cycle
+    detection, so a self-referencing template must be rejected *before* it reaches
+    the scrubber. Returning a value from this function is the promise that it is
+    safe to scrub.
     """
     prompt = resolved_parameters.get("prompt")
     if prompt is None or isinstance(prompt, bool):
         return None
-
-    text: str | None = None
-    from_json = False
     if isinstance(prompt, str):
-        text = prompt.strip() or None
-    elif isinstance(prompt, (dict, list)):
-        if prompt:
-            try:
-                text = json.dumps(prompt, default=str)
-                from_json = True
-            except (TypeError, ValueError):
-                _warn_approval_prompt("Could not serialize approval prompt; storing no prompt")
-    else:
-        text = str(prompt).strip() or None
+        return prompt.strip() or None
+    if isinstance(prompt, (dict, list)):
+        if not prompt:
+            return None
+        try:
+            json.dumps(prompt, default=str)
+        except (TypeError, ValueError):
+            _warn_approval_prompt("Could not serialize approval prompt; storing no prompt")
+            return None
+    return prompt
 
-    if not text:
+
+def _approval_prompt_text(value: Any) -> str | None:  # noqa: ANN401
+    """Render an already-scrubbed prompt value to the text that gets stored.
+
+    Runs last so the length cap is applied to the final string. Scrubbing can
+    *lengthen* a value — ``[REDACTED]`` is 10 characters and a secret may be as
+    short as 4 — so truncating before scrubbing can push the result back over the
+    limit and turn ``POST /approvals`` into a validation failure.
+
+    Objects that do not fit are dropped rather than stored as a broken JSON
+    fragment. Oversized plain text is truncated with a trailing ellipsis so
+    approvers can see it was clipped.
+    """
+    if value is None:
         return None
 
-    max_len = FieldLimits.DESCRIPTION_MAX_LENGTH
-    if len(text) <= max_len:
+    if isinstance(value, (dict, list)):
+        text = json.dumps(value, default=str)
+        if len(text) > _APPROVAL_PROMPT_MAX_LENGTH:
+            _warn_approval_prompt(
+                f"Approval prompt JSON length {len(text)} exceeds "
+                f"{_APPROVAL_PROMPT_MAX_LENGTH} characters; storing no prompt"
+            )
+            return None
         return text
 
-    if from_json:
-        _warn_approval_prompt(
-            f"Approval prompt JSON length {len(text)} exceeds {max_len} characters; storing no prompt"
-        )
+    text = (value if isinstance(value, str) else str(value)).strip()
+    if not text:
         return None
+    if len(text) <= _APPROVAL_PROMPT_MAX_LENGTH:
+        return text
 
-    _warn_approval_prompt(f"Approval prompt length {len(text)} exceeds {max_len} characters; truncating")
-    return text[: max_len - 1] + "…"
+    _warn_approval_prompt(
+        f"Approval prompt length {len(text)} exceeds {_APPROVAL_PROMPT_MAX_LENGTH} characters; truncating"
+    )
+    return text[: _APPROVAL_PROMPT_MAX_LENGTH - 1] + "…"
 
 
 class WorkflowApprovalMixin:
@@ -107,13 +136,10 @@ class WorkflowApprovalMixin:
     _detached_nodes: set[str]
     _TEMPORAL_MARGIN: ClassVar[int]
 
-    def _scrub_data(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Redact secrets from activity payloads.
-
-        ``OrchestratorWorkflow`` overrides this with credential and secret-value
-        scrubbing. Identity fallback keeps the mixin testable in isolation.
-        """
-        return data
+    # Provided by OrchestratorWorkflow; declared here for mypy only. Deliberately
+    # not given an identity-function body — a redaction step that silently becomes
+    # a no-op if the MRO changes fails open, and this one guards secrets.
+    _scrub_data: Callable[[dict[str, Any]], dict[str, Any]]
 
     async def _expire_approvals(self, node_id: str | None, activity_id: str) -> None:
         """Best-effort expire pending approval requests.
@@ -352,11 +378,13 @@ class WorkflowApprovalMixin:
             self._project_id,
         ]
         if workflow.patched(_APPROVAL_PROMPT_PATCH):
-            prompt = _resolved_approval_prompt(resolved_parameters)
-            if prompt:
-                scrubbed = self._scrub_data({"prompt": prompt}).get("prompt")
-                prompt = scrubbed if isinstance(scrubbed, str) else None
-            args.append(prompt)
+            # select+guard -> scrub -> coerce+truncate. Order is load-bearing:
+            # the guard proves the value is safe to recurse into, and scrubbing
+            # before truncation keeps the final string inside the column limit.
+            value = _approval_prompt_value(resolved_parameters)
+            if value is not None:
+                value = self._scrub_data({"prompt": value})["prompt"]
+            args.append(_approval_prompt_text(value))
         return args
 
     async def _execute_approval_node(

--- a/backend/tests/unit/workflows/workflow_engine/test_dynamic_workflow_approval.py
+++ b/backend/tests/unit/workflows/workflow_engine/test_dynamic_workflow_approval.py
@@ -10,11 +10,12 @@ Tests cover:
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from temporalio.exceptions import ApplicationError
 
+from syntara.approvals.models import ActivitySummary, ApprovalCreateRequest, WorkflowContext
 from syntara.core.constants import FieldLimits
 from syntara.workflows.utils.namespace_resolver import NamespaceResolver
 from syntara.workflows.workflow_engine.dynamic_workflow import OrchestratorWorkflow
@@ -22,6 +23,12 @@ from syntara.workflows.workflow_engine.graph import ActivityNode, WorkflowGraph
 from syntara.workflows.workflow_engine.graph_backend import InMemoryGraphBackend
 from syntara.workflows.workflow_engine.models.workflow_definition import ActivityName
 from tests.unit.workflows.workflow_engine.conftest import init_workflow_runtime
+
+# Value registered in ``_secret_values`` by the prompt-scrubbing tests, used to probe
+# for leaks. Its alphabet is deliberately disjoint from the padding characters those
+# tests use ("p", "q", "x", "y") and from "[REDACTED]", which is uppercase — so any of
+# these characters appearing in a stored prompt is unambiguously a leaked fragment.
+_LEAK_PROBE = "abcd"
 
 
 @pytest.fixture(autouse=True)
@@ -632,6 +639,128 @@ class TestPrepareApprovalArgs:
         assert args[10] is not None
         assert "super-secret-token" not in args[10]
         assert "[REDACTED]" in args[10]
+
+    @pytest.mark.asyncio
+    async def test_oversized_prompt_with_short_secret_stays_within_limit(self) -> None:
+        """Scrubbing must not push a truncated prompt back over the column limit.
+
+        ``[REDACTED]`` is 10 characters and a tracked secret may be as short as 4
+        (``MIN_LEAK_PROBE_LENGTH``), so redaction *lengthens* the text. Truncating before
+        scrubbing produced a value longer than ``ApprovalCreateRequest.prompt`` allows,
+        which fails validation on POST /approvals and kills the approval node
+        (approval nodes resolve to ``RetryPolicy(maximum_attempts=1)``).
+        """
+        wf = _make_workflow()
+        wf._secret_values.add(_LEAK_PROBE)
+        graph = _build_approval_graph()
+        node = ActivityNode("approval", "approval", {}, name="Review")
+        # A secret every 100 characters, total well over the limit.
+        oversized = (_LEAK_PROBE + "x" * 96) * 40 + "y" * 500
+
+        mock_execute = AsyncMock(return_value={"user_ids": [], "group_ids": []})
+        with patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_execute):
+            args = await wf._prepare_approval_args(node, graph, {"prompt": oversized})
+
+        assert args[10] is not None
+        assert len(args[10]) <= FieldLimits.DESCRIPTION_MAX_LENGTH
+        # The padding alphabet is disjoint from the secret's, and "[REDACTED]" is
+        # uppercase, so no character of the secret may survive anywhere — this
+        # catches a fragment left by a cut at any offset, not just the whole value.
+        assert not set(_LEAK_PROBE) & set(args[10])
+
+    @pytest.mark.asyncio
+    async def test_scrubbed_prompt_is_accepted_by_the_create_request_model(self) -> None:
+        """The stored prompt must satisfy the model the activity actually POSTs.
+
+        Guards the workflow-side truncation against the API-side ``max_length``;
+        they are coupled and nothing else checks that they agree.
+        """
+        wf = _make_workflow()
+        wf._secret_values.add(_LEAK_PROBE)
+        graph = _build_approval_graph()
+        node = ActivityNode("approval", "approval", {}, name="Review")
+        oversized = (_LEAK_PROBE + "x" * 96) * 40 + "y" * 500
+
+        mock_execute = AsyncMock(return_value={"user_ids": [], "group_ids": []})
+        with patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_execute):
+            args = await wf._prepare_approval_args(node, graph, {"prompt": oversized})
+
+        ApprovalCreateRequest(
+            execution_id=uuid4(),
+            project_id=uuid4(),
+            approval_node_id="approval",
+            name="Review",
+            prompt=args[10],
+            next_step_approved=ActivitySummary(id="step", name="Step", type="task"),
+            workflow_context=WorkflowContext(workflow_name="Test Workflow", inputs={}),
+        )
+
+    @pytest.mark.asyncio
+    async def test_secret_straddling_the_truncation_point_is_not_left_partial(self) -> None:
+        """Truncating first bisects a secret so the scrubber can no longer match it."""
+        wf = _make_workflow()
+        wf._secret_values.add(_LEAK_PROBE)
+        graph = _build_approval_graph()
+        node = ActivityNode("approval", "approval", {}, name="Review")
+        # Position the secret so a cut near the limit lands inside it.
+        straddling = "p" * (FieldLimits.DESCRIPTION_MAX_LENGTH - 3) + _LEAK_PROBE + "q" * 500
+
+        mock_execute = AsyncMock(return_value={"user_ids": [], "group_ids": []})
+        with patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_execute):
+            args = await wf._prepare_approval_args(node, graph, {"prompt": straddling})
+
+        assert args[10] is not None
+        # Assert on the secret's alphabet rather than the whole value or a
+        # specific tail: any surviving character is a leak regardless of where
+        # truncation cut or what marker it appended.
+        assert not set(_LEAK_PROBE) & set(args[10])
+
+    @pytest.mark.asyncio
+    async def test_object_prompt_is_scrubbed_by_credential_key_name(self) -> None:
+        """Key-name redaction only works while the value is still a dict.
+
+        ``json.dumps`` before scrubbing turns ``{"bearer_token": ...}`` into a plain
+        string, and ``scrub_credentials`` is a no-op on strings — the token would be
+        persisted verbatim even though its key is in ``CREDENTIAL_KEYS``.
+        """
+        wf = _make_workflow()
+        graph = _build_approval_graph()
+        node = ActivityNode("approval", "approval", {}, name="Review")
+
+        mock_execute = AsyncMock(return_value={"user_ids": [], "group_ids": []})
+        with patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_execute):
+            args = await wf._prepare_approval_args(
+                node,
+                graph,
+                {"prompt": {"bearer_token": "eyJhbGciOiJIUzI1NiJ9.leaked", "note": "deploy"}},
+            )
+
+        assert args[10] is not None
+        assert "leaked" not in args[10]
+        assert "[REDACTED]" in args[10]
+        assert "deploy" in args[10]
+
+    @pytest.mark.asyncio
+    async def test_cyclic_prompt_is_dropped_before_reaching_the_scrubber(self) -> None:
+        """The scrubbers recurse without cycle detection, so the guard must run first.
+
+        ``scrub_credentials`` and ``scrub_credential_values`` raise ``RecursionError``
+        on a self-referencing structure, and ``RecursionError`` is not caught by the
+        ``(TypeError, ValueError)`` guard — it would escape ``_prepare_approval_args``
+        and fail the node. Keep the serializability check ahead of the scrub.
+        """
+        wf = _make_workflow()
+        wf._secret_values.add(_LEAK_PROBE)
+        graph = _build_approval_graph()
+        node = ActivityNode("approval", "approval", {}, name="Review")
+        cyclic: list[object] = []
+        cyclic.append(cyclic)
+
+        mock_execute = AsyncMock(return_value={"user_ids": [], "group_ids": []})
+        with patch("syntara.workflows.workflow_engine.approval_mixin.workflow.execute_activity", mock_execute):
+            args = await wf._prepare_approval_args(node, graph, {"prompt": cyclic})
+
+        assert args[10] is None
 
 
 class TestDispatchApprovalNode:


### PR DESCRIPTION
## Description

Truncating before scrubbing could leak secrets when a secret straddled the cut point or when redaction lengthened the text back over the limit.

- Reorder to select+guard → scrub → coerce+truncate
- Split _resolved_approval_prompt into two stages
- Add tests validating edge cases

Refs: AAP-87735
Assisted-by: Claude Code (Claude Opus 4.8)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement


## Related Issues

Related to AAP-87735

## How to Test

```bash
K="oversized_prompt_with_short_secret or accepted_by_the_create_request or straddling or object_prompt_is_scrubbed or cyclic_prompt_is_dropped"
T=tests/unit/workflows/workflow_engine/test_dynamic_workflow_approval.py
```

1. cd backend/
2. git stash push -- src/syntara/workflows/workflow_engine/approval_mixin.py
3. uv run python -m pytest $T -k "$K" -q
4. verify 4 expected test failures in prior step
5. git stash pop
6. uv run python -m pytest $T -k "$K" -q
7. verify no test failures

## Additional Notes

Removed additional sections as this PR targets another PR.
