### PR TITLE
chore(e2e/search-filter-sort): remove duplicate 'empty search results show appropriate message' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
@@ -79,32 +79,6 @@ test.describe('Workflows Table - Search, Filter, and Sort', () => {
     }
   })
 
-  test('empty search results show appropriate message', async ({ app }) => {
-    await app.goto(toAppUrl('/workflows'))
-    await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
-
-    // Search for non-existent workflow
-    const impossibleSearch = `nonexistent-${Date.now()}`
-    await app.getByPlaceholder('Filter by name').fill(impossibleSearch)
-    await app.getByRole('button', { name: 'Apply filter' }).click()
-
-    // Wait for filter to be applied
-    const nameChipGroup = app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })
-    await expect(nameChipGroup).toBeVisible()
-
-    // Check for empty state
-    const table = app.getByRole('grid', { name: 'Workflows table' })
-    const tableVisible = await table.isVisible().catch(() => false)
-
-    if (!tableVisible) {
-      // Empty state should be shown
-      await expect(app.getByRole('heading', { name: 'No results found' })).toBeVisible()
-
-      // Verify clear filters button is available
-      await expect(app.getByRole('button', { name: 'Clear all filters' }).last()).toBeVisible()
-    }
-  })
-
   test('filter state persists in URL for sharing', async ({ app }) => {
     const workflows = await createTestWorkflows(app, 1)
     expect(workflows).toHaveLength(1)


### PR DESCRIPTION
## Summary
Removes `'empty search results show appropriate message'` from `e2e/workflows/search-filter-sort.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `empty search results show appropriate message` |
| **What it tests** | Filter by an impossible name, assert `No results found` heading and `Clear all filters` button |
| **Duplication rule violated** | Rule 3 — Same scenario in multiple spec files; Rule 7 — Parallel per-resource pattern |

## Why it is redundant
Covered by `workflows/table.spec.ts::empty state displays when no workflows match filter` (same resource, same assertions) and by the shared `EmptyStateFilter` component tested for credentials. The test has a conditional guard (`if (!tableVisible)`) that makes it pass even when the table IS visible — undermining it as a regression guard.

## Coverage retained
Empty filter state is covered by `workflows/table.spec.ts::empty state displays when no workflows match filter`.

## Risk
Low — duplicate of table.spec.ts test with weaker assertion structure.