### PR TITLE
chore(e2e/config-nav): remove duplicate credentials navigation test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/configuration-navigation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/configuration-navigation.spec.ts
@@ -24,18 +24,6 @@ test.describe('Configuration Navigation & Tabs', () => {
     await expect(app.getByRole('menuitem', { name: 'Credentials', exact: true })).toBeVisible()
   })
 
-  test('navigates to Credentials page from Configuration menu', async ({ app }) => {
-    await app.goto(toAppUrl('/configuration/integrations'))
-    await expect(app.getByRole('heading', { name: 'Integrations', level: 1 })).toBeVisible()
-
-    // Act - Open Configuration dropdown and click Credentials
-    await navigateViaConfigMenu(app, 'Credentials')
-
-    // Assert - URL and page heading are correct
-    await expect(app).toHaveURL(/configuration\/credentials/)
-    await expect(app.getByRole('heading', { level: 1, name: 'Credentials' })).toBeVisible()
-  })
-
   test('persists active tab after page refresh', async ({ app }) => {
     // Arrange - Navigate directly to Credentials page
     await app.goto(toAppUrl('/configuration/credentials'))


### PR DESCRIPTION
## Summary
Removes `'navigates to Credentials page from Configuration menu'` from `e2e/configuration-navigation.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `navigates to Credentials page from Configuration menu` in `configuration-navigation.spec.ts` |
| **What it tests** | Navigate to `/configuration/integrations`, open Configuration dropdown, click Credentials, assert URL and heading |
| **Duplication rule violated** | Rule 6 — Navigation sub-step covered by superset test |

## Why it is redundant
Every test in `credential-detail.spec.ts` and `credentials-list.spec.ts` already navigates to the credentials page as a setup step. If the navigation were broken, all those tests would fail — this standalone navigation assertion adds zero incremental confidence.

## Coverage retained
The credentials navigation path is exercised by every test in `credential-detail.spec.ts` and `credentials-list.spec.ts` as a prerequisite step.

## Risk
Low — purely redundant navigation assertion.