### PR TITLE
chore(e2e/search-filter-sort): remove duplicate 'user can clear search filter' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
@@ -42,48 +42,6 @@ test.describe('Workflows Table - Search, Filter, and Sort', () => {
     return workflows
   }
 
-  test('user can clear search filter', async ({ app }) => {
-    const workflows = await createTestWorkflows(app, 1)
-    expect(workflows).toHaveLength(1)
-
-    try {
-      const searchTerm = workflows[0].name
-
-      await app.goto(toAppUrl('/workflows'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
-
-      // Apply filter
-      await app.getByPlaceholder('Filter by name').fill(searchTerm)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      const nameChipGroup = app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })
-      await expect(nameChipGroup).toBeVisible()
-
-      // Clear filter via "Clear all filters" button
-      await app.getByRole('search', { name: 'Filters' }).getByRole('button', { name: 'Clear all filters' }).click()
-
-      // Verify filter chip is removed
-      await expect(nameChipGroup).not.toBeVisible()
-
-      // Verify URL no longer contains filter
-      await expect(app).not.toHaveURL(/name%5Bcontains%5D/)
-
-      // Verify table shows more results (or at least doesn't show empty state)
-      const table = app.getByRole('grid', { name: 'Workflows table' })
-      const emptyState = app.getByRole('heading', { name: 'No results found' })
-
-      // Either table is visible or there genuinely are no workflows
-      const tableVisible = await table.isVisible().catch(() => false)
-      const emptyVisible = await emptyState.isVisible().catch(() => false)
-
-      expect(tableVisible || emptyVisible).toBe(true)
-    } finally {
-      for (const wf of workflows) {
-        await deleteWorkflowViaApi(app, wf.id)
-      }
-    }
-  })
-
   test('user can remove individual filter chip', async ({ app }) => {
     const workflows = await createTestWorkflows(app, 1)
     expect(workflows).toHaveLength(1)


### PR DESCRIPTION
## Summary
Removes `'user can clear search filter'` from `e2e/workflows/search-filter-sort.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `user can clear search filter` |
| **What it tests** | Apply filter, click `Clear all filters`, assert chip gone, URL updated, table or empty state visible |
| **Duplication rule violated** | Rule 7 — Parallel "same pattern, different resource" over-testing |

## Why it is redundant
The `Clear all filters` button is the same PatternFly `ChipGroup` clear action used across all resource types, already verified by `execution-filtering.spec.ts`. The residual assertion (`tableVisible || emptyVisible`) accepts any state, providing weak coverage.

## Coverage retained
Filter clearing is covered by `execution-filtering.spec.ts::individual filter chips can be removed independently`.

## Risk
Low — shared component behavior, broadly tested.