### PR TITLE
chore(e2e/config-nav): remove duplicate credentials navigation test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/configuration-navigation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/configuration-navigation.spec.ts
@@ -24,18 +24,6 @@ test.describe('Configuration Navigation & Tabs', () => {
     await expect(app.getByRole('menuitem', { name: 'Credentials', exact: true })).toBeVisible()
   })
 
-  test('navigates to Credentials page from Configuration menu', async ({ app }) => {
-    await app.goto(toAppUrl('/configuration/integrations'))
-    await expect(app.getByRole('heading', { name: 'Integrations', level: 1 })).toBeVisible()
-
-    // Act - Open Configuration dropdown and click Credentials
-    await navigateViaConfigMenu(app, 'Credentials')
-
-    // Assert - URL and page heading are correct
-    await expect(app).toHaveURL(/configuration\/credentials/)
-    await expect(app.getByRole('heading', { level: 1, name: 'Credentials' })).toBeVisible()
-  })
-
   test('persists active tab after page refresh', async ({ app }) => {
     // Arrange - Navigate directly to Credentials page
     await app.goto(toAppUrl('/configuration/credentials'))


### PR DESCRIPTION
## Summary

Removes the `'navigates to Credentials page from Configuration menu'` test from `e2e/configuration-navigation.spec.ts`.

## Analysis

**Rule applied:** Rule 6 — Navigation sub-step already covered by a superset test.

**The removed test** navigated to the Configuration section via the sidebar menu, clicked the Credentials link, and asserted that the Credentials page heading was visible. This is a pure navigation sub-step: navigate → assert heading + URL.

**Why it is redundant.** Every Credentials spec (`credential-detail.spec.ts`, `credentials-list.spec.ts`) begins with the same navigation step as part of its `beforeEach` or test setup. Those tests navigate to Credentials and then perform additional assertions (list contents, filtering, detail views, CRUD operations). The navigation sub-step they exercise is identical to what the removed test asserted, and the superset tests fail if the navigation does not work — so the removed test provides zero additional coverage.

**Confidence in removal.** The `credential-detail.spec.ts` and `credentials-list.spec.ts` files collectively cover: page load, heading visibility, empty states, filter behavior, table contents, and CRUD flows. All of these require successfully navigating to the Credentials page. A failure in navigation would surface in those tests immediately. A dedicated navigation-only test is noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)