### PR TITLE
fix: do not treat all of .github as product CI changes

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -48,8 +48,9 @@ jobs:
             exit 0
           fi
 
-          # Detect overall backend changes (for jobs that need any backend change)
-          if grep -qE '^(backend/|\.github/)' <<< "$FILES"; then
+          # Detect overall backend changes (for jobs that need any backend change).
+          # Do not treat all of .github/ as backend (CODEOWNERS, PR template, etc.).
+          if grep -qE '^(backend/|\.github/workflows/ci-backend\.yml|\.github/actions/)' <<< "$FILES"; then
             echo "backend=true" >> "$GITHUB_OUTPUT"
           else
             echo "backend=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -71,7 +71,9 @@ jobs:
             { echo "code=true"; echo "backend=true"; echo "contracts=true"; echo "scripts=true"; echo "frontend=true"; } >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if grep -qE '^(frontend/|backend/|\.github/)' <<< "$FILES"; then
+          # Workflow/action edits that affect this stack, not all of .github/
+          # (CODEOWNERS, PR template, etc. used to turn on full frontend CI).
+          if grep -qE '^(frontend/|backend/|\.github/workflows/ci-frontend\.yml|\.github/actions/)' <<< "$FILES"; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -194,6 +194,8 @@ npm run lint               # Run ESLint
 npm run tsc                # Type check only
 ```
 
+GitHub `CI Frontend` treats a PR as frontend code when it touches `frontend/`, `backend/`, `.github/workflows/ci-frontend.yml`, or `.github/actions/`. Paths like `.github/CODEOWNERS` do not turn on that suite.
+
 ## Connecting to Real Backend
 
 To use the real backend instead of the mock API:


### PR DESCRIPTION
## Description

`ci-frontend` and `ci-backend` treat any path under `.github/` as product code. a CODEOWNERS-only PR then turns on full Required Checks waiters for checks that never start.

narrow those greps to this stack's workflow file plus `.github/actions/`. documents the frontend rule in `frontend/AGENTS.md` so this PR also touches `frontend/` (yml-only PRs #432 and #435 never got `pull_request` Actions runs).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] `ci-frontend.yml` `code=true` matches `frontend/`, `backend/`, `ci-frontend.yml`, and `.github/actions/`
- [x] `ci-backend.yml` `backend=true` matches `backend/`, `ci-backend.yml`, and `.github/actions/`
- [x] `frontend/AGENTS.md` notes when GitHub frontend CI treats a PR as code

## Out of Scope

does not change CODEOWNERS. does not change Konflux/Pre-commit waiter jobs.

## Related Issues

Related to #432
Related to #435

## How to Test

1. this PR touches `frontend/`, so `CI Frontend` / `CI Backend` `pull_request` runs should start (unlike #435).
2. after merge, a PR that only edits `.github/CODEOWNERS` should not set frontend `code=true` or backend `backend=true`.

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [x] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->