### PR TITLE
chore(e2e/execution-filtering): remove duplicate filter-state persistence test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/execution-filtering.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/execution-filtering.spec.ts
@@ -211,26 +211,6 @@ test.describe('Execution Filtering @pr-check', () => {
     await newPage.close()
   })
 
-  test('filter state persists across navigation', async ({ app }) => {
-    await switchFieldSelector(app, 'Workflow name', 'Status')
-
-    const filterToolbar = app.getByRole('search', { name: 'Filters' })
-    await filterToolbar.getByRole('button', { name: 'Filter by status' }).click()
-    await app.getByRole('option', { name: 'Running' }).click()
-
-    await expect(app).toHaveURL(/status=running/)
-    const urlWithFilter = app.url()
-
-    await app.goto(toAppUrl('/'))
-
-    await app.goto(urlWithFilter)
-
-    await expect(app.getByRole('heading', { level: 1, name: 'Workflow Runs' })).toBeVisible()
-    const statusChipGroup = app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Status' })
-    await expect(statusChipGroup.getByText('Running')).toBeVisible()
-    await expect(app).toHaveURL(/status=running/)
-  })
-
   test('individual filter chips can be removed independently', async ({ app }) => {
     const filterToolbar = app.getByRole('search', { name: 'Filters' })
 


### PR DESCRIPTION
## Summary

Removes the `'filter state persists across navigation'` test from `e2e/execution-filtering.spec.ts`.

## Analysis

**Rule applied:** Rule 7 — Parallel per-resource over-testing of shared-hook behaviors.

**The removed test** applied an execution filter, navigated to a different page, navigated back, and asserted that the filter chip was still visible in the URL/UI. This is a URL-based filter-persistence assertion.

**Why this is per-resource over-testing.** Filter state persistence is implemented once by `useCursorPagination`, which syncs all filter state to the URL via `useSearchParams`. Any resource page that uses `useCursorPagination` inherits this behavior automatically. The canonical filter-persistence test in `workflows/search-filter-sort.spec.ts` (`'filter state persists in URL for sharing'` and `'search input is preserved after page reload'`) already cover this behavior end-to-end. Testing the identical mechanism for executions adds CI time without adding confidence that the mechanism is correct — a failure in the shared hook would surface in the Workflows spec first.

**What the execution-filtering suite still covers.** The remaining tests verify: filter chips appear when filters are applied, individual filter chips can be removed, and the clear-all action resets the filter state. These are execution-specific UI interactions; only the persistence cross-navigation was a shared-hook behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)