### PR TITLE
fix(integrations): verify LLM credentials on an auth-gated probe

### DIFF
--- a/backend/src/syntara/integrations/adapters/llm_provider.py
+++ b/backend/src/syntara/integrations/adapters/llm_provider.py
@@ -216,6 +216,55 @@ class LLMProviderAdapter:
         )
         return success, error_msg, error_type
 
+    def _next_page_params(self, response: httpx.Response) -> dict[str, str] | None:
+        """Return query params for the next catalog page, or None if done or unparseable."""
+        try:
+            return self._provider.next_page_params(response.json())
+        except (ValueError, KeyError, TypeError):
+            return None
+
+    async def _paginate_model_pages(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        headers: dict[str, str],
+        first_response: httpx.Response,
+        timeout_seconds: int,
+    ) -> tuple[bool, str | None, HealthCheckErrorType | None, list[httpx.Response]]:
+        """Fetch remaining catalog pages after a successful first page."""
+        responses = [first_response]
+        response = first_response
+        for page in range(1, _MAX_PAGINATION_PAGES):
+            params = self._next_page_params(response)
+            if params is None:
+                break
+
+            logger.debug(
+                "Fetching next page of models",
+                provider=self._config.provider_hint,
+                page=page + 1,
+            )
+            success, error_msg, error_type, next_response = await self._do_get(
+                client,
+                url,
+                headers,
+                params,
+                timeout_seconds=timeout_seconds,
+            )
+            if not success or next_response is None:
+                return success, error_msg, error_type, []
+            response = next_response
+            responses.append(response)
+        else:
+            if self._next_page_params(response) is not None:
+                logger.warning(
+                    "Pagination cap reached, results may be incomplete",
+                    provider=self._config.provider_hint,
+                    max_pages=_MAX_PAGINATION_PAGES,
+                )
+
+        return True, None, None, responses
+
     async def _fetch_models(
         self,
         resolved_credential: dict[str, Any],
@@ -232,8 +281,9 @@ class LLMProviderAdapter:
             timeout_seconds: Maximum seconds to wait for the HTTP response.
             paginate: If True, follow pagination until exhausted (up to
                 ``_MAX_PAGINATION_PAGES``). If False, make a single request.
-            confirm_credential: If True, after the first catalog 200 run the
-                provider's auth-gated probe (validate only).
+            confirm_credential: If True, after the catalog 200 run the
+                provider's auth-gated probe once (validate only), before
+                any pagination.
 
         Returns:
             (success, error_msg, error_type, responses) tuple.
@@ -256,7 +306,6 @@ class LLMProviderAdapter:
 
         responses: list[httpx.Response] = []
         params: dict[str, str] | None = None
-        credential_confirmed = not confirm_credential
 
         verify = build_integration_httpx_verify(
             insecure_skip_tls_verify=self._config.insecure_skip_tls_verify,
@@ -264,51 +313,35 @@ class LLMProviderAdapter:
         )
 
         async with httpx.AsyncClient(timeout=timeout_seconds, verify=verify) as client:
-            for page in range(_MAX_PAGINATION_PAGES):
-                success, error_msg, error_type, response = await self._do_get(
+            success, error_msg, error_type, response = await self._do_get(
+                client,
+                url,
+                headers,
+                params,
+                timeout_seconds=timeout_seconds,
+            )
+            if not success or response is None:
+                return success, error_msg, error_type, []
+
+            if confirm_credential:
+                confirmed, confirm_error, confirm_type = await self._confirm_credential(
+                    client,
+                    base_url,
+                    headers,
+                    timeout_seconds=timeout_seconds,
+                )
+                if not confirmed:
+                    return False, confirm_error, confirm_type, []
+
+            if paginate:
+                return await self._paginate_model_pages(
                     client,
                     url,
                     headers,
-                    params,
-                    timeout_seconds=timeout_seconds,
+                    response,
+                    timeout_seconds,
                 )
-                if not success or response is None:
-                    return success, error_msg, error_type, []
-
-                if not credential_confirmed:
-                    confirmed, confirm_error, confirm_type = await self._confirm_credential(
-                        client,
-                        base_url,
-                        headers,
-                        timeout_seconds=timeout_seconds,
-                    )
-                    if not confirmed:
-                        return False, confirm_error, confirm_type, []
-                    credential_confirmed = True
-
-                responses.append(response)
-
-                if not paginate:
-                    break
-
-                try:
-                    params = self._provider.next_page_params(response.json())
-                except (ValueError, KeyError, TypeError):
-                    break
-                if params is None:
-                    break
-
-                logger.debug(
-                    "Fetching next page of models",
-                    provider=self._config.provider_hint,
-                    page=page + 2,
-                )
-            else:
-                logger.warning(
-                    "Pagination cap reached, results may be incomplete",
-                    provider=self._config.provider_hint,
-                    max_pages=_MAX_PAGINATION_PAGES,
-                )
+            responses.append(response)
 
         return True, None, None, responses
 

--- a/backend/src/syntara/integrations/adapters/llm_provider.py
+++ b/backend/src/syntara/integrations/adapters/llm_provider.py
@@ -1,11 +1,12 @@
 """LLM provider adapter implementing validate() and discover().
 
-validate(): Lightweight connectivity ping — hits the provider's model listing
-  endpoint to verify reachability and credential validity without parsing the
-  full response.
+validate(): Hits the provider's model listing endpoint, then (for
+  OpenAI-compatible providers) GET {base_url}/key so a public catalog 200
+  cannot mark an invalid API key as healthy. The listing body is not parsed.
 
-discover(): Calls the provider's model listing endpoint and parses the
-  response into DiscoveredLLMModel objects. Does not persist anything.
+discover(): Paginated model listing parsed into DiscoveredLLMModel objects.
+  Does not persist anything and does not run the /key probe — listing is a
+  catalog fetch. Refresh uses this path.
 
 Provider dispatch uses LLMProviderConfiguration.provider_hint to select the
 correct provider implementation (OpenAI-compatible, Anthropic, or Gemini).
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 
 import httpx
 import structlog
-from httpx import HTTPStatusError
+from httpx import HTTPStatusError, codes
 
 from syntara.core.lib.tls_utils import build_integration_httpx_verify
 from syntara.integrations.adapters.factory import register_health_check_adapter
@@ -48,6 +49,12 @@ from syntara.integrations.models.integration_configuration import (
 logger = structlog.stdlib.get_logger(__name__)
 
 _MAX_PAGINATION_PAGES = 10
+
+# 404/405/501 on the credential probe means the gateway has no /key-style
+# endpoint (OpenAI, vLLM). Trust the models listing instead of failing.
+_PROBE_ABSENT_STATUSES = frozenset(
+    {codes.NOT_FOUND, codes.METHOD_NOT_ALLOWED, codes.NOT_IMPLEMENTED},
+)
 
 _PROVIDER_CONSTRUCTORS: dict[LLMProviderHint, Callable[[], LLMProviderBase]] = {
     LLMProviderHint.OPENAI: OpenAICompatibleProvider,
@@ -103,8 +110,12 @@ class LLMProviderAdapter:
         params: dict[str, str] | None = None,
         *,
         timeout_seconds: int | None = None,
+        allow_absent_statuses: frozenset[int] | None = None,
     ) -> tuple[bool, str | None, HealthCheckErrorType | None, httpx.Response | None]:
         """Execute a single GET request with standardized error handling.
+
+        ``allow_absent_statuses`` HTTP codes are treated as success (used by
+        the credential probe when GET /key is not implemented).
 
         Returns:
             (success, error_msg, error_type, response) tuple.
@@ -120,9 +131,10 @@ class LLMProviderAdapter:
             result_response = await client.get(url, headers=headers, params=params)
             result_response.raise_for_status()
             logger.debug(
-                "Received LLM models response",
+                "Received LLM HTTP response",
                 provider=self._config.provider_hint,
                 status_code=result_response.status_code,
+                url=url,
             )
 
         except (TimeoutError, httpx.TimeoutException):
@@ -136,6 +148,14 @@ class LLMProviderAdapter:
             )
 
         except HTTPStatusError as exc:
+            if allow_absent_statuses and exc.response.status_code in allow_absent_statuses:
+                logger.debug(
+                    "LLM credential probe endpoint absent",
+                    provider=self._config.provider_hint,
+                    status_code=exc.response.status_code,
+                    url=url,
+                )
+                return True, None, None, exc.response
             success = False
             error_type, error_msg = classify_http_error([exc])
             logger.warning(
@@ -165,12 +185,44 @@ class LLMProviderAdapter:
 
         return success, error_msg, error_type, result_response if success else None
 
+    async def _confirm_credential(
+        self,
+        client: httpx.AsyncClient,
+        base_url: str,
+        headers: dict[str, str],
+        *,
+        timeout_seconds: int,
+    ) -> tuple[bool, str | None, HealthCheckErrorType | None]:
+        """Prove the API key on an auth-gated path when the provider has one.
+
+        Called after the models catalog returns 200. A public catalog must
+        not mark a rejected key as healthy.
+        """
+        url = self._provider.build_credential_confirmation_url(base_url)
+        if url is None:
+            return True, None, None
+
+        logger.debug(
+            "Sending LLM credential confirmation request",
+            provider=self._config.provider_hint,
+            url=url,
+        )
+        success, error_msg, error_type, _ = await self._do_get(
+            client,
+            url,
+            headers,
+            timeout_seconds=timeout_seconds,
+            allow_absent_statuses=_PROBE_ABSENT_STATUSES,
+        )
+        return success, error_msg, error_type
+
     async def _fetch_models(
         self,
         resolved_credential: dict[str, Any],
         timeout_seconds: int,
         *,
         paginate: bool = False,
+        confirm_credential: bool = False,
     ) -> tuple[bool, str | None, HealthCheckErrorType | None, list[httpx.Response]]:
         """Hit the provider's models endpoint.
 
@@ -180,6 +232,8 @@ class LLMProviderAdapter:
             timeout_seconds: Maximum seconds to wait for the HTTP response.
             paginate: If True, follow pagination until exhausted (up to
                 ``_MAX_PAGINATION_PAGES``). If False, make a single request.
+            confirm_credential: If True, after the first catalog 200 run the
+                provider's auth-gated probe (validate only).
 
         Returns:
             (success, error_msg, error_type, responses) tuple.
@@ -202,6 +256,7 @@ class LLMProviderAdapter:
 
         responses: list[httpx.Response] = []
         params: dict[str, str] | None = None
+        credential_confirmed = not confirm_credential
 
         verify = build_integration_httpx_verify(
             insecure_skip_tls_verify=self._config.insecure_skip_tls_verify,
@@ -219,6 +274,17 @@ class LLMProviderAdapter:
                 )
                 if not success or response is None:
                     return success, error_msg, error_type, []
+
+                if not credential_confirmed:
+                    confirmed, confirm_error, confirm_type = await self._confirm_credential(
+                        client,
+                        base_url,
+                        headers,
+                        timeout_seconds=timeout_seconds,
+                    )
+                    if not confirmed:
+                        return False, confirm_error, confirm_type, []
+                    credential_confirmed = True
 
                 responses.append(response)
 
@@ -251,14 +317,18 @@ class LLMProviderAdapter:
         resolved_credential: dict[str, Any],
         timeout_seconds: int,
     ) -> ValidateResult:
-        """Lightweight connectivity ping against the LLM provider's models endpoint.
+        """Check provider reachability and credential acceptance.
 
         Args:
             resolved_credential: Decrypted credential extra_vars dict.
             timeout_seconds: HTTP request timeout.
 
         """
-        success, error_msg, error_type, _ = await self._fetch_models(resolved_credential, timeout_seconds)
+        success, error_msg, error_type, _ = await self._fetch_models(
+            resolved_credential,
+            timeout_seconds,
+            confirm_credential=True,
+        )
         if success:
             logger.info("LLM validate succeeded", provider=self._config.provider_hint)
         return ValidateResult(

--- a/backend/src/syntara/integrations/adapters/providers/base.py
+++ b/backend/src/syntara/integrations/adapters/providers/base.py
@@ -48,6 +48,25 @@ class LLMProviderBase(ABC):
         """Build the full models listing URL. Override for custom paths."""
         return f"{base_url.rstrip('/')}{self.models_endpoint}"
 
+    @property
+    def credential_confirmation_path(self) -> str | None:
+        """Auth-gated path used to prove the API key after a catalog 200.
+
+        ``GET {base_url}{path}`` must return 401/403 for a rejected key.
+        ``None`` means the models listing is already the credential check
+        (Anthropic, Gemini). Used by ``validate()`` only. A 404/405/501 on
+        this path is treated as "endpoint absent" and the models listing
+        result is trusted.
+        """
+        return None
+
+    def build_credential_confirmation_url(self, base_url: str) -> str | None:
+        """Build the credential-confirmation URL, or None if the provider has no probe."""
+        path = self.credential_confirmation_path
+        if not path:
+            return None
+        return f"{base_url.rstrip('/')}{path}"
+
     def next_page_params(self, json_data: dict[str, Any]) -> dict[str, str] | None:  # noqa: ARG002
         """Return query params for the next page, or None if done. Default: single-page."""
         return None

--- a/backend/src/syntara/integrations/adapters/providers/openai_compatible.py
+++ b/backend/src/syntara/integrations/adapters/providers/openai_compatible.py
@@ -13,6 +13,11 @@ class OpenAICompatibleProvider(LLMProviderBase):
 
     Auth: ``Authorization: Bearer {api_key}``
     Models endpoint: ``GET {base_url}/models``
+    Credential probe: ``GET {base_url}/key`` during ``validate()`` after a
+    catalog 200. Some gateways (e.g. OpenRouter) publish ``/models`` without
+    checking the key; ``/key`` is auth-gated. A 404/405/501 means the probe
+    is absent (OpenAI, vLLM) and the catalog result is trusted. ``discover()``
+    does not call this probe.
     Response format::
 
         { "data": [{ "id": "gpt-4o", "object": "model", "created": 1686935002, "owned_by": "openai" }] }
@@ -35,6 +40,11 @@ class OpenAICompatibleProvider(LLMProviderBase):
     def default_base_url(self) -> str | None:
         """Default base URL."""
         return self._default_url
+
+    @property
+    def credential_confirmation_path(self) -> str:
+        """OpenRouter-compatible auth-gated key endpoint."""
+        return "/key"
 
     def build_headers(self, api_key: str) -> dict[str, str]:
         """Build Bearer auth headers."""

--- a/backend/tests/unit/integrations/adapters/providers/test_base.py
+++ b/backend/tests/unit/integrations/adapters/providers/test_base.py
@@ -54,3 +54,8 @@ class TestLLMProviderBaseDefaults:
     def test_next_page_params_empty_dict(self) -> None:
         provider = _ConcreteProvider()
         assert provider.next_page_params({}) is None
+
+    def test_credential_confirmation_path_default_none(self) -> None:
+        provider = _ConcreteProvider()
+        assert provider.credential_confirmation_path is None
+        assert provider.build_credential_confirmation_url("https://api.example.com/v1") is None

--- a/backend/tests/unit/integrations/adapters/providers/test_openai_compatible.py
+++ b/backend/tests/unit/integrations/adapters/providers/test_openai_compatible.py
@@ -64,3 +64,15 @@ class TestOpenAICompatibleProvider:
         """OpenAI does not paginate — base class default returns None."""
         provider = OpenAICompatibleProvider()
         assert provider.next_page_params({"data": [{"id": "gpt-4o"}]}) is None
+
+    def test_credential_confirmation_path(self) -> None:
+        provider = OpenAICompatibleProvider()
+        assert provider.credential_confirmation_path == "/key"
+        assert (
+            provider.build_credential_confirmation_url("https://openrouter.ai/api/v1")
+            == "https://openrouter.ai/api/v1/key"
+        )
+        assert (
+            provider.build_credential_confirmation_url("https://openrouter.ai/api/v1/")
+            == "https://openrouter.ai/api/v1/key"
+        )

--- a/backend/tests/unit/integrations/test_llm_provider_health_check.py
+++ b/backend/tests/unit/integrations/test_llm_provider_health_check.py
@@ -783,6 +783,169 @@ class TestLLMProviderLogging:
 
 
 # ---------------------------------------------------------------------------
+# Credential confirmation (OpenAI-compatible GET /key after catalog 200)
+# ---------------------------------------------------------------------------
+
+
+class TestLLMProviderCredentialConfirmation:
+    """validate() must not treat a public /models catalog as a valid API key."""
+
+    @pytest.mark.asyncio
+    async def test_custom_models_200_key_401_validate_fails(self) -> None:
+        """OpenRouter-style: public catalog + rejected key → AUTH_FAILURE."""
+        adapter = LLMProviderAdapter(_make_config("custom", base_url="https://openrouter.ai/api/v1"))
+        with patch("syntara.integrations.adapters.llm_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(
+                side_effect=[_mock_response({"data": [{"id": "openai/gpt-4o"}]}), _mock_http_error(401)]
+            )
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await adapter.validate(_openai_cred("sk-or-v1-INVALID000"), timeout_seconds=10)
+
+        assert result.success is False
+        assert result.error_type == HealthCheckErrorType.AUTH_FAILURE
+        assert mock_client.get.call_count == 2
+        assert mock_client.get.call_args_list[0].args[0].endswith("/models")
+        assert mock_client.get.call_args_list[1].args[0].endswith("/key")
+
+    @pytest.mark.asyncio
+    async def test_custom_models_200_discover_does_not_probe_key(self) -> None:
+        """Discover lists the catalog only; a public /models 200 is enough."""
+        adapter = LLMProviderAdapter(_make_config("custom", base_url="https://openrouter.ai/api/v1"))
+        catalog = _mock_response({"data": [{"id": "openai/gpt-4o"}]})
+        with patch("syntara.integrations.adapters.llm_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=catalog)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await adapter.discover(_openai_cred("sk-or-v1-INVALID000"), timeout_seconds=10)
+
+        assert result.success is True
+        assert result.discovered_models is not None
+        assert len(result.discovered_models) == 1
+        mock_client.get.assert_called_once()
+        assert mock_client.get.call_args.args[0].endswith("/models")
+
+    @pytest.mark.asyncio
+    async def test_custom_models_200_key_200_validate_succeeds(self) -> None:
+        adapter = LLMProviderAdapter(_make_config("custom", base_url="https://openrouter.ai/api/v1"))
+        with _mock_httpx(response=_mock_response({"data": []})) as mock_client:
+            result = await adapter.validate(_openai_cred(), timeout_seconds=10)
+
+        assert result.success is True
+        assert mock_client.get.call_count == 2
+        assert mock_client.get.call_args_list[1].args[0].endswith("/key")
+
+    @pytest.mark.asyncio
+    async def test_openai_models_401_does_not_probe_key(self) -> None:
+        """Auth-gated catalogs fail on the first request; /key is not called."""
+        adapter = LLMProviderAdapter(_make_config("openai"))
+        with patch("syntara.integrations.adapters.llm_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=_mock_http_error(401))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await adapter.validate(_openai_cred(), timeout_seconds=10)
+
+        assert result.success is False
+        assert result.error_type == HealthCheckErrorType.AUTH_FAILURE
+        mock_client.get.assert_called_once()
+        assert mock_client.get.call_args.args[0].endswith("/models")
+
+    @pytest.mark.asyncio
+    async def test_openai_models_200_key_404_validate_succeeds(self) -> None:
+        """OpenAI has no /key endpoint; 404 is treated as probe-absent."""
+        adapter = LLMProviderAdapter(_make_config("openai"))
+        with patch("syntara.integrations.adapters.llm_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(
+                side_effect=[_mock_response({"data": [{"id": "gpt-4o"}]}), _mock_response({}, status_code=404)]
+            )
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await adapter.validate(_openai_cred(), timeout_seconds=10)
+
+        assert result.success is True
+        assert mock_client.get.call_count == 2
+        assert mock_client.get.call_args_list[1].args[0].endswith("/key")
+
+    @pytest.mark.asyncio
+    async def test_custom_models_200_key_404_validate_succeeds(self) -> None:
+        """vLLM-style: public catalog and no /key → still success."""
+        adapter = LLMProviderAdapter(_make_config("custom", base_url="http://localhost:8000/v1"))
+        with patch("syntara.integrations.adapters.llm_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(
+                side_effect=[_mock_response({"data": [{"id": "llama"}]}), _mock_http_error(404)]
+            )
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await adapter.validate(_openai_cred(), timeout_seconds=10)
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_key_probe_timeout_fails_validate(self) -> None:
+        adapter = LLMProviderAdapter(_make_config("custom", base_url="https://openrouter.ai/api/v1"))
+        with patch("syntara.integrations.adapters.llm_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=[_mock_response({"data": []}), TimeoutError("timed out")])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await adapter.validate(_openai_cred(), timeout_seconds=5)
+
+        assert result.success is False
+        assert result.error_type == HealthCheckErrorType.TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_anthropic_does_not_probe_key(self) -> None:
+        adapter = LLMProviderAdapter(_make_config("anthropic", base_url=None))
+        with patch("syntara.integrations.adapters.llm_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=_mock_response({"data": []}))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await adapter.validate(_openai_cred(), timeout_seconds=10)
+
+        assert result.success is True
+        mock_client.get.assert_called_once()
+        assert "/key" not in mock_client.get.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_rejected_key_not_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+        test_api_key = "sk-or-v1-INVALID000"
+        adapter = LLMProviderAdapter(_make_config("custom", base_url="https://openrouter.ai/api/v1"))
+        with patch("syntara.integrations.adapters.llm_provider.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=[_mock_response({"data": []}), _mock_http_error(401)])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            await adapter.validate({"llm_api_key": test_api_key}, timeout_seconds=10)
+
+        assert test_api_key not in caplog.text
+
+
+# ---------------------------------------------------------------------------
 # Pagination
 # ---------------------------------------------------------------------------
 
@@ -877,6 +1040,7 @@ class TestLLMProviderDiscoverPagination:
 
         assert result.success is True
         assert mock_client.get.call_count == 1
+        assert mock_client.get.call_args.args[0].endswith("/models")
 
     @pytest.mark.asyncio
     async def test_pagination_stops_at_max_pages(self) -> None:


### PR DESCRIPTION
## Description

`POST /integrations/{id}/validate` on an LLM integration could return `success: true` and set `validation_status: available` with a garbage API key. OpenAI-compatible `GET /models` is public on some gateways (OpenRouter): HTTP 200 only proved the catalog was reachable.

After a catalog 200, OpenAI-compatible `validate()` now calls `GET {base_url}/key` with the same Bearer token. `401`/`403` → `AUTH_FAILURE` (unhealthy). `404`/`405`/`501` → probe absent (OpenAI, vLLM); the catalog result is trusted. Anthropic and Gemini skip the probe; their listing APIs already require the key.

Discover, refresh, and wizard **Test connection** still list `/models` only. Execution uses a separate credential.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- [x] OpenAI-compatible providers expose `credential_confirmation_path` (`/key`); `validate()` probes it after catalog 200
- [x] Unit tests for rejected key, absent probe, timeout, Anthropic skip, and discover not probing `/key`

## Out of Scope

- No OpenAPI or `backend/docs/` changes (avoid contract/leads review for a description-only update)
- Discover/refresh behavior unchanged
- No billed `chat/completions` health check


## How to Test

1. Create a custom LLM integration pointed at `https://openrouter.ai/api/v1` with a garbage API key.
2. **Refresh models** / wizard **Test connection** can still list the catalog.
3. Kebab **Validate integration** should fail; Status should be **Error** (not Available).
4. Repeat with a real OpenRouter key: validate should succeed.
5. Optional: OpenAI or a local vLLM with no `/key` — validate should still succeed on catalog 200 + 404 on `/key`.

Restart the API process after deploying so it picks up the adapter change (`server_reload` defaults to false).

## Additional Notes

Health checks use `validate()`, so a bad management key on OpenRouter will now show Error on the interval as well as on manual validate.
