### PR TITLE
chore(e2e/search-filter): remove duplicate individual filter chip removal test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
@@ -42,35 +42,6 @@ test.describe('Workflows Table - Search, Filter, and Sort', () => {
     return workflows
   }
 
-  test('user can remove individual filter chip', async ({ app }) => {
-    const workflows = await createTestWorkflows(app, 1)
-    expect(workflows).toHaveLength(1)
-
-    try {
-      const searchTerm = workflows[0].name
-
-      await app.goto(toAppUrl('/workflows'))
-      await app.getByPlaceholder('Filter by name').fill(searchTerm)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      const nameChipGroup = app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })
-      await expect(nameChipGroup).toBeVisible()
-
-      // Remove filter chip by clicking its close button
-      // Find the chip containing our search term, then click its close button
-      const chipWithText = nameChipGroup.filter({ hasText: searchTerm })
-      await chipWithText.getByRole('button', { name: /close/i }).click()
-
-      // Verify filter is removed
-      await expect(nameChipGroup).not.toBeVisible()
-      await expect(app).not.toHaveURL(new RegExp(`name.*${searchTerm}`))
-    } finally {
-      for (const wf of workflows) {
-        await deleteWorkflowViaApi(app, wf.id)
-      }
-    }
-  })
-
   test('search results update as user types and applies filter', async ({ app }) => {
     const workflows = await createTestWorkflows(app, 2)
     expect(workflows.length).toBeGreaterThanOrEqual(2)


### PR DESCRIPTION
## Summary

Removes the `'user can remove individual filter chip'` test from `e2e/workflows/search-filter-sort.spec.ts`.

## Analysis

**Rule applied:** Rule 7 — Parallel per-resource over-testing of shared-hook behaviors.

**The removed test** applied a name filter, then clicked the × on the filter chip to remove it, and asserted that the full list was restored. Individual chip removal is implemented by the shared `FilterBar` component's chip dismiss handler, which calls `onFilterChange` with the chip's filter removed from the active set.

**Why this is per-resource over-testing.** Individual chip removal behavior is already covered by `execution-filtering.spec.ts`, which contains `'user can remove an individual filter chip'` exercising the identical `FilterBar` chip dismiss path for the Executions list. Since both Workflows and Executions use the same `FilterBar` component and the same `onFilterChange` callback contract, testing this interaction for both resource types adds CI time without adding unique confidence. A regression in the chip dismiss handler would surface in the execution-filtering test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)