### PR TITLE
chore(e2e/credentials-list): remove duplicate non-matching filter empty state test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/credentials-list.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credentials-list.spec.ts
@@ -230,23 +230,6 @@ test.describe('Name Keyword Filtering', () => {
     }
   })
 
-  test('non-matching filter shows EmptyStateFilter', async ({ app }) => {
-    const { name: credName } = await createTestCredential(app, { prefix: 'e2e-filter-nomatch' })
-
-    try {
-      await goToCredentialsList(app)
-      await expect(app.getByPlaceholder('Filter by keyword')).toBeVisible({ timeout: 15_000 })
-      const nonexistent = buildUniqueName('e2e-no-match-ever')
-      await filterCredentialByName(app, nonexistent)
-
-      await expect(app.getByText('No results found')).toBeVisible()
-      await expect(
-        app.getByRole('search', { name: 'Filters' }).getByRole('button', { name: 'Clear all filters' })
-      ).toBeVisible()
-    } finally {
-      await deleteCredentialByName(app, credName)
-    }
-  })
 })
 
 // ---------------------------------------------------------------------------

--- a/frontend/packages/syntara-ui/e2e/credentials-list.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credentials-list.spec.ts
@@ -229,7 +229,6 @@ test.describe('Name Keyword Filtering', () => {
       await deleteCredentialByName(app, credName)
     }
   })
-
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Removes `'non-matching filter shows EmptyStateFilter'` from `e2e/credentials-list.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `non-matching filter shows EmptyStateFilter` in `credentials-list.spec.ts` |
| **What it tests** | Filter credentials by a non-existent name, assert `No results found` and `Clear all filters` are visible |
| **Duplication rule violated** | Rule 7 — Parallel "same pattern, different resource" over-testing |

## Why it is redundant
The empty-state-filter pattern is already covered by `workflows/table.spec.ts::empty state displays when no workflows match filter` and `workflows/search-filter-sort.spec.ts::empty search results show appropriate message`. The `EmptyStateFilter` component is shared across all resource lists — testing it once for workflows is sufficient.

## Coverage retained
The credentials filter behavior (including happy-path filtering) is covered by the remaining tests in the `Name Keyword Filtering` describe block.

## Risk
Low — shared component behavior, duplicate coverage.