### PR TITLE
fix(ui): replace ARIA roles with semantic HTML on canvas nodes (AAP-78096)

### DIFF
--- a/frontend/packages/syntara-ui/e2e/v2-workflow-migration.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/v2-workflow-migration.spec.ts
@@ -362,7 +362,7 @@ test.describe('V2 Workflow Schema Migration', () => {
       ]
       for (const nodeName of nodeNames) {
         await expect(
-          app.locator('.react-flow').getByRole('group', { name: new RegExp(`^${nodeName}(,|$)`) }),
+          app.locator('.react-flow').getByRole('button', { name: new RegExp(`^${nodeName}(,|$)`) }),
           `node "${nodeName}" should be present after reload`
         ).toBeAttached({ timeout: 15_000 })
       }

--- a/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeComponent.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeComponent.test.tsx
@@ -60,7 +60,7 @@ describe('NodeComponent semantic zoom', () => {
     )
 
     expect(screen.getByText('Detailed body')).toBeInTheDocument()
-    expect(screen.queryByRole('group', { name: 'T, Agentic' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'T, Task Agent' })).not.toBeInTheDocument()
   })
 
   it('renders semantic color block when zoom is at threshold', () => {
@@ -76,7 +76,7 @@ describe('NodeComponent semantic zoom', () => {
     )
 
     expect(screen.queryByText('Detailed body')).not.toBeInTheDocument()
-    expect(screen.getByRole('group', { name: 'Analyze, Task Agent' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Analyze, Task Agent' })).toBeInTheDocument()
   })
 
   it('semantic zoom layout has no accessibility violations', async () => {

--- a/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeMenu.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeMenu.test.tsx
@@ -227,23 +227,70 @@ describe('NodeMenu', () => {
 
       expect(parentMouseDownHandler).not.toHaveBeenCalled()
     })
+
+    it('stops Enter key propagation on MenuToggle', async () => {
+      const user = userEvent.setup()
+      const parentKeyDownHandler = vi.fn()
+      const actions = [createMenuAction()]
+
+      render(
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div onKeyDown={parentKeyDownHandler}>
+          <NodeMenu menuActions={actions} />
+        </div>
+      )
+
+      screen.getByRole('button', { name: /step actions menu/i }).focus()
+      await user.keyboard('{Enter}')
+
+      expect(parentKeyDownHandler).not.toHaveBeenCalledWith(expect.objectContaining({ key: 'Enter' }))
+    })
+
+    it('stops Space key propagation on MenuToggle', async () => {
+      const user = userEvent.setup()
+      const parentKeyDownHandler = vi.fn()
+      const actions = [createMenuAction()]
+
+      render(
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div onKeyDown={parentKeyDownHandler}>
+          <NodeMenu menuActions={actions} />
+        </div>
+      )
+
+      screen.getByRole('button', { name: /step actions menu/i }).focus()
+      await user.keyboard(' ')
+
+      expect(parentKeyDownHandler).not.toHaveBeenCalledWith(expect.objectContaining({ key: ' ' }))
+    })
+
+    it('does not stop propagation for other keys on MenuToggle', async () => {
+      const user = userEvent.setup()
+      const parentKeyDownHandler = vi.fn()
+      const actions = [createMenuAction()]
+
+      render(
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div onKeyDown={parentKeyDownHandler}>
+          <NodeMenu menuActions={actions} />
+        </div>
+      )
+
+      screen.getByRole('button', { name: /step actions menu/i }).focus()
+      await user.keyboard('{Escape}')
+
+      expect(parentKeyDownHandler).toHaveBeenCalledWith(expect.objectContaining({ key: 'Escape' }))
+    })
   })
 
   describe('accessibility', () => {
-    it('has button role on wrapper', () => {
+    it('wrapper has no interactive role — interactivity is on the inner MenuToggle button', () => {
       const actions = [createMenuAction()]
       render(<NodeMenu menuActions={actions} />)
 
       const wrapper = screen.getByTestId('node-menu-wrapper')
-      expect(wrapper).toHaveAttribute('role', 'button')
-    })
-
-    it('has tabIndex 0 on wrapper', () => {
-      const actions = [createMenuAction()]
-      render(<NodeMenu menuActions={actions} />)
-
-      const wrapper = screen.getByTestId('node-menu-wrapper')
-      expect(wrapper).toHaveAttribute('tabIndex', '0')
+      expect(wrapper).not.toHaveAttribute('role')
+      expect(wrapper).not.toHaveAttribute('tabIndex')
     })
 
     it('menu toggle has aria-label', () => {

--- a/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeMenu.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeMenu.tsx
@@ -32,20 +32,7 @@ export function NodeMenu(props: Readonly<NodeMenuProps>) {
   }
 
   return (
-    <div
-      data-testid="node-menu-wrapper"
-      onClick={(e) => e.stopPropagation()}
-      onMouseDown={(e) => e.stopPropagation()}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.stopPropagation()
-        }
-      }}
-      className={`nodrag nopan ${props.className ?? ''}`}
-      role="button"
-      tabIndex={0}
-      style={props.style}
-    >
+    <div data-testid="node-menu-wrapper" className={`nodrag nopan ${props.className ?? ''}`} style={props.style}>
       <Dropdown
         isOpen={isMenuOpen}
         onOpenChange={(isOpen) => setIsMenuOpen(isOpen)}
@@ -54,7 +41,16 @@ export function NodeMenu(props: Readonly<NodeMenuProps>) {
           <MenuToggle
             ref={toggleRef}
             variant="plain"
-            onClick={() => setIsMenuOpen(!isMenuOpen)}
+            onClick={(event) => {
+              event.stopPropagation()
+              setIsMenuOpen(!isMenuOpen)
+            }}
+            onMouseDown={(event) => event.stopPropagation()}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.stopPropagation()
+              }
+            }}
             isExpanded={isMenuOpen}
             aria-label="Step actions menu"
             className="nodrag nopan"

--- a/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeSemanticZoomBody.module.css
+++ b/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeSemanticZoomBody.module.css
@@ -1,0 +1,18 @@
+/**
+ * Reset native <button> chrome so the semantic zoom bar renders identically
+ * to the previous <div>. Width/height fill the wrapper so the tooltip trigger
+ * surface covers the full bar area.
+ */
+.tooltipTrigger {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+}

--- a/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeSemanticZoomBody.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeSemanticZoomBody.test.tsx
@@ -17,9 +17,7 @@ describe('NodeSemanticZoomBody', () => {
       />
     )
 
-    const bar = screen.getByRole('group', { name: 'Analyze Data, Task Agent' })
-    expect(bar).toBeInTheDocument()
-    expect(bar).toHaveAttribute('tabindex', '0')
+    expect(screen.getByRole('button', { name: 'Analyze Data, Task Agent' })).toBeInTheDocument()
   })
 
   it('has no accessibility violations', async () => {
@@ -48,7 +46,7 @@ describe('NodeSemanticZoomBody', () => {
       />
     )
 
-    await user.hover(screen.getByRole('group', { name: 'My Task, REST API' }))
+    await user.hover(screen.getByRole('button', { name: 'My Task, REST API' }))
 
     expect(await screen.findByText('My Task')).toBeInTheDocument()
     expect(screen.getByText('REST API')).toBeInTheDocument()

--- a/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeSemanticZoomBody.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/NodeSemanticZoomBody.tsx
@@ -4,6 +4,7 @@ import type { CSSProperties, ReactNode } from 'react'
 import { SEMANTIC_ZOOM_BAR_HEIGHT_PX } from '../../semanticZoom'
 import type { SemanticZoomBranchSource } from '../../semanticZoomTypes'
 
+import styles from './NodeSemanticZoomBody.module.css'
 import { SemanticZoomBranchSourceHandles } from './SemanticZoomBranchSourceHandles'
 
 export function NodeSemanticZoomBody(props: {
@@ -70,7 +71,7 @@ export function NodeSemanticZoomBody(props: {
     width: '100%',
     height: SEMANTIC_ZOOM_BAR_HEIGHT_PX,
     minHeight: SEMANTIC_ZOOM_BAR_HEIGHT_PX,
-    // Not role=button, but the node still selects / opens the builder detail path like full-size nodes
+    // Click bubbles to the ReactFlow node, which selects / opens the builder detail path.
     cursor: 'pointer',
   }
 
@@ -78,22 +79,12 @@ export function NodeSemanticZoomBody(props: {
     <div style={rowStyle}>
       <Tooltip content={tooltipContent} position="top">
         {/*
-          PatternFly Tooltip opens on focus; tabIndex gives keyboard users a trigger. role="group" + aria-label
-          name the bar for SRs (not a button).
+          PatternFly Tooltip opens on focus; the native <button> gives keyboard
+          users a focus target and announces the node name + type to screen readers.
         */}
-        {/* eslint-disable jsx-a11y/no-noninteractive-tabindex -- focus target for tooltip; group is not a button */}
-        <div
-          role="group"
-          aria-label={`${props.title}, ${props.typeLabel}`}
-          tabIndex={0}
-          style={{
-            width: '100%',
-            height: '100%',
-          }}
-        >
+        <button type="button" aria-label={`${props.title}, ${props.typeLabel}`} className={styles.tooltipTrigger}>
           <div style={baseBarStyle} />
-        </div>
-        {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
+        </button>
       </Tooltip>
       <SemanticZoomBranchSourceHandles handles={props.branchSources ?? []} />
     </div>


### PR DESCRIPTION
## Description

Resolves SonarQube S6819 by replacing ARIA roles on workflow canvas node components with native semantic HTML. Native elements provide built-in keyboard handling, focus management, and assistive technology support that ARIA roles alone cannot guarantee.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

- **NodeSemanticZoomBody**: Replace `<div role="group" tabIndex={0}>` with native `<button type="button">` for the semantic zoom tooltip trigger; add CSS module button reset to preserve visual appearance
- **NodeMenu**: Remove misleading `role="button"` and `tabIndex={0}` from the wrapper `<div>` — interactivity lives on the inner PatternFly `MenuToggle` button
- Update unit tests to match new semantics (`getByRole('button')` instead of `getByRole('group')`)
- Remove `eslint-disable jsx-a11y/no-noninteractive-tabindex` suppression

## Out of Scope

- Adding `vitest-axe` to `NodeMenu` (pre-existing gap)
- Visual regression baseline updates (no semantic-zoom page in `page-registry.ts`)

## Related Issues

Fixes AAP-78096

## How to Test

1. Open a workflow in the builder canvas
2. Zoom out to semantic zoom level — verify colored node bars render identically to before
3. Tab to a semantic zoom node bar — confirm tooltip appears on focus and `aria-label` announces node name + type
4. Hover a semantic zoom bar — confirm tooltip still shows title and type label
5. Click a node's kebab menu — confirm menu opens and does not trigger node selection
6. Run unit tests:
   ```bash
   cd frontend/packages/syntara-ui
   npx vitest run src/routes/workflows/canvas/nodes/common/NodeMenu.test.tsx src/routes/workflows/canvas/nodes/common/NodeSemanticZoomBody.test.tsx
   ```

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`) — targeted tests: 20/20 pass
- [x] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes - N/A no visible changes

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## Screenshots / Demo (if applicable)

<!-- TODO: attach screenshots of semantic zoom bars and node kebab menu -->

## Additional Notes

- SonarQube S6819 instance count should drop to 0 after merge
- `NodeMenu` wrapper is intentionally a non-interactive `<div>` (event propagation boundary only); using a native `<button>` wrapper would create invalid nested-button HTML with the inner `MenuToggle`

Made with [Cursor](https://cursor.com)