### PR TITLE
chore(e2e/execution-filtering): remove duplicate filter-state persistence test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/execution-filtering.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/execution-filtering.spec.ts
@@ -211,26 +211,6 @@ test.describe('Execution Filtering @pr-check', () => {
     await newPage.close()
   })
 
-  test('filter state persists across navigation', async ({ app }) => {
-    await switchFieldSelector(app, 'Workflow name', 'Status')
-
-    const filterToolbar = app.getByRole('search', { name: 'Filters' })
-    await filterToolbar.getByRole('button', { name: 'Filter by status' }).click()
-    await app.getByRole('option', { name: 'Running' }).click()
-
-    await expect(app).toHaveURL(/status=running/)
-    const urlWithFilter = app.url()
-
-    await app.goto(toAppUrl('/'))
-
-    await app.goto(urlWithFilter)
-
-    await expect(app.getByRole('heading', { level: 1, name: 'Workflow Runs' })).toBeVisible()
-    const statusChipGroup = app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Status' })
-    await expect(statusChipGroup.getByText('Running')).toBeVisible()
-    await expect(app).toHaveURL(/status=running/)
-  })
-
   test('individual filter chips can be removed independently', async ({ app }) => {
     const filterToolbar = app.getByRole('search', { name: 'Filters' })
 


### PR DESCRIPTION
## Summary
Removes `'filter state persists across navigation'` from `e2e/execution-filtering.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `filter state persists across navigation` in `execution-filtering.spec.ts` |
| **What it tests** | Apply status=running filter, navigate away, return to saved URL, assert filter chip still shows |
| **Duplication rule violated** | Rule 7 — Parallel "same pattern, different resource" over-testing |

## Why it is redundant
URL-based filter persistence is a cross-cutting concern implemented by the shared `useFilterParams` hook. This same pattern is tested by `workflows/search-filter-sort.spec.ts::filter state persists in URL for sharing` and `::search input is preserved after page reload`. Testing URL persistence for every resource type adds CI time without testing any execution-filtering-specific logic.

## Coverage retained
Execution filtering behavior is covered by the remaining tests in `execution-filtering.spec.ts`.

## Risk
Low — cross-cutting hook behavior, already tested elsewhere.