### PR TITLE
 fix: disable RP-initiated logout for AAP OIDC to prevent token wipe

### DIFF
--- a/backend/docs/authentication.md
+++ b/backend/docs/authentication.md
@@ -62,6 +62,8 @@ When `enable_rp_initiated_logout` is set to `true` on an OIDC provider's configu
 
 **Configuration:** Set `enable_rp_initiated_logout: true` and optionally `end_session_endpoint` in the provider's OIDC configuration. If `end_session_endpoint` is not set, it is discovered automatically via the OIDC well-known endpoint.
 
+**AAP warning:** For Ansible Automation Platform (`idp_type: "aap"`), keep `enable_rp_initiated_logout` disabled. The AAP push-button setup registers a single shared OAuth2 application for all users; RP-initiated logout redirects the browser to AAP's `end_session_endpoint`, which triggers django-oauth-toolkit to delete API tokens tied to that shared application — including tokens belonging to other users. Syntara does not call AAP token-revocation APIs directly; disabling RP-initiated logout is the safe mitigation until AAP scopes revoke-on-logout.
+
 ## CSRF Protection
 
 Cookie-authenticated endpoints (`POST /auth/refresh`, `POST /auth/logout`) are protected against Cross-Site Request Forgery using the **Synchronizer Token** pattern with HMAC derivation.
@@ -903,9 +905,17 @@ The `POST /identity_providers/setup-aap-oidc` endpoint automates the full AAP OI
    - `scopes` = `"read write openid roles"`
    - JMESPath group extraction for AAP teams and organizations
    - `aap_role_mapping_enabled` = `true` (see [AAP Role Mapping](#aap-role-mapping))
-   - `enable_rp_initiated_logout` = `true`
+   - `enable_rp_initiated_logout` = `false` (see [AAP warning](#rp-initiated-logout-oidc) — must stay off for shared AAP OAuth apps)
    - `disable_tls_verify` mirrors the request's `insecure_skip_tls_verify` value
 4. The created identity provider is returned (201).
+
+**Existing deployments:** Upgrades apply a one-time migration that sets `enable_rp_initiated_logout` to `false` on all AAP identity providers. Admins can still enable single logout manually per provider, but doing so on AAP risks deleting OAuth application API tokens (see AAP warning above).
+
+**Manual verification (requires a real AAP):**
+
+1. Two AAP users each create API tokens assigned to the shared Syntara OAuth application.
+2. User A logs into Syntara via AAP OIDC, then logs out.
+3. Confirm User B's tokens still exist in AAP.
 
 **Prerequisites:**
 

--- a/backend/docs/authentication.md
+++ b/backend/docs/authentication.md
@@ -64,6 +64,8 @@ When `enable_rp_initiated_logout` is set to `true` on an OIDC provider's configu
 
 **AAP warning:** For Ansible Automation Platform (`idp_type: "aap"`), keep `enable_rp_initiated_logout` disabled. The AAP push-button setup registers a single shared OAuth2 application for all users; RP-initiated logout redirects the browser to AAP's `end_session_endpoint`, which triggers django-oauth-toolkit to delete API tokens tied to that shared application — including tokens belonging to other users. Syntara does not call AAP token-revocation APIs directly; disabling RP-initiated logout is the safe mitigation until AAP scopes revoke-on-logout.
 
+**AAP platform follow-up (recommended):** File an AAP-side issue to scope django-oauth-toolkit revoke-on-logout (`token_types_to_delete`) so OIDC single sign-out revokes only the current user's session tokens, not all OAuth application API tokens. That would allow Syntara to re-enable RP-initiated logout safely. See [Django OAuth Toolkit OIDC settings](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html).
+
 ## CSRF Protection
 
 Cookie-authenticated endpoints (`POST /auth/refresh`, `POST /auth/logout`) are protected against Cross-Site Request Forgery using the **Synchronizer Token** pattern with HMAC derivation.

--- a/backend/src/syntara/core/database/migrations/versions/e8f4b2a91c3d_disable_aap_rp_initiated_logout.py
+++ b/backend/src/syntara/core/database/migrations/versions/e8f4b2a91c3d_disable_aap_rp_initiated_logout.py
@@ -1,0 +1,46 @@
+"""disable RP-initiated logout on existing AAP identity providers
+
+Revision ID: e8f4b2a91c3d
+Revises: c7e4a91b2d03
+Create Date: 2026-08-27 00:00:00.000000
+
+Remediates AAP-89344: RP-initiated logout against a shared AAP OAuth2 application
+causes django-oauth-toolkit to delete API tokens tied to that application across
+all users. Disable the flag on existing AAP IdP records created before the fix.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e8f4b2a91c3d"
+down_revision: str | Sequence[str] | None = "c7e4a91b2d03"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Disable RP-initiated logout on AAP OIDC identity providers."""
+    # CUSTOM: data migration — JSONB configuration update not handled by autogenerate
+    op.execute(
+        """
+        UPDATE identity_providers
+        SET configuration = jsonb_set(
+            configuration,
+            '{enable_rp_initiated_logout}',
+            'false'::jsonb
+        )
+        WHERE configuration->>'provider_type' = 'oidc'
+          AND configuration->>'idp_type' = 'aap'
+          AND COALESCE((configuration->>'enable_rp_initiated_logout')::boolean, false) = true
+        """
+    )
+    # END CUSTOM
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # CUSTOM: intentional no-op — re-enabling RP-initiated logout on AAP providers
+    # can delete OAuth application API tokens across all users (AAP-89344).
+    # END CUSTOM

--- a/backend/src/syntara/identity_providers/services/aap_oidc_setup_service.py
+++ b/backend/src/syntara/identity_providers/services/aap_oidc_setup_service.py
@@ -137,7 +137,14 @@ class AAPOIDCSetupService:
                 claim_mapping=OIDCClaimMapping(),
                 group_jmespath_expression=_AAP_GROUP_JMESPATH,
                 aap_role_mapping_enabled=True,
-                enable_rp_initiated_logout=True,
+                # RP-initiated logout must stay disabled for the AAP push-button
+                # setup. The OAuth2 application created above is a single shared
+                # application for all users; redirecting logout to AAP's OIDC
+                # end-session endpoint causes AAP to purge every API token tied
+                # to that shared application across all users, not just the one
+                # logging out. Admins who want single-sign-out can still enable
+                # it manually per identity provider.
+                enable_rp_initiated_logout=False,
                 allow_all_authenticated=False,
                 disable_tls_verify=request.insecure_skip_tls_verify,
             ),

--- a/backend/tests/unit/identity_providers/services/test_aap_oidc_setup_service.py
+++ b/backend/tests/unit/identity_providers/services/test_aap_oidc_setup_service.py
@@ -140,7 +140,7 @@ class TestSetupHappyPath:
         assert str(config.issuer_url) == f"{_AAP_URL}/o/"
         assert config.scopes == "read write openid roles"
         assert config.aap_role_mapping_enabled is True
-        assert config.enable_rp_initiated_logout is True
+        assert config.enable_rp_initiated_logout is False
         assert config.auto_discovery is True
         assert config.allow_all_authenticated is False
 

--- a/backend/tests/unit/identity_providers/services/test_aap_oidc_setup_service.py
+++ b/backend/tests/unit/identity_providers/services/test_aap_oidc_setup_service.py
@@ -146,6 +146,28 @@ class TestSetupHappyPath:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_rp_initiated_logout_disabled_to_prevent_token_wipe(self) -> None:
+        """Regression: AAP push-button setup must NOT enable RP-initiated logout.
+
+        The setup registers a single shared OAuth2 application on AAP that every
+        user logs in through. When RP-initiated logout is enabled, logging out of
+        AO redirects to AAP's OIDC end-session endpoint and AAP deletes every API
+        token tied to that shared application -- across all users, not just the
+        one logging out. The setup must leave RP-initiated logout disabled so a
+        logout can never wipe other users' AAP API tokens.
+        """
+        respx.get(f"{_AAP_API}/organizations/").mock(return_value=httpx.Response(200, json=_org_response()))
+        respx.post(f"{_AAP_API}/applications/").mock(return_value=httpx.Response(201, json=_app_response()))
+
+        idp_service = _mock_idp_service()
+        service = _make_service(idp_service=idp_service)
+        await service.setup(_make_request())
+
+        config = idp_service.create_provider.call_args[0][0].configuration
+        assert config.enable_rp_initiated_logout is False
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_constructs_redirect_uri_from_settings(self) -> None:
         respx.get(f"{_AAP_API}/organizations/").mock(return_value=httpx.Response(200, json=_org_response()))
         respx.post(f"{_AAP_API}/applications/").mock(return_value=httpx.Response(201, json=_app_response()))

--- a/frontend/packages/syntara-mock-api/src/handlers.ts
+++ b/frontend/packages/syntara-mock-api/src/handlers.ts
@@ -2489,7 +2489,7 @@ export const handlers = [
         scopes: 'read write openid roles',
         claim_mapping: { subject: 'sub', email: 'email', username: 'preferred_username', full_name: 'name' },
         aap_role_mapping_enabled: true,
-        enable_rp_initiated_logout: true,
+        enable_rp_initiated_logout: false,
         allow_all_authenticated: false,
         disable_tls_verify: body.insecure_skip_tls_verify ?? false,
         group_jmespath_expression: "[aap_teams[*].join('/', [organization, name]), aap_organizations[*].name] | []",

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderFormFields.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderFormFields.tsx
@@ -165,7 +165,12 @@ function IdpTypeField({
   )
 }
 
-function RpInitiatedLogoutField({ control }: Readonly<{ control: Control<IdentityProviderFormData> }>) {
+function RpInitiatedLogoutField({
+  control,
+  idpType,
+}: Readonly<{ control: Control<IdentityProviderFormData>; idpType: string | undefined }>) {
+  const isAapProvider = idpType === IdpTypeKey.AAP
+
   return (
     <Controller
       name="enableRpInitiatedLogout"
@@ -184,6 +189,13 @@ function RpInitiatedLogoutField({ control }: Readonly<{ control: Control<Identit
               <HelperTextItem>
                 When enabled, users will be redirected to the identity provider&apos;s logout page on sign-out.
               </HelperTextItem>
+              {isAapProvider && (
+                <HelperTextItem variant="warning">
+                  For Ansible Automation Platform, enabling single logout may delete API tokens tied to the shared OAuth
+                  application across all users when AAP processes the end-session request. Leave disabled unless AAP
+                  revoke-on-logout is scoped to the current session only.
+                </HelperTextItem>
+              )}
             </HelperText>
           </FormHelperText>
         </FormGroup>
@@ -442,7 +454,7 @@ export function IdentityProviderFormFields({
                 <ScopesField control={control} isPresetTemplate={isPresetTemplate} />
                 <AllowAllAuthenticatedField control={control} />
                 {idpType === IdpTypeKey.AAP && <AapRoleMappingField control={control} />}
-                <RpInitiatedLogoutField control={control} />
+                <RpInitiatedLogoutField control={control} idpType={idpType} />
               </FormSection>
             </Form>
           </StackItem>

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/idpTypePresets.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/idpTypePresets.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { IdpTypeKey, IDP_TYPE_PRESETS } from './idpTypePresets'
+
+describe('IDP_TYPE_PRESETS', () => {
+  it('AAP preset disables RP-initiated logout to prevent token wipe', () => {
+    expect(IDP_TYPE_PRESETS[IdpTypeKey.AAP].enableRpInitiatedLogout).toBe(false)
+  })
+
+  it('custom preset disables RP-initiated logout by default', () => {
+    expect(IDP_TYPE_PRESETS[IdpTypeKey.CUSTOM].enableRpInitiatedLogout).toBe(false)
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/idpTypePresets.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/idpTypePresets.ts
@@ -37,7 +37,7 @@ export const IDP_TYPE_PRESETS: Record<string, IdpTypePreset> = {
       lastName: 'family_name',
     },
     groupMappingExpression: "[aap_teams[*].join('/', [organization, name]), aap_organizations[*].name] | []",
-    enableRpInitiatedLogout: true,
+    enableRpInitiatedLogout: false,
     aapRoleMappingEnabled: true,
   },
   [IdpTypeKey.CUSTOM]: {


### PR DESCRIPTION
## Summary
- Disable RP-initiated logout by default for AAP OIDC push-button setup and manual AAP IdP preset so logging out of Syntara no longer redirects to AAP's `end_session_endpoint` (which triggers django-oauth-toolkit to delete API tokens tied to the shared OAuth application across all users).
- Add AAP-specific UI warning on the Single logout switch, update docs/mock API, and migrate existing AAP IdPs to `enable_rp_initiated_logout=false`.

## Why
 Syntara does not call AAP token-revocation APIs; the deletion is AAP-side behavior triggered by OIDC RP-initiated logout against a single shared OAuth2 application.

**Trade-off:** AO logout no longer performs OIDC single sign-out against AAP until AAP scopes revoke-on-logout safely.

## Changes
- `aap_oidc_setup_service.py`: default `enable_rp_initiated_logout=False` for push-button setup
- `idpTypePresets.ts` + UI warning in `IdentityProviderFormFields.tsx`
- Alembic migration `e8f4b2a91c3d`: disable RP logout on existing AAP IdPs
- `authentication.md` + mock API handler aligned

## Test plan
- [x] `tests/unit/identity_providers/services/test_aap_oidc_setup_service.py` (including regression test)
- [x] `idpTypePresets.test.ts`
- [ ] Manual E2E against real AAP: two users' tokens survive one user's AO logout (procedure documented in `authentication.md`)


Made with [Cursor](https://cursor.com)