### PR TITLE
chore(e2e/search-filter): remove duplicate filter URL persistence test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
@@ -79,39 +79,6 @@ test.describe('Workflows Table - Search, Filter, and Sort', () => {
     }
   })
 
-  test('filter state persists in URL for sharing', async ({ app }) => {
-    const workflows = await createTestWorkflows(app, 1)
-    expect(workflows).toHaveLength(1)
-
-    try {
-      const searchTerm = workflows[0].name
-
-      await app.goto(toAppUrl('/workflows'))
-      await app.getByPlaceholder('Filter by name').fill(searchTerm)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      // Capture URL with filter
-      const filteredUrl = app.url()
-      expect(filteredUrl).toContain('name')
-      expect(filteredUrl).toContain(searchTerm)
-
-      // Navigate away
-      await app.goto(toAppUrl('/'))
-
-      // Navigate back using the filtered URL
-      await app.goto(filteredUrl)
-
-      // Verify filter is restored
-      await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
-      const nameChipGroup = app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })
-      await expect(nameChipGroup.getByText(searchTerm)).toBeVisible()
-    } finally {
-      for (const wf of workflows) {
-        await deleteWorkflowViaApi(app, wf.id)
-      }
-    }
-  })
-
   test('multiple workflows can be found using partial name search', async ({ app }) => {
     const workflows = await createTestWorkflows(app, 2)
     expect(workflows.length).toBeGreaterThanOrEqual(2)


### PR DESCRIPTION
## Summary

Removes the `'filter state persists in URL for sharing'` test from `e2e/workflows/search-filter-sort.spec.ts`.

## Analysis

**Rule applied:** Rule 7 — Parallel per-resource over-testing of shared-hook behaviors.

**The removed test** applied a name filter, copied the current URL, navigated away, pasted the URL back, and asserted that the filter chip was still active. This is a URL-based filter-persistence (shareable-URL) assertion.

**Why this is per-resource over-testing.** URL-synced filter state is implemented once by `useCursorPagination`, which uses `useSearchParams` to persist filter values in the URL query string. This behavior is identical across all resource list pages (Workflows, Executions, Credentials, Service Accounts) because they all use the same hook. The canonical test for this behavior is `'filter state persists across navigation'` in `execution-filtering.spec.ts` (which is the existing Execution filter persistence test). Testing the same mechanism for Workflows adds CI time without adding confidence that the shared hook is correct.

Per Rule 7 in the E2E deduplication rules: "Do not duplicate these cross-cutting tests for every resource type. One representative spec per behavior pattern is enough."

🤖 Generated with [Claude Code](https://claude.com/claude-code)