### PR TITLE
chore(e2e/create): remove duplicate 'create button navigates to builder with new workflow' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/create.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/create.spec.ts
@@ -66,20 +66,6 @@ test.describe('Workflows - Create New Workflow', () => {
     }
   })
 
-  test('create button navigates to builder with new workflow', async ({ app }) => {
-    await app.goto(toAppUrl('/workflows'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
-
-    await app.getByRole('button', { name: 'Create workflow' }).click()
-
-    await expect(app).toHaveURL(/workflow-builder\/new/)
-
-    const workflowNameInput = app.getByPlaceholder('Workflow name')
-    await expect(workflowNameInput).toBeVisible()
-
-    await expect(app.getByRole('heading', { name: 'Select a trigger node' })).toBeVisible()
-  })
-
   test('workflow name can be customized before saving', async ({ app }) => {
     const customName = buildUniqueName('e2e-custom')
 


### PR DESCRIPTION
## Summary
Removes `'create button navigates to builder with new workflow'` from `e2e/workflows/create.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `create button navigates to builder with new workflow` |
| **What it tests** | Click `Create workflow` button, assert URL matches `/workflow-builder/new`, assert name input + heading visible |
| **Duplication rule violated** | Rule 6 — Navigation sub-step covered by superset test |

## Why it is redundant
Every other test in `workflows/create.spec.ts` navigates to `/workflow-builder/new` as its first step. The navigation and initial state assertions are implicitly verified by `user can create workflow and immediately edit it` and by tests in `e2e/builder.spec.ts`. If the Create button navigation broke, all of those tests would fail first.

## Coverage retained
The Create button navigation path is exercised as a setup step in every other workflow creation test.

## Risk
Low — pure navigation sub-step, covered by every superset test.