### PR TITLE
chore(e2e/builder): remove duplicate 'multiple edges can be created sequentially' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/builder.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/builder.spec.ts
@@ -464,32 +464,6 @@ test('two nodes can be connected with an edge', async ({ app }) => {
   }
 })
 
-test('multiple edges can be created sequentially', async ({ app }) => {
-  const workflowName = buildUniqueName('e2e-builder')
-  await createWorkflowWithTrigger(app, workflowName)
-
-  try {
-    await closeNodeEditorPanel(app)
-    await expect(app.getByText('Manual trigger')).toBeVisible()
-
-    // Add three nodes
-    await addScriptNode(app, 'Node 1', 'print("1")')
-    await addScriptNode(app, 'Node 2', 'print("2")')
-    await addScriptNode(app, 'Node 3', 'print("3")')
-
-    // Layout to position nodes
-    await triggerLayout(app)
-
-    // Verify all nodes are visible — three successful addScriptNode calls prove
-    // three edges were sequentially created (each call clicks an edge overlay button).
-    await verifyNodeVisible(app, 'Node 1')
-    await verifyNodeVisible(app, 'Node 2')
-    await verifyNodeVisible(app, 'Node 3')
-  } finally {
-    await deleteWorkflow(app, workflowName)
-  }
-})
-
 test('edge follows connection path between nodes', async ({ app }) => {
   const workflowName = buildUniqueName('e2e-builder')
   await createWorkflowWithTrigger(app, workflowName)


### PR DESCRIPTION
## Summary
Removes `'multiple edges can be created sequentially'` from `e2e/workflows/builder.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `multiple edges can be created sequentially` |
| **What it tests** | Add Node 1, Node 2, Node 3; trigger layout; verify all three are visible |
| **Duplication rule violated** | Rule 2 — Strict-subset assertion |

## Why it is redundant
The test asserts that three `addScriptNode` calls succeed and all three nodes are visible after layout. This is a strict subset of `'edge follows connection path between nodes'` (which verifies actual SVG edge geometry) and `'two nodes can be connected with an edge'`. The "sequential" nature being tested is proven by any test that calls `addScriptNode` more than once.

## Coverage retained
Sequential node addition is exercised by `'edge follows connection path between nodes'` and workflow creation tests.

## Risk
Low — subset assertion, covered by multiple remaining tests.