### PR TITLE
chore(e2e/table): remove duplicate multiple workflows display test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/table.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/table.spec.ts
@@ -83,42 +83,4 @@ test.describe('Workflows Table - Display and Navigation', () => {
     }
   })
 
-  test('multiple workflows display in table with unique identifiers', async ({ app }) => {
-    // Create 2 workflows for this test
-    const project = await ensureProject(app)
-    const projectId = project?.id
-    const prefix = buildUniqueName('e2e-multi')
-
-    const workflow1 = await createWorkflowViaApi(app, {
-      name: `${prefix}-workflow-1`,
-      projectId,
-    })
-
-    const workflow2 = await createWorkflowViaApi(app, {
-      name: `${prefix}-workflow-2`,
-      projectId,
-    })
-
-    if (!workflow1 || !workflow2) throw new Error('Failed to create test workflows')
-
-    try {
-      await app.goto(toAppUrl('/workflows'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
-
-      // Filter by prefix to show only our test workflows
-      await app.getByPlaceholder('Filter by name').fill(prefix)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      // Check if table exists
-      const table = app.getByRole('grid', { name: 'Workflows table' })
-      await expect(table).toBeVisible({ timeout: 5000 })
-
-      // Verify both workflows are visible
-      await expect(table.getByRole('row', { name: new RegExp(workflow1.name) })).toBeVisible()
-      await expect(table.getByRole('row', { name: new RegExp(workflow2.name) })).toBeVisible()
-    } finally {
-      await deleteWorkflowViaApi(app, workflow1.id)
-      await deleteWorkflowViaApi(app, workflow2.id)
-    }
-  })
 })


### PR DESCRIPTION
## Summary

Removes the `'multiple workflows display in table with unique identifiers'` test from `e2e/workflows/table.spec.ts`.

## Analysis

**Rule applied:** Rule 2 — Strict-subset assertions, and Rule 5 — Journey test whose sub-steps each have their own spec.

**The removed test** seeded two workflows via API, navigated to the Workflows list, and asserted that both workflow names appeared as distinct rows in the table. Its assertions (two named rows visible, no row duplication) are a strict subset of the broader table and search-filter tests.

**Why it is redundant:**

1. **Subset of the status-filter and search tests.** The `search-filter-sort.spec.ts` tests seed two workflows (one matching the filter, one not) and assert that specific rows appear or disappear. Those tests implicitly verify that: (a) multiple workflows can coexist in the table, (b) each row shows its unique name, and (c) rows are not deduplicated or merged. A test that only asserts (a)+(b) without the filtering step is a subset.

2. **Covered by the delete-workflow flow.** The retained test `'user can delete a workflow'` seeds a workflow, verifies it appears in the table, and deletes it — demonstrating the round-trip between API creation and table display. If two seeded workflows produced duplicate rows or missing rows, any test that creates and then interacts with a specific row would fail.

3. **"Unique identifiers" is not a product behavior.** The test was asserting that row content is distinct, which is a consequence of the table rendering each row's `name` field. This is a rendering-correctness check better suited to a unit test on the table component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)