### PR TITLE
chore(e2e/search-filter-sort): remove duplicate 'filter state persists in URL for sharing' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/search-filter-sort.spec.ts
@@ -79,39 +79,6 @@ test.describe('Workflows Table - Search, Filter, and Sort', () => {
     }
   })
 
-  test('filter state persists in URL for sharing', async ({ app }) => {
-    const workflows = await createTestWorkflows(app, 1)
-    expect(workflows).toHaveLength(1)
-
-    try {
-      const searchTerm = workflows[0].name
-
-      await app.goto(toAppUrl('/workflows'))
-      await app.getByPlaceholder('Filter by name').fill(searchTerm)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      // Capture URL with filter
-      const filteredUrl = app.url()
-      expect(filteredUrl).toContain('name')
-      expect(filteredUrl).toContain(searchTerm)
-
-      // Navigate away
-      await app.goto(toAppUrl('/'))
-
-      // Navigate back using the filtered URL
-      await app.goto(filteredUrl)
-
-      // Verify filter is restored
-      await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
-      const nameChipGroup = app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })
-      await expect(nameChipGroup.getByText(searchTerm)).toBeVisible()
-    } finally {
-      for (const wf of workflows) {
-        await deleteWorkflowViaApi(app, wf.id)
-      }
-    }
-  })
-
   test('multiple workflows can be found using partial name search', async ({ app }) => {
     const workflows = await createTestWorkflows(app, 2)
     expect(workflows.length).toBeGreaterThanOrEqual(2)


### PR DESCRIPTION
## Summary
Removes `'filter state persists in URL for sharing'` from `e2e/workflows/search-filter-sort.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `filter state persists in URL for sharing` |
| **What it tests** | Apply filter, capture URL, navigate away, navigate back to URL, assert filter chip still visible |
| **Duplication rule violated** | Rule 7 — Parallel "same pattern, different resource" over-testing |

## Why it is redundant
URL-based filter persistence is a cross-cutting concern implemented by `useFilterParams`. The navigate-away-and-return pattern is identical to `execution-filtering.spec.ts::filter state persists across navigation`. Both exercise the same hook deserialization logic — testing it for workflows AND executions adds CI time with no additional confidence.

## Coverage retained
URL-based filter persistence is covered by `execution-filtering.spec.ts` and the URL assertions within `search results update as user types and applies filter`.

## Risk
Low — cross-cutting hook, identical pattern already tested.