### PR TITLE
chore(e2e/manual-run): remove skipped 'clicking Run opens live run details panel' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/manual-run-canvas.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/manual-run-canvas.spec.ts
@@ -30,35 +30,6 @@ async function waitForBadge(app: Page, name: string, count?: number) {
   }
 }
 
-// Skip: tests consistently time out in CI waiting for workflow execution to complete
-test.skip('clicking Run and confirming opens the live run details panel', async ({ app }) => {
-  test.setTimeout(120_000)
-  const workflowName = buildUniqueName('e2e-manual-run')
-  // validateMinimumWorkflow requires: trigger + at least one node + an edge connecting them
-  const { id: workflowId } = await createWorkflowViaApi(
-    app,
-    workflowName,
-    [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-    [{ id: 'action_1', type: 'script', name: 'Test step', parameters: { language: 'python', code: "print('hi')" } }],
-    [{ from: 'trigger_1', to: 'action_1' }]
-  )
-  try {
-    await openBuilderById(app, workflowId)
-    await expect(app.getByText('Manual trigger')).toBeVisible({ timeout: 30_000 })
-
-    await app.getByRole('button', { name: 'Run' }).click()
-    const dialog = app.getByRole('dialog')
-    await expect(dialog).toBeVisible()
-    await dialog.getByRole('button', { name: 'Run now' }).click()
-    await expect(dialog).not.toBeVisible()
-
-    // The run details panel appears below the canvas once execution completes
-    await expect(app.getByRole('heading', { name: 'Run details' })).toBeVisible({ timeout: 30_000 })
-  } finally {
-    await deleteWorkflowViaApi(app, workflowId)
-  }
-})
-
 test.skip('node status badges show success after execution completes', async ({ app }) => {
   test.setTimeout(120_000)
   const workflowName = buildUniqueName('e2e-manual-run-badge')


### PR DESCRIPTION
## Description

Briefly describe what this pull request does and why it's needed.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [ ] List the specific changes made
- [ ] Include any new dependencies or configuration changes

## Out of Scope

<!-- What this PR intentionally does NOT include, to set reviewer expectations -->

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## How to Test

<!-- Manual testing directions, for example:
1. Log in as an admin
2. Go to the `/workflows` route
3. Click on a thing
4. Validate that something changed
-->

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [ ] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [ ] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->