### PR TITLE
chore(e2e/create): remove duplicate 'workflow name can be customized before saving' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/create.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/create.spec.ts
@@ -66,36 +66,6 @@ test.describe('Workflows - Create New Workflow', () => {
     }
   })
 
-  test('workflow name can be customized before saving', async ({ app }) => {
-    const customName = buildUniqueName('e2e-custom')
-
-    try {
-      await app.goto(toAppUrl('/workflow-builder/new'))
-      await expect(app.getByRole('heading', { name: 'Select a trigger node' })).toBeVisible()
-
-      await app.getByRole('button', { name: 'Manual trigger' }).click()
-      await app.getByRole('textbox', { name: 'Name', exact: true }).fill('Manual trigger')
-      await app.getByRole('button', { name: 'Create' }).click()
-
-      await selectProjectIfRequired(app)
-
-      const workflowNameInput = app.getByPlaceholder('Workflow name')
-      await expect(workflowNameInput).toBeVisible()
-
-      await workflowNameInput.clear()
-      await workflowNameInput.fill(customName)
-
-      const saveButton = app.getByRole('button', { name: 'Save' })
-      await expect(saveButton).toBeVisible()
-      await saveButton.click()
-
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15000 })
-      await expect(app.getByPlaceholder('Workflow name')).toHaveValue(customName)
-    } finally {
-      await deleteWorkflow(app, customName)
-    }
-  })
-
   test('user can create workflow and immediately edit it', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-edit')
 


### PR DESCRIPTION
## Summary
Removes `'workflow name can be customized before saving'` from `e2e/workflows/create.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `workflow name can be customized before saving` |
| **What it tests** | Create workflow, fill custom name, save, assert URL `/workflow-builder/<id>` and name input value |
| **Duplication rule violated** | Rule 2 — Strict-subset assertion |

## Why it is redundant
All three assertions (name input accepts value, URL changes from `/new` to `/<id>`, name persists) are a strict subset of `'user creates and saves a multi-node workflow'` in `e2e/builder.spec.ts` and `'user can create workflow and immediately edit it'`. The `selectProjectIfRequired` call introduces a timing dependency on the project selector that can cause flakiness under load.

## Coverage retained
Workflow naming and save-to-URL behavior is covered by `user can create workflow and immediately edit it`.

## Risk
Low — subset assertion with a mild flakiness risk from the project selector timing.