### PR TITLE
fix(AAP-84198): standardize toast notification titles and descriptions

### DIFF
--- a/frontend/packages/syntara-ui/e2e/visual-regression/page-entries-interactive.ts
+++ b/frontend/packages/syntara-ui/e2e/visual-regression/page-entries-interactive.ts
@@ -590,10 +590,10 @@ export const workflowDialogPages: CanvasPageEntry[] = [
         // a published status badge so the DOM is fully settled before re-clicking
         await expect(page.getByRole('dialog')).not.toBeVisible()
         await expect(page.getByText('Published', { exact: true }).first()).toBeVisible()
-        // The "Workflow published successfully" toast auto-dismisses after several
+        // The "Workflow published" toast auto-dismisses after several
         // seconds — wait it out so it isn't still on screen (overlapping the
         // "Unpublish workflow?" dialog) when the final screenshot is captured.
-        await expect(page.getByText('Workflow published successfully')).not.toBeVisible({ timeout: 12_000 })
+        await expect(page.getByText('Workflow published', { exact: true })).not.toBeVisible({ timeout: 12_000 })
         await workflowKebab.click()
         const unpublishAfterPublish = page.getByRole('menuitem', { name: /Unpublish workflow/i })
         await expect(unpublishAfterPublish).toBeVisible()
@@ -637,7 +637,7 @@ export const workflowDialogPages: CanvasPageEntry[] = [
       await page.getByRole('button', { name: 'Publish' }).click()
       const publishedWorkflowId = new URL((await publishResponse).url()).pathname.split('/')[4] ?? null
       await expect(page.getByRole('dialog')).not.toBeVisible()
-      await expect(page.getByText('Workflow published successfully')).not.toBeVisible({ timeout: 12_000 })
+      await expect(page.getByText('Workflow published', { exact: true })).not.toBeVisible({ timeout: 12_000 })
 
       await workflowKebab.click()
       await page.getByRole('menuitem', { name: /Run published version/i }).click()

--- a/frontend/packages/syntara-ui/e2e/workflow-verification.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflow-verification.spec.ts
@@ -124,7 +124,7 @@ test.describe('Verify button in toolbar', () => {
 
       await triggerVerifyWorkflow(app)
 
-      await expect(app.getByText('Workflow definition is valid')).toBeVisible({ timeout: VERIFY_BANNER_TIMEOUT })
+      await expect(app.getByText('Workflow verified')).toBeVisible({ timeout: VERIFY_BANNER_TIMEOUT })
     } finally {
       await app.unroute(VALIDATE_ROUTE)
       await deleteWorkflow(app, workflowName)

--- a/frontend/packages/syntara-ui/src/routes/access/AssignRoleDialog.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/AssignRoleDialog.test.tsx
@@ -491,6 +491,8 @@ describe('AssignRoleDialog', () => {
         })
         expect(onSuccess).toHaveBeenCalled()
         expect(onClose).toHaveBeenCalled()
+        expect(screen.getByText('Assignment added')).toBeInTheDocument()
+        expect(screen.getByText('Assignment for alice has been added.')).toBeInTheDocument()
       }
     }, 25_000)
 

--- a/frontend/packages/syntara-ui/src/routes/access/AssignRoleDialog.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/AssignRoleDialog.tsx
@@ -40,6 +40,30 @@ import { PRINCIPAL_ID_FIELD, roleAssignmentsQueryKey, useAlreadyAssignedRoles } 
 
 const PAGE_SIZE = 20
 
+type NamedOption = { value: string; label: string }
+
+function assignmentAddedDescription(
+  data: AssignRoleFormData,
+  userOptions: NamedOption[],
+  groupOptions: NamedOption[],
+  serviceAccountOptions: NamedOption[]
+): string {
+  const optionsByType = {
+    [RolePrincipalType.USER]: userOptions,
+    [RolePrincipalType.GROUP]: groupOptions,
+    [RolePrincipalType.SERVICE_ACCOUNT]: serviceAccountOptions,
+  }
+  const idByType = {
+    [RolePrincipalType.USER]: data.userId,
+    [RolePrincipalType.GROUP]: data.groupId,
+    [RolePrincipalType.SERVICE_ACCOUNT]: data.serviceAccountId,
+  }
+  const principalId = idByType[data.principalType]
+  const principalName =
+    optionsByType[data.principalType].find((option) => option.value === principalId)?.label ?? principalId
+  return `Assignment for ${principalName} has been added.`
+}
+
 // ── Form body (extracted to stay within max-lines-per-function) ───────────
 
 type AssignRoleFormBodyProps = {
@@ -434,7 +458,10 @@ export function AssignRoleDialog({ onClose, onSuccess }: Readonly<AssignRoleDial
           queryKey: roleAssignmentsQueryKey(data.principalType, principalId),
         })
       )
-      showSuccess({ title: 'Assignment added', description: 'Assignment created successfully' })
+      showSuccess({
+        title: 'Assignment added',
+        description: assignmentAddedDescription(data, userOptions, groupOptions, serviceAccountOptions),
+      })
       onSuccess()
       onClose()
     }

--- a/frontend/packages/syntara-ui/src/routes/access/AssignmentsTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/AssignmentsTab.test.tsx
@@ -872,6 +872,7 @@ describe('AssignmentsTab', () => {
 
       await waitFor(() => {
         expect(screen.queryByText('Remove assignment?')).not.toBeInTheDocument()
+        expect(screen.getByText('Failed to remove assignment')).toBeInTheDocument()
       })
     })
   })

--- a/frontend/packages/syntara-ui/src/routes/access/AssignmentsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/AssignmentsTab.tsx
@@ -276,7 +276,8 @@ export function AssignmentsTab() {
       detachPromise(queryClient.invalidateQueries({ queryKey: ['role-assignments'] }))
       refetch()
     }
-    const onError = (error: unknown) => showError({ title: 'Remove failed', description: getErrorMessage(error) })
+    const onError = (error: unknown) =>
+      showError({ title: 'Failed to remove assignment', description: getErrorMessage(error) })
     const onSettled = deleteDialog.close
     const callbacks = { onSuccess, onError, onSettled }
 

--- a/frontend/packages/syntara-ui/src/routes/access/EditRoleDialog.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/EditRoleDialog.test.tsx
@@ -227,6 +227,8 @@ describe('EditRoleDialog', () => {
 
       expect(mockOnSuccess).toHaveBeenCalled()
       expect(mockOnClose).toHaveBeenCalled()
+      expect(screen.getByText('Role updated')).toBeInTheDocument()
+      expect(screen.getByText('my-custom-role has been updated.')).toBeInTheDocument()
     })
 
     it('shows error on failed mutation without calling onSuccess/onClose', async () => {

--- a/frontend/packages/syntara-ui/src/routes/access/EditRoleDialog.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/EditRoleDialog.tsx
@@ -66,7 +66,7 @@ export function EditRoleDialog({ role, onClose, onSuccess }: Readonly<EditRoleDi
       },
       {
         onSuccess: () => {
-          showSuccess({ title: 'Role updated', description: 'Role updated successfully' })
+          showSuccess({ title: 'Role updated', description: `${data.name} has been updated.` })
           invalidateAuthzCaches(queryClient)
           onSuccess()
           onClose()

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.delete.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.delete.test.tsx
@@ -299,8 +299,7 @@ describe('BuilderContent - Delete Workflow', () => {
     // Verify error alert
     await waitFor(() => {
       expect(mockDeleteMutate).toHaveBeenCalled()
-      expect(screen.getByText('Delete failed')).toBeInTheDocument()
-      expect(screen.getByText(/Failed to delete workflow/)).toBeInTheDocument()
+      expect(screen.getAllByText(/Failed to delete workflow/).length).toBeGreaterThanOrEqual(2)
     })
   })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.delete.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.delete.test.tsx
@@ -299,7 +299,8 @@ describe('BuilderContent - Delete Workflow', () => {
     // Verify error alert
     await waitFor(() => {
       expect(mockDeleteMutate).toHaveBeenCalled()
-      expect(screen.getAllByText(/Failed to delete workflow/).length).toBeGreaterThanOrEqual(2)
+      expect(screen.getByText('Failed to delete workflow')).toBeInTheDocument()
+      expect(screen.getByText(/Failed to delete workflow ".+":/)).toBeInTheDocument()
     })
   })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.test.tsx
@@ -798,7 +798,7 @@ describe('BuilderContent', () => {
       await user.click(screen.getByRole('button', { name: 'Run' }))
 
       await waitFor(() => {
-        expect(screen.getByText('Workflow failed')).toBeInTheDocument()
+        expect(screen.getByText('Failed to run workflow')).toBeInTheDocument()
       })
     })
 
@@ -2311,7 +2311,7 @@ describe('BuilderContent', () => {
 
       await waitFor(() => {
         expect(screen.getByText('No workflow to save')).toBeInTheDocument()
-        expect(screen.getByText('Save failed')).toBeInTheDocument()
+        expect(screen.getByText('Failed to save workflow')).toBeInTheDocument()
       })
     })
   })

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.test.tsx
@@ -98,7 +98,7 @@ describe('useBuilderSaveWorkflow', () => {
     const { result } = renderHook(() => useBuilderSaveWorkflow(buildParams({ currentWorkflow: null, showError })))
 
     await expect(result.current()).resolves.toBe(false)
-    expect(showError).toHaveBeenCalledWith({ title: 'Save failed', description: 'No workflow to save' })
+    expect(showError).toHaveBeenCalledWith({ title: 'Failed to save workflow', description: 'No workflow to save' })
   })
 
   it('returns false and shows danger toast when create path has no project', async () => {
@@ -209,7 +209,7 @@ describe('useBuilderSaveWorkflow', () => {
 
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith({
-      title: 'Create failed',
+      title: 'Failed to create workflow',
       description: expect.stringContaining('Failed to create workflow') as unknown as string,
     })
   })
@@ -267,7 +267,7 @@ describe('useBuilderSaveWorkflow', () => {
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Create failed',
+        title: 'Failed to create workflow',
         description: expect.stringContaining('has warnings') as unknown as string,
       })
     )
@@ -287,7 +287,7 @@ describe('useBuilderSaveWorkflow', () => {
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Update failed',
+        title: 'Failed to update workflow',
         description: expect.stringContaining('has warnings') as unknown as string,
       })
     )
@@ -426,7 +426,7 @@ describe('useBuilderSaveWorkflow', () => {
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Update failed',
+        title: 'Failed to update workflow',
         description: expect.stringContaining(
           'Step "Orphan Script" is unreachable from any trigger'
         ) as unknown as string,

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.ts
@@ -73,7 +73,7 @@ function reportSaveError(
 ): void {
   const findings = extractValidationErrorsFromUnknown(error)
   showError({
-    title: `${action.charAt(0).toUpperCase()}${action.slice(1)} failed`,
+    title: `Failed to ${action} workflow`,
     description: formatSaveFailureDescription(error, action),
   })
   if (findings && findings.length > 0) {
@@ -320,7 +320,7 @@ export function useBuilderSaveWorkflow(
       const effectiveExpectedVersion = options?.expectedVersionOverride ?? expectedVersion
       const willPatchExisting = Boolean(workflowId && !isNew)
       if (!currentWorkflow) {
-        showError({ title: 'Save failed', description: 'No workflow to save' })
+        showError({ title: 'Failed to save workflow', description: 'No workflow to save' })
         return false
       }
       if (!willPatchExisting && !selectedProject?.id) {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderToolbarHandlers.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderToolbarHandlers.test.tsx
@@ -251,7 +251,7 @@ describe('useBuilderToolbarHandlers', () => {
     await result.current.handleRunWorkflow()
 
     expect(showError).toHaveBeenCalledWith({
-      title: 'Workflow failed',
+      title: 'Failed to run workflow',
       description: 'Failed to start workflow "My workflow": boom',
     })
   })
@@ -376,7 +376,7 @@ describe('useBuilderToolbarHandlers', () => {
     expect(options?.onError).toEqual(expect.any(Function))
     expect(showSuccess).toHaveBeenCalledWith({
       title: 'Workflow deleted',
-      description: 'Successfully deleted workflow "My workflow"',
+      description: 'Workflow "My workflow" has been deleted.',
     })
     expect(setLocation).toHaveBeenCalledWith('/workflows')
   })
@@ -767,7 +767,7 @@ describe('useBuilderToolbarHandlers', () => {
     result.current.handleDeleteWorkflow()
 
     expect(showError).toHaveBeenCalledWith({
-      title: 'Delete failed',
+      title: 'Failed to delete workflow',
       description: 'Failed to delete workflow "My workflow": delete failed',
     })
     expect(dispatch).toHaveBeenCalledWith({ type: 'SET_DELETE_DIALOG', payload: false })

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderToolbarHandlers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderToolbarHandlers.ts
@@ -192,7 +192,7 @@ export function useBuilderToolbarHandlers({
           },
           onError: (error) => {
             showError({
-              title: 'Workflow failed',
+              title: 'Failed to run workflow',
               description: `Failed to start workflow "${workflowName}": ${getErrorMessage(error)}`,
             })
             dispatch({ type: 'SET_CONFIRM_DIALOG', payload: false })
@@ -223,13 +223,13 @@ export function useBuilderToolbarHandlers({
       { params: { path: { workflow_id: workflow.id } } },
       {
         onSuccess: () => {
-          showSuccess({ title: 'Workflow deleted', description: `Successfully deleted workflow "${workflowName}"` })
+          showSuccess({ title: 'Workflow deleted', description: `Workflow "${workflowName}" has been deleted.` })
           dispatch({ type: 'SET_DELETE_DIALOG', payload: false })
           setLocation('/workflows')
         },
         onError: (error) => {
           showError({
-            title: 'Delete failed',
+            title: 'Failed to delete workflow',
             description: `Failed to delete workflow "${workflowName}": ${getErrorMessage(error)}`,
           })
           dispatch({ type: 'SET_DELETE_DIALOG', payload: false })

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/usePublishWorkflow.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/usePublishWorkflow.test.ts
@@ -154,7 +154,7 @@ describe('usePublishWorkflow', () => {
       result.current.publish('v1.0', 'release notes')
     })
 
-    expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow published successfully' })
+    expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow published' })
     expect(mockShowWarning).not.toHaveBeenCalled()
   })
 
@@ -197,7 +197,7 @@ describe('usePublishWorkflow', () => {
       result.current.publish('v1.0')
     })
 
-    expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow published successfully' })
+    expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow published' })
     expect(mockShowWarning).not.toHaveBeenCalled()
   })
 
@@ -503,7 +503,7 @@ describe('useUnpublishWorkflow', () => {
       result.current.unpublish()
     })
 
-    expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow unpublished successfully' })
+    expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow unpublished' })
   })
 
   it('shows error alert on unpublish failure', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/usePublishWorkflow.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/usePublishWorkflow.ts
@@ -83,7 +83,7 @@ export function usePublishWorkflow(
                 description: data.warning,
               })
             } else {
-              showSuccess({ title: 'Workflow published successfully' })
+              showSuccess({ title: 'Workflow published' })
             }
             if (workflowDefinition) useWorkflowStore.getState().markClean()
             if (data?.current_version != null) {
@@ -137,7 +137,7 @@ export function useUnpublishWorkflow(workflowId: string | null) {
       },
       {
         onSuccess: () => {
-          showSuccess({ title: 'Workflow unpublished successfully' })
+          showSuccess({ title: 'Workflow unpublished' })
           detachPromise(queryClient.invalidateQueries({ predicate: isWorkflowQuery }))
         },
         onError: (error: unknown) => {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useVersionHistory.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useVersionHistory.test.ts
@@ -445,7 +445,7 @@ describe('useVersionHistory', () => {
       })
 
       expect(mockRefetch).toHaveBeenCalled()
-      expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Version published successfully' })
+      expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Version published' })
     })
 
     it('calls onVersionUpdated when publish response includes current_version', () => {
@@ -509,7 +509,7 @@ describe('useVersionHistory', () => {
         result.current.publishVersion(2)
       })
 
-      expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Version published successfully' })
+      expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Version published' })
     })
 
     it('shows error alert on publish failure', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useVersionHistory.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useVersionHistory.ts
@@ -112,7 +112,7 @@ export function useVersionHistory({ workflowId, isNew, onVersionUpdated }: UseVe
         },
         {
           onSuccess: (data) => {
-            showSuccess({ title: 'Version published successfully' })
+            showSuccess({ title: 'Version published' })
             if (data?.current_version != null) {
               onVersionUpdated?.(data.current_version)
             }

--- a/frontend/packages/syntara-ui/src/routes/builder/useWorkflowImportExport.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/useWorkflowImportExport.test.ts
@@ -173,7 +173,7 @@ describe('useWorkflowImportExport', () => {
       act(() => result.current.handleExport())
 
       expect(mockShowError).toHaveBeenCalledWith({
-        title: 'Export failed',
+        title: 'Failed to export workflow',
         description: 'Build failed',
       })
       expect(mockDispatch).toHaveBeenCalledWith({ type: 'SET_KEBAB_OPEN', payload: false })
@@ -260,7 +260,7 @@ describe('useWorkflowImportExport', () => {
 
       await waitFor(() => {
         expect(mockShowError).toHaveBeenCalledWith({
-          title: 'Import failed',
+          title: 'Failed to import workflow',
           description: 'File is too large',
         })
       })

--- a/frontend/packages/syntara-ui/src/routes/builder/useWorkflowImportExport.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/useWorkflowImportExport.ts
@@ -95,7 +95,7 @@ export function useWorkflowImportExport({
           }
         })
         .catch((err: unknown) => {
-          showError({ title: 'Import failed', description: getErrorMessage(err) })
+          showError({ title: 'Failed to import workflow', description: getErrorMessage(err) })
         })
 
       event.target.value = ''
@@ -120,7 +120,7 @@ export function useWorkflowImportExport({
       })
       downloadWorkflowDefinition(definition as Record<string, unknown>, name)
     } catch (err: unknown) {
-      showError({ title: 'Export failed', description: getErrorMessage(err) })
+      showError({ title: 'Failed to export workflow', description: getErrorMessage(err) })
     }
     dispatch({ type: 'SET_KEBAB_OPEN', payload: false })
   }, [dispatch, showError, workflowName, workflowDescription])

--- a/frontend/packages/syntara-ui/src/routes/builder/useWorkflowVerification.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/useWorkflowVerification.test.ts
@@ -109,7 +109,7 @@ describe('useWorkflowVerification', () => {
     expect(clearCall).toBeDefined()
 
     await waitFor(() => {
-      expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow definition is valid' })
+      expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow verified' })
     })
   })
 
@@ -128,7 +128,7 @@ describe('useWorkflowVerification', () => {
 
     await waitFor(() => {
       expect(mockDispatch).toHaveBeenCalledWith({ type: 'CLEAR_VALIDATION_ERRORS' })
-      expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow definition is valid' })
+      expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow verified' })
     })
   })
 
@@ -382,7 +382,7 @@ describe('useWorkflowVerification', () => {
       act(() => result.current.handleVerify())
 
       await waitFor(() => {
-        expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow definition is valid' })
+        expect(mockShowSuccess).toHaveBeenCalledWith({ title: 'Workflow verified' })
       })
     })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/useWorkflowVerification.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/useWorkflowVerification.ts
@@ -134,7 +134,7 @@ function processValidateResponse(
   if (callbacks.onValid) {
     callbacks.onValid()
   } else if (!callbacks.silent) {
-    callbacks.showSuccess({ title: 'Workflow definition is valid' })
+    callbacks.showSuccess({ title: 'Workflow verified' })
   }
 }
 

--- a/frontend/packages/syntara-ui/src/routes/workflows/Workflows.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/Workflows.test.tsx
@@ -1136,7 +1136,8 @@ describe('Workflows Component', () => {
       // Verify error alert
       await waitFor(() => {
         expect(mockDeleteMutate).toHaveBeenCalled()
-        expect(screen.getAllByText(/Failed to delete workflow/).length).toBeGreaterThanOrEqual(2)
+        expect(screen.getByText('Failed to delete workflow')).toBeInTheDocument()
+        expect(screen.getByText(/Failed to delete workflow ".+":/)).toBeInTheDocument()
       })
     })
 

--- a/frontend/packages/syntara-ui/src/routes/workflows/Workflows.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/Workflows.test.tsx
@@ -474,7 +474,7 @@ describe('Workflows Component', () => {
 
       // Verify error alert is shown
       await waitFor(() => {
-        expect(screen.getByText('Workflow failed')).toBeInTheDocument()
+        expect(screen.getByText('Failed to run workflow')).toBeInTheDocument()
         expect(screen.getByText(/Failed to start workflow "Important Project Workflow"/)).toBeInTheDocument()
       })
     })
@@ -514,7 +514,7 @@ describe('Workflows Component', () => {
 
       // Verify error alert is shown with generic message
       await waitFor(() => {
-        expect(screen.getByText('Workflow failed')).toBeInTheDocument()
+        expect(screen.getByText('Failed to run workflow')).toBeInTheDocument()
         expect(
           screen.getByText(/Failed to start workflow "Important Project Workflow": An unexpected error occurred/)
         ).toBeInTheDocument()
@@ -1071,7 +1071,7 @@ describe('Workflows Component', () => {
         expect(mockDeleteMutate).toHaveBeenCalled()
         expect(mockRefetch).toHaveBeenCalled()
         expect(screen.getByText('Workflow deleted')).toBeInTheDocument()
-        expect(screen.getByText(/Successfully deleted workflow/)).toBeInTheDocument()
+        expect(screen.getByText(/Workflow ".+" has been deleted/)).toBeInTheDocument()
       })
     })
 
@@ -1136,8 +1136,7 @@ describe('Workflows Component', () => {
       // Verify error alert
       await waitFor(() => {
         expect(mockDeleteMutate).toHaveBeenCalled()
-        expect(screen.getByText('Delete failed')).toBeInTheDocument()
-        expect(screen.getByText(/Failed to delete workflow/)).toBeInTheDocument()
+        expect(screen.getAllByText(/Failed to delete workflow/).length).toBeGreaterThanOrEqual(2)
       })
     })
 
@@ -1756,7 +1755,7 @@ describe('Workflows Component', () => {
       await user.click(duplicateItem)
 
       await waitFor(() => {
-        expect(screen.getByText('Duplicate failed')).toBeInTheDocument()
+        expect(screen.getByText('Failed to duplicate workflow')).toBeInTheDocument()
       })
     })
 
@@ -1793,7 +1792,7 @@ describe('Workflows Component', () => {
       await user.click(duplicateItem)
 
       await waitFor(() => {
-        expect(screen.getByText('Duplicate failed')).toBeInTheDocument()
+        expect(screen.getByText('Failed to duplicate workflow')).toBeInTheDocument()
       })
     })
 
@@ -1904,7 +1903,7 @@ describe('Workflows Component', () => {
       await user.click(duplicateItem)
 
       await waitFor(() => {
-        expect(screen.getByText('Duplicate failed')).toBeInTheDocument()
+        expect(screen.getByText('Failed to duplicate workflow')).toBeInTheDocument()
       })
     })
 
@@ -1918,7 +1917,7 @@ describe('Workflows Component', () => {
       await user.click(duplicateItem)
 
       await waitFor(() => {
-        expect(screen.getByText('Duplicate failed')).toBeInTheDocument()
+        expect(screen.getByText('Failed to duplicate workflow')).toBeInTheDocument()
       })
     })
 
@@ -1938,7 +1937,7 @@ describe('Workflows Component', () => {
       await user.click(duplicateItem)
 
       await waitFor(() => {
-        expect(screen.getByText('Duplicate failed')).toBeInTheDocument()
+        expect(screen.getByText('Failed to duplicate workflow')).toBeInTheDocument()
         expect(screen.getByText('Workflow has no definition to duplicate')).toBeInTheDocument()
       })
     })
@@ -1969,7 +1968,7 @@ describe('Workflows Component', () => {
       await user.click(duplicateItem)
 
       await waitFor(() => {
-        expect(screen.getByText('Duplicate failed')).toBeInTheDocument()
+        expect(screen.getByText('Failed to duplicate workflow')).toBeInTheDocument()
         expect(screen.getByText('Workflow must have a project ID')).toBeInTheDocument()
       })
     })
@@ -2222,7 +2221,7 @@ describe('Workflows Component', () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByText('Workflow published successfully')).toBeInTheDocument()
+        expect(screen.getByText('Workflow published')).toBeInTheDocument()
       })
     })
 
@@ -2517,7 +2516,7 @@ describe('Workflows Component', () => {
 
       await waitFor(() => {
         expect(mockUnpublishMutate).toHaveBeenCalled()
-        expect(screen.getByText('Workflow unpublished successfully')).toBeInTheDocument()
+        expect(screen.getByText('Workflow unpublished')).toBeInTheDocument()
       })
     })
 

--- a/frontend/packages/syntara-ui/src/routes/workflows/useDuplicateWorkflow.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/useDuplicateWorkflow.tsx
@@ -39,13 +39,13 @@ export function useDuplicateWorkflow({ showAlert, showError, setLocation, onSucc
           params: { path: { workflow_id: workflow.id } },
         })
         if (fetchError || !fullWorkflow) {
-          showError({ title: 'Duplicate failed', description: getErrorMessage(fetchError) })
+          showError({ title: 'Failed to duplicate workflow', description: getErrorMessage(fetchError) })
           return
         }
 
         const definition = fullWorkflow.version?.workflow_definition as Record<string, unknown> | undefined
         if (!definition) {
-          showError({ title: 'Duplicate failed', description: 'Workflow has no definition to duplicate' })
+          showError({ title: 'Failed to duplicate workflow', description: 'Workflow has no definition to duplicate' })
           return
         }
 
@@ -85,7 +85,7 @@ export function useDuplicateWorkflow({ showAlert, showError, setLocation, onSucc
         }
 
         if (!workflow.project_id) {
-          showError({ title: 'Duplicate failed', description: 'Workflow must have a project ID' })
+          showError({ title: 'Failed to duplicate workflow', description: 'Workflow must have a project ID' })
           return
         }
 
@@ -103,7 +103,7 @@ export function useDuplicateWorkflow({ showAlert, showError, setLocation, onSucc
         })
 
         if (createError) {
-          showError({ title: 'Duplicate failed', description: getErrorMessage(createError) })
+          showError({ title: 'Failed to duplicate workflow', description: getErrorMessage(createError) })
           return
         }
 
@@ -120,7 +120,7 @@ export function useDuplicateWorkflow({ showAlert, showError, setLocation, onSucc
         })
         onSuccess()
       } catch (err: unknown) {
-        showError({ title: 'Duplicate failed', description: getErrorMessage(err) })
+        showError({ title: 'Failed to duplicate workflow', description: getErrorMessage(err) })
       } finally {
         setIsDuplicating(false)
       }

--- a/frontend/packages/syntara-ui/src/routes/workflows/useWorkflowActions.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/useWorkflowActions.test.tsx
@@ -200,7 +200,7 @@ describe('useWorkflowActions', () => {
       await waitFor(() => {
         expect(mockShowSuccess).toHaveBeenCalledWith({
           title: 'Workflow deleted',
-          description: 'Successfully deleted workflow "My Workflow"',
+          description: 'Workflow "My Workflow" has been deleted.',
         })
       })
     })
@@ -222,7 +222,29 @@ describe('useWorkflowActions', () => {
 
       await waitFor(() => {
         expect(mockShowSuccess).toHaveBeenCalledWith({
-          title: 'Workflow published successfully',
+          title: 'Workflow published',
+        })
+      })
+    })
+
+    it('shows correct unpublish success message', async () => {
+      const { result } = renderHook(
+        () =>
+          useWorkflowActions({
+            showSuccess: mockShowSuccess,
+            showError: mockShowError,
+            onNavigate: mockOnNavigate,
+            onRefetch: mockOnRefetch,
+          }),
+        { wrapper: createWrapper() }
+      )
+
+      const workflow = mockWorkflow({ name: 'My Workflow' })
+      result.current.handleUnpublishWorkflow(workflow)
+
+      await waitFor(() => {
+        expect(mockShowSuccess).toHaveBeenCalledWith({
+          title: 'Workflow unpublished',
         })
       })
     })

--- a/frontend/packages/syntara-ui/src/routes/workflows/useWorkflowActions.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/useWorkflowActions.ts
@@ -62,7 +62,7 @@ export function useWorkflowActions({
       })
       if (error || !data?.id) {
         showError({
-          title: 'Workflow failed',
+          title: 'Failed to run workflow',
           description: `Failed to start workflow "${workflow.name}": ${getErrorMessage(error)}`,
         })
       } else {
@@ -80,12 +80,12 @@ export function useWorkflowActions({
         { params: { path: { workflow_id: workflow.id } } },
         {
           onSuccess: () => {
-            showSuccess({ title: 'Workflow deleted', description: `Successfully deleted workflow "${workflow.name}"` })
+            showSuccess({ title: 'Workflow deleted', description: `Workflow "${workflow.name}" has been deleted.` })
             onRefetch()
           },
           onError: (error: unknown) => {
             showError({
-              title: 'Delete failed',
+              title: 'Failed to delete workflow',
               description: `Failed to delete workflow "${workflow.name}": ${getErrorMessage(error)}`,
             })
           },
@@ -109,7 +109,7 @@ export function useWorkflowActions({
         },
         {
           onSuccess: () => {
-            showSuccess({ title: 'Workflow published successfully' })
+            showSuccess({ title: 'Workflow published' })
             onRefetch()
           },
           onError: (error: unknown) => {
@@ -132,7 +132,7 @@ export function useWorkflowActions({
         { params: { path: { workflow_id: workflow.id } } },
         {
           onSuccess: () => {
-            showSuccess({ title: 'Workflow unpublished successfully' })
+            showSuccess({ title: 'Workflow unpublished' })
             onRefetch()
           },
           onError: (error: unknown) => {


### PR DESCRIPTION
## Description

aligns toast titles and descriptions with the ux copy standard. success titles are sentence case past tense with no "successfully" adverb. error titles use "Failed to [action] [resource]". descriptions include the entity name where the ticket asked for it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] workflow list and builder toasts: publish, unpublish, run, delete, save, duplicate, import, export, verify
- [x] access toasts: add assignment description, edit role description, remove assignment error title
- [x] unit and e2e assertions updated to match the new copy
- [ ] Include any new dependencies or configuration changes

## Out of Scope

other toast strings not listed in AAP-84198 (integrations, `ImportWorkflowDialog`, `Workflows` export, builder conflict duplicate, `useDeleteAction` default, etc.)

## Related Issues

Fixes AAP-84198

## How to Test

1. log in as an admin
2. publish, unpublish, delete, duplicate, and run a workflow from `/workflows`. confirm success titles like "Workflow published" and errors like "Failed to delete workflow"
3. in the builder, save with no workflow, import/export a failure path, and verify. confirm "Failed to save workflow", "Failed to import workflow", "Failed to export workflow", and "Workflow verified"
4. add a role assignment and edit a role. confirm "Assignment for [name] has been added." and "[role name] has been updated."
5. remove an assignment and fail the request (or inspect the error toast). confirm "Failed to remove assignment"

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->