### PR TITLE
fix: keep run history closed when entering run mode

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetail.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetail.test.tsx
@@ -385,7 +385,7 @@ describe('ExecutionDetail', () => {
     )
   })
 
-  it('shows history panel by default', () => {
+  it('does not show history panel by default and keeps the run history icon', () => {
     const queryClient = new QueryClient()
     render(
       <QueryClientProvider client={queryClient}>
@@ -393,7 +393,8 @@ describe('ExecutionDetail', () => {
       </QueryClientProvider>
     )
 
-    expect(screen.getByTestId('workflow-history-card')).toBeInTheDocument()
+    expect(screen.queryByTestId('workflow-history-card')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Run history')).toBeInTheDocument()
   })
 
   it('shows history panel when history=open query param is present', () => {
@@ -435,6 +436,8 @@ describe('ExecutionDetail', () => {
   })
 
   it('toggles history panel closed when history button is clicked', async () => {
+    vi.mocked(useRouterState).mockReturnValue('?history=open' as never)
+
     const user = userEvent.setup()
     const queryClient = new QueryClient()
     render(
@@ -442,6 +445,8 @@ describe('ExecutionDetail', () => {
         <ExecutionDetail />
       </QueryClientProvider>
     )
+
+    expect(screen.getByTestId('workflow-history-card')).toBeInTheDocument()
 
     const historyButton = screen.getByLabelText('Run history')
     await user.click(historyButton)

--- a/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetail.tsx
@@ -302,7 +302,7 @@ export default function ExecutionDetail() {
 
   const historyCardOpen = useMemo(() => {
     const params = new URLSearchParams(searchParams)
-    return params.get('history') !== 'closed'
+    return params.get('history') === 'open'
   }, [searchParams])
 
   const { executionFilters, handleExecutionFilterChange, executionsQuery, executionPaginationFooterProps } =


### PR DESCRIPTION
## Description

When a user clicks **Run**, the canvas goes into run mode with the Run history side panel already open. That panel should stay closed so the canvas is unobstructed. The Run history icon in the header still opens and closes the panel.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] Execution detail treats the history panel as open only when `history=open` (previously open unless `history=closed`)
- [x] Unit tests updated for default-closed, icon present, and open/close toggle

## Out of Scope

- Builder kebab “Run history” (editor, not run mode)
- In-editor live run overlay
- Visual regression baseline updates (local-only; CI does not require them)

## Related Issues

Fixes AAP-71830

## How to Test

1. Open a saved workflow in the builder.
2. Click **Run** and confirm.
3. Confirm the canvas is in run mode and the Run history panel is **not** open.
4. Confirm the Run history icon is in the header.
5. Click the icon — the panel opens. Click it again (or the panel close control) — the panel closes.
6. Optional: with the panel open, select another run in the list — the panel stays open.

## Frontend Checklist

- [x] Unit tests updated and passing for `ExecutionDetail`
- [x] Accessibility: Run history control remains a labeled header button; default view no longer covers the canvas
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab

Local-only `execution-detail` snapshots previously included the open panel. After this change they will show canvas-only run mode. Update baselines locally if you run that suite; otherwise the weekly refresh will pick up the drift.

## Screenshots / Demo (if applicable)

Please attach:
- After Run: canvas in run mode, history panel closed, icon in the header
- After clicking the icon: history panel open

https://github.com/user-attachments/assets/9928534a-999e-4263-b092-823facde6044

