### PR TITLE
feat(ci): post PR comments for /run-e2e-ui-tests status

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -23,6 +23,10 @@ on:
         description: 'PR head branch ref'
         required: true
         type: string
+      actor:
+        description: 'GitHub actor who triggered the workflow (for comment correlation)'
+        required: false
+        type: string
       enable_currents:
         description: 'Enable Currents reporting'
         required: false

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -23,10 +23,6 @@ on:
         description: 'PR head branch ref'
         required: true
         type: string
-      actor:
-        description: 'GitHub actor who triggered the workflow (for comment correlation)'
-        required: false
-        type: string
       enable_currents:
         description: 'Enable Currents reporting'
         required: false

--- a/.github/workflows/run-e2e-ui-tests-listener.yml
+++ b/.github/workflows/run-e2e-ui-tests-listener.yml
@@ -34,11 +34,14 @@ jobs:
       - name: Get PR metadata
         id: pr
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER_INPUT: ${{ inputs.pr_number }}
         with:
           script: |
             // For workflow_dispatch, use the input; for issue_comment, use context
-            const prNumber = '${{ github.event_name }}' === 'workflow_dispatch'
-              ? '${{ inputs.pr_number }}'
+            const prNumber = process.env.EVENT_NAME === 'workflow_dispatch'
+              ? process.env.PR_NUMBER_INPUT
               : context.issue.number;
 
             const pr = await github.rest.pulls.get({
@@ -53,36 +56,54 @@ jobs:
             }
             core.setOutput('ref', pr.data.head.ref);
             core.setOutput('pr_number', prNumber);
+            core.setOutput('actor', context.actor);
 
       - name: Dispatch E2E UI workflow
         if: steps.pr.outcome == 'success'
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
           PR_REF: ${{ steps.pr.outputs.ref }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-        run: |
-          gh workflow run ci-frontend.yml \
-            --repo "$REPO" \
-            --ref devel \
-            --field pr_number="$PR_NUMBER" \
-            --field pr_ref="$PR_REF"
+          ACTOR: ${{ steps.pr.outputs.actor }}
+        with:
+          script: |
+            const prRef = process.env.PR_REF;
+            const prNumber = process.env.PR_NUMBER;
+            const actor = process.env.ACTOR;
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci-frontend.yml',
+              ref: 'devel',
+              inputs: {
+                pr_number: prNumber,
+                pr_ref: prRef,
+                actor: actor,
+              },
+            });
 
       - name: Wait for workflow run to be created
-        run: sleep 3
+        run: sleep 5
 
       - name: Find and post workflow run link
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          ACTOR: ${{ steps.pr.outputs.actor }}
         run: |
-          # Find the most recent workflow_dispatch run for ci-frontend.yml
-          RUN_ID=$(gh api "repos/$REPO/actions/workflows/ci-frontend.yml/runs?event=workflow_dispatch&per_page=5" \
-            --jq "[.workflow_runs[] | select(.created_at > \"$(date -u -v-2M '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '2 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')\")][0].id")
+          # Find the dispatched run by correlating on pr_number + actor + recent timestamp.
+          # Query the workflow run inputs to match pr_number and actor.
+          CUTOFF=$(date -u -v-30S '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '30 seconds ago' '+%Y-%m-%dT%H:%M:%SZ')
+
+          RUN_ID=$(gh api "repos/$REPO/actions/workflows/ci-frontend.yml/runs?event=workflow_dispatch&per_page=10" \
+            --jq --arg cutoff "$CUTOFF" --arg pr "$PR_NUMBER" --arg actor "$ACTOR" \
+            '[.workflow_runs[] | select(.created_at > $cutoff)] |
+             map(select(.inputs.pr_number == $pr and .inputs.actor == $actor)) |
+             .[0].id // empty')
 
           if [ -z "$RUN_ID" ]; then
-            echo "Warning: Could not find the dispatched workflow run"
+            echo "Warning: Could not find the dispatched workflow run (pr=$PR_NUMBER, actor=$ACTOR)"
             exit 0
           fi
 

--- a/.github/workflows/run-e2e-ui-tests-listener.yml
+++ b/.github/workflows/run-e2e-ui-tests-listener.yml
@@ -7,6 +7,12 @@ name: '/run-e2e-ui-tests'
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to test with'
+        required: true
+        type: string
 
 permissions:
   actions: write
@@ -15,11 +21,14 @@ permissions:
 jobs:
   dispatch:
     name: Validate & Dispatch
+    # For issue_comment: validate comment and permissions
+    # For workflow_dispatch: allow manual testing
     if: >-
-      github.event.issue.pull_request
-      && github.event.comment.user.type != 'Bot'
-      && contains(github.event.comment.body, '/run-e2e-ui-tests')
-      && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
+      github.event_name == 'workflow_dispatch'
+      || (github.event.issue.pull_request
+          && github.event.comment.user.type != 'Bot'
+          && contains(github.event.comment.body, '/run-e2e-ui-tests')
+          && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association))
     runs-on: ubuntu-24.04
     steps:
       - name: Get PR metadata
@@ -27,10 +36,15 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
+            // For workflow_dispatch, use the input; for issue_comment, use context
+            const prNumber = '${{ github.event_name }}' === 'workflow_dispatch'
+              ? '${{ inputs.pr_number }}'
+              : context.issue.number;
+
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number,
+              pull_number: prNumber,
             });
             const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
             if (pr.data.head.repo.full_name !== baseRepo) {
@@ -38,7 +52,7 @@ jobs:
               return;
             }
             core.setOutput('ref', pr.data.head.ref);
-            core.setOutput('pr_number', context.issue.number);
+            core.setOutput('pr_number', prNumber);
 
       - name: Get PR head SHA
         id: sha

--- a/.github/workflows/run-e2e-ui-tests-listener.yml
+++ b/.github/workflows/run-e2e-ui-tests-listener.yml
@@ -96,6 +96,8 @@ jobs:
           # Query the workflow run inputs to match pr_number and actor.
           CUTOFF=$(date -u -v-30S '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '30 seconds ago' '+%Y-%m-%dT%H:%M:%SZ')
 
+          # shellcheck disable=SC2016
+          # ^ $cutoff, $pr, $actor are jq variables from --arg, not shell variables
           RUN_ID=$(gh api "repos/$REPO/actions/workflows/ci-frontend.yml/runs?event=workflow_dispatch&per_page=10" \
             --jq --arg cutoff "$CUTOFF" --arg pr "$PR_NUMBER" --arg actor "$ACTOR" \
             '[.workflow_runs[] | select(.created_at > $cutoff)] |

--- a/.github/workflows/run-e2e-ui-tests-listener.yml
+++ b/.github/workflows/run-e2e-ui-tests-listener.yml
@@ -98,22 +98,30 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-          ACTOR: ${{ steps.pr.outputs.actor }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          # Find the dispatched run by correlating on pr_number + actor + recent timestamp.
-          # Query the workflow run inputs to match pr_number and actor.
+          # Find the dispatched run by correlating on head_branch + recent timestamp.
+          # GitHub's workflow run inputs field is not reliably populated by the API,
+          # so we correlate by the dispatch ref (head_branch) instead.
           CUTOFF=$(date -u -v-30S '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '30 seconds ago' '+%Y-%m-%dT%H:%M:%SZ')
 
+          # Determine which branch we dispatched to
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            DISPATCH_BRANCH="${GITHUB_REF#refs/heads/}"
+          else
+            DISPATCH_BRANCH="devel"
+          fi
+
           # shellcheck disable=SC2016
-          # ^ $cutoff, $pr, $actor are jq variables from --arg, not shell variables
+          # ^ $cutoff, $branch are jq variables from --arg, not shell variables
           RUN_ID=$(gh api "repos/$REPO/actions/workflows/ci-frontend.yml/runs?event=workflow_dispatch&per_page=10" \
-            | jq --arg cutoff "$CUTOFF" --arg pr "$PR_NUMBER" --arg actor "$ACTOR" -r \
-            '[.workflow_runs[] | select(.created_at > $cutoff)] |
-             map(select(.inputs.pr_number == $pr and .inputs.actor == $actor)) |
+            | jq --arg cutoff "$CUTOFF" --arg branch "$DISPATCH_BRANCH" -r \
+            '[.workflow_runs[] | select(.created_at > $cutoff and .head_branch == $branch)] |
              .[0].id // empty')
 
           if [ -z "$RUN_ID" ]; then
-            echo "Warning: Could not find the dispatched workflow run (pr=$PR_NUMBER, actor=$ACTOR)"
+            echo "Warning: Could not find the dispatched workflow run (branch=$DISPATCH_BRANCH)"
             exit 0
           fi
 

--- a/.github/workflows/run-e2e-ui-tests-listener.yml
+++ b/.github/workflows/run-e2e-ui-tests-listener.yml
@@ -16,7 +16,7 @@ on:
 
 permissions:
   actions: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   dispatch:

--- a/.github/workflows/run-e2e-ui-tests-listener.yml
+++ b/.github/workflows/run-e2e-ui-tests-listener.yml
@@ -54,16 +54,6 @@ jobs:
             core.setOutput('ref', pr.data.head.ref);
             core.setOutput('pr_number', prNumber);
 
-      - name: Get PR head SHA
-        id: sha
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-        run: |
-          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
-          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-
       - name: Dispatch E2E UI workflow
         if: steps.pr.outcome == 'success'
         env:
@@ -86,7 +76,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-          HEAD_SHA: ${{ steps.sha.outputs.head_sha }}
         run: |
           # Find the most recent workflow_dispatch run for ci-frontend.yml
           RUN_ID=$(gh api "repos/$REPO/actions/workflows/ci-frontend.yml/runs?event=workflow_dispatch&per_page=5" \
@@ -99,9 +88,4 @@ jobs:
 
           RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
 
-          BODY="<!-- e2e-ui-tests-status run_id=$RUN_ID sha=$HEAD_SHA -->
-          🚀 E2E UI tests triggered: [View workflow run]($RUN_URL)
-
-          _Status: Running..._"
-
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "🚀 E2E UI tests triggered: [View workflow run]($RUN_URL)"

--- a/.github/workflows/run-e2e-ui-tests-listener.yml
+++ b/.github/workflows/run-e2e-ui-tests-listener.yml
@@ -40,23 +40,54 @@ jobs:
             core.setOutput('ref', pr.data.head.ref);
             core.setOutput('pr_number', context.issue.number);
 
+      - name: Get PR head SHA
+        id: sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch E2E UI workflow
         if: steps.pr.outcome == 'success'
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           PR_REF: ${{ steps.pr.outputs.ref }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-        with:
-          script: |
-            const prRef = process.env.PR_REF;
-            const prNumber = process.env.PR_NUMBER;
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'ci-frontend.yml',
-              ref: 'devel',
-              inputs: {
-                pr_number: prNumber,
-                pr_ref: prRef,
-              },
-            });
+        run: |
+          gh workflow run ci-frontend.yml \
+            --repo "$REPO" \
+            --ref devel \
+            --field pr_number="$PR_NUMBER" \
+            --field pr_ref="$PR_REF"
+
+      - name: Wait for workflow run to be created
+        run: sleep 3
+
+      - name: Find and post workflow run link
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.sha.outputs.head_sha }}
+        run: |
+          # Find the most recent workflow_dispatch run for ci-frontend.yml
+          RUN_ID=$(gh api "repos/$REPO/actions/workflows/ci-frontend.yml/runs?event=workflow_dispatch&per_page=5" \
+            --jq "[.workflow_runs[] | select(.created_at > \"$(date -u -v-2M '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '2 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')\")][0].id")
+
+          if [ -z "$RUN_ID" ]; then
+            echo "Warning: Could not find the dispatched workflow run"
+            exit 0
+          fi
+
+          RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
+
+          BODY="<!-- e2e-ui-tests-status run_id=$RUN_ID sha=$HEAD_SHA -->
+          🚀 E2E UI tests triggered: [View workflow run]($RUN_URL)
+
+          _Status: Running..._"
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"

--- a/.github/workflows/run-e2e-ui-tests-listener.yml
+++ b/.github/workflows/run-e2e-ui-tests-listener.yml
@@ -107,7 +107,7 @@ jobs:
           # shellcheck disable=SC2016
           # ^ $cutoff, $pr, $actor are jq variables from --arg, not shell variables
           RUN_ID=$(gh api "repos/$REPO/actions/workflows/ci-frontend.yml/runs?event=workflow_dispatch&per_page=10" \
-            --jq --arg cutoff "$CUTOFF" --arg pr "$PR_NUMBER" --arg actor "$ACTOR" \
+            | jq --arg cutoff "$CUTOFF" --arg pr "$PR_NUMBER" --arg actor "$ACTOR" -r \
             '[.workflow_runs[] | select(.created_at > $cutoff)] |
              map(select(.inputs.pr_number == $pr and .inputs.actor == $actor)) |
              .[0].id // empty')

--- a/.github/workflows/run-e2e-ui-tests-listener.yml
+++ b/.github/workflows/run-e2e-ui-tests-listener.yml
@@ -7,12 +7,6 @@ name: '/run-e2e-ui-tests'
 on:
   issue_comment:
     types: [created]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to test with'
-        required: true
-        type: string
 
 permissions:
   actions: write
@@ -21,28 +15,19 @@ permissions:
 jobs:
   dispatch:
     name: Validate & Dispatch
-    # For issue_comment: validate comment and permissions
-    # For workflow_dispatch: allow manual testing
     if: >-
-      github.event_name == 'workflow_dispatch'
-      || (github.event.issue.pull_request
-          && github.event.comment.user.type != 'Bot'
-          && contains(github.event.comment.body, '/run-e2e-ui-tests')
-          && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association))
+      github.event.issue.pull_request
+      && github.event.comment.user.type != 'Bot'
+      && contains(github.event.comment.body, '/run-e2e-ui-tests')
+      && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
     runs-on: ubuntu-24.04
     steps:
       - name: Get PR metadata
         id: pr
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER_INPUT: ${{ inputs.pr_number }}
         with:
           script: |
-            // For workflow_dispatch, use the input; for issue_comment, use context
-            const prNumber = process.env.EVENT_NAME === 'workflow_dispatch'
-              ? process.env.PR_NUMBER_INPUT
-              : context.issue.number;
+            const prNumber = context.issue.number;
 
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -56,7 +41,6 @@ jobs:
             }
             core.setOutput('ref', pr.data.head.ref);
             core.setOutput('pr_number', prNumber);
-            core.setOutput('actor', context.actor);
 
       - name: Dispatch E2E UI workflow
         if: steps.pr.outcome == 'success'
@@ -64,29 +48,18 @@ jobs:
         env:
           PR_REF: ${{ steps.pr.outputs.ref }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-          ACTOR: ${{ steps.pr.outputs.actor }}
-          EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF: ${{ github.ref }}
         with:
           script: |
             const prRef = process.env.PR_REF;
             const prNumber = process.env.PR_NUMBER;
-            const actor = process.env.ACTOR;
-            // For testing via workflow_dispatch, use the current branch ref
-            // (since devel may not have the actor input yet).
-            // For production issue_comment, always use devel.
-            const dispatchRef = process.env.EVENT_NAME === 'workflow_dispatch'
-              ? process.env.GITHUB_REF.replace('refs/heads/', '')
-              : 'devel';
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'ci-frontend.yml',
-              ref: dispatchRef,
+              ref: 'devel',
               inputs: {
                 pr_number: prNumber,
                 pr_ref: prRef,
-                actor: actor,
               },
             });
 
@@ -98,30 +71,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-          EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF: ${{ github.ref }}
         run: |
           # Find the dispatched run by correlating on head_branch + recent timestamp.
           # GitHub's workflow run inputs field is not reliably populated by the API,
           # so we correlate by the dispatch ref (head_branch) instead.
+          #
+          # If this ever links the wrong run, use a unique request ID passed as a
+          # workflow input and included in ci-frontend.yml's run-name, then match
+          # that ID here instead of relying on the branch/time window.
           CUTOFF=$(date -u -v-30S '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '30 seconds ago' '+%Y-%m-%dT%H:%M:%SZ')
 
-          # Determine which branch we dispatched to
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            DISPATCH_BRANCH="${GITHUB_REF#refs/heads/}"
-          else
-            DISPATCH_BRANCH="devel"
-          fi
-
           # shellcheck disable=SC2016
-          # ^ $cutoff, $branch are jq variables from --arg, not shell variables
+          # ^ $cutoff is a jq variable from --arg, not a shell variable
           RUN_ID=$(gh api "repos/$REPO/actions/workflows/ci-frontend.yml/runs?event=workflow_dispatch&per_page=10" \
-            | jq --arg cutoff "$CUTOFF" --arg branch "$DISPATCH_BRANCH" -r \
-            '[.workflow_runs[] | select(.created_at > $cutoff and .head_branch == $branch)] |
+            | jq --arg cutoff "$CUTOFF" -r \
+            '[.workflow_runs[] | select(.created_at > $cutoff and .head_branch == "devel")] |
              .[0].id // empty')
 
           if [ -z "$RUN_ID" ]; then
-            echo "Warning: Could not find the dispatched workflow run (branch=$DISPATCH_BRANCH)"
+            echo "Warning: Could not find the dispatched workflow run (branch=devel)"
             exit 0
           fi
 

--- a/.github/workflows/run-e2e-ui-tests-listener.yml
+++ b/.github/workflows/run-e2e-ui-tests-listener.yml
@@ -65,16 +65,24 @@ jobs:
           PR_REF: ${{ steps.pr.outputs.ref }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           ACTOR: ${{ steps.pr.outputs.actor }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
         with:
           script: |
             const prRef = process.env.PR_REF;
             const prNumber = process.env.PR_NUMBER;
             const actor = process.env.ACTOR;
+            // For testing via workflow_dispatch, use the current branch ref
+            // (since devel may not have the actor input yet).
+            // For production issue_comment, always use devel.
+            const dispatchRef = process.env.EVENT_NAME === 'workflow_dispatch'
+              ? process.env.GITHUB_REF.replace('refs/heads/', '')
+              : 'devel';
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'ci-frontend.yml',
-              ref: 'devel',
+              ref: dispatchRef,
               inputs: {
                 pr_number: prNumber,
                 pr_ref: prRef,

--- a/.github/workflows/run-e2e-ui-tests-update-comment.yml
+++ b/.github/workflows/run-e2e-ui-tests-update-comment.yml
@@ -1,8 +1,8 @@
 ---
-name: "/run-e2e-ui-tests Update Comment"
+name: "/run-e2e-ui-tests Post Results"
 
-# Watches for ci-frontend.yml workflow_dispatch completions and updates
-# the initial comment posted by run-e2e-ui-tests-listener.yml with results.
+# Watches for ci-frontend.yml workflow_dispatch completions and posts
+# a follow-up comment with results on the PR.
 #
 # SECURITY NOTE: This workflow uses workflow_run, which runs in the base
 # repository context. This usage is safe because:
@@ -46,8 +46,8 @@ permissions:
   contents: read
 
 jobs:
-  update-comment:
-    name: Update E2E Comment
+  post-results:
+    name: Post E2E Results
     runs-on: ubuntu-latest
     # For workflow_run: only update for workflow_dispatch events (manual /run-e2e-ui-tests triggers).
     # For workflow_dispatch: allow manual testing.
@@ -83,7 +83,7 @@ jobs:
 
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-      - name: Update comment with results
+      - name: Post results comment
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -92,39 +92,26 @@ jobs:
           CONCLUSION: ${{ github.event_name == 'workflow_dispatch' && inputs.conclusion || github.event.workflow_run.conclusion }}
           RUN_URL: ${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, inputs.run_id) }}
         run: |
-          # Find the comment posted by the listener workflow
-          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq ".[] | select(.body | contains(\"<!-- e2e-ui-tests-status run_id=$RUN_ID\")) | .id" | tail -1)
-
-          if [ -z "$COMMENT_ID" ]; then
-            echo "No comment found for run_id=$RUN_ID"
-            exit 0
-          fi
-
           # Build the status message based on conclusion
           case "$CONCLUSION" in
             success)
               STATUS_EMOJI="✅"
-              STATUS_TEXT="Completed successfully"
+              STATUS_TEXT="completed successfully"
               ;;
             failure)
               STATUS_EMOJI="❌"
-              STATUS_TEXT="Failed"
+              STATUS_TEXT="failed"
               ;;
             cancelled)
               STATUS_EMOJI="⚠️"
-              STATUS_TEXT="Cancelled"
+              STATUS_TEXT="was cancelled"
               ;;
             *)
               STATUS_EMOJI="⚠️"
-              STATUS_TEXT="Completed with status: $CONCLUSION"
+              STATUS_TEXT="completed with status: $CONCLUSION"
               ;;
           esac
 
-          # Update the comment with results
-          BODY="<!-- e2e-ui-tests-status run_id=$RUN_ID -->
-          $STATUS_EMOJI E2E UI tests $STATUS_TEXT: [View results]($RUN_URL)"
-
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
-            -X PATCH \
-            -f body="$BODY"
+          # Post a new comment with results
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "$STATUS_EMOJI E2E UI tests $STATUS_TEXT: [View results]($RUN_URL)"

--- a/.github/workflows/run-e2e-ui-tests-update-comment.yml
+++ b/.github/workflows/run-e2e-ui-tests-update-comment.yml
@@ -9,11 +9,16 @@ name: "/run-e2e-ui-tests Post Results"
 # 1. We never check out any code from the PR or triggering workflow
 # 2. We never execute any code from the PR
 # 3. We only read workflow metadata (conclusion, run ID, inputs)
-# 4. We only update a PR comment with status information
+# 4. We only post a follow-up comment with status information
 # 5. All data comes from GitHub's workflow_run event, not PR-controlled sources
 #
 # The workflow_run trigger is necessary to watch for workflow completions.
 # There is no alternative trigger that provides this functionality.
+#
+# WARNING: The workflow_dispatch trigger is for testing only and has no
+# authorization checks. Anyone who can dispatch workflows can post fabricated
+# status comments via this path. This is acceptable for temporary testing but
+# consider removing before merge or restricting to repository admins.
 on:
   workflow_run:
     workflows:
@@ -42,8 +47,6 @@ on:
 permissions:
   actions: read
   pull-requests: write
-  issues: write
-  contents: read
 
 jobs:
   post-results:
@@ -84,6 +87,7 @@ jobs:
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Post results comment
+        if: steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/run-e2e-ui-tests-update-comment.yml
+++ b/.github/workflows/run-e2e-ui-tests-update-comment.yml
@@ -14,35 +14,12 @@ name: "/run-e2e-ui-tests Post Results"
 #
 # The workflow_run trigger is necessary to watch for workflow completions.
 # There is no alternative trigger that provides this functionality.
-#
-# WARNING: The workflow_dispatch trigger is for testing only and has no
-# authorization checks. Anyone who can dispatch workflows can post fabricated
-# status comments via this path. This is acceptable for temporary testing but
-# consider removing before merge or restricting to repository admins.
 on:
   workflow_run:
     workflows:
       - CI Frontend
     types:
       - completed
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number'
-        required: true
-        type: string
-      run_id:
-        description: 'Workflow run ID to reference'
-        required: true
-        type: string
-      conclusion:
-        description: 'Test conclusion (success/failure/cancelled)'
-        required: true
-        type: choice
-        options:
-          - success
-          - failure
-          - cancelled
 
 permissions:
   actions: read
@@ -52,34 +29,20 @@ jobs:
   post-results:
     name: Post E2E Results
     runs-on: ubuntu-latest
-    # For workflow_run: only update for workflow_dispatch events (manual /run-e2e-ui-tests triggers).
-    # For workflow_dispatch: allow manual testing.
-    # This prevents updating comments for regular PR runs or scheduled runs.
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      || github.event.workflow_run.event == 'workflow_dispatch'
+    # Only update comments for manually dispatched E2E runs, not regular CI,
+    # scheduled runs, or merge-queue runs.
+    if: github.event.workflow_run.event == 'workflow_dispatch'
     steps:
       - name: Find PR from workflow inputs
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER_INPUT: ${{ inputs.pr_number }}
         run: |
-          # Get the PR number.
-          # For workflow_dispatch: use the input
-          # For workflow_run: get from the workflow run inputs
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            PR_NUMBER="$PR_NUMBER_INPUT"
-          else
-            # This data comes from GitHub's workflow_run event, not from PR code.
-            # The pr_number was passed as an input when ci-frontend.yml was dispatched.
-            PR_NUMBER=$(gh api "repos/$REPO/actions/runs/$RUN_ID" \
-              --jq '.inputs.pr_number // empty')
-          fi
+          # This data comes from GitHub's workflow_run event, not from PR code.
+          # The pr_number was passed as an input when ci-frontend.yml was dispatched.
+          PR_NUMBER=$(gh api "repos/$REPO/actions/runs/${{ github.event.workflow_run.id }}" \
+            --jq '.inputs.pr_number // empty')
 
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR number found in workflow inputs, this might be a scheduled run"
@@ -94,9 +57,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
-          CONCLUSION: ${{ github.event_name == 'workflow_dispatch' && inputs.conclusion || github.event.workflow_run.conclusion }}
-          RUN_URL: ${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, inputs.run_id) }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
           # Build the status message based on conclusion
           case "$CONCLUSION" in

--- a/.github/workflows/run-e2e-ui-tests-update-comment.yml
+++ b/.github/workflows/run-e2e-ui-tests-update-comment.yml
@@ -20,6 +20,24 @@ on:
       - CI Frontend
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number'
+        required: true
+        type: string
+      run_id:
+        description: 'Workflow run ID to reference'
+        required: true
+        type: string
+      conclusion:
+        description: 'Test conclusion (success/failure/cancelled)'
+        required: true
+        type: choice
+        options:
+          - success
+          - failure
+          - cancelled
 
 permissions:
   actions: read
@@ -31,23 +49,32 @@ jobs:
   update-comment:
     name: Update E2E Comment
     runs-on: ubuntu-latest
-    # Only update for workflow_dispatch events (manual /run-e2e-ui-tests triggers).
+    # For workflow_run: only update for workflow_dispatch events (manual /run-e2e-ui-tests triggers).
+    # For workflow_dispatch: allow manual testing.
     # This prevents updating comments for regular PR runs or scheduled runs.
-    if: github.event.workflow_run.event == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.event == 'workflow_dispatch'
     steps:
       - name: Find PR from workflow inputs
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          # Get the PR number from the workflow run inputs.
-          # This data comes from GitHub's workflow_run event, not from PR code.
-          # The pr_number was passed as an input when ci-frontend.yml was dispatched.
-          PR_NUMBER=$(gh api "repos/$REPO/actions/runs/$RUN_ID" \
-            --jq '.inputs.pr_number // empty')
+          # Get the PR number.
+          # For workflow_dispatch: use the input
+          # For workflow_run: get from the workflow run inputs
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+          else
+            # This data comes from GitHub's workflow_run event, not from PR code.
+            # The pr_number was passed as an input when ci-frontend.yml was dispatched.
+            PR_NUMBER=$(gh api "repos/$REPO/actions/runs/$RUN_ID" \
+              --jq '.inputs.pr_number // empty')
+          fi
 
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR number found in workflow inputs, this might be a scheduled run"
@@ -57,14 +84,13 @@ jobs:
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Update comment with results
-        if: steps.pr.outputs.number
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
+          CONCLUSION: ${{ github.event_name == 'workflow_dispatch' && inputs.conclusion || github.event.workflow_run.conclusion }}
+          RUN_URL: ${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, inputs.run_id) }}
         run: |
           # Find the comment posted by the listener workflow
           COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \

--- a/.github/workflows/run-e2e-ui-tests-update-comment.yml
+++ b/.github/workflows/run-e2e-ui-tests-update-comment.yml
@@ -66,12 +66,14 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER_INPUT: ${{ inputs.pr_number }}
         run: |
           # Get the PR number.
           # For workflow_dispatch: use the input
           # For workflow_run: get from the workflow run inputs
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PR_NUMBER="${{ inputs.pr_number }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$PR_NUMBER_INPUT"
           else
             # This data comes from GitHub's workflow_run event, not from PR code.
             # The pr_number was passed as an input when ci-frontend.yml was dispatched.

--- a/.github/workflows/run-e2e-ui-tests-update-comment.yml
+++ b/.github/workflows/run-e2e-ui-tests-update-comment.yml
@@ -3,6 +3,17 @@ name: "/run-e2e-ui-tests Update Comment"
 
 # Watches for ci-frontend.yml workflow_dispatch completions and updates
 # the initial comment posted by run-e2e-ui-tests-listener.yml with results.
+#
+# SECURITY NOTE: This workflow uses workflow_run, which runs in the base
+# repository context. This usage is safe because:
+# 1. We never check out any code from the PR or triggering workflow
+# 2. We never execute any code from the PR
+# 3. We only read workflow metadata (conclusion, run ID, inputs)
+# 4. We only update a PR comment with status information
+# 5. All data comes from GitHub's workflow_run event, not PR-controlled sources
+#
+# The workflow_run trigger is necessary to watch for workflow completions.
+# There is no alternative trigger that provides this functionality.
 on:
   workflow_run:
     workflows:
@@ -20,7 +31,8 @@ jobs:
   update-comment:
     name: Update E2E Comment
     runs-on: ubuntu-latest
-    # Only update for workflow_dispatch events (manual /run-e2e-ui-tests triggers)
+    # Only update for workflow_dispatch events (manual /run-e2e-ui-tests triggers).
+    # This prevents updating comments for regular PR runs or scheduled runs.
     if: github.event.workflow_run.event == 'workflow_dispatch'
     steps:
       - name: Find PR from workflow inputs
@@ -31,8 +43,9 @@ jobs:
           RUN_ID: ${{ github.event.workflow_run.id }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          # Get the PR number from the workflow run inputs
-          # (ci-frontend.yml workflow_dispatch accepts pr_number as input)
+          # Get the PR number from the workflow run inputs.
+          # This data comes from GitHub's workflow_run event, not from PR code.
+          # The pr_number was passed as an input when ci-frontend.yml was dispatched.
           PR_NUMBER=$(gh api "repos/$REPO/actions/runs/$RUN_ID" \
             --jq '.inputs.pr_number // empty')
 

--- a/.github/workflows/run-e2e-ui-tests-update-comment.yml
+++ b/.github/workflows/run-e2e-ui-tests-update-comment.yml
@@ -1,0 +1,91 @@
+---
+name: '/run-e2e-ui-tests' Update Comment
+
+# Watches for ci-frontend.yml workflow_dispatch completions and updates
+# the initial comment posted by run-e2e-ui-tests-listener.yml with results.
+on:
+  workflow_run:
+    workflows:
+      - CI Frontend
+    types:
+      - completed
+
+permissions:
+  actions: read
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  update-comment:
+    name: Update E2E Comment
+    runs-on: ubuntu-latest
+    # Only update for workflow_dispatch events (manual /run-e2e-ui-tests triggers)
+    if: github.event.workflow_run.event == 'workflow_dispatch'
+    steps:
+      - name: Find PR from workflow inputs
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Get the PR number from the workflow run inputs
+          # (ci-frontend.yml workflow_dispatch accepts pr_number as input)
+          PR_NUMBER=$(gh api "repos/$REPO/actions/runs/$RUN_ID" \
+            --jq '.inputs.pr_number // empty')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR number found in workflow inputs, this might be a scheduled run"
+            exit 0
+          fi
+
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Update comment with results
+        if: steps.pr.outputs.number
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          # Find the comment posted by the listener workflow
+          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"<!-- e2e-ui-tests-status run_id=$RUN_ID\")) | .id" | tail -1)
+
+          if [ -z "$COMMENT_ID" ]; then
+            echo "No comment found for run_id=$RUN_ID"
+            exit 0
+          fi
+
+          # Build the status message based on conclusion
+          case "$CONCLUSION" in
+            success)
+              STATUS_EMOJI="✅"
+              STATUS_TEXT="Completed successfully"
+              ;;
+            failure)
+              STATUS_EMOJI="❌"
+              STATUS_TEXT="Failed"
+              ;;
+            cancelled)
+              STATUS_EMOJI="⚠️"
+              STATUS_TEXT="Cancelled"
+              ;;
+            *)
+              STATUS_EMOJI="⚠️"
+              STATUS_TEXT="Completed with status: $CONCLUSION"
+              ;;
+          esac
+
+          # Update the comment with results
+          BODY="<!-- e2e-ui-tests-status run_id=$RUN_ID -->
+          $STATUS_EMOJI E2E UI tests $STATUS_TEXT: [View results]($RUN_URL)"
+
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+            -X PATCH \
+            -f body="$BODY"

--- a/.github/workflows/run-e2e-ui-tests-update-comment.yml
+++ b/.github/workflows/run-e2e-ui-tests-update-comment.yml
@@ -1,5 +1,5 @@
 ---
-name: '/run-e2e-ui-tests' Update Comment
+name: "/run-e2e-ui-tests Update Comment"
 
 # Watches for ci-frontend.yml workflow_dispatch completions and updates
 # the initial comment posted by run-e2e-ui-tests-listener.yml with results.


### PR DESCRIPTION
## Description

The /run-e2e-ui-tests slash command now posts PR comments for visibility. An initial comment appears with the workflow run link when triggered, then a follow-up comment posts with results when tests complete.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- Listener workflow posts initial comment when tests are triggered
- New workflow watches for completion and posts a follow-up comment with results

## Out of Scope

Not changing test execution, only adding comment visibility.

## How to Test

1. Comment `/run-e2e-ui-tests` on a PR
2. Verify initial comment appears with workflow link
3. Wait for tests to complete
4. Verify a second comment appears with final results

## Backend Checklist

Not applicable (workflow-only change)

## Frontend Checklist

Not applicable (workflow-only change)

## Visual Regression

Not applicable

## General Checklist

- [ ] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [ ] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

Not applicable

## Additional Notes

Based on ansible-ui workflow pattern using workflow_run triggers. The workflow_dispatch inputs on both workflows are for testing only (since issue_comment and workflow_run triggers always run from the default branch).

> 🤖 PR description AI-assisted