### PR TITLE
[UX]: Add August 2026 patterns

### DIFF
--- a/.claude/skills/frontend-patternfly-ux/SKILL.md
+++ b/.claude/skills/frontend-patternfly-ux/SKILL.md
@@ -32,15 +32,6 @@ This document serves as the definitive technical and design North Star for **thi
 
 **In short:** We use this framework to build faster, stay aligned with the broader PatternFly ecosystem, and ensure that this product remains premium and stable.
 
-### Publication and Branding Constraints
-
-This skill is published upstream and must **not** contain product branding, marketing names, or internal tooling references in prose. When writing or updating this document:
-
-- **Do not reference** in prose: Automation Orchestrator, AO, Nexus, Jira, Syntara (as a product name), Ansible, or Red Hat (as employer branding).
-- **Use generic terms** instead: "this product", "the platform", "the UI repository", "contributor channels", "the issue tracker".
-- **Do not cite ticket IDs** (e.g., `AAP-12345`) — describe the behavioral reason directly.
-- **Code identifiers are fine** — file paths, package names, component names, CSS custom properties, and API field names are technical references, not branding.
-
 ### UI/UX Team
 
 For engagement questions, reach out to the UX team in the project's contributor channels.

--- a/.claude/skills/frontend-patternfly-ux/SKILL.md
+++ b/.claude/skills/frontend-patternfly-ux/SKILL.md
@@ -32,6 +32,15 @@ This document serves as the definitive technical and design North Star for **thi
 
 **In short:** We use this framework to build faster, stay aligned with the broader PatternFly ecosystem, and ensure that this product remains premium and stable.
 
+### Publication and Branding Constraints
+
+This skill is published upstream and must **not** contain product branding, marketing names, or internal tooling references in prose. When writing or updating this document:
+
+- **Do not reference** in prose: Automation Orchestrator, AO, Nexus, Jira, Syntara (as a product name), Ansible, or Red Hat (as employer branding).
+- **Use generic terms** instead: "this product", "the platform", "the UI repository", "contributor channels", "the issue tracker".
+- **Do not cite ticket IDs** (e.g., `AAP-12345`) — describe the behavioral reason directly.
+- **Code identifiers are fine** — file paths, package names, component names, CSS custom properties, and API field names are technical references, not branding.
+
 ### UI/UX Team
 
 For engagement questions, reach out to the UX team in the project's contributor channels.
@@ -62,7 +71,10 @@ How this UI is anchored, and how it relates to other design tooling:
   3. **Engage PatternFly.** If UX confirms the gap, UX coordinates with PatternFly on resolution — new component, variant, token, or an accepted override — often via a PatternFly GitHub issue or direct conversation.
   4. **Document and track.** If a temporary override is approved, create an issue with the label `patternfly-override` to track technical debt. Link the PatternFly issue if one exists.
   5. **Resolve upstream.** The aim is to remove the override by contributing back to PatternFly. Overrides without a resolution path should be periodically reviewed.
-- **`Nx` prefix convention** — opinionated global components use the `Nx` prefix (e.g., `SynPage`, `SynPanel`, `NxConfirmationDialog`, `NxDetailList`) and live in `frontend/packages/syntara-ui/src/components/` organized by subdirectory: `layout/`, `dialogs/`, `details/`, `tabs/`, `states/`. These wrap raw PatternFly primitives with project-specific defaults and behavior — use the `Nx*` wrapper, not the raw PF component, for these patterns.
+- **Opinionated component prefixes** — global wrappers live in `frontend/packages/syntara-ui/src/components/` organized by subdirectory: `layout/`, `dialogs/`, `details/`, `tabs/`, `states/`, `labels/`, `table/`, `panels/`. Two prefixes are in use:
+  - **`Syn*`** — layout, state, tables, labels, links, and kebab menus (e.g., `SynPage`, `SynPanel`, `SynPageHeader`, `SynErrorState`, `SynScrollableTableContainer`, `SynLabel`, `SynKebabMenu`, `SynLink`)
+  - **`Nx*`** — dialogs, details, tabs, and list panels (e.g., `NxConfirmationDialog`, `NxDetailList`, `NxUrlTabs`, `NxListPanel`)
+  - Always use the `Syn*` / `Nx*` wrapper, not the raw PatternFly component, for these patterns.
 - **What this is not** — The experience is **not** built on custom libraries. This product deliberately uses a PatternFly-first stack.
 
 ---
@@ -234,6 +246,8 @@ There are different kinds of page headers:
   - Left-aligned breadcrumbs (via `SynPageBreadcrumbs`) + page title
   - No action buttons in the header — Save and Cancel live in the `SynPanel` sticky footer (see Sticky Form Footer above)
 
+- **Documentation link** — when a page has product documentation, pass `docLink={useDocLink('key')}` to `SynPageHeader`. Never hardcode doc URLs — add new keys to `src/utils/docs/docsUrls.json` and resolve via `useDocLink`. Wire doc links on list pages, detail pages, form pages, and multi-step wizards (e.g., integration configure, identity provider create, user create/edit) wherever the docs team has published guidance.
+
 ### Breadcrumbs
 
 Use `SynPageBreadcrumbs` for detail and form page navigation.
@@ -316,7 +330,7 @@ Filter bar is visible when data exists or when filters are active; hidden only w
   - Every table row has a kebab menu (⋮) in the rightmost column containing all available actions for that resource
   - The actions column has no column header label
   - All row actions live inside the kebab — no direct buttons or links in the actions column
-  - **Exception — inline enable/disable**: A `Switch` toggle may appear in a dedicated "State" column (not the actions column) for resources where toggling the enabled state is the most frequent action (e.g., credentials, identity providers). The switch patches the resource directly. **Note:** Workflows no longer use an inline Switch — they use the Publish lifecycle with status badges (see §17).
+  - **Exception — inline enable/disable**: A `Switch` toggle may appear in a dedicated "State" column (not the actions column) for resources where toggling the enabled state is the most frequent action (e.g., credentials, identity providers, user accounts). The switch patches the resource directly — do not duplicate the toggle on the edit form when it belongs on the list. **Note:** Workflows no longer use an inline Switch — they use the Publish lifecycle with status badges (see §17).
   - **Full labels:** Always use `"Action + resource"` format in kebab menus — e.g., "Edit credential", "Delete credential", "Duplicate workflow" (not just "Edit" or "Delete"). Each item includes an icon via the `IconLabel` pattern.
   - Destructive items use `isDanger: true` (e.g., "Delete credential" renders in red)
   - Action order: non-destructive actions first (e.g., "Edit credential", "Duplicate workflow", "Disable credential"), then a divider, then destructive actions last (e.g., "Delete credential", "Remove integration")
@@ -332,11 +346,14 @@ Filter bar is visible when data exists or when filters are active; hidden only w
   - Use `IconLabel` for action titles: `<IconLabel icon={<RhUiEditIcon />}>Edit workflow</IconLabel>`
   - Permission-gated items: `isAriaDisabled: true` + `tooltipProps: { content: tooltip }` (visible but non-actionable, stays focusable)
   - **Only one kebab open at a time** — this is built into `SynKebabMenu` itself via a module-level registry of open-menu close callbacks; opening any `SynKebabMenu` automatically closes every other one on the page. Callers don't opt in or manage this — it's automatic across separate table rows and between a table row and an adjacent panel (e.g., a history panel row).
-- **Expandable rows** — When a table uses expandable rows to show nested detail (e.g., policies under a role, execution steps in a workflow run):
+- **Expandable rows** — When a table uses expandable rows to show nested detail (e.g., policies under a role assignment, execution steps in a workflow run):
   - Pass `isExpandable` to `SynScrollableTableContainer` for proper PF6 table styling
   - Include an expand-all / collapse-all toggle in the `<Thead>` using the `expand` prop on the first `<Th>`
   - Use `ExpandableRowContent` for the expanded row body
   - Expanded content should use compact gray `Label` components for list-style data (e.g., attached policies)
+  - **Hide expand toggle when row has no nested content** — if a row has nothing to expand (e.g., an assignment with zero policies), do not render the expand chevron. Follow the credentials/approvals pattern.
+  - **Use `useExpandableRowIds`** (`hooks/useExpandableRowIds.ts`) for expand/collapse-all state — pass the current page's row IDs and wire `expandedRows`, `allRowsExpanded`, `handleToggleRow`, and `handleCollapseAll` to the table.
+  - **Policies in expandable rows** — assignment tables show attached policies in the expanded row as grey filled labels, not as a crowded Policies column. This keeps the main row scannable while still exposing full policy lists on demand.
   - Column order left to right: expand/collapse chevron → [checkbox if selectable] → data columns → actions
 - **Footer/pagination** — use `PaginationFooter` via the `SynScrollableTableContainer` `footer` prop. `PaginationFooter` wraps PatternFly's [Pagination](https://www.patternfly.org/components/pagination) component; supports `page`, `perPage`, `total` (optional), `hasNext`, `onPrev`, `onNext`, and `onPerPageChange`. When `total` is unknown (cursor-based APIs), item count is estimated from `page`, `perPage`, and `hasNext`. Pair with `useCursorPagination` from `src/hooks/useCursorPagination.tsx` for cursor state management
 
@@ -614,7 +631,7 @@ Use for editing complex resources with many fields or multi-step creation.
 
 - Pre-populate all fields with existing values
 - Track dirty state (unsaved changes)
-- Warn on navigation with unsaved changes
+- Warn on navigation with unsaved changes via `useDirtyFormGuard` (see §7)
 - Show loading state while saving
 
 ### Update/Edit: Modal
@@ -805,6 +822,7 @@ Integrations (e.g., tool providers) use a 3-step PatternFly Wizard for initial c
 
 - Header: integration name with enabled/disabled `Switch` toggle (inline, not modal-gated)
 - "Test connection" secondary button in the detail header — must pass before enabling tools
+- **Last checked** — show `last_validated_at` as a "Last checked" field on the detail page and as a sortable "Last checked" column on the integrations list. Render through `DateCell` / `UserTimestamp` (same timestamp conventions as §3 Table Component).
 - **Tools tab:** Table of available tools from the integration, each with an individual `Switch` to enable/disable
 - Enable/disable the integration itself via the header Switch; enable/disable individual tools via per-row Switches
 - All Switches follow standard PF behavior — toggle takes effect immediately, no confirmation for enable, standard confirmation for disable
@@ -816,6 +834,8 @@ Access Management uses consistent terminology and navigation:
 - **Tab label:** "Check access" (not "Can I") — verb-first label for the self-service permission-checking tab
 - **Self-service flows** (Check access, My tokens) are moved to the **My Profile** page, not Access Management
 - Access Management contains only admin-level tabs: Users, Groups, Projects, Roles, Policies, Assignments
+- **Role assignment pickers** — filter out roles already assigned to the selected principal at the relevant scope from dropdown options (system scope for global assignments, project scope for project assignments). Build an `assignedRolesByPrincipal` map from existing assignments and exclude matching role IDs before rendering options.
+- **Policy multi-select pickers** — include a "Select All" action above the option list that fetches **all pages** of policies and merges with any existing selection (not just the first page). Disable "Select All" while the fetch is in progress; surface fetch errors inline. See `PolicySelectOptionsList` and `policySelectConstants.ts`.
 
 ### My Profile Page
 
@@ -868,6 +888,8 @@ When a user attempts to navigate away from a form or builder with unsaved change
 - **Modal variant:** Medium — three buttons plus explanatory body copy need more width than Small
 - Use specific action labels: `"Save workflow"` instead of generic `"Save"` when the resource type matters
 - Cancel dismisses the modal and returns the user to their current context without saving or discarding
+
+**`useDirtyFormGuard` registration** — forms and settings surfaces that need navigation protection should register via `useDirtyFormGuard` (`hooks/useDirtyFormGuard.ts`), which wraps the shared `UnsavedChangesProvider`. Pass `isDirty`, optional `onSave` (omit to hide the Save button in the modal), `onDiscard`, modal `title`/`body`, and `saveLabel`. Call `dismiss()` before programmatic navigation after a successful save to prevent a double-modal. Set `isActive: false` when the guarded surface is mounted but not visible (e.g., an inactive tab in a tabbed detail view).
 
 ---
 
@@ -1137,7 +1159,7 @@ Principal type and scope are **different dimensions** — use colors from their 
 | -------------------- | ----------- |
 | Single-value callout | Filled grey |
 
-Do **not** show per-group item count badges on project group headers in All projects views — row counts are misleading when groups are paginated or filtered (see AAP-85112).
+Do **not** show per-group item count badges on project group headers in All projects views — row counts are misleading when groups are paginated or filtered.
 
 ### Grace-Period / Time-Remaining Indicator
 
@@ -1468,6 +1490,15 @@ These badges use `Label` with no icons — text and color only.
 - **Loading:** "Saving…" + spinner via mutation `isPending`
 - **Tooltip:** Shows `"Last saved {formatted datetime}"` when previously saved; `"Save workflow"` when never saved
 - **Toast policy:** Success toast on **create** (new workflow); **no toast** on update (dirty state clearing + tooltip timestamp are sufficient)
+- **Browser tab dirty indicator** — when the workflow builder has unsaved changes, prepend `●` to the `<title>` element (via `toPageTitle`), following the IDE convention for unsaved files. Clear the indicator when the workflow is saved or when undo returns the canvas to a clean state.
+
+### Run History Panel
+
+Run history rows must be real navigable links, not `Button` + `navigate`:
+
+- Use `HistoryListItemLink` (`routes/builder/HistoryListItemLink.tsx`) — a TanStack Router `<Link>` styled as a PatternFly `SimpleList` item. Unmodified left-click runs `onSelect`; modified clicks (Ctrl/Cmd, middle-click) open the route in a new tab.
+- **`SynLink` cannot be used here** — it renders a PF `Button`, not an anchor, so it breaks link semantics and "open in new tab" behavior.
+- **Overlay pattern for nested controls** — when a row contains nested interactive elements (version link, kebab menu), render an absolutely-positioned `HistoryListItemLink` with `overlay` to cover the row while nested controls sit above with higher z-index. This preserves both row-level navigation and independent nested click targets.
 
 ### Step Interactions
 
@@ -1939,12 +1970,12 @@ This project ships with a Chrome DevTools MCP server configured in `.mcp.json`. 
 
 ## 21. Storybook Review Workflow
 
-The project ships with Storybook for documenting and reviewing `Nx*` components. Use it alongside the dev server for UI verification.
+The project ships with Storybook for documenting and reviewing `Syn*` / `Nx*` components. Use it alongside the dev server for UI verification.
 
 - **Start Storybook:** `npm run storybook` (port 5174)
 - **Light and dark mode:** Preview components in both themes via the Storybook toolbar (System / Light / Dark) before sign-off
 - **Composed stories over isolated demos:** Stories should reflect real app compositions (e.g., a full list page layout), not isolated prop playgrounds
-- **Autodocs:** Foundational `Nx*` components have `autodocs` enabled — browse auto-generated API docs alongside live examples
+- **Autodocs:** Foundational `Syn*` / `Nx*` components have `autodocs` enabled — browse auto-generated API docs alongside live examples
 - **Available stories:** `SynPage`, `SynPageHeader`, `SynPageBreadcrumbs`, `SynPanel`, `SynPanelContentStack`, `NxUrlTabs`, `NxConfirmationDialog`, `NxCodeBlock`, `NxDetail`, `NxDetailList`, `SynErrorState`, `SynLoadingState`, `SynEmptyStateNoData`, `SynEmptyStateFilter`, `SynEmptyStateServiceUnavailable`, `NxListPanel`, `SynKebabMenu`, `SynLabel`, `SynUserTag`, `SynScrollableTableContainer`
 
 ---
@@ -1956,7 +1987,7 @@ The project ships with Storybook for documenting and reviewing `Nx*` components.
 - Follow the accessibility guidelines in section 18
 - Follow the styling rules in section 19
 - Use Chrome DevTools MCP (section 20) to verify your implementation against the live app
-- Use Storybook (section 21) to review `Nx*` component documentation and test in light/dark mode
+- Use Storybook (section 21) to review `Syn*` / `Nx*` component documentation and test in light/dark mode
 
 ---
 

--- a/frontend/.cursor/rules/patternfly-ux-design-system.mdc
+++ b/frontend/.cursor/rules/patternfly-ux-design-system.mdc
@@ -15,8 +15,6 @@ alwaysApply: false
 
 When building frontend UI in this project, follow these opinionated PatternFly patterns. This ensures consistency across feature teams and reduces cognitive load for users.
 
-**Publication constraint:** This rule must not contain product branding or internal tooling references in prose (no Automation Orchestrator, AO, Nexus, Jira, etc.). Use generic terms like "this product" or "the platform". See the full skill for details.
-
 ## Philosophy
 
 Our UX is designed around the **supervisor** mental model — an operator who must understand, trust, and intervene in complex automation across scale.

--- a/frontend/.cursor/rules/patternfly-ux-design-system.mdc
+++ b/frontend/.cursor/rules/patternfly-ux-design-system.mdc
@@ -15,6 +15,8 @@ alwaysApply: false
 
 When building frontend UI in this project, follow these opinionated PatternFly patterns. This ensures consistency across feature teams and reduces cognitive load for users.
 
+**Publication constraint:** This rule must not contain product branding or internal tooling references in prose (no Automation Orchestrator, AO, Nexus, Jira, etc.). Use generic terms like "this product" or "the platform". See the full skill for details.
+
 ## Philosophy
 
 Our UX is designed around the **supervisor** mental model — an operator who must understand, trust, and intervene in complex automation across scale.
@@ -34,7 +36,7 @@ How the UI is anchored:
 - **Automation builder** — Based on [React Flow](https://reactflow.dev/) with PatternFly as visual wrapper
 - **Accessibility** — Must achieve [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG2AA-Conformance) and [Section 508](https://www.section508.gov/) compliance
 - **PatternFly gaps** — Check PF docs first → Raise with UX team → Engage PatternFly → Document with `patternfly-override` label → Resolve upstream
-- **`Nx` prefix convention** — opinionated global components use the `Nx` prefix (e.g., `SynPage`, `SynPanel`, `NxConfirmationDialog`, `NxDetailList`) in `src/components/` organized by: `layout/`, `dialogs/`, `details/`, `tabs/`, `states/`. Use the `Nx*` wrapper, not the raw PF component.
+- **Opinionated component prefixes** — `Syn*` for layout, state, tables, labels, links, and kebab menus (`SynPage`, `SynPanel`, `SynScrollableTableContainer`, `SynLabel`, `SynKebabMenu`); `Nx*` for dialogs, details, tabs, and list panels (`NxConfirmationDialog`, `NxUrlTabs`, `NxListPanel`). Use the wrapper, not raw PF components.
 
 ## Page Layout (MANDATORY)
 
@@ -68,6 +70,7 @@ Every page must follow this structural hierarchy:
 - **Main page header** — Left-aligned title, right-aligned actions
 - **Details page header** — Left-aligned breadcrumbs (`SynPageBreadcrumbs`) + title; toolbar left→right: Switch → Edit (primary) → kebab
 - **Form page header** — Left-aligned breadcrumbs + title; no action buttons in the header — Save and Cancel live in the `SynPanel` sticky footer
+- **Documentation link** — pass `docLink={useDocLink('key')}` to `SynPageHeader`; never hardcode doc URLs. Add keys to `docsUrls.json`.
 
 ### Breadcrumbs
 
@@ -121,7 +124,7 @@ Use a docked icon navigation (left sidebar) with PatternFly's flyout panels comp
 - Clicking resource name navigates to details view
 - "Created"/"Modified" columns: username (linked) + date together. Date format: `MMM DD, YYYY, H:MM:SS AM/PM` — always use `DateCell` / `formatDateTime()` from `dateUtils.ts` (never `toLocaleString` or PF `Timestamp`)
 - Text-heavy columns (names, descriptions, emails, URLs) MUST use `<Truncate>` — ellipsis with tooltip on hover; `table-layout: fixed` for equal column distribution (do not opt out with `useFixedLayout={false}`)
-- Expandable rows: pass `isExpandable` to `SynScrollableTableContainer`, add expand-all/collapse-all toggle in `<Thead>` via `expand` prop, use `ExpandableRowContent` for nested detail, compact gray `Label` for list data
+- Expandable rows: pass `isExpandable` to `SynScrollableTableContainer`, add expand-all/collapse-all toggle in `<Thead>` via `expand` prop, use `ExpandableRowContent` for nested detail, compact gray `Label` for list data. Hide expand toggle when row has no nested content. Use `useExpandableRowIds` for expand state. Assignment policies belong in expanded rows, not a crowded column.
 - Footer/pagination: cursor-based via `SynScrollableTableContainer`'s `footer` prop (`TableFooterProps`)
   - Left: item count — `"5 workflows (of 100 total)"`
   - Right: Previous / Next buttons using API cursor tokens (`prev`, `next`) — no page numbers or per-page selector
@@ -191,7 +194,7 @@ Action verb pairings: "Create" ↔ "Delete", "Add" ↔ "Remove" (internal resour
 ### Update/Edit
 
 - **Full page:** 5+ fields, multi-step, or if create is full page
-  - Pre-populate fields, track dirty state, warn on unsaved navigation, show loading while saving
+  - Pre-populate fields, track dirty state, warn on unsaved navigation via `useDirtyFormGuard`, show loading while saving
 - **Modal:** 2–4 fields, or if create is a modal
 - **Inline:** Single-field edits, toggles (use PatternFly Switch Checked with Label), renames
 
@@ -355,6 +358,8 @@ All icons MUST use the **`RhUi` prefix** (e.g., `RhUiAddIcon`, `RhUiEditIcon`, `
 - **Approval side panel:** Right-side panel on execution viewer for inline approval review. Mutually exclusive with history panel; auto-opens on pending approval via `useAutoApprovalDetection`. **Multi-approval navigation:** `ApprovalNavigationHeader` with prev/next arrows, "2 of 5" counter, keyboard nav support.
 - **Wait node countdown:** Live `HH:MM:SS` countdown on canvas during execution via `useWaitCountdown` (1s interval). Clears on terminal status.
 - **Import confirmation:** Modal with radio choices ("Import as new" vs "Import into current") for existing saved workflows. Direct import for new/empty. Warns about unsaved changes when `isDirty`.
+- **Run history rows:** Use `HistoryListItemLink` (real `<a>` via TanStack Router), not `Button` + `navigate`. Overlay pattern when row has nested controls (version link, kebab). `SynLink` cannot be used — it renders a Button.
+- **Browser tab dirty indicator:** Prepend `●` to `<title>` when builder has unsaved changes (via `toPageTitle`).
 
 ## Permission Gating
 
@@ -381,6 +386,7 @@ Non-dismissible alert dialog for security-critical time warnings: `Modal variant
 - 3-step PatternFly Wizard for initial setup: Select type → Configure connection → Review & confirm with "Test connection"
 - Detail page header: integration name + enabled/disabled `Switch` toggle (immediate, no confirmation for enable)
 - "Test connection" secondary button — must pass before enabling tools
+- **Last checked:** show `last_validated_at` as "Last checked" on list (sortable column) and detail (via `DateCell` / `UserTimestamp`)
 - Tools tab: table of available tools with per-row `Switch` to enable/disable individual tools
 
 ## Access Management & My Profile
@@ -388,6 +394,9 @@ Non-dismissible alert dialog for security-critical time warnings: `Modal variant
 - Access Management tab label: **"Check access"** (not "Can I")
 - Self-service flows (Check access, My tokens) live on the **My Profile** page, not Access Management
 - Access Management contains only admin tabs: Users, Groups, Projects, Roles, Policies, Assignments
+- **Role assignment pickers:** filter out already-assigned roles for the selected principal at the relevant scope
+- **Policy multi-select:** include "Select All" that fetches all pages and merges with existing selection
+- **User enabled toggle:** lives on the users list table State column (Switch), not on the edit user form
 - **My Profile** (`/my-profile`): reuses `UserDetail` with `isMyProfile` flag; no breadcrumbs; extra tabs (My tokens, Check access); accessible from user avatar menu in masthead
 
 ## Full-Page Wizard


### PR DESCRIPTION
## Summary
- Add **Publication * section
- Capture verified patterns from merged frontend PRs since the July audit (#972):
  - `useDocLink` / `docLink` on page headers
  - `useDirtyFormGuard` for form navigation protection
  - `useExpandableRowIds` + hide-when-empty expandable rows; assignment policies in expanded rows
  - User enabled toggle on list table (not edit form)
  - Integration "Last checked" (`last_validated_at`) column/field
  - `HistoryListItemLink` overlay pattern for run history rows
  - Browser tab `●` dirty indicator in workflow builder
  - Role assignment picker filtering + policy "Select All" pagination
- Update `Syn*` / `Nx*` prefix convention to reflect the layout/state vs. dialog/table split
- Sync condensed Cursor rule (`patternfly-ux-design-system.mdc`)

## Test plan
- [ ] Review `.claude/skills/frontend-patternfly-ux/SKILL.md` for accuracy against current `devel` implementation
- [ ] Confirm no branding/marketing references remain in skill prose (code identifiers are fine)
- [ ] Mark PR ready for review once UX team sign-off is complete

Made with [Cursor](https://cursor.com)