### PR TITLE
chore(e2e/credentials-list): remove duplicate non-matching filter empty state test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/credentials-list.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credentials-list.spec.ts
@@ -230,23 +230,6 @@ test.describe('Name Keyword Filtering', () => {
     }
   })
 
-  test('non-matching filter shows EmptyStateFilter', async ({ app }) => {
-    const { name: credName } = await createTestCredential(app, { prefix: 'e2e-filter-nomatch' })
-
-    try {
-      await goToCredentialsList(app)
-      await expect(app.getByPlaceholder('Filter by keyword')).toBeVisible({ timeout: 15_000 })
-      const nonexistent = buildUniqueName('e2e-no-match-ever')
-      await filterCredentialByName(app, nonexistent)
-
-      await expect(app.getByText('No results found')).toBeVisible()
-      await expect(
-        app.getByRole('search', { name: 'Filters' }).getByRole('button', { name: 'Clear all filters' })
-      ).toBeVisible()
-    } finally {
-      await deleteCredentialByName(app, credName)
-    }
-  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Removes the `'non-matching filter shows EmptyStateFilter'` test from `e2e/credentials-list.spec.ts`.

## Analysis

**Rule applied:** Rule 7 — Parallel per-resource over-testing of shared-hook behaviors.

**The removed test** applied a filter that matched no credentials and asserted that the `EmptyStateFilter` component was rendered. This is a filter-empty-state assertion.

**Why this is per-resource over-testing.** The `EmptyStateFilter` component and its trigger condition (active filters + zero results) are implemented by a shared `FilterBar` + `SynEmptyStateFilter` pattern wired through `useCursorPagination`. This behavior is already tested in the Workflows spec (`workflows/search-filter-sort.spec.ts`) which covers "empty search results show appropriate message." Testing the same component behavior for every resource type (Credentials, Workflows, Executions, Service Accounts …) multiplies CI time with no additional confidence in the component itself.

**What the credential-list suite still covers.** The remaining tests in `credentials-list.spec.ts` verify: list renders with expected credentials, credential creation via UI, credential deletion via UI, and the baseline empty state (no data at all). The filter-empty-state scenario is the only removed case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)