### PR TITLE
chore(ci): fixes xfail false positives, run E2E with Currents only on daily schedule

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -10,6 +10,9 @@ on:
     branches: [devel, early-access]
   push:
     branches: [devel, early-access]
+  schedule:
+    # Daily E2E run with Currents reporting at 2 AM UTC
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -20,6 +23,11 @@ on:
         description: 'PR head branch ref'
         required: true
         type: string
+      enable_currents:
+        description: 'Enable Currents reporting'
+        required: false
+        type: boolean
+        default: false
 
 # Required permissions for this workflow:
 # - contents:read - checkout code in all jobs
@@ -461,25 +469,31 @@ jobs:
   # - Auto-run on PRs when frontend/ or ci-frontend.yml changes
   # - Skip on backend-only PRs (save ~15-20 min on 8-core runner)
   # - Always run in merge queue (final safety check)
+  # - Daily scheduled run with Currents reporting (2 AM UTC)
   # - Manual trigger via /run-e2e-ui-tests comment (OWNER/MEMBER only)
   # See docs/ci/workflows.md for complete behavior table and debugging guide.
   test-compose-e2e:
     name: (Frontend) Test Podman Compose E2E
     needs: [changes, frontend-checks-gate]
-    # Only auto-trigger on same-repo PRs with frontend changes, or manual dispatch, or merge queue.
+    # Only auto-trigger on same-repo PRs with frontend changes, or manual dispatch, or merge queue, or schedule.
     # Fork PRs are explicitly excluded from auto-triggering to prevent security risks.
     # always() + gate != failure|cancelled lets workflow_dispatch still run when the
     # checks gate is skipped (e.g. docs-only PR), while preserving fast-fail when
     # lint/unit actually failed.
     if: |
       always() &&
-      needs.changes.result == 'success' &&
-      needs.frontend-checks-gate.result != 'failure' &&
-      needs.frontend-checks-gate.result != 'cancelled' &&
       (
-        (needs.changes.outputs.frontend == 'true' && github.event_name != 'push' && github.event.pull_request.head.repo.full_name == github.repository) ||
-        github.event_name == 'merge_group' ||
-        github.event_name == 'workflow_dispatch'
+        github.event_name == 'schedule' ||
+        (
+          needs.changes.result == 'success' &&
+          needs.frontend-checks-gate.result != 'failure' &&
+          needs.frontend-checks-gate.result != 'cancelled' &&
+          (
+            (needs.changes.outputs.frontend == 'true' && github.event_name != 'push' && github.event.pull_request.head.repo.full_name == github.repository) ||
+            github.event_name == 'merge_group' ||
+            github.event_name == 'workflow_dispatch'
+          )
+        )
       )
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 120
@@ -534,7 +548,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_ref || github.sha }}
+          # Schedule runs use devel, workflow_dispatch uses PR ref, others use commit SHA
+          ref: ${{ github.event_name == 'schedule' && 'devel' || (github.event_name == 'workflow_dispatch' && inputs.pr_ref || github.sha) }}
           persist-credentials: false
 
       - name: Set up Node.js
@@ -675,9 +690,10 @@ jobs:
           SYNTARA_E2E_BASE_URL: http://localhost:8080
           SYNTARA_E2E_PASSWORD: ${{ env.SYNTARA_E2E_PASSWORD }}
           SYNTARA_XFAIL_SOURCE: https://raw.githubusercontent.com/syntara-orchestration/syntara-ci/refs/heads/main/
-          CURRENTS_PROJECT_ID: ${{ secrets.CURRENTS_PROJECT_ID }}
-          CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
-          CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
+          # Enable Currents reporting only for scheduled daily runs or when manually enabled
+          CURRENTS_PROJECT_ID: ${{ (github.event_name == 'schedule' || inputs.enable_currents) && secrets.CURRENTS_PROJECT_ID || '' }}
+          CURRENTS_RECORD_KEY: ${{ (github.event_name == 'schedule' || inputs.enable_currents) && secrets.CURRENTS_RECORD_KEY || '' }}
+          CURRENTS_API_KEY: ${{ (github.event_name == 'schedule' || inputs.enable_currents) && secrets.CURRENTS_API_KEY || '' }}
 
       - name: Upload Playwright report
         if: always()

--- a/backend/tests/fixtures/xfail_from_url.py
+++ b/backend/tests/fixtures/xfail_from_url.py
@@ -86,29 +86,58 @@ def _parse_xfail_entries(content: str) -> list[tuple[str, str]]:
 def _matches(nodeid: str, pattern: str) -> bool:
     """Check whether *nodeid* matches *pattern*.
 
-    A pattern is treated as a prefix when it looks like a directory or file
-    path (no ``::``), and as an exact match otherwise.
+    A pattern without ``::`` is treated as a directory/file prefix.
+
+    A pattern with ``::`` mirrors pytest's own node-id selection: the base id
+    of a test also selects its parametrizations and (for a class base id) its
+    methods. So ``test_foo.py::test_bar`` matches ``test_foo.py::test_bar`` and
+    ``test_foo.py::test_bar[case-1]``, and ``test_foo.py::TestC`` matches
+    ``test_foo.py::TestC::test_m[a-b]``. Without this, a flaky parametrized
+    test quarantined by its base id would not be marked xfail and would fail
+    the suite.
     """
     if "::" in pattern:
-        return nodeid == pattern
+        # ``pattern[`` = parametrized instance; ``pattern::`` = class/module
+        # base id selecting its sub-items.
+        return nodeid == pattern or nodeid.startswith((f"{pattern}[", f"{pattern}::"))
     return nodeid.startswith(pattern)
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+# Cache the parsed entries on the session config so the file is fetched once and
+# shared between pytest_report_header and pytest_collection_modifyitems.
+_ENTRIES_KEY: pytest.StashKey[list[tuple[str, str]]] = pytest.StashKey()
+
+
+def _get_entries(config: pytest.Config) -> list[tuple[str, str]]:
+    """Load and cache the parsed xfail entries for this session (fail-open to [])."""
+    if _ENTRIES_KEY in config.stash:
+        return config.stash[_ENTRIES_KEY]
+
     source: str | None = config.getoption("--xfail-from-url")
-    if not source:
-        return
-    content = _load_xfail_file(source)
-    if content is None:
-        return
+    entries: list[tuple[str, str]] = []
+    if source:
+        content = _load_xfail_file(source)
+        if content is not None:
+            entries = _parse_xfail_entries(content)
+    config.stash[_ENTRIES_KEY] = entries
+    return entries
 
-    entries = _parse_xfail_entries(content)
+
+def pytest_report_header(config: pytest.Config) -> list[str] | None:
+    """Print the active xfail rules at the start of the run."""
+    entries = _get_entries(config)
     if not entries:
-        logger.info("url_xfail: no patterns found in file")
-        return
+        return None
+    source = config.getoption("--xfail-from-url")
+    lines = [f"url xfail: {len(entries)} rule(s) from {source}"]
+    lines += [f"  {pattern} — {reason}" for pattern, reason in entries]
+    return lines
 
-    patterns = [e[0] for e in entries]
-    logger.info("url_xfail: loaded patterns", count=len(entries), patterns=patterns)
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    entries = _get_entries(config)
+    if not entries:
+        return
 
     matched = 0
     for item in items:
@@ -118,4 +147,4 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
                 matched += 1
                 break
 
-    logger.info("url_xfail: marked tests", matched=matched, total=len(items))
+    logger.info("url_xfail: marked tests", matched=matched, total=len(items), patterns=[e[0] for e in entries])

--- a/backend/tests/unit/fixtures/test_xfail_from_url.py
+++ b/backend/tests/unit/fixtures/test_xfail_from_url.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
-from tests.fixtures.xfail_from_url import _matches, _parse_xfail_entries
+from tests.fixtures.xfail_from_url import (
+    _matches,
+    _parse_xfail_entries,
+    pytest_collection_modifyitems,
+    pytest_report_header,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestParseXfailEntries:
@@ -87,3 +97,121 @@ class TestMatches:
     )
     def test_various_non_matches(self, nodeid: str, pattern: str) -> None:
         assert _matches(nodeid, pattern) is False
+
+
+class TestMatchesParametrized:
+    """A pattern that lists the base node-id must match parametrized instances.
+
+    Mirrors pytest's own node-id selection semantics, where
+    ``test_foo.py::test_bar`` selects every ``test_bar[...]`` variant. Without
+    this, a flaky parametrized test quarantined by its base id is *not* marked
+    xfail and fails the suite (the reported bug).
+    """
+
+    @pytest.mark.parametrize(
+        ("nodeid", "pattern"),
+        [
+            # base function id must match a single parametrization
+            ("tests/unit/test_foo.py::test_bar[case-1]", "tests/unit/test_foo.py::test_bar"),
+            # ... and match regardless of which parametrization it is
+            ("tests/unit/test_foo.py::test_bar[case-2]", "tests/unit/test_foo.py::test_bar"),
+            # base id with a class-scoped parametrized method
+            ("tests/unit/test_foo.py::TestC::test_m[a-b]", "tests/unit/test_foo.py::TestC::test_m"),
+            # a class base id must match its (non-parametrized) methods
+            ("tests/unit/test_foo.py::TestC::test_m", "tests/unit/test_foo.py::TestC"),
+            # a class base id must match its parametrized methods
+            ("tests/unit/test_foo.py::TestC::test_m[a-b]", "tests/unit/test_foo.py::TestC"),
+            # an exact parametrized id still matches itself
+            ("tests/unit/test_foo.py::test_bar[case-1]", "tests/unit/test_foo.py::test_bar[case-1]"),
+        ],
+    )
+    def test_base_id_matches_parametrized_instances(self, nodeid: str, pattern: str) -> None:
+        assert _matches(nodeid, pattern) is True
+
+    @pytest.mark.parametrize(
+        ("nodeid", "pattern"),
+        [
+            # a base id must not match a different function sharing a prefix
+            ("tests/unit/test_foo.py::test_bar_extended", "tests/unit/test_foo.py::test_bar"),
+            # ... nor a differently-named parametrized function sharing a prefix
+            ("tests/unit/test_foo.py::test_bard[x]", "tests/unit/test_foo.py::test_bar"),
+            # a class base id must not match a differently-named class sharing a prefix
+            ("tests/unit/test_foo.py::TestCandidate::test_m", "tests/unit/test_foo.py::TestC"),
+        ],
+    )
+    def test_base_id_does_not_over_match(self, nodeid: str, pattern: str) -> None:
+        assert _matches(nodeid, pattern) is False
+
+
+class _FakeItem:
+    """Minimal stand-in for a collected pytest item."""
+
+    def __init__(self, nodeid: str) -> None:
+        self.nodeid = nodeid
+        self.markers: list[pytest.MarkDecorator] = []
+
+    def add_marker(self, marker: pytest.MarkDecorator) -> None:
+        self.markers.append(marker)
+
+
+class _FakeConfig:
+    def __init__(self, source: str | None) -> None:
+        self._source = source
+        self.stash = pytest.Stash()
+
+    def getoption(self, name: str) -> str | None:
+        assert name == "--xfail-from-url"
+        return self._source
+
+
+class TestCollectionModifyItems:
+    """End-to-end: the collection hook marks the right items xfail.
+
+    This is the behavior the bug report is about — a quarantined test must not
+    fail the suite. Here we assert the hook actually attaches an xfail marker to
+    the matching items (including a parametrized instance listed by base id).
+    """
+
+    def test_parametrized_instance_marked_by_base_id(self, tmp_path: Path) -> None:
+        md = tmp_path / "backend.md"
+        md.write_text("# tests/unit/test_foo.py::test_bar\nflaky under load\n")
+
+        param_item = _FakeItem("tests/unit/test_foo.py::test_bar[case-1]")
+        unrelated_item = _FakeItem("tests/unit/test_foo.py::test_other")
+        items = [param_item, unrelated_item]
+
+        pytest_collection_modifyitems(_FakeConfig(str(md)), items)  # type: ignore[arg-type]
+
+        assert len(param_item.markers) == 1
+        assert param_item.markers[0].name == "xfail"
+        assert "flaky under load" in param_item.markers[0].kwargs["reason"]
+        assert unrelated_item.markers == []
+
+    def test_no_source_is_a_noop(self) -> None:
+        item = _FakeItem("tests/unit/test_foo.py::test_bar[case-1]")
+        items = [item]
+        pytest_collection_modifyitems(_FakeConfig(None), items)  # type: ignore[arg-type]
+        assert item.markers == []
+
+
+class TestReportHeader:
+    """The active xfail rules are surfaced at the start of the run."""
+
+    def test_header_lists_every_rule(self, tmp_path: Path) -> None:
+        md = tmp_path / "backend.md"
+        md.write_text(
+            "# tests/unit/test_foo.py::test_bar\nflaky under load\n\n# tests/integration/\ninfra flaky\n",
+        )
+
+        header = pytest_report_header(_FakeConfig(str(md)))  # type: ignore[arg-type]
+
+        assert header is not None
+        joined = "\n".join(header)
+        assert "2 rule(s)" in joined
+        assert "tests/unit/test_foo.py::test_bar" in joined
+        assert "flaky under load" in joined
+        assert "tests/integration/" in joined
+        assert "infra flaky" in joined
+
+    def test_header_is_absent_without_source(self) -> None:
+        assert pytest_report_header(_FakeConfig(None)) is None  # type: ignore[arg-type]

--- a/backend/tests/unit/fixtures/test_xfail_from_url_integration.py
+++ b/backend/tests/unit/fixtures/test_xfail_from_url_integration.py
@@ -1,0 +1,155 @@
+"""End-to-end integration tests for the ``--xfail-from-url`` pytest plugin.
+
+Unlike the pure-logic tests in ``test_xfail_from_url.py``, these run a *real*
+pytest session in a subprocess with the plugin loaded and a generated Markdown
+xfail list, then assert on the actual outcome (return code and xfail/pass/fail
+counts). This validates the whole mechanism end to end: collection, pattern
+matching (including parametrized ids matched by base id), and the applied
+``xfail`` marker.
+
+They live under ``tests/unit/`` (not ``tests/integration/``) on purpose: the
+integration tree has autouse fixtures that require the database/container
+runtime, which this subprocess-based test does not need. The subprocess itself
+is the integration boundary, so it runs in the fast unit job with no infra.
+
+Isolation: ``PYTEST_DISABLE_PLUGIN_AUTOLOAD`` stops the backend conftest /
+test-sdk plugins from loading in the child, a throwaway ``pytest.ini`` fixes the
+rootdir to the temp dir, and only ``tests.fixtures.xfail_from_url`` is loaded
+explicitly via ``-p``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# tests/unit/fixtures/test_xfail_from_url_integration.py -> backend/
+_BACKEND_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _run_pytest(
+    tmp_path: Path,
+    *,
+    test_src: str,
+    md_src: str | None,
+    extra_args: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess[str]:
+    """Run pytest over *test_src* in an isolated subprocess, optionally with an xfail list."""
+    (tmp_path / "pytest.ini").write_text("[pytest]\naddopts =\n")
+    (tmp_path / "test_sample.py").write_text(test_src)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        str(tmp_path),
+        "-p",
+        "tests.fixtures.xfail_from_url",
+        "-p",
+        "no:cacheprovider",
+        "-q",
+        *extra_args,
+    ]
+    if md_src is not None:
+        md = tmp_path / "xfail.md"
+        md.write_text(md_src)
+        cmd += ["--xfail-from-url", str(md)]
+
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(_BACKEND_ROOT),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+    }
+    return subprocess.run(cmd, cwd=tmp_path, env=env, capture_output=True, text=True, check=False)  # noqa: S603
+
+
+def _count(output: str, word: str) -> int:
+    """Extract the ``<n> <word>`` count from pytest's summary line (0 if absent)."""
+    match = re.search(rf"(\d+) {word}", output)
+    return int(match.group(1)) if match else 0
+
+
+class TestXfailFromUrlIntegration:
+    """Run the plugin in a real (sub)pytest session and assert on the outcome."""
+
+    def test_listed_failures_are_xfailed_and_suite_passes(self, tmp_path: Path) -> None:
+        test_src = (
+            "import pytest\n\n"
+            '@pytest.mark.parametrize("case", ["a", "b"])\n'
+            "def test_param(case):\n"
+            "    assert False\n\n"
+            "def test_plain_fail():\n"
+            "    assert False\n\n"
+            "def test_control_pass():\n"
+            "    assert True\n"
+        )
+        md_src = "# test_sample.py::test_param\nflaky param\n\n# test_sample.py::test_plain_fail\nknown bad\n"
+
+        result = _run_pytest(tmp_path, test_src=test_src, md_src=md_src)
+        output = result.stdout + result.stderr
+
+        assert result.returncode == 0, output
+        # 2 parametrizations matched by base id + 1 plain test = 3 xfailed; control passes.
+        assert _count(output, "xfailed") == 3, output
+        assert _count(output, "passed") == 1, output
+        assert _count(output, "failed") == 0, output
+
+    def test_parametrized_test_matched_by_base_id(self, tmp_path: Path) -> None:
+        # The reported bug: a flaky parametrized test quarantined by its BASE id
+        # (no ``[param]`` suffix) must be marked xfail for every parametrization.
+        test_src = (
+            "import pytest\n\n"
+            '@pytest.mark.parametrize("case", ["a", "b", "c"])\n'
+            "def test_flaky(case):\n"
+            "    assert False\n"
+        )
+        md_src = "# test_sample.py::test_flaky\nflaky under load\n"
+
+        result = _run_pytest(tmp_path, test_src=test_src, md_src=md_src)
+        output = result.stdout + result.stderr
+
+        assert result.returncode == 0, output
+        assert _count(output, "xfailed") == 3, output
+        assert _count(output, "failed") == 0, output
+
+    def test_unlisted_failure_still_fails_the_suite(self, tmp_path: Path) -> None:
+        # Control: proves the plugin is load-bearing — a failure that is NOT in
+        # the list is reported normally and fails the run.
+        test_src = "def test_not_listed():\n    assert False\n"
+        md_src = "# test_sample.py::test_something_else\nunrelated\n"
+
+        result = _run_pytest(tmp_path, test_src=test_src, md_src=md_src)
+        output = result.stdout + result.stderr
+
+        assert result.returncode != 0, output
+        assert _count(output, "failed") == 1, output
+        assert _count(output, "xfailed") == 0, output
+
+    def test_report_header_lists_rules_at_start_of_run(self, tmp_path: Path) -> None:
+        # The rules are printed in the run header (visible with normal/verbose
+        # output; -v cancels the repo's default -q). Run with -v to assert it.
+        test_src = "def test_plain_fail():\n    assert False\n"
+        md_src = "# test_sample.py::test_plain_fail\nknown flaky under load\n"
+
+        result = _run_pytest(tmp_path, test_src=test_src, md_src=md_src, extra_args=("-v",))
+        output = result.stdout + result.stderr
+
+        assert result.returncode == 0, output
+        assert "url xfail: 1 rule(s)" in output, output
+        assert "test_sample.py::test_plain_fail — known flaky under load" in output, output
+
+    def test_listed_test_that_passes_is_tolerated(self, tmp_path: Path) -> None:
+        # Non-strict xfail semantics: a listed test that unexpectedly passes is an
+        # XPASS and does NOT fail the suite (the signal to remove it from the list).
+        test_src = "def test_listed_but_passing():\n    assert True\n"
+        md_src = "# test_sample.py::test_listed_but_passing\nexpected to fail\n"
+
+        result = _run_pytest(tmp_path, test_src=test_src, md_src=md_src)
+        output = result.stdout + result.stderr
+
+        assert result.returncode == 0, output
+        assert _count(output, "xpassed") == 1, output
+        assert _count(output, "failed") == 0, output

--- a/frontend/packages/syntara-ui/.gitignore
+++ b/frontend/packages/syntara-ui/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.tmp-xfail-int-*
 
 # Editor directories and files
 .vscode/*

--- a/frontend/packages/syntara-ui/e2e/fixtures.ts
+++ b/frontend/packages/syntara-ui/e2e/fixtures.ts
@@ -4,7 +4,13 @@ import { expect, test as base, type Page, type Request } from '@playwright/test'
 import { APP_TITLE } from './helpers/appTitle'
 import { isSkipWebServerForPlaywrightTests } from './playwrightWebServerEnv'
 import { type RoleSetupResult, setupRoleUsers } from './utils/roleSetup'
-import { type XfailEntry, loadXfailEntries, matchesXfail } from './xfailFromUrl'
+import {
+  type XfailEntry,
+  applyQuarantineAfterRun,
+  loadXfailEntries,
+  matchesXfail,
+  xfailSourceFromEnv,
+} from './xfailFromUrl'
 
 const processEnv: Record<string, string | undefined> = (
   process as unknown as { env: Record<string, string | undefined> }
@@ -72,12 +78,11 @@ const currentsBase = base.extend<CurrentsFixtures, CurrentsWorkerFixtures>({
 const xfailBase = currentsBase.extend<{ _xfailCheck: void }, { _xfailEntries: XfailEntry[] }>({
   _xfailEntries: [
     async ({}, use) => {
-      const base = processEnv['SYNTARA_XFAIL_SOURCE']
-      if (!base) {
+      const source = xfailSourceFromEnv(processEnv)
+      if (!source) {
         await use([])
         return
       }
-      const source = base.endsWith('/') ? `${base}playwright.md` : `${base}/playwright.md`
       const entries = await loadXfailEntries(source)
       if (entries.length > 0) {
         process.stderr.write(`xfail: loaded ${entries.length} pattern(s) from ${source}\n`)
@@ -88,11 +93,12 @@ const xfailBase = currentsBase.extend<{ _xfailCheck: void }, { _xfailEntries: Xf
   ],
   _xfailCheck: [
     async ({ _xfailEntries }, use, testInfo) => {
+      // Match before the test so titlePath is complete; apply quarantine after
+      // so a listed failure is skipped (Currents-style) and a listed pass is
+      // left as a pass rather than Playwright "Expected to fail, but passed".
       const match = matchesXfail(testInfo, _xfailEntries)
-      if (match) {
-        testInfo.fail(true, `xfail: ${match.reason}`)
-      }
       await use()
+      applyQuarantineAfterRun(testInfo, match)
     },
     { auto: true },
   ],

--- a/frontend/packages/syntara-ui/e2e/global-setup.ts
+++ b/frontend/packages/syntara-ui/e2e/global-setup.ts
@@ -17,6 +17,7 @@
 import { request as playwrightRequest, type APIRequestContext } from '@playwright/test'
 
 import { isSkipWebServerForPlaywrightTests } from './playwrightWebServerEnv'
+import { formatXfailRules, loadXfailEntries, xfailSourceFromEnv } from './xfailFromUrl'
 
 const appBaseUrl: string = process.env['SYNTARA_E2E_BASE_URL'] ?? 'http://localhost:4173'
 
@@ -169,7 +170,20 @@ async function probeExecutionEngine(
   return result
 }
 
+/** Print the active xfail rules once, at the very start of the run. */
+async function logXfailRules(): Promise<void> {
+  const source = xfailSourceFromEnv()
+  if (!source) return
+
+  const entries = await loadXfailEntries(source)
+  for (const line of formatXfailRules(entries, source)) {
+    console.log(`[global-setup] ${line}`)
+  }
+}
+
 export default async function globalSetup(): Promise<void> {
+  await logXfailRules()
+
   // Default to healthy — tests run unless probe positively confirms otherwise
   process.env['SYNTARA_E2E_HAS_EXECUTION_ENGINE'] = '1'
   process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'] = '1'

--- a/frontend/packages/syntara-ui/e2e/xfailFromUrl.ts
+++ b/frontend/packages/syntara-ui/e2e/xfailFromUrl.ts
@@ -7,6 +7,86 @@ export type XfailEntry = {
   reason: string
 }
 
+/** Custom annotation type applied when a listed playwright.md test passed. */
+export const XFAIL_ANNOTATION_TYPE = 'xfail'
+
+/** Prefix of skip-annotation descriptions applied when a listed test is quarantined. */
+export const XFAIL_ANNOTATION_PREFIX = 'xfail:'
+
+export type XfailAnnotation = {
+  type: string
+  description?: string
+}
+
+/** Mutable test-info fields needed to quarantine after the test body runs. */
+export type QuarantineTarget = {
+  status?: TestInfo['status']
+  annotations: XfailAnnotation[]
+}
+
+/** One finished test attempt, as seen by a Playwright reporter. */
+export type XfailRunRecord = {
+  status: string
+  titlePath: string[]
+  annotations: XfailAnnotation[]
+}
+
+export type ListedXfailPass = {
+  testId: string
+  reason: string
+}
+
+/**
+ * Currents-style quarantine: run the test normally, then rewrite a listed failure
+ * so it does not fail the suite. A listed pass is left as a pass (stale list entry).
+ *
+ * Listed failures are swallowed on the attempt that failed. That also prevents
+ * Playwright from retrying them, which would leave an earlier failed result and
+ * still fail the run.
+ */
+export function applyQuarantineAfterRun(testInfo: QuarantineTarget, match: XfailEntry | null): void {
+  if (!match) return
+
+  if (testInfo.status === 'passed') {
+    testInfo.annotations.push({ type: XFAIL_ANNOTATION_TYPE, description: match.reason })
+    return
+  }
+
+  if (testInfo.status !== 'failed' && testInfo.status !== 'timedOut') return
+
+  testInfo.annotations.push({
+    type: 'skip',
+    description: `${XFAIL_ANNOTATION_PREFIX} ${match.reason}`,
+  })
+  testInfo.status = 'skipped'
+}
+
+export function listedXfailPass(record: XfailRunRecord): ListedXfailPass | null {
+  if (record.status !== 'passed') return null
+  const match = record.annotations.find((annotation) => annotation.type === XFAIL_ANNOTATION_TYPE)
+  if (!match) return null
+  return {
+    testId: record.titlePath.filter(Boolean).join(' > '),
+    reason: match.description?.trim() || 'listed in xfail list',
+  }
+}
+
+export function collectListedXfailPasses(records: XfailRunRecord[]): ListedXfailPass[] {
+  return records.flatMap((record) => {
+    const found = listedXfailPass(record)
+    return found ? [found] : []
+  })
+}
+
+/** End-of-run summary lines; empty when no listed tests passed. */
+export function formatListedXfailPasses(passes: ListedXfailPass[]): string[] {
+  if (passes.length === 0) return []
+  return [
+    `xpass: ${passes.length} listed test(s) passed (remove from playwright.md):`,
+    ...passes.map(({ testId, reason }) => `  - ${testId} — ${reason.replace(/\n/g, ' ')}`),
+  ]
+}
+
 const HEADING_RE = /^#\s+(.+)$/
 
 export function parseXfailEntries(content: string): XfailEntry[] {
@@ -42,6 +122,27 @@ function isFilePath(source: string): boolean {
   return source.startsWith('/') || source.startsWith('./') || source.startsWith('../')
 }
 
+/**
+ * Resolve the xfail Markdown URL/path from SYNTARA_XFAIL_SOURCE, or null if unset.
+ * The env var is a base URL/dir; the Playwright list lives at `<base>/playwright.md`.
+ */
+export function xfailSourceFromEnv(env: Record<string, string | undefined> = process.env): string | null {
+  const base = env['SYNTARA_XFAIL_SOURCE']
+  if (!base) return null
+  return base.endsWith('/') ? `${base}playwright.md` : `${base}/playwright.md`
+}
+
+/** Human-readable summary lines for the active xfail rules, for printing at the start of a run. */
+export function formatXfailRules(entries: XfailEntry[], source: string): string[] {
+  if (entries.length === 0) {
+    return [`xfail: no rules loaded from ${source}`]
+  }
+  return [
+    `xfail: ${entries.length} rule(s) from ${source}:`,
+    ...entries.map(({ pattern, reason }) => `  - ${pattern} — ${reason.replace(/\n/g, ' ')}`),
+  ]
+}
+
 export async function loadXfailEntries(source: string): Promise<XfailEntry[]> {
   try {
     let content: string
@@ -63,14 +164,12 @@ export async function loadXfailEntries(source: string): Promise<XfailEntry[]> {
   }
 }
 
-function buildTestId(testInfo: TestInfo): string {
-  const testDir = testInfo.project.testDir
-  let relPath = testInfo.file
-  if (testDir && relPath.startsWith(testDir)) {
-    relPath = relPath.slice(testDir.length).replace(/^[/\\]/, '')
-  }
-  const titles = testInfo.titlePath.filter(Boolean)
-  return [relPath, ...titles].join(' > ')
+export function buildTestId(testInfo: Pick<TestInfo, 'titlePath'>): string {
+  // testInfo.titlePath already starts with the testDir-relative spec path, so
+  // it is the full id on its own: [relPath, ...describeTitles, testTitle].
+  // Do NOT prepend testInfo.file — that duplicates the spec path in the id
+  // (e.g. "a.spec.ts > a.spec.ts > test") and breaks exact-match patterns.
+  return testInfo.titlePath.filter(Boolean).join(' > ')
 }
 
 export function matchPattern(testId: string, pattern: string): boolean {

--- a/frontend/packages/syntara-ui/e2e/xfailReporter.ts
+++ b/frontend/packages/syntara-ui/e2e/xfailReporter.ts
@@ -1,0 +1,34 @@
+import type { Reporter, TestCase, TestResult } from '@playwright/test/reporter'
+
+import { collectListedXfailPasses, formatListedXfailPasses, type XfailRunRecord } from './xfailFromUrl'
+
+function toRecord(test: TestCase, result: TestResult): XfailRunRecord {
+  return {
+    status: result.status ?? '',
+    titlePath: [...test.titlePath()],
+    annotations: [...(test.annotations ?? []), ...(result.annotations ?? [])],
+  }
+}
+
+/**
+ * Prints listed playwright.md tests that passed so they can be removed from the
+ * quarantine list. Exit status is unchanged: listed failures are already
+ * rewritten to skipped by `_xfailCheck`.
+ */
+export default class XfailReporter implements Reporter {
+  private readonly lastByTestId = new Map<string, XfailRunRecord>()
+
+  printsToStdio(): boolean {
+    return false
+  }
+
+  onTestEnd(test: TestCase, result: TestResult): void {
+    this.lastByTestId.set(test.id, toRecord(test, result))
+  }
+
+  onEnd(): void {
+    for (const line of formatListedXfailPasses(collectListedXfailPasses([...this.lastByTestId.values()]))) {
+      console.log(line)
+    }
+  }
+}

--- a/frontend/packages/syntara-ui/eslint.config.js
+++ b/frontend/packages/syntara-ui/eslint.config.js
@@ -366,8 +366,8 @@ export default tseslint.config(
     },
   },
   {
-    // Playwright globalSetup runs in Node before tests — requires default export and uses console for logging
-    files: ['e2e/global-setup.ts'],
+    // Playwright globalSetup / reporters run in Node — require default export and use console for logging
+    files: ['e2e/global-setup.ts', 'e2e/xfailReporter.ts'],
     rules: {
       'no-console': 'off',
       'no-restricted-exports': 'off',

--- a/frontend/packages/syntara-ui/playwright.config.ts
+++ b/frontend/packages/syntara-ui/playwright.config.ts
@@ -42,6 +42,8 @@ export default defineConfig({
     ['json', { outputFile: 'test-results/results.json' }],
     ['html', { outputFolder: 'playwright-report', open: 'never' }],
     ...(process.env.CURRENTS_PROJECT_ID && process.env.CURRENTS_RECORD_KEY ? [currentsReporter()] : []),
+    // Last: prints listed playwright.md tests that passed so they can be removed.
+    ['./e2e/xfailReporter.ts'],
   ],
   use: {
     baseURL,

--- a/frontend/packages/syntara-ui/src/utils/xfailFromUrl.integration.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/xfailFromUrl.integration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * End-to-end integration test for the Playwright xfail / quarantine mechanism.
+ *
+ * Unlike the pure-logic tests in `xfailFromUrl.test.ts`, this spawns a real
+ * Playwright runner against a temp project that imports the actual e2e
+ * `fixtures.ts` (the `_xfailCheck` auto-fixture) and points `SYNTARA_XFAIL_SOURCE`
+ * at a generated `playwright.md`. It then asserts on the JSON report, validating
+ * the whole chain: env → load list → build test id → match pattern → quarantine.
+ *
+ * No browser is launched (the specs never use `page`), so this needs no browser
+ * download and runs in a couple of seconds.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join, resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const nodeRequire = createRequire(__filename)
+const packageDir = resolve(__dirname, '../..') // packages/syntara-ui
+const fixturesModule = resolve(__dirname, '../../e2e/fixtures')
+const xfailReporterModule = resolve(__dirname, '../../e2e/xfailReporter')
+const playwrightCli = nodeRequire.resolve('@playwright/test/cli')
+
+type SpecResult = { title: string; ok: boolean; expectedStatus?: string; lastStatus?: string }
+type RunResult = { exitCode: number; specs: SpecResult[]; output: string }
+type JsonSpec = {
+  title: string
+  ok: boolean
+  tests: { expectedStatus?: string; results?: { status?: string }[] }[]
+}
+
+function collectSpecs(node: { suites?: unknown[]; specs?: unknown[] }): SpecResult[] {
+  const out: SpecResult[] = []
+  for (const suite of (node.suites as { suites?: unknown[]; specs?: unknown[] }[]) ?? []) {
+    out.push(...collectSpecs(suite))
+  }
+  for (const spec of (node.specs as JsonSpec[] | undefined) ?? []) {
+    const results = spec.tests[0]?.results ?? []
+    out.push({
+      title: spec.title,
+      ok: spec.ok,
+      expectedStatus: spec.tests[0]?.expectedStatus,
+      lastStatus: results.at(-1)?.status,
+    })
+  }
+  return out
+}
+
+/** Run Playwright over `specSource` with `mdSource` as the xfail list; return exit code, parsed specs, and output. */
+function runPlaywright(specSource: string, mdSource: string, extraConfig = ''): RunResult {
+  // Keep the temp project under this package so Playwright loads the ESM reporter
+  // the same way real e2e does. /tmp is CJS and cannot import e2e/xfailReporter.ts.
+  const dir = mkdtempSync(join(packageDir, '.tmp-xfail-int-'))
+  try {
+    const specsDir = join(dir, 'specs')
+    const xfailDir = join(dir, 'xfail')
+    mkdirSync(specsDir)
+    mkdirSync(xfailDir)
+    const reportFile = join(dir, 'report.json')
+
+    writeFileSync(join(xfailDir, 'playwright.md'), mdSource)
+    writeFileSync(join(specsDir, 'mech.spec.ts'), specSource)
+    writeFileSync(
+      join(dir, 'pw.config.ts'),
+      `import { defineConfig } from '@playwright/test'\n` +
+        `export default defineConfig({ testDir: ${JSON.stringify(specsDir)}, ${extraConfig}` +
+        `reporter: [['json', { outputFile: ${JSON.stringify(reportFile)} }], ` +
+        `[${JSON.stringify(xfailReporterModule)}]] })\n`
+    )
+
+    let exitCode = 0
+    let output = ''
+    try {
+      output = execFileSync(process.execPath, [playwrightCli, 'test', '--config', join(dir, 'pw.config.ts')], {
+        cwd: packageDir,
+        env: { ...process.env, SYNTARA_XFAIL_SOURCE: `${xfailDir}/` },
+        stdio: 'pipe',
+        encoding: 'utf-8',
+      })
+    } catch (error) {
+      const err = error as { status?: number; stdout?: string; stderr?: string }
+      exitCode = err.status ?? 1
+      output = `${err.stdout ?? ''}${err.stderr ?? ''}`
+    }
+
+    let raw: string
+    try {
+      raw = readFileSync(reportFile, 'utf-8')
+    } catch {
+      throw new Error(`Playwright produced no report (exit ${exitCode}). Output:\n${output}`)
+    }
+    const report = JSON.parse(raw) as { suites?: unknown[] }
+    return { exitCode, specs: collectSpecs(report), output }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe('xfail mechanism (Playwright integration)', () => {
+  it('quarantines a listed failing test and keeps the suite green', () => {
+    const spec = [
+      `import { test, expect } from ${JSON.stringify(fixturesModule)}`,
+      `test.describe('xfail-mechanism', () => {`,
+      `  test('listed failing', async () => { expect(1).toBe(2) })`,
+      `  test('control passing', async () => { expect(1).toBe(1) })`,
+      `})`,
+    ].join('\n')
+    const md = '# mech.spec.ts > xfail-mechanism > listed failing\nknown flaky\n'
+
+    const { exitCode, specs, output } = runPlaywright(spec, md)
+
+    expect(exitCode).toBe(0)
+    const listed = specs.find((s) => s.title === 'listed failing')
+    const control = specs.find((s) => s.title === 'control passing')
+    expect(listed).toMatchObject({ ok: true, expectedStatus: 'passed', lastStatus: 'skipped' })
+    expect(control).toMatchObject({ ok: true, expectedStatus: 'passed', lastStatus: 'passed' })
+    expect(output).not.toContain('listed test(s) passed')
+  }, 120_000)
+
+  it('does not affect a failing test that is not listed (control)', () => {
+    const spec = [
+      `import { test, expect } from ${JSON.stringify(fixturesModule)}`,
+      `test('unlisted failing', async () => { expect(1).toBe(2) })`,
+    ].join('\n')
+    const md = '# mech.spec.ts > some other test\nunrelated\n'
+
+    const { exitCode, specs, output } = runPlaywright(spec, md)
+
+    expect(exitCode).not.toBe(0)
+    expect(specs.find((s) => s.title === 'unlisted failing')).toMatchObject({ ok: false, lastStatus: 'failed' })
+    expect(output).not.toContain('listed test(s) passed')
+  }, 120_000)
+
+  it('prints listed tests that passed and keeps the suite green', () => {
+    const spec = [
+      `import { test, expect } from ${JSON.stringify(fixturesModule)}`,
+      `test.describe('xfail-mechanism', () => {`,
+      `  test('listed passing', async () => { expect(1).toBe(1) })`,
+      `})`,
+    ].join('\n')
+    const md = '# mech.spec.ts > xfail-mechanism > listed passing\nknown flaky\n'
+
+    const { exitCode, specs, output } = runPlaywright(spec, md)
+
+    expect(exitCode).toBe(0)
+    expect(specs.find((s) => s.title === 'listed passing')).toMatchObject({
+      ok: true,
+      expectedStatus: 'passed',
+      lastStatus: 'passed',
+    })
+    expect(output).toContain('xpass: 1 listed test(s) passed (remove from playwright.md):')
+    expect(output).toContain('mech.spec.ts > xfail-mechanism > listed passing — known flaky')
+  }, 120_000)
+
+  it('still fails the suite when a listed pass is mixed with a real failure', () => {
+    const spec = [
+      `import { test, expect } from ${JSON.stringify(fixturesModule)}`,
+      `test.describe('xfail-mechanism', () => {`,
+      `  test('listed passing', async () => { expect(1).toBe(1) })`,
+      `  test('unlisted failing', async () => { expect(1).toBe(2) })`,
+      `})`,
+    ].join('\n')
+    const md = '# mech.spec.ts > xfail-mechanism > listed passing\nknown flaky\n'
+
+    const { exitCode, output } = runPlaywright(spec, md)
+
+    expect(exitCode).not.toBe(0)
+    expect(output).toContain('xpass: 1 listed test(s) passed (remove from playwright.md):')
+  }, 120_000)
+
+  it('quarantines a listed failure even when retries are configured', () => {
+    const spec = [
+      `import { test, expect } from ${JSON.stringify(fixturesModule)}`,
+      `test('listed failing', async () => { expect(1).toBe(2) })`,
+    ].join('\n')
+    const md = '# mech.spec.ts > listed failing\nknown flaky\n'
+
+    const { exitCode, specs } = runPlaywright(spec, md, 'retries: 1, ')
+
+    expect(exitCode).toBe(0)
+    expect(specs.find((s) => s.title === 'listed failing')).toMatchObject({
+      ok: true,
+      lastStatus: 'skipped',
+    })
+  }, 120_000)
+})

--- a/frontend/packages/syntara-ui/src/utils/xfailFromUrl.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/xfailFromUrl.test.ts
@@ -1,6 +1,16 @@
+import type { TestInfo } from '@playwright/test'
 import { describe, expect, it } from 'vitest'
 
-import { matchPattern, parseXfailEntries } from '../../e2e/xfailFromUrl'
+import {
+  applyQuarantineAfterRun,
+  buildTestId,
+  formatListedXfailPasses,
+  formatXfailRules,
+  listedXfailPass,
+  matchPattern,
+  parseXfailEntries,
+  xfailSourceFromEnv,
+} from '../../e2e/xfailFromUrl'
 
 describe('parseXfailEntries', () => {
   it('parses a single heading with reason', () => {
@@ -47,6 +57,176 @@ describe('parseXfailEntries', () => {
   it('ignores non-h1 headings', () => {
     const content = '## h2 heading\ntext\n### h3 heading\nmore text'
     expect(parseXfailEntries(content)).toEqual([])
+  })
+})
+
+describe('xfailSourceFromEnv', () => {
+  it('returns null when the env var is unset', () => {
+    expect(xfailSourceFromEnv({})).toBeNull()
+  })
+
+  it('appends playwright.md to a base ending in a slash', () => {
+    expect(xfailSourceFromEnv({ SYNTARA_XFAIL_SOURCE: 'https://example.com/ci/' })).toBe(
+      'https://example.com/ci/playwright.md'
+    )
+  })
+
+  it('inserts a slash when the base does not end in one', () => {
+    expect(xfailSourceFromEnv({ SYNTARA_XFAIL_SOURCE: 'https://example.com/ci' })).toBe(
+      'https://example.com/ci/playwright.md'
+    )
+  })
+})
+
+describe('formatXfailRules', () => {
+  it('lists every rule with its reason', () => {
+    const lines = formatXfailRules(
+      [
+        { pattern: 'auth/login.spec.ts', reason: 'flaky' },
+        { pattern: 'settings.spec.ts > saves', reason: 'known bad' },
+      ],
+      'https://example.com/ci/playwright.md'
+    )
+    expect(lines[0]).toBe('xfail: 2 rule(s) from https://example.com/ci/playwright.md:')
+    expect(lines).toContain('  - auth/login.spec.ts — flaky')
+    expect(lines).toContain('  - settings.spec.ts > saves — known bad')
+  })
+
+  it('collapses multi-line reasons onto one line', () => {
+    const lines = formatXfailRules([{ pattern: 'a.spec.ts', reason: 'line one\nline two' }], 'src')
+    expect(lines).toContain('  - a.spec.ts — line one line two')
+  })
+
+  it('reports when no rules were loaded', () => {
+    expect(formatXfailRules([], 'src')).toEqual(['xfail: no rules loaded from src'])
+  })
+})
+
+describe('applyQuarantineAfterRun', () => {
+  const listed = { pattern: 'a.spec.ts > listed', reason: 'flaky under load' }
+
+  function target(overrides: { status?: 'passed' | 'failed' | 'timedOut' | 'skipped' | 'interrupted' }) {
+    return {
+      status: overrides.status,
+      annotations: [] as { type: string; description?: string }[],
+    }
+  }
+
+  it('does nothing when the test is not listed', () => {
+    const testInfo = target({ status: 'failed' })
+    applyQuarantineAfterRun(testInfo, null)
+    expect(testInfo.status).toBe('failed')
+    expect(testInfo.annotations).toEqual([])
+  })
+
+  it('annotates a listed pass and leaves status passed', () => {
+    const testInfo = target({ status: 'passed' })
+    applyQuarantineAfterRun(testInfo, listed)
+    expect(testInfo.status).toBe('passed')
+    expect(testInfo.annotations).toEqual([{ type: 'xfail', description: 'flaky under load' }])
+  })
+
+  it('skips a listed failure', () => {
+    const testInfo = target({ status: 'failed' })
+    applyQuarantineAfterRun(testInfo, listed)
+    expect(testInfo.status).toBe('skipped')
+    expect(testInfo.annotations).toEqual([{ type: 'skip', description: 'xfail: flaky under load' }])
+  })
+
+  it('skips a listed timeout', () => {
+    const testInfo = target({ status: 'timedOut' })
+    applyQuarantineAfterRun(testInfo, listed)
+    expect(testInfo.status).toBe('skipped')
+  })
+
+  it('does not rewrite an interrupted listed test', () => {
+    const testInfo = target({ status: 'interrupted' })
+    applyQuarantineAfterRun(testInfo, listed)
+    expect(testInfo.status).toBe('interrupted')
+    expect(testInfo.annotations).toEqual([])
+  })
+})
+
+describe('listedXfailPass', () => {
+  const listedPass = {
+    status: 'passed',
+    titlePath: ['auth/login.spec.ts', 'login form', 'should succeed'],
+    annotations: [{ type: 'xfail', description: 'flaky under load' }],
+  }
+
+  it('returns the test id and reason for a listed test that passed', () => {
+    expect(listedXfailPass(listedPass)).toEqual({
+      testId: 'auth/login.spec.ts > login form > should succeed',
+      reason: 'flaky under load',
+    })
+  })
+
+  it('ignores a listed test that was quarantined (skipped)', () => {
+    expect(listedXfailPass({ ...listedPass, status: 'skipped' })).toBeNull()
+  })
+
+  it('ignores a passing test that was not listed', () => {
+    expect(listedXfailPass({ ...listedPass, annotations: [] })).toBeNull()
+  })
+
+  it('uses the default reason when the annotation has no description', () => {
+    expect(listedXfailPass({ ...listedPass, annotations: [{ type: 'xfail' }] })).toEqual({
+      testId: 'auth/login.spec.ts > login form > should succeed',
+      reason: 'listed in xfail list',
+    })
+  })
+
+  it('drops empty titlePath segments', () => {
+    expect(
+      listedXfailPass({
+        ...listedPass,
+        titlePath: ['', 'auth/login.spec.ts', 'should succeed'],
+      })?.testId
+    ).toBe('auth/login.spec.ts > should succeed')
+  })
+})
+
+describe('formatListedXfailPasses', () => {
+  it('returns nothing when no listed tests passed', () => {
+    expect(formatListedXfailPasses([])).toEqual([])
+  })
+
+  it('lists every listed pass with its reason', () => {
+    const lines = formatListedXfailPasses([
+      { testId: 'auth/login.spec.ts > should succeed', reason: 'flaky' },
+      { testId: 'settings.spec.ts > saves', reason: 'line one\nline two' },
+    ])
+    expect(lines[0]).toBe('xpass: 2 listed test(s) passed (remove from playwright.md):')
+    expect(lines).toContain('  - auth/login.spec.ts > should succeed — flaky')
+    expect(lines).toContain('  - settings.spec.ts > saves — line one line two')
+  })
+})
+
+describe('buildTestId', () => {
+  // testInfo.titlePath already starts with the testDir-relative spec path
+  // (verified against Playwright: e.g. ['sub/foo.spec.ts', 'describe', 'test']).
+  const asTestInfo = (titlePath: string[]): Pick<TestInfo, 'titlePath'> =>
+    ({ titlePath }) as Pick<TestInfo, 'titlePath'>
+
+  it('joins the titlePath without duplicating the spec path', () => {
+    // Regression: buildTestId used to prepend testInfo.file, yielding
+    // "sub/foo.spec.ts > sub/foo.spec.ts > ...". The id must contain the spec
+    // path exactly once so exact-match patterns work.
+    const id = buildTestId(asTestInfo(['sub/foo.spec.ts', 'login form', 'should succeed']))
+    expect(id).toBe('sub/foo.spec.ts > login form > should succeed')
+  })
+
+  it('handles a spec with no describe block', () => {
+    expect(buildTestId(asTestInfo(['foo.spec.ts', 'works']))).toBe('foo.spec.ts > works')
+  })
+
+  it('drops empty segments', () => {
+    expect(buildTestId(asTestInfo(['foo.spec.ts', '', 'works']))).toBe('foo.spec.ts > works')
+  })
+
+  it('produces an id an exact file:title pattern matches', () => {
+    const id = buildTestId(asTestInfo(['auth/login.spec.ts', 'login form', 'should succeed']))
+    expect(matchPattern(id, 'auth/login.spec.ts: login form > should succeed')).toBe(true)
   })
 })
 

--- a/frontend/packages/syntara-ui/vitest.config.ts
+++ b/frontend/packages/syntara-ui/vitest.config.ts
@@ -18,7 +18,14 @@ export default defineConfig({
     setupFiles: './src/test/setup.ts',
     css: true,
     mockReset: true,
-    exclude: ['**/node_modules/**', '**/dist/**', '**/e2e/**', '**/playwright.config.ts', '**/*.browser.test.{ts,tsx}'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/e2e/**',
+      '**/playwright.config.ts',
+      '**/*.browser.test.{ts,tsx}',
+      '**/.tmp-xfail-int-*/**',
+    ],
     coverage: {
       provider: 'v8',
       reportsDirectory: process.env.VITEST_COVERAGE_DIR ?? 'coverage',


### PR DESCRIPTION
## Description

E2E tests now run with Currents reporting only on daily scheduled runs instead of every PR. This reduces CI costs while maintaining test analytics.

Also includes changes from #440 - pipeline no longer fails for a quarantined test that passes.

## Type of Change

- [x] Performance improvement

## Changes Made

- Daily scheduled E2E run with Currents at 2 AM UTC
- Conditional Currents reporter based on trigger type
- Optional manual Currents enablement via workflow dispatch

## Out of Scope

N/A

## How to Test

1. Verify PR E2E runs complete without Currents
2. Check scheduled runs enable Currents after merge
3. Test manual workflow dispatch with enable_currents flag

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Additional Notes

First scheduled run occurs tomorrow at 2 AM UTC.

> 🤖 PR description AI-assisted