### PR TITLE
chore(e2e/search-filter-sort): remove duplicate 'user can search workflows by name' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
@@ -42,40 +42,6 @@ test.describe('Workflows Table - Search, Filter, and Sort', () => {
     return workflows
   }
 
-  test('user can search workflows by name', async ({ app }) => {
-    const workflows = await createTestWorkflows(app, 1)
-    expect(workflows).toHaveLength(1)
-
-    try {
-      const searchTerm = workflows[0].name
-
-      // Navigate to workflows page
-      await app.goto(toAppUrl('/workflows'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
-
-      // Enter search term
-      const searchInput = app.getByPlaceholder('Filter by name')
-      await searchInput.fill(searchTerm)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      // Verify filter chip appears
-      const nameChipGroup = app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })
-      await expect(nameChipGroup).toBeVisible()
-      await expect(nameChipGroup.getByText(searchTerm)).toBeVisible()
-
-      // Verify URL contains filter
-      await expect(app).toHaveURL(new RegExp(`name.*${searchTerm}`))
-
-      // Verify matching workflow appears
-      const table = app.getByRole('grid', { name: 'Workflows table' })
-      await expect(table.getByRole('row', { name: new RegExp(workflows[0].name) })).toBeVisible()
-    } finally {
-      for (const wf of workflows) {
-        await deleteWorkflowViaApi(app, wf.id)
-      }
-    }
-  })
-
   test('user can clear search filter', async ({ app }) => {
     const workflows = await createTestWorkflows(app, 1)
     expect(workflows).toHaveLength(1)


### PR DESCRIPTION
## Summary
Removes `'user can search workflows by name'` from `e2e/workflows/search-filter-sort.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `user can search workflows by name` |
| **What it tests** | Fill filter input, click Apply, assert chip visible, URL updated, row visible |
| **Duplication rule violated** | Rule 3 — Same scenario in multiple spec files |

## Why it is redundant
The exact same scenario is covered more completely by `'search results update as user types and applies filter'` (verifies with two workflows, partial-name matching, URL encoding) and `'multiple workflows can be found using partial name search'` (same filter-and-assert pattern with stronger multi-result assertions) in the same describe block.

## Coverage retained
Name filtering is covered by `search results update as user types and applies filter` and `multiple workflows can be found using partial name search`.

## Risk
Low — identical pattern covered by remaining tests in the same describe.