### PR TITLE
fix(e2e/group-membership): replace ineffective CI guard with @konflux-skip tag

### DIFF
--- a/frontend/packages/syntara-ui/e2e/group-membership.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/group-membership.spec.ts
@@ -104,9 +104,7 @@ test.describe('Group Detail — Navigation & Tabs', () => {
   })
 
   test.describe('Member add/remove (typeahead)', () => {
-    test.skip(!!process.env.CI, "Typeahead dropdown timing is unreliable in CI — options don't render within timeout")
-
-    test('add and remove a member from the group detail', async ({ app }) => {
+    test('add and remove a member from the group detail', { tag: ['@konflux-skip'] }, async ({ app }) => {
       const table = app.getByRole('grid', { name: 'Groups table' })
       await table.getByRole('button', { name: 'admins', exact: true }).click()
       await expect(app.getByRole('heading', { level: 1, name: 'admins', exact: true })).toBeVisible()


### PR DESCRIPTION
## Summary

Fixes an ineffective CI guard in `group-membership.spec.ts` by replacing `test.skip(!!process.env.CI, ...)` with `{ tag: ['@konflux-skip'] }` on the combined "add and remove a member from the group detail" test.

## Analysis

**Rule applied:** Rule 8 — Ineffective `CI` guards.

**The broken guard.** The file previously contained:

```typescript
test.skip(!!process.env.CI, 'Typeahead dropdown timing ...')
test('add and remove a member from the group detail', async ({ app }) => { ... })
```

`test.skip(condition, reason)` as a standalone call acts as a describe-level guard: when the condition is truthy it skips the immediately following test. Konflux does **not** set `CI=true`, so `!!process.env.CI` evaluates to `false` in Konflux and the skip fires nowhere — neither locally nor in CI. The comment documenting the reason is also lost as an untethered standalone call.

**The fix.** The two calls were merged into a single test declaration with `{ tag: ['@konflux-skip'] }`:

```typescript
test('add and remove a member from the group detail', { tag: ['@konflux-skip'] }, async ({ app }) => { ... })
```

This tag is explicitly excluded by Konflux via `--grep-invert @konflux-skip`. The test still runs locally and in GitHub CI, preserving the coverage where the typeahead timing is reliable.

**Why `@konflux-skip` and not deletion.** The test is not redundant — it covers a real functional path (adding and removing group members via a typeahead UI). The skip reason (typeahead dropdown timing depends on search API latency) is a valid Konflux constraint per Rule 9. Only the mechanism was wrong; the intent was correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)