### PR TITLE
chore(e2e/create): remove duplicate workflow custom name test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/create.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/create.spec.ts
@@ -66,36 +66,6 @@ test.describe('Workflows - Create New Workflow', () => {
     }
   })
 
-  test('workflow name can be customized before saving', async ({ app }) => {
-    const customName = buildUniqueName('e2e-custom')
-
-    try {
-      await app.goto(toAppUrl('/workflow-builder/new'))
-      await expect(app.getByRole('heading', { name: 'Select a trigger node' })).toBeVisible()
-
-      await app.getByRole('button', { name: 'Manual trigger' }).click()
-      await app.getByRole('textbox', { name: 'Name', exact: true }).fill('Manual trigger')
-      await app.getByRole('button', { name: 'Create' }).click()
-
-      await selectProjectIfRequired(app)
-
-      const workflowNameInput = app.getByPlaceholder('Workflow name')
-      await expect(workflowNameInput).toBeVisible()
-
-      await workflowNameInput.clear()
-      await workflowNameInput.fill(customName)
-
-      const saveButton = app.getByRole('button', { name: 'Save' })
-      await expect(saveButton).toBeVisible()
-      await saveButton.click()
-
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15000 })
-      await expect(app.getByPlaceholder('Workflow name')).toHaveValue(customName)
-    } finally {
-      await deleteWorkflow(app, customName)
-    }
-  })
-
   test('user can create workflow and immediately edit it', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-edit')
 


### PR DESCRIPTION
## Summary

Removes the `'workflow name can be customized before saving'` test from `e2e/workflows/create.spec.ts`.

## Analysis

**Rule applied:** Rule 2 — Strict-subset assertions.

**The removed test** navigated to the builder, typed a custom name into the workflow name input, and asserted that the input reflected the typed value. This is a single-field form-input assertion.

**Why it is a strict subset.** The test `'user can create a basic workflow and see it in the list'` (retained in `create.spec.ts`) sets a custom workflow name, saves the workflow, and then navigates to the list and asserts that the workflow appears with that exact name. If the name input did not accept custom values (i.e., the field was broken), the list assertion would fail because the default name would appear instead of the custom one.

The removed test's assertion ("the input shows the typed value") is a strict subset of the superset's assertion ("the workflow was saved and appears in the list with the custom name"). The superset exercises the entire flow; the subset adds no unique coverage.

**Note on naming validation.** The removed test was not checking name constraints (length limits, special characters, duplicate prevention) — it was only checking that the input is a functional text input. That behavior is covered by form unit tests in `src/routes/builder/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)