### PR TITLE
chore(e2e/builder): remove duplicate 'connected nodes form a workflow DAG' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/builder.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/builder.spec.ts
@@ -491,28 +491,3 @@ test('edge follows connection path between nodes', async ({ app }) => {
   }
 })
 
-test('connected nodes form a workflow DAG', async ({ app }) => {
-  const workflowName = buildUniqueName('e2e-builder')
-  await createWorkflowWithTrigger(app, workflowName)
-
-  try {
-    await closeNodeEditorPanel(app)
-    await expect(app.getByText('Manual trigger')).toBeVisible()
-
-    // Add nodes that will form a linear DAG: Manual Trigger -> Script 1 -> Script 2
-    await addScriptNode(app, 'Processing Step', 'print("processing")')
-    await addScriptNode(app, 'Final Step', 'print("final")')
-
-    // Layout to visualize the DAG
-    await triggerLayout(app)
-
-    // Verify all DAG nodes are present and visible after layout.
-    // DAG structure (trigger→processing→final) is proven by addScriptNode succeeding
-    // for each node — each call clicks an edge overlay button that only exists on a connected edge.
-    await verifyNodeVisible(app, 'Manual trigger')
-    await verifyNodeVisible(app, 'Processing Step')
-    await verifyNodeVisible(app, 'Final Step')
-  } finally {
-    await deleteWorkflow(app, workflowName)
-  }
-})

--- a/frontend/packages/syntara-ui/e2e/workflows/builder.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/builder.spec.ts
@@ -490,4 +490,3 @@ test('edge follows connection path between nodes', async ({ app }) => {
     await deleteWorkflow(app, workflowName)
   }
 })
-


### PR DESCRIPTION
## Summary
Removes `'connected nodes form a workflow DAG'` from `e2e/workflows/builder.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `connected nodes form a workflow DAG` |
| **What it tests** | Add Processing Step + Final Step nodes, trigger layout, verify all three node labels visible |
| **Duplication rule violated** | Rule 2 — Strict-subset assertion; Rule 1 — Effectively assertion-free |

## Why it is redundant
The test comment documents its own redundancy: "DAG structure (trigger→processing→final) is proven by addScriptNode succeeding for each node." It does not assert edge connectivity, node ordering, or DAG-specific properties (acyclicity, topological ordering). The path exercised is identical to `'edge follows connection path between nodes'`, which additionally checks SVG path positions.

## Coverage retained
`'edge follows connection path between nodes'` covers the same canvas construction with stronger geometric assertions.

## Risk
Low — subset assertion, no unique coverage.