### PR TITLE
chore(e2e/credential-detail): remove vague 'count in footer' tab test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/credential-detail.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-detail.spec.ts
@@ -109,22 +109,6 @@ test.describe('Credential Detail Page & Workflows Tab', () => {
     }
   })
 
-  test('workflows tab shows count in footer when workflows exist', async ({ app }) => {
-    const { name } = await createTestCredential(app, { prefix: 'e2e-detail-wf-count' })
-    try {
-      await navigateToCredentialDetail(app, name)
-      await app.getByRole('tab', { name: /Workflows/ }).click()
-
-      // Assert - Either count footer, empty state, or error renders
-      const countFooter = app.getByText(/\d+ workflows?/)
-      const emptyState = app.getByText('No workflows using this credential')
-      const errorState = app.getByText('Failed to load workflows')
-      await expect(countFooter.or(emptyState).or(errorState)).toBeVisible()
-    } finally {
-      await deleteCredentialByName(app, name)
-    }
-  })
-
   test('workflow names display as bold text in table', async ({ app }) => {
     const { name } = await createTestCredential(app, { prefix: 'e2e-detail-wf-bold' })
     try {


### PR DESCRIPTION
## Summary
Removes `'workflows tab shows count in footer when workflows exist'` from `e2e/credential-detail.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `workflows tab shows count in footer when workflows exist` in `credential-detail.spec.ts` |
| **What it tests** | Navigate to credential detail Workflows tab, assert (count footer OR empty state OR error) is visible |
| **Duplication rule violated** | Rule 1 — Effectively assertion-free: accepts any of three states including the error state |

## Why it is redundant
Same issue as the previous test: the disjunctive `.or()` assertion accepts any of three possible states. A freshly created credential has no workflows, so the count assertion (`\d+ workflows?`) never fires — the test always passes via the `emptyState` branch. The test name ("shows count in footer when workflows **exist**") is misleading: it creates a credential with no workflow references and the count assertion is never exercised.

## Coverage retained
The Workflows tab is covered by `workflow names display as bold text in table`.

## Risk
Low — the removed test was not providing meaningful verification.