### PR TITLE
chore(e2e/table): remove duplicate empty state filter test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/table.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/table.spec.ts
@@ -83,40 +83,6 @@ test.describe('Workflows Table - Display and Navigation', () => {
     }
   })
 
-  test('empty state displays when no workflows match filter', async ({ app }) => {
-    // Create a workflow to ensure we have data, then filter for something else
-    const project = await ensureProject(app)
-    const workflowName = buildUniqueName('e2e-empty-state')
-    const workflow = await createWorkflowViaApi(app, {
-      name: workflowName,
-      projectId: project?.id,
-    })
-
-    if (!workflow) throw new Error('Failed to create test workflow')
-
-    try {
-      // Navigate to workflows page
-      await app.goto(toAppUrl('/workflows'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
-
-      // Filter for a name that definitely won't match our created workflow
-      const impossibleName = `zzz-nonexistent-${Date.now()}`
-      await app.getByPlaceholder('Filter by name').fill(impossibleName)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      const nameChipGroup = app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })
-      await expect(nameChipGroup).toBeVisible()
-
-      // Empty state should be visible
-      await expect(app.getByRole('heading', { name: 'No results found' })).toBeVisible()
-
-      // Verify "Clear all filters" button exists in empty state
-      await expect(app.getByRole('button', { name: 'Clear all filters' }).last()).toBeVisible()
-    } finally {
-      await deleteWorkflowViaApi(app, workflow.id)
-    }
-  })
-
   test('multiple workflows display in table with unique identifiers', async ({ app }) => {
     // Create 2 workflows for this test
     const project = await ensureProject(app)


### PR DESCRIPTION
## Summary

Removes the `'empty state displays when no workflows match filter'` test from `e2e/workflows/table.spec.ts`.

## Analysis

**Rule applied:** Rule 7 — Parallel per-resource over-testing of shared-hook behaviors.

**The removed test** applied a filter that matched no workflows and asserted that the `SynEmptyStateFilter` component was rendered. This is the filter-empty-state assertion.

**Why this is per-resource over-testing.** As established in PR #375 (which removed this same assertion from `search-filter-sort.spec.ts`), the filter-empty-state behavior is implemented by the shared `FilterBar` + `SynEmptyStateFilter` + `useCursorPagination` stack. Having the assertion in both `search-filter-sort.spec.ts` AND `table.spec.ts` for the same Workflows resource doubles the CI time for testing the same shared component, with no additional confidence.

With PR #375 removing it from `search-filter-sort.spec.ts` and this PR removing it from `table.spec.ts`, the filter-empty-state for workflows is covered by:
- `execution-filtering.spec.ts` (canonical test of this shared behavior)
- Unit tests for `SynEmptyStateFilter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)