### PR TITLE
test: Multi-org commit status

### DIFF
--- a/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
@@ -38,15 +38,13 @@ spec:
       value: '{{pull_request_number}}'
   pipelineRef:
     params:
-      - name: name
-        value: ao-api-tests
-      - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/ao-api-tests:0.1@sha256:c5e04d21740314af736b6b39a66680d0c7dbfff68a1e88a76f18932a54638376
-      - name: kind
-        value: pipeline
-      - name: secret
-        value: quay-aap-ci-viewer
-    resolver: bundles
+      - name: url
+        value: https://github.com/ansible-automation-platform/aap-konflux-pipelines
+      - name: revision
+        value: anstrat-2240-multi-org-commit-status
+      - name: pathInRepo
+        value: pipelines/test/ao-api-tests/0.1/pipeline.yaml
+    resolver: git
 
   taskRunTemplate:
     serviceAccountName: konflux-integration-runner

--- a/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
+++ b/.tekton/automation-orchestrator-api-tests-devel-pull-request.yaml
@@ -38,12 +38,20 @@ spec:
       value: '{{pull_request_number}}'
   pipelineRef:
     params:
-      - name: url
-        value: https://github.com/ansible-automation-platform/aap-konflux-pipelines
+      - name: org
+        value: ansible-automation-platform
+      - name: repo
+        value: aap-konflux-pipelines
       - name: revision
         value: anstrat-2240-multi-org-commit-status
       - name: pathInRepo
         value: pipelines/test/ao-api-tests/0.1/pipeline.yaml
+      - name: token
+        value: github-aap-org-secret
+      - name: tokenKey
+        value: password
+      - name: scmType
+        value: github
     resolver: git
 
   taskRunTemplate:


### PR DESCRIPTION
## Summary

**This is a TEST PR to validate multi-org commit status reporting.**

Updates API tests pipeline to use git resolver pointing to test branches with multi-org commit status support.

## What to Verify

When this PR's API tests run, commit statuses should appear in:
1. ✅ This PR's commits in `syntara-orchestration/syntara`
2. ✅ Commits from `automation-nexus/nexus-combined` (if in snapshot)


## After Testing

- [ ] Verify commit statuses appear in both orgs
- [ ] Merge tool and pipelines PRs
- [ ] Revert this PR or update to use bundle resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)