### PR TITLE
chore(e2e/credential-detail): remove vague 'workflow references' tab test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/credential-detail.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-detail.spec.ts
@@ -109,23 +109,6 @@ test.describe('Credential Detail Page & Workflows Tab', () => {
     }
   })
 
-  test('workflows tab shows workflow references when available', async ({ app }) => {
-    const { name } = await createTestCredential(app, { prefix: 'e2e-detail-wf-refs' })
-    try {
-      await navigateToCredentialDetail(app, name)
-      await app.getByRole('tab', { name: /Workflows/ }).click()
-
-      // This credential was just created — it won't have workflows referencing it
-      // Assert the empty state or table renders correctly
-      const emptyState = app.getByText('No workflows using this credential')
-      const table = app.getByRole('grid', { name: 'Workflows using this credential' })
-      const errorState = app.getByText('Failed to load workflows')
-      await expect(emptyState.or(table).or(errorState)).toBeVisible()
-    } finally {
-      await deleteCredentialByName(app, name)
-    }
-  })
-
   test('workflows tab shows count in footer when workflows exist', async ({ app }) => {
     const { name } = await createTestCredential(app, { prefix: 'e2e-detail-wf-count' })
     try {
@@ -170,6 +153,22 @@ test.describe('Credential Detail Page & Workflows Tab', () => {
     }
   })
 
+  test.skip('shows empty state when no workflows use credential', async ({ app }) => {
+    // A freshly created credential has no workflows referencing it
+    const { name } = await createTestCredential(app, { prefix: 'e2e-detail-wf-empty' })
+    try {
+      await navigateToCredentialDetail(app, name)
+      await app.getByRole('tab', { name: /Workflows/ }).click()
+
+      // Assert - Empty state or error (if endpoint not implemented yet)
+      const emptyState = app.getByText('No workflows using this credential')
+      const errorState = app.getByText('Failed to load workflows')
+      await expect(emptyState.or(errorState)).toBeVisible()
+    } finally {
+      await deleteCredentialByName(app, name)
+    }
+  })
+
   test('navigates to Integrations tab', async ({ app }) => {
     const { name } = await createTestCredential(app, { prefix: 'e2e-detail-int-nav' })
     try {
@@ -197,22 +196,6 @@ test.describe('Credential Detail Page & Workflows Tab', () => {
       // Assert - Empty state or error (freshly created credential has no integrations)
       const emptyState = app.getByText('No integrations using this credential')
       const errorState = app.getByText('Failed to load integrations')
-      await expect(emptyState.or(errorState)).toBeVisible()
-    } finally {
-      await deleteCredentialByName(app, name)
-    }
-  })
-
-  test.skip('shows empty state when no workflows use credential', async ({ app }) => {
-    // A freshly created credential has no workflows referencing it
-    const { name } = await createTestCredential(app, { prefix: 'e2e-detail-wf-empty' })
-    try {
-      await navigateToCredentialDetail(app, name)
-      await app.getByRole('tab', { name: /Workflows/ }).click()
-
-      // Assert - Empty state or error (if endpoint not implemented yet)
-      const emptyState = app.getByText('No workflows using this credential')
-      const errorState = app.getByText('Failed to load workflows')
       await expect(emptyState.or(errorState)).toBeVisible()
     } finally {
       await deleteCredentialByName(app, name)


### PR DESCRIPTION
## Summary
Removes `'workflows tab shows workflow references when available'` from `e2e/credential-detail.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `workflows tab shows workflow references when available` in `credential-detail.spec.ts` |
| **What it tests** | Navigate to credential detail, click Workflows tab, assert (empty state OR table OR error) is visible |
| **Duplication rule violated** | Rule 1 — Effectively assertion-free: accepts any of three states |

## Why it is redundant
The test accepts **any** of three states: `No workflows using this credential`, a `grid`, or `Failed to load workflows`. Since a freshly created credential has no workflows referencing it, the test always hits the empty state — but the `.or()` assertion means the test would pass even if the error state appeared. This disjunctive assertion provides zero confidence that the feature works correctly.

## Coverage retained
The Workflows tab is covered by `workflow names display as bold text in table` which verifies the tab with actual workflow references.

## Risk
Low — the removed test's assertion set is so broad it was not catching bugs.