### PR TITLE
chore(e2e/table): remove duplicate 'multiple workflows display in table with unique identifiers' test

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/table.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/table.spec.ts
@@ -82,5 +82,4 @@ test.describe('Workflows Table - Display and Navigation', () => {
       await deleteWorkflowViaApi(app, workflow.id)
     }
   })
-
 })

--- a/frontend/packages/syntara-ui/e2e/workflows/table.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/table.spec.ts
@@ -83,42 +83,4 @@ test.describe('Workflows Table - Display and Navigation', () => {
     }
   })
 
-  test('multiple workflows display in table with unique identifiers', async ({ app }) => {
-    // Create 2 workflows for this test
-    const project = await ensureProject(app)
-    const projectId = project?.id
-    const prefix = buildUniqueName('e2e-multi')
-
-    const workflow1 = await createWorkflowViaApi(app, {
-      name: `${prefix}-workflow-1`,
-      projectId,
-    })
-
-    const workflow2 = await createWorkflowViaApi(app, {
-      name: `${prefix}-workflow-2`,
-      projectId,
-    })
-
-    if (!workflow1 || !workflow2) throw new Error('Failed to create test workflows')
-
-    try {
-      await app.goto(toAppUrl('/workflows'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
-
-      // Filter by prefix to show only our test workflows
-      await app.getByPlaceholder('Filter by name').fill(prefix)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      // Check if table exists
-      const table = app.getByRole('grid', { name: 'Workflows table' })
-      await expect(table).toBeVisible({ timeout: 5000 })
-
-      // Verify both workflows are visible
-      await expect(table.getByRole('row', { name: new RegExp(workflow1.name) })).toBeVisible()
-      await expect(table.getByRole('row', { name: new RegExp(workflow2.name) })).toBeVisible()
-    } finally {
-      await deleteWorkflowViaApi(app, workflow1.id)
-      await deleteWorkflowViaApi(app, workflow2.id)
-    }
-  })
 })


### PR DESCRIPTION
## Summary
Removes `'multiple workflows display in table with unique identifiers'` from `e2e/workflows/table.spec.ts`.

## Analysis

| Criterion | Detail |
|---|---|
| **Test** | `multiple workflows display in table with unique identifiers` |
| **What it tests** | Create 2 workflows with a shared prefix, filter by prefix, assert both rows visible in the table |
| **Duplication rule violated** | Rule 2 — Strict-subset assertion |

## Why it is redundant
The test is a strict subset of `'multiple workflows can be found using partial name search'` in `search-filter-sort.spec.ts`, which creates 2+ workflows, filters by partial name, asserts both rows visible, AND additionally verifies the filter chip and URL encoding. The `table.spec.ts` version omits the URL and chip assertions, making it weaker.

The "unique identifiers" language suggests the test was intended to verify something beyond name visibility, but the assertion is only `getByRole('row', { name: new RegExp(workflow.name) })` — it asserts name visibility, not uniqueness.

## Coverage retained
Multiple workflow display is covered by `search-filter-sort.spec.ts::multiple workflows can be found using partial name search`.

## Risk
Low — strict subset of another test with weaker assertions.