### PR TITLE
chore(e2e/service-accounts): remove duplicate 'admin can create a service account via UI' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/service-accounts-project-admin.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/service-accounts-project-admin.spec.ts
@@ -6,28 +6,12 @@
  */
 import { test, expect } from './fixtures'
 import {
-  createServiceAccountViaUI,
   createTestServiceAccount,
-  deleteServiceAccountByName,
   deleteServiceAccountViaApi,
   goToServiceAccountDetail,
 } from './helpers/service-accounts'
-import { buildUniqueName } from './helpers/workflows'
 
 test.describe('UI-11: Service Account CRUD Lifecycle', () => {
-  test('admin can create a service account via UI', async ({ app }) => {
-    const saName = buildUniqueName('sa-create')
-
-    const creds = await createServiceAccountViaUI(app, { name: saName })
-
-    try {
-      expect(creds.clientId).toBeTruthy()
-      expect(creds.clientSecret).toBeTruthy()
-    } finally {
-      await deleteServiceAccountByName(app, saName)
-    }
-  })
-
   test.describe('edit and delete', () => {
     let sa: { id: string; name: string }
 


### PR DESCRIPTION
## Summary
Removes `'admin can create a service account via UI'` from `e2e/service-accounts-project-admin.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `admin can create a service account via UI` |
| **What it tests** | Call `createServiceAccountViaUI`, assert `clientId` and `clientSecret` are truthy, delete via UI |
| **Duplication rule violated** | Rule 5 — Journey test whose sub-steps have their own spec |

## Why it is redundant
The credential creation flow is also exercised as setup in the `edit and delete` describe block (via `createTestServiceAccount` in `beforeAll`). The assertion (`expect(creds.clientId).toBeTruthy()`) is a JavaScript truthiness check on the helper's return value — it does not assert any UI state.

## Coverage retained
Service account creation is exercised as a setup step in the `edit and delete` describe block.

## Risk
Low — creation is covered as infrastructure for the remaining test.