### PR TITLE
fix(AAP-75181): use named, sentence-case titles on user forms

### DIFF
--- a/frontend/packages/syntara-ui/e2e/access-management-create-buttons.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/access-management-create-buttons.spec.ts
@@ -12,8 +12,7 @@
  * - Roles tab: "Create role" button → dialog title and submit both read "Create role"
  * - Assignments tab: "Add assignment" button → dialog title "Add Assignment"; submit "Add assignment"
  *
- * Note: the Users form page heading uses title case ("Create User") while the submit button
- * uses sentence case ("Create user") — both are intentional per PatternFly casing conventions.
+ * Note: the Users form page heading and submit button both use sentence case ("Create user").
  * The Assignments dialog heading uses title case ("Add Assignment") by existing convention;
  * this area was not modified by this PR.
  *
@@ -97,7 +96,7 @@ test.describe('Access Management — Create button labels', () => {
     await createButton.click()
 
     await expect(app).toHaveURL(new RegExp(`${ACCESS_URL}/users/create`))
-    await expect(app.getByRole('heading', { name: 'Create User' })).toBeVisible()
+    await expect(app.getByRole('heading', { name: 'Create user' })).toBeVisible()
     await expect(app.getByRole('button', { name: 'Create user' })).toBeVisible()
 
     await app.getByRole('button', { name: 'Cancel' }).click()

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -282,7 +282,7 @@ test.describe('Permission gating — Route guards', () => {
     await app.goto(toAppUrl(`${AM_URL}/users/create`))
 
     await expect(app.getByRole('heading', { name: 'Access denied' })).not.toBeVisible()
-    await expect(app.getByRole('heading', { name: /Create User/i })).toBeVisible()
+    await expect(app.getByRole('heading', { name: 'Create user' })).toBeVisible()
   })
 })
 

--- a/frontend/packages/syntara-ui/e2e/visual-regression/page-entries-interactive.ts
+++ b/frontend/packages/syntara-ui/e2e/visual-regression/page-entries-interactive.ts
@@ -1128,7 +1128,7 @@ export const userCreateFormPages: PageEntry[] = [
     name: 'user-create-validation-errors',
     path: AppRoute.AccessManagement.CreateUser,
     waitFor: async (page) => {
-      await expect(page.getByRole('heading', { name: 'Create User' })).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'Create user' })).toBeVisible()
     },
     setup: async (page) => {
       await page.getByRole('button', { name: 'Create user' }).click()

--- a/frontend/packages/syntara-ui/e2e/visual-regression/page-registry.ts
+++ b/frontend/packages/syntara-ui/e2e/visual-regression/page-registry.ts
@@ -270,7 +270,7 @@ export const pages: PageEntry[] = [
     name: 'user-create',
     path: AppRoute.AccessManagement.CreateUser,
     waitFor: async (page) => {
-      await expect(page.getByRole('heading', { name: 'Create User' })).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'Create user' })).toBeVisible()
     },
   },
   {
@@ -286,7 +286,7 @@ export const pages: PageEntry[] = [
     name: 'user-edit',
     path: AppRoute.AccessManagement.EditUser.replace(':userId', MOCK_USER_ID),
     waitFor: async (page) => {
-      await expect(page.getByRole('heading', { name: 'Edit User' })).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'Edit Demo Admin' })).toBeVisible()
     },
   },
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/CreateUser.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/CreateUser.test.tsx
@@ -64,6 +64,6 @@ describe('CreateUser', () => {
 
     render(<CreateUser />, { wrapper })
 
-    expect(screen.getByRole('heading', { name: 'Create User' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Create user' })).toBeInTheDocument()
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/EditUser.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/EditUser.test.tsx
@@ -102,7 +102,7 @@ describe('EditUser', () => {
     setupSuccessMocks()
     render(<EditUser />, { wrapper })
 
-    expect(screen.getByRole('heading', { name: 'Edit User' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Edit John Doe' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
   })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserDetailActions.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserDetailActions.test.tsx
@@ -59,7 +59,9 @@ describe('UserDetailToolbar', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: 'Edit user' })).toBeInTheDocument()
+    const editButton = screen.getByRole('button', { name: 'Edit user' })
+    expect(editButton).toBeInTheDocument()
+    expect(editButton).toHaveClass('pf-m-primary')
     await user.click(screen.getByRole('button', { name: 'User actions' }))
     expect(screen.getByRole('menuitem', { name: 'Revoke tokens' })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: 'Delete user' })).toBeInTheDocument()

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.test.tsx
@@ -151,12 +151,24 @@ describe('UserForm', () => {
   })
 
   describe('create mode', () => {
-    it('renders with "Create User" heading and "Create user" submit button', () => {
+    it('renders with "Create user" heading and "Create user" submit button', () => {
       setupCreateMocks()
       render(<UserForm mode="create" />, { wrapper })
 
-      expect(screen.getByRole('heading', { name: 'Create User' })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Create user' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Create user' })).toBeInTheDocument()
+    })
+
+    it('places Create user to the left of Cancel', () => {
+      setupCreateMocks()
+      render(<UserForm mode="create" />, { wrapper })
+
+      const submit = screen.getByRole('button', { name: 'Create user' })
+      const cancel = screen.getByRole('button', { name: 'Cancel' })
+      expect(cancel).toHaveClass('pf-m-link')
+      expect(submit.compareDocumentPosition(cancel) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING
+      )
     })
 
     it('uses createUser documentation key', () => {
@@ -335,12 +347,24 @@ describe('UserForm', () => {
   })
 
   describe('edit mode', () => {
-    it('renders with "Edit User" heading and "Save" submit button', () => {
+    it('renders with the user display name in the heading and "Save" submit button', () => {
       setupEditMocks()
       render(<UserForm mode="edit" />, { wrapper })
 
-      expect(screen.getByRole('heading', { name: 'Edit User' })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Edit John Doe' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    })
+
+    it('places Save to the left of Cancel', () => {
+      setupEditMocks()
+      render(<UserForm mode="edit" />, { wrapper })
+
+      const submit = screen.getByRole('button', { name: 'Save' })
+      const cancel = screen.getByRole('button', { name: 'Cancel' })
+      expect(cancel).toHaveClass('pf-m-link')
+      expect(submit.compareDocumentPosition(cancel) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING
+      )
     })
 
     it('uses users documentation key', () => {
@@ -373,6 +397,7 @@ describe('UserForm', () => {
 
       const nav = screen.getByRole('navigation', { name: 'Breadcrumb' })
       expect(within(nav).getByText('jdoe')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Edit jdoe' })).toBeInTheDocument()
     })
 
     it('calls updateUser mutation with form data on submit', async () => {
@@ -485,6 +510,7 @@ describe('UserForm', () => {
 
       render(<UserForm mode="edit" />, { wrapper })
 
+      expect(screen.getByRole('heading', { name: 'Edit user' })).toBeInTheDocument()
       expect(screen.getByText('User not found')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /Back to users/ })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /Retry/ })).toBeInTheDocument()
@@ -582,7 +608,7 @@ describe('UserForm', () => {
 
       render(<UserForm mode="edit" />, { wrapper })
 
-      expect(screen.getByRole('heading', { name: 'Edit User' })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Edit user' })).toBeInTheDocument()
       expect(screen.getByRole('progressbar', { name: 'Loading' })).toBeInTheDocument()
       // The form submit button should not be visible in loading state
       expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.tsx
@@ -39,6 +39,22 @@ const DEFAULT_VALUES: UserFormData = {
   group_names: ['users'],
 }
 
+const CREATE_USER_PAGE_TITLE = 'Create user'
+const EDIT_USER_PAGE_TITLE = 'Edit user'
+
+function userFormPageTitle(
+  isEdit: boolean,
+  user: { first_name?: string | null; last_name?: string | null; username: string } | undefined
+): string {
+  if (!isEdit) {
+    return CREATE_USER_PAGE_TITLE
+  }
+  if (user) {
+    return `Edit ${userDisplayName(user)}`
+  }
+  return EDIT_USER_PAGE_TITLE
+}
+
 function PasswordWarningAlert({ isSelf }: Readonly<{ isSelf: boolean }>) {
   const title = isSelf ? 'You will be signed out' : 'User will be signed out'
   const description = isSelf
@@ -57,7 +73,7 @@ function userFormBreadcrumbTrail(
   isEdit: boolean,
   pageTitle: string,
   userId: string | undefined,
-  user: { first_name: string; last_name?: string | null; username: string } | undefined
+  user: { first_name?: string | null; last_name?: string | null; username: string } | undefined
 ): AppBreadcrumbItem[] {
   if (!isEdit) {
     return breadcrumbsCreateUser()
@@ -119,7 +135,7 @@ function UserFormMainPanel({
 function UserFormEditNotFoundPage({ onBack, onRetry }: Readonly<{ onBack: () => void; onRetry: () => void }>) {
   return (
     <SynPage>
-      <SynPageHeader title="Edit User" breadcrumbs={breadcrumbsUserFormLoading('Edit user')} />
+      <SynPageHeader title="Edit user" breadcrumbs={breadcrumbsUserFormLoading('Edit user')} />
       <SynPageBody>
         <SynPanel isFullHeight>
           <UserNotFoundState onBack={onBack} onRetry={onRetry} />
@@ -144,10 +160,10 @@ export function UserForm({ mode }: Readonly<UserFormProps>) {
   const navigate = useNavigate()
   const isEdit = mode === 'edit'
   const usersDocLink = useDocLink(isEdit ? 'users' : 'createUser')
-  const pageTitle = isEdit ? 'Edit User' : 'Create User'
   const submitLabel = isEdit ? 'Save' : 'Create user'
 
   const { userId, isValidId, userQuery, isBuiltinUser, isFederatedUser, isSelf, formValues } = useUserFormData(isEdit)
+  const pageTitle = userFormPageTitle(isEdit, userQuery.data)
 
   const schema = isEdit ? userFormSchema : userCreateSchema
   const {


### PR DESCRIPTION
## Description

user create/edit form titles did not match the resource-naming / sentence-case pattern. create is now `Create user`; edit is `Edit [full name or username]` (falls back to `Edit user` while loading or if the user is missing).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] create form heading is sentence case `Create user`
- [x] edit form heading uses the users display name (`Edit John Doe`), else username
- [x] unit/e2e locators and assertions updated for those headings
- [x] tests lock in the already-on-devel detail header and form action order so they do not regress

## Out of Scope

already on devel (same pattern as group detail), not changed here:
- details page primary `Edit user` with RHDS edit icon (`variant=primary`)
- details kebab to the right of edit, with `Delete user` last (danger + RHDS delete icon)
- create/edit form actions: primary leftmost, Cancel `variant=link` to the right

## Related Issues

Fixes AAP-75181

## How to Test

1. log in as an admin
2. System Administration, Access management, Users
3. Create user: heading is `Create user`; Create is leftmost, Cancel link on the right
4. open a user (e.g. John Doe): primary Edit user, kebab with Delete last (already on devel)
5. Edit user: heading is `Edit John Doe` (or the username if there is no full name)

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<img width="850" height="300" alt="image" src="https://github.com/user-attachments/assets/d8631296-96ed-4c0a-b2e8-44708324792d" />