### PR TITLE
chore(ci): bump ao-api-tests and ao-ui-tests Tekton bundles to deploy 4 backend replicas

### DIFF
--- a/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:09b63f7777b9d3244a7de072a66c827fc1410bd3c038fe9829e190f9ffb44796
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:c5e04d21740314af736b6b39a66680d0c7dbfff68a1e88a76f18932a54638376
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-api-tests-early-access-pull-request.yaml
+++ b/.tekton/automation-orchestrator-api-tests-early-access-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:09b63f7777b9d3244a7de072a66c827fc1410bd3c038fe9829e190f9ffb44796
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:c5e04d21740314af736b6b39a66680d0c7dbfff68a1e88a76f18932a54638376
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-ui-tests-devel-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:3d11f0d59c73fe491dbd9de6a7a0b8836a80cdc71680c5553c3e5fe538cc65e3
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:32b785f0e9086c44fa105c72f33de2c9fbb3cb42d1e0a214181b42c8290f2662
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/automation-orchestrator-ui-tests-early-access-pull-request.yaml
+++ b/.tekton/automation-orchestrator-ui-tests-early-access-pull-request.yaml
@@ -41,7 +41,7 @@ spec:
       - name: name
         value: ao-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:3d11f0d59c73fe491dbd9de6a7a0b8836a80cdc71680c5553c3e5fe538cc65e3
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-ui-tests:0.1@sha256:32b785f0e9086c44fa105c72f33de2c9fbb3cb42d1e0a214181b42c8290f2662
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
Bumps both AO E2E pipeline bundles so the Konflux runs deploy the AO backend with **4 replicas** instead of the operator default of 2. The pipelines have been failing in ways consistent with the backend being overloaded; spreading the load across more pods is a low-risk thing to try.

| Pipeline | New digest |
|---|---|
| `ao-api-tests:0.1` | `sha256:c5e04d21740314af736b6b39a66680d0c7dbfff68a1e88a76f18932a54638376` |
| `ao-ui-tests:0.1` | `sha256:32b785f0e9086c44fa105c72f33de2c9fbb3cb42d1e0a214181b42c8290f2662` |

### What's in these bundles

Two upstream `aap-konflux-pipelines` PRs, which had to land in order:

1. **[#3415](https://github.com/ansible-automation-platform/aap-konflux-pipelines/pull/3415)** — adds the `ao-backend-replicas` param to the `deploy-ao-using-aap-dev` task and to both AO test pipelines. It reaches aap-dev as `AO_BACKEND_REPLICAS`, which declares `spec.backend.replicas` on the `AutomationOrchestrator` CR *before* it is rendered, so the backend comes up at the right size rather than being scaled up after deploy.
2. **[#3417](https://github.com/ansible-automation-platform/aap-konflux-pipelines/pull/3417)** — re-pins the task bundle *inside* both pipelines to the rebuild that actually declares that param. #3415 alone left the pipelines passing a param the pinned task did not accept, so the replica count silently never took effect.

### Verification

Both bundle digests were resolved from the `:0.1` tags with `skopeo` and their contents checked with `tkn bundle list`:

- each pins `deploy-ao-using-aap-dev:0.1@sha256:1339117e…`, the task build that declares `ao-backend-replicas` and exports `AO_BACKEND_REPLICAS`
- each declares and passes `ao-backend-replicas` (default `"4"`)

The two digests are distinct images — `ao-api-tests` and `ao-ui-tests` are separate bundles and never share a digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)