### PR TITLE
refactor: convert project from soft delete to hard delete

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 ---
 name: Bug report
 description: Report a bug to help us improve
-
 body:
   - type: dropdown
     attributes:
@@ -14,14 +13,12 @@ body:
         - Unknown
     validations:
       required: true
-
   - type: textarea
     attributes:
       label: Summary
       description: A clear description of the bug.
     validations:
       required: true
-
   - type: textarea
     attributes:
       label: Steps to reproduce
@@ -32,39 +29,35 @@ body:
         3.
     validations:
       required: true
-
   - type: textarea
     attributes:
       label: Expected results
       description: What you expected to happen.
     validations:
       required: true
-
   - type: textarea
     attributes:
       label: Actual results
       description: What actually happened.
     validations:
       required: true
-
   - type: textarea
     attributes:
       label: Logs / error output
       description: Paste any relevant log output or error messages.
       render: console
-
   - type: textarea
     attributes:
       label: Environment
       description: >
         Any relevant environment details.
+
       placeholder: |
         OS: (e.g., RHEL 9, Fedora 44, Ubuntu 22.04, macOS 14)
         Browser: (e.g., Chrome 120, Firefox 121)
         Python version: (e.g., 3.12)
         Node version: (e.g., 22.x)
         Deployment method: (e.g., Podman, local dev)
-
   - type: checkboxes
     attributes:
       label: Code of Conduct

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -202,7 +202,7 @@ ignore = [
 ]
 "tests/performance/conftest.py" = ["E402"]  # pytest_plugins must precede imports
 "src/syntara/api/repositories/*.py" = ["ANN401"]  # Allow Any for database row types
-"src/syntara/core/database/migrations/**/*.py" = ["INP001", "D400", "D415", "PLR0915"]  # Alembic files (auto-generated)
+"src/syntara/core/database/migrations/**/*.py" = ["INP001", "D400", "D415", "PLR0915", "S608"]  # Alembic files (auto-generated, trusted SQL)
 "src/cli/**/*.py" = ["ANN401", "SLF001", "PLC0415"]  # CLI: dynamic types, private access to bundler, deferred imports
 "src/syntara/api/main.py" = ["S104"]  # Binding to all interfaces for development
 "tools/ci/check_migrations.py" = [

--- a/backend/src/api_client/syntara_api_client/api/projects/delete_project.py
+++ b/backend/src/api_client/syntara_api_client/api/projects/delete_project.py
@@ -90,7 +90,7 @@ def sync_detailed(
 ) -> Response[Any | ErrorData]:
     """Delete project
 
-     Delete a project (soft-delete). Requires: project:delete permission scoped to this project.
+     Delete a project (hard-delete). Requires: project:delete permission scoped to this project.
 
     Args:
         project_id (UUID):
@@ -121,7 +121,7 @@ def sync(
 ) -> Any | ErrorData | None:
     """Delete project
 
-     Delete a project (soft-delete). Requires: project:delete permission scoped to this project.
+     Delete a project (hard-delete). Requires: project:delete permission scoped to this project.
 
     Args:
         project_id (UUID):
@@ -147,7 +147,7 @@ async def asyncio_detailed(
 ) -> Response[Any | ErrorData]:
     """Delete project
 
-     Delete a project (soft-delete). Requires: project:delete permission scoped to this project.
+     Delete a project (hard-delete). Requires: project:delete permission scoped to this project.
 
     Args:
         project_id (UUID):
@@ -176,7 +176,7 @@ async def asyncio(
 ) -> Any | ErrorData | None:
     """Delete project
 
-     Delete a project (soft-delete). Requires: project:delete permission scoped to this project.
+     Delete a project (hard-delete). Requires: project:delete permission scoped to this project.
 
     Args:
         project_id (UUID):

--- a/backend/src/cli/orchestrator_cli/openapi.yaml
+++ b/backend/src/cli/orchestrator_cli/openapi.yaml
@@ -13851,7 +13851,7 @@ paths:
         - bearerAuth: []
     delete:
       summary: Delete project
-      description: 'Delete a project (soft-delete). Requires: project:delete permission scoped to this project.'
+      description: 'Delete a project (hard-delete). Requires: project:delete permission scoped to this project.'
       operationId: delete_project
       x-app-permission:
         resource: project

--- a/backend/src/syntara/authz/dependencies.py
+++ b/backend/src/syntara/authz/dependencies.py
@@ -127,7 +127,6 @@ class PermissionChecker:
         result = await db.exec(
             select(Project.name).where(
                 Project.id == (project_id if isinstance(project_id, UUID) else UUID(str(project_id))),
-                Project.deleted_at.is_(None),  # type: ignore[union-attr]
             )
         )
         return result.first() or ""

--- a/backend/src/syntara/authz/engine.py
+++ b/backend/src/syntara/authz/engine.py
@@ -286,7 +286,6 @@ async def _resolve_project_ids(db: AsyncSession, project_names: list[str]) -> li
     projects_result = await db.exec(
         select(Project).where(
             Project.name.in_(project_names),  # type: ignore[attr-defined]
-            Project.deleted_at.is_(None),  # type: ignore[union-attr]
         )
     )
     return [p.id for p in projects_result.all()]

--- a/backend/src/syntara/authz/exceptions.py
+++ b/backend/src/syntara/authz/exceptions.py
@@ -1,11 +1,16 @@
 """Authorization exceptions."""
 
+from typing import TYPE_CHECKING
+
 from fastapi import Request, status
 from fastapi.responses import JSONResponse
 
 from syntara.core.error_handlers import PROBLEM_TYPES, create_problem_details_response
 from syntara.core.exception_registry import fastapi_exception
 from syntara.core.exceptions import SyntaraError
+
+if TYPE_CHECKING:
+    from uuid import UUID
 
 
 def authorization_denied_handler(
@@ -95,6 +100,33 @@ def _default_project_protection_handler(request: Request, exc: SyntaraError) -> 
 @fastapi_exception(handler=_default_project_protection_handler)
 class DefaultProjectProtectionError(SyntaraError):
     """Raised when attempting to delete the default project."""
+
+
+def _project_active_executions_handler(request: Request, exc: "ProjectHasActiveExecutionsError") -> JSONResponse:
+    return create_problem_details_response(
+        status_code=status.HTTP_409_CONFLICT,
+        problem_type=PROBLEM_TYPES["resource_conflict"],
+        title="Project Has Active Executions",
+        detail=exc.message,
+        code="PROJECT_HAS_ACTIVE_EXECUTIONS",
+        retryable=True,
+        instance=str(request.url),
+    )
+
+
+@fastapi_exception(handler=_project_active_executions_handler)
+class ProjectHasActiveExecutionsError(SyntaraError):
+    """Raised when a project cannot be deleted because it has non-terminal executions."""
+
+    def __init__(self, project_id: "UUID", active_count: int) -> None:
+        """Initialize with project ID and active execution count."""
+        self.project_id = project_id
+        self.active_count = active_count
+        plural = "s" if active_count != 1 else ""
+        super().__init__(
+            f"Cannot delete project: {active_count} execution{plural} still running. "
+            "Wait for them to complete or cancel them first."
+        )
 
 
 @fastapi_exception(handler=_conflict_handler)

--- a/backend/src/syntara/authz/models/project.py
+++ b/backend/src/syntara/authz/models/project.py
@@ -4,46 +4,40 @@ Projects provide soft-tenant isolation for grouping and scoping resources.
 Resources belong to a project and all queries are project-scoped.
 """
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
-from sqlmodel import Field, Index, text
+from sqlmodel import Field, UniqueConstraint, text
 
-from syntara.core.models.base import NamedResource, SoftDeletableResource
+from syntara.core.models.base import NamedResource
 
 
-class Project(NamedResource, SoftDeletableResource, table=True):
-    """Project for resource isolation.
+class Project(NamedResource, table=True):
+    """Project for resource isolation (hard delete).
 
     Attributes:
         id: Primary key UUID (from BaseResource)
-        name: Project name (from NamedResource, unique across non-deleted)
+        name: Project name (from NamedResource, unique)
         description: Optional project description (from NamedResource)
         labels: JSONB key-value labels (from BaseResource)
         created_at: Creation timestamp (from BaseResource)
         updated_at: Last update timestamp (from BaseResource)
-        deleted_at: Soft delete timestamp (from SoftDeletableResource)
-        deleted_by: UUID of deleter (from SoftDeletableResource)
         is_default: Whether this is the default project
 
     """
+
+    FIELD_SCHEMA_EXTRAS: ClassVar[dict[str, dict[str, Any]]] = {
+        **NamedResource.FIELD_SCHEMA_EXTRAS,
+    }
 
     __tablename__ = "projects"
 
     __filterable_fields__: ClassVar[list[str]] = [
         *NamedResource.__filterable_fields__,
-        *SoftDeletableResource.__filterable_fields__,
         "is_default",
         "is_builtin",
     ]
 
-    __sortable_fields__: ClassVar[list[str]] = list(
-        dict.fromkeys(
-            [
-                *NamedResource.__sortable_fields__,
-                *SoftDeletableResource.__sortable_fields__,
-            ]
-        )
-    )
+    __sortable_fields__: ClassVar[list[str]] = list(dict.fromkeys(NamedResource.__sortable_fields__))
 
     is_default: bool = Field(
         default=False,
@@ -57,14 +51,7 @@ class Project(NamedResource, SoftDeletableResource, table=True):
         sa_column_kwargs={"server_default": text("false")},
     )
 
-    __table_args__ = (
-        Index(
-            "ix_projects_name_unique",
-            "name",
-            unique=True,
-            postgresql_where=text("deleted_at IS NULL"),
-        ),
-    )
+    __table_args__ = (UniqueConstraint("name", name="uq_projects_name"),)
 
     def __repr__(self) -> str:
         """Return string representation."""

--- a/backend/src/syntara/authz/resolver.py
+++ b/backend/src/syntara/authz/resolver.py
@@ -290,7 +290,6 @@ async def resolve_effective_policies(
         projects_result = await db.exec(
             select(Project).where(
                 Project.id.in_(list(project_role_names.keys())),  # type: ignore[attr-defined]
-                Project.deleted_at.is_(None),  # type: ignore[union-attr]
             )
         )
         project_map = {p.id: p.name for p in projects_result.all()}

--- a/backend/src/syntara/authz/router.py
+++ b/backend/src/syntara/authz/router.py
@@ -175,7 +175,6 @@ async def _resolve_project_input(db: AsyncSession, resource_project: str) -> str
     result = await db.exec(
         select(Project.name).where(
             Project.id == project_id,
-            Project.deleted_at.is_(None),  # type: ignore[union-attr]
         )
     )
     return result.first() or resource_project
@@ -186,7 +185,6 @@ async def _ids_to_names(db: AsyncSession, project_ids: set[UUID]) -> set[str]:
     projects_result = await db.exec(
         select(Project.name).where(
             Project.id.in_(list(project_ids)),  # type: ignore[attr-defined]
-            Project.deleted_at.is_(None),  # type: ignore[union-attr]
         )
     )
     return set(projects_result.all())

--- a/backend/src/syntara/authz/seed.py
+++ b/backend/src/syntara/authz/seed.py
@@ -111,7 +111,6 @@ async def _seed_groups_and_project(
     existing_proj = await session.exec(
         select(Project).where(
             Project.name == "default",
-            Project.deleted_at.is_(None),  # type: ignore[union-attr]
         )
     )
     default_project = existing_proj.one_or_none()
@@ -124,7 +123,6 @@ async def _seed_groups_and_project(
     existing_system = await session.exec(
         select(Project).where(
             Project.name == BUILTIN_PROJECT_NAME,
-            Project.deleted_at.is_(None),  # type: ignore[union-attr]
         )
     )
     system_project = existing_system.one_or_none()

--- a/backend/src/syntara/authz/services/role_assignment_service.py
+++ b/backend/src/syntara/authz/services/role_assignment_service.py
@@ -642,7 +642,6 @@ class RoleAssignmentService:
         result = await self.session.exec(
             select(Project.name).where(
                 Project.id == project_id,
-                Project.deleted_at.is_(None),  # type: ignore[union-attr]
             )
         )
         return result.first()

--- a/backend/src/syntara/core/database/migrations/versions/f1b3c7d9e2a4_project_hard_delete.py
+++ b/backend/src/syntara/core/database/migrations/versions/f1b3c7d9e2a4_project_hard_delete.py
@@ -25,10 +25,11 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+_SOFT_DELETED = "SELECT id FROM projects WHERE deleted_at IS NOT NULL"
+
+
 def _delete_by_project(table: str) -> sa.TextClause:
-    return sa.text(
-        "DELETE FROM " + table + " WHERE project_id IN (SELECT id FROM projects WHERE deleted_at IS NOT NULL)"
-    )
+    return sa.text("DELETE FROM " + table + f" WHERE project_id IN ({_SOFT_DELETED})")
 
 
 def upgrade() -> None:
@@ -45,42 +46,62 @@ def upgrade() -> None:
     op.execute(
         sa.text(
             "UPDATE workflows SET published_version_id = NULL, is_enabled = false "
-            "WHERE project_id IN (SELECT id FROM projects WHERE deleted_at IS NOT NULL)"
+            f"WHERE project_id IN ({_SOFT_DELETED})"
         )
     )
     op.execute(
         sa.text(
             "DELETE FROM webhook_triggers WHERE workflow_id IN "
-            "(SELECT id FROM workflows WHERE project_id IN "
-            "(SELECT id FROM projects WHERE deleted_at IS NOT NULL))"
+            f"(SELECT id FROM workflows WHERE project_id IN ({_SOFT_DELETED}))"
         )
     )
     op.execute(
         sa.text(
             "DELETE FROM workflow_versions WHERE workflow_id IN "
-            "(SELECT id FROM workflows WHERE project_id IN "
-            "(SELECT id FROM projects WHERE deleted_at IS NOT NULL))"
+            f"(SELECT id FROM workflows WHERE project_id IN ({_SOFT_DELETED}))"
         )
     )
     op.execute(_delete_by_project("workflows"))
 
-    # Credentials: capture secret_ids, delete credentials first (removes FK reference),
-    # then delete their secrets and encrypted_secrets
+    # Credentials + secrets: scoped cleanup.
+    # Skip credentials referenced by a live integration — ON DELETE RESTRICT on
+    # integrations.management_credential_id would fail the migration. Those
+    # credentials (and their secrets) stay; the admin must reassign the
+    # integration's credential and re-run the migration.
+    #
+    # Capture secret_ids BEFORE deleting credentials so the secret deletion
+    # is scoped to this migration's projects, not a global orphan sweep.
+    _integration_refs = "SELECT management_credential_id FROM integrations WHERE management_credential_id IS NOT NULL"
     op.execute(
         sa.text(
-            "DELETE FROM encrypted_secrets WHERE secret_id IN "
-            "(SELECT secret_id FROM credentials WHERE project_id IN "
-            "(SELECT id FROM projects WHERE deleted_at IS NOT NULL) AND secret_id IS NOT NULL)"
+            "CREATE TEMP TABLE _purge_secret_ids AS "
+            "SELECT DISTINCT secret_id FROM credentials "
+            f"WHERE project_id IN ({_SOFT_DELETED}) "
+            "AND secret_id IS NOT NULL "
+            f"AND id NOT IN ({_integration_refs})"
         )
     )
-    op.execute(_delete_by_project("credentials"))
+    op.execute(sa.text("DELETE FROM encrypted_secrets WHERE secret_id IN (SELECT secret_id FROM _purge_secret_ids)"))
     op.execute(
         sa.text(
-            "DELETE FROM secrets WHERE id NOT IN "
-            "(SELECT secret_id FROM credentials WHERE secret_id IS NOT NULL) "
-            "AND id NOT IN (SELECT secret_id FROM identity_providers WHERE secret_id IS NOT NULL)"
+            "UPDATE credentials SET secret_id = NULL "
+            f"WHERE project_id IN ({_SOFT_DELETED}) "
+            f"AND id NOT IN ({_integration_refs})"
         )
     )
+    op.execute(
+        sa.text(f"DELETE FROM credentials WHERE project_id IN ({_SOFT_DELETED}) AND id NOT IN ({_integration_refs})")
+    )
+    # Delete only the captured secrets — scoped, not a global orphan sweep.
+    # Exclude any secret still referenced by an identity provider.
+    op.execute(
+        sa.text(
+            "DELETE FROM secrets WHERE id IN (SELECT secret_id FROM _purge_secret_ids) "
+            "AND id NOT IN "
+            "(SELECT secret_id FROM identity_providers WHERE secret_id IS NOT NULL)"
+        )
+    )
+    op.execute(sa.text("DROP TABLE IF EXISTS _purge_secret_ids"))
 
     op.execute(_delete_by_project("file_metadata"))
     op.execute(_delete_by_project("integration_project_assignments"))
@@ -89,8 +110,7 @@ def upgrade() -> None:
     op.execute(
         sa.text(
             "DELETE FROM service_account_credentials WHERE service_account_id IN "
-            "(SELECT id FROM service_accounts WHERE project_id IN "
-            "(SELECT id FROM projects WHERE deleted_at IS NOT NULL))"
+            f"(SELECT id FROM service_accounts WHERE project_id IN ({_SOFT_DELETED}))"
         )
     )
     op.execute(_delete_by_project("service_accounts"))

--- a/backend/src/syntara/core/database/migrations/versions/f1b3c7d9e2a4_project_hard_delete.py
+++ b/backend/src/syntara/core/database/migrations/versions/f1b3c7d9e2a4_project_hard_delete.py
@@ -1,0 +1,138 @@
+"""project hard delete
+
+Convert projects from soft delete to hard delete per the cascade-everything
+decision (meeting 2026-08-20). Soft-deleted project rows are purged; the
+deleted_at/deleted_by columns and partial unique index are dropped.
+
+Application-level cascade in ProjectService handles child resource cleanup
+before the project row itself is deleted.
+
+Revision ID: f1b3c7d9e2a4
+Revises: 7367ba3d8ccb
+Create Date: 2026-08-31 10:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f1b3c7d9e2a4"
+down_revision: str | Sequence[str] | None = "7367ba3d8ccb"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _delete_by_project(table: str) -> sa.TextClause:
+    return sa.text(
+        "DELETE FROM " + table + " WHERE project_id IN (SELECT id FROM projects WHERE deleted_at IS NOT NULL)"
+    )
+
+
+def upgrade() -> None:
+    """Purge soft-deleted projects, drop soft-delete columns and partial index."""
+    # CUSTOM: Cascade-delete child resources of soft-deleted projects before purging.
+    # Order respects FK constraints.
+
+    op.execute(_delete_by_project("approval_requests"))
+    op.execute(_delete_by_project("invocations"))
+    op.execute(_delete_by_project("executions"))
+
+    # Workflows: disable, null published_version_id, delete triggers/versions, then workflows
+    # Setting is_enabled = false is required by ck_workflows_is_enabled_published_version_id
+    op.execute(
+        sa.text(
+            "UPDATE workflows SET published_version_id = NULL, is_enabled = false "
+            "WHERE project_id IN (SELECT id FROM projects WHERE deleted_at IS NOT NULL)"
+        )
+    )
+    op.execute(
+        sa.text(
+            "DELETE FROM webhook_triggers WHERE workflow_id IN "
+            "(SELECT id FROM workflows WHERE project_id IN "
+            "(SELECT id FROM projects WHERE deleted_at IS NOT NULL))"
+        )
+    )
+    op.execute(
+        sa.text(
+            "DELETE FROM workflow_versions WHERE workflow_id IN "
+            "(SELECT id FROM workflows WHERE project_id IN "
+            "(SELECT id FROM projects WHERE deleted_at IS NOT NULL))"
+        )
+    )
+    op.execute(_delete_by_project("workflows"))
+
+    # Credentials: capture secret_ids, delete credentials first (removes FK reference),
+    # then delete their secrets and encrypted_secrets
+    op.execute(
+        sa.text(
+            "DELETE FROM encrypted_secrets WHERE secret_id IN "
+            "(SELECT secret_id FROM credentials WHERE project_id IN "
+            "(SELECT id FROM projects WHERE deleted_at IS NOT NULL) AND secret_id IS NOT NULL)"
+        )
+    )
+    op.execute(_delete_by_project("credentials"))
+    op.execute(
+        sa.text(
+            "DELETE FROM secrets WHERE id NOT IN "
+            "(SELECT secret_id FROM credentials WHERE secret_id IS NOT NULL) "
+            "AND id NOT IN (SELECT secret_id FROM identity_providers WHERE secret_id IS NOT NULL)"
+        )
+    )
+
+    op.execute(_delete_by_project("file_metadata"))
+    op.execute(_delete_by_project("integration_project_assignments"))
+
+    # Service account credentials (must precede service_accounts — FK has no CASCADE)
+    op.execute(
+        sa.text(
+            "DELETE FROM service_account_credentials WHERE service_account_id IN "
+            "(SELECT id FROM service_accounts WHERE project_id IN "
+            "(SELECT id FROM projects WHERE deleted_at IS NOT NULL))"
+        )
+    )
+    op.execute(_delete_by_project("service_accounts"))
+    op.execute(_delete_by_project("role_assignments"))
+    op.execute(_delete_by_project("roles"))
+    op.execute(_delete_by_project("policies"))
+
+    # Purge soft-deleted project rows
+    op.execute(sa.text("DELETE FROM projects WHERE deleted_at IS NOT NULL"))
+    # END CUSTOM
+
+    # Drop partial unique index and replace with plain unique constraint
+    op.drop_index("ix_projects_name_unique", table_name="projects")
+    op.create_unique_constraint("uq_projects_name", "projects", ["name"])
+
+    # Drop indexes on deleted_at/deleted_by before dropping columns
+    op.drop_index(op.f("ix_projects_deleted_at"), table_name="projects")
+    op.drop_index(op.f("ix_projects_deleted_by"), table_name="projects")
+
+    # Drop soft-delete columns
+    op.drop_column("projects", "deleted_at")
+    op.drop_column("projects", "deleted_by")
+
+
+def downgrade() -> None:
+    """Restore soft-delete columns, indexes, and partial unique index.
+
+    WARNING: Rows purged by upgrade() are NOT recoverable.
+    """
+    op.add_column("projects", sa.Column("deleted_by", sa.UUID(), nullable=True))
+    op.add_column("projects", sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True))
+
+    op.create_index(op.f("ix_projects_deleted_at"), "projects", ["deleted_at"], unique=False)
+    op.create_index(op.f("ix_projects_deleted_by"), "projects", ["deleted_by"], unique=False)
+
+    op.drop_constraint("uq_projects_name", "projects", type_="unique")
+    op.create_index(
+        "ix_projects_name_unique",
+        "projects",
+        ["name"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+    op.create_foreign_key("projects_deleted_by_fkey", "projects", "users", ["deleted_by"], ["id"])

--- a/backend/src/syntara/core/queries/project_queries.py
+++ b/backend/src/syntara/core/queries/project_queries.py
@@ -2,7 +2,7 @@
 
 Provides reusable query functions for project liveness checks, used by
 services that create resources scoped to a project to prevent orphaned
-resources against soft-deleted projects.
+resources against deleted projects.
 """
 
 from uuid import UUID
@@ -15,20 +15,19 @@ from syntara.authz.models.project import Project
 
 
 async def assert_project_alive(session: AsyncSession, project_id: UUID) -> None:
-    """Verify a project exists and is not soft-deleted.
+    """Verify a project exists.
 
     Args:
         session: Database session
         project_id: Project UUID to validate
 
     Raises:
-        ProjectNotFoundError: If project not found or soft-deleted
+        ProjectNotFoundError: If project not found
 
     """
     result = await session.exec(
         select(Project.id).where(
             Project.id == project_id,
-            Project.deleted_at.is_(None),  # type: ignore[union-attr]
         )
     )
     if result.first() is None:

--- a/backend/src/syntara/core/websocket/endpoint_factory.py
+++ b/backend/src/syntara/core/websocket/endpoint_factory.py
@@ -862,7 +862,7 @@ async def _check_websocket_authorization(
                 stmt = (
                     select(Project.name)
                     .join(Execution, Execution.project_id == Project.id)  # type: ignore[arg-type]
-                    .where(Execution.id == uuid.UUID(resource_id), Project.deleted_at.is_(None))  # type: ignore[union-attr]
+                    .where(Execution.id == uuid.UUID(resource_id))
                 )
             elif resource_type == "invocation":
                 from syntara.agent_orchestrator.models.invocation import Invocation  # noqa: PLC0415
@@ -870,7 +870,7 @@ async def _check_websocket_authorization(
                 stmt = (
                     select(Project.name)
                     .join(Invocation, Invocation.project_id == Project.id)  # type: ignore[arg-type]
-                    .where(Invocation.id == uuid.UUID(resource_id), Project.deleted_at.is_(None))  # type: ignore[union-attr]
+                    .where(Invocation.id == uuid.UUID(resource_id))
                 )
             else:
                 # Fail closed: new resource types must add a branch here

--- a/backend/src/syntara/files/file_manager.py
+++ b/backend/src/syntara/files/file_manager.py
@@ -499,21 +499,16 @@ class FileManager:
         project_id: UUID,
         session: AsyncSession,
     ) -> bool:
-        """Return whether the owning project is soft-deleted or missing.
+        """Return whether the owning project no longer exists.
 
-        Mirrors the service-account pattern: files are retained after project
-        deletion, and callers learn the orphaned state via this flag.
-
-        Selecting the full row distinguishes an active project (``deleted_at``
-        is NULL) from a hard-deleted/missing project (no row). Selecting only
-        ``deleted_at`` would return ``None`` for both and incorrectly mark
-        hard-deleted projects as active.
+        With hard-delete, the project row is removed entirely, so a missing
+        row means the project was deleted.
         """
         from syntara.authz.models.project import Project  # noqa: PLC0415
 
         result = await session.exec(select(Project).where(Project.id == project_id))
         project = result.one_or_none()
-        return project is None or project.deleted_at is not None
+        return project is None
 
     async def batch_is_project_deleted(
         self,
@@ -534,7 +529,7 @@ class FileManager:
         result = await session.exec(select(Project).where(col(Project.id).in_(project_ids)))
         projects = {p.id: p for p in result.all()}
 
-        return {pid: (pid not in projects or projects[pid].deleted_at is not None) for pid in project_ids}
+        return {pid: (pid not in projects) for pid in project_ids}
 
     async def update_file_status(
         self,

--- a/backend/src/syntara/projects/router.py
+++ b/backend/src/syntara/projects/router.py
@@ -256,7 +256,7 @@ async def replace_project(
     operation_id="delete_project",
     response_description="Project deleted",
 )
-@audit(EventCategory.USER_ACTION)
+@audit(EventCategory.USER_ACTION, event_action="project_delete", capture_args={"project_id"})
 async def delete_project(
     project_id: UUID,
     service: Annotated[ProjectService, Depends(get_project_service)],

--- a/backend/src/syntara/projects/router.py
+++ b/backend/src/syntara/projects/router.py
@@ -261,7 +261,7 @@ async def delete_project(
     project_id: UUID,
     service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> None:
-    """Delete a project (soft-delete). Requires: project:delete permission scoped to this project."""
+    """Delete a project (hard-delete). Requires: project:delete permission scoped to this project."""
     await service.delete_project(project_id)
 
 

--- a/backend/src/syntara/projects/service.py
+++ b/backend/src/syntara/projects/service.py
@@ -294,8 +294,12 @@ class ProjectService(BaseService):
         Uses bulk SQL for efficiency. Ordering respects FK constraints.
         External side-effects (Temporal schedules, file storage) are best-effort.
         """
+        from sqlalchemy import func as sa_func  # noqa: PLC0415
+        from sqlmodel import col  # noqa: PLC0415
+
         from syntara.agent_orchestrator.models.invocation import Invocation  # noqa: PLC0415
         from syntara.approvals.models.approval_request import ApprovalRequest  # noqa: PLC0415
+        from syntara.authz.exceptions import ProjectHasActiveExecutionsError  # noqa: PLC0415
         from syntara.authz.models.policy import Policy  # noqa: PLC0415
         from syntara.authz.models.role import Role  # noqa: PLC0415
         from syntara.core.models.secret import EncryptedSecret, Secret  # noqa: PLC0415
@@ -304,14 +308,34 @@ class ProjectService(BaseService):
         from syntara.integrations.models.integration import IntegrationProjectAssignment  # noqa: PLC0415
         from syntara.service_accounts.models.service_account import ServiceAccount  # noqa: PLC0415
         from syntara.service_accounts.models.service_account_credential import ServiceAccountCredential  # noqa: PLC0415
-        from syntara.workflows.models.execution import Execution  # noqa: PLC0415
+        from syntara.workflows.models.execution import TERMINAL_EXECUTION_STATUSES, Execution  # noqa: PLC0415
         from syntara.workflows.models.webhook_trigger import WebhookTrigger  # noqa: PLC0415
         from syntara.workflows.models.workflow import Workflow  # noqa: PLC0415
         from syntara.workflows.models.workflow_version import WorkflowVersion  # noqa: PLC0415
 
+        # Step 1: Lock workflow rows FOR UPDATE to prevent new executions from being
+        # created while we check and delete.  Any concurrent create_execution() will
+        # block on the workflow SELECT until this transaction commits or rolls back,
+        # closing the TOCTOU race between the active-execution check and the DELETE.
+        result = await self.session.exec(select(Workflow).where(Workflow.project_id == project_id).with_for_update())
+        locked_workflows = list(result.all())
+        locked_wf_ids = [w.id for w in locked_workflows]
+
+        if locked_wf_ids:
+            non_terminal_count = await self.session.scalar(
+                select(sa_func.count())
+                .select_from(Execution)
+                .where(
+                    col(Execution.workflow_id).in_(locked_wf_ids),
+                    col(Execution.status).not_in(TERMINAL_EXECUTION_STATUSES),
+                )
+            )
+            if non_terminal_count:
+                raise ProjectHasActiveExecutionsError(project_id, non_terminal_count)
+
         # --- External cleanup (best-effort, must run BEFORE DB deletes) ---
         # _cleanup_file_storage reads FileMetadata rows to get storage paths,
-        # so it must precede the file_metadata DELETE in step 6 below.
+        # so it must precede the file_metadata DELETE below.
         await self._cleanup_temporal_schedules(project_id)
         await self._cleanup_file_storage(project_id)
 

--- a/backend/src/syntara/projects/service.py
+++ b/backend/src/syntara/projects/service.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import delete, update
-from sqlmodel import select
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from syntara.authz.engine import AllowedProjectsResult, assign_authenticated_group_project_user, assign_project_admin
@@ -72,15 +72,10 @@ class ProjectService(BaseService):
             The project.
 
         Raises:
-            SafeValueError: If project not found or deleted.
+            ProjectNotFoundError: If project not found.
 
         """
-        result = await self.session.exec(
-            select(Project).where(
-                Project.id == project_id,
-                Project.deleted_at.is_(None),  # type: ignore[union-attr]
-            )
-        )
+        result = await self.session.exec(select(Project).where(Project.id == project_id))
         project = result.first()
         if not project:
             from syntara.authz.exceptions import ProjectNotFoundError  # noqa: PLC0415
@@ -93,7 +88,7 @@ class ProjectService(BaseService):
         self,
         allowed_projects: AllowedProjectsResult | None = None,
     ) -> list[Project]:
-        """List non-deleted projects, filtered by authorization.
+        """List projects, filtered by authorization.
 
         Args:
             allowed_projects: When provided, filters to only projects the user
@@ -103,9 +98,7 @@ class ProjectService(BaseService):
             List of projects.
 
         """
-        query = select(Project).where(
-            Project.deleted_at.is_(None),  # type: ignore[union-attr]
-        )
+        query = select(Project)
 
         if allowed_projects is not None and not allowed_projects.all_projects:
             if not allowed_projects.project_ids:
@@ -198,13 +191,17 @@ class ProjectService(BaseService):
         return project
 
     async def delete_project(self, project_id: UUID) -> None:
-        """Soft-delete a project and cascade-clean all project-scoped resources.
+        """Hard-delete a project and cascade-delete all project-scoped resources.
+
+        All child resources (workflows, executions, invocations, credentials,
+        etc.) are permanently removed. The audit log serves as the historical
+        record.
 
         Args:
             project_id: Project UUID.
 
         Raises:
-            SafeValueError: If project not found.
+            ProjectNotFoundError: If project not found.
 
         """
         project = await self.get_project(project_id)
@@ -218,11 +215,35 @@ class ProjectService(BaseService):
 
             msg = "Default project cannot be deleted"
             raise DefaultProjectProtectionError(msg)
+        await self._check_no_active_executions(project_id)
         await self._check_credentials_not_referenced_by_integrations(project.id, project.name)
         await self._cascade_cleanup_project_resources(project_id)
-        project.soft_delete(self.user.id)
-        self.session.add(project)
+        await self.session.delete(project)
         await self.session.commit()
+
+    async def _check_no_active_executions(self, project_id: UUID) -> None:
+        """Raise 409 if the project has any non-terminal executions.
+
+        Deleting a project cascade-deletes all executions. Purging in-flight
+        executions would orphan Temporal workflows, so we require the caller
+        to cancel or wait for them first.
+        """
+        from sqlalchemy import func  # noqa: PLC0415
+
+        from syntara.authz.exceptions import ProjectHasActiveExecutionsError  # noqa: PLC0415
+        from syntara.workflows.models.execution import TERMINAL_EXECUTION_STATUSES, Execution  # noqa: PLC0415
+
+        result = await self.session.exec(
+            select(func.count())
+            .select_from(Execution)
+            .where(
+                Execution.project_id == project_id,
+                col(Execution.status).not_in(TERMINAL_EXECUTION_STATUSES),
+            )
+        )
+        active_count = result.one() or 0
+        if active_count:
+            raise ProjectHasActiveExecutionsError(project_id, active_count)
 
     async def _check_credentials_not_referenced_by_integrations(self, project_id: UUID, project_name: str) -> None:
         """Raise 409 if any credential in this project is still referenced by an integration.
@@ -268,64 +289,66 @@ class ProjectService(BaseService):
         raise ProjectCredentialInUseError(project_name, credential_names, integration_names, total_count)
 
     async def _cascade_cleanup_project_resources(self, project_id: UUID) -> None:
-        """Remove all project-scoped resources before soft-deleting the project.
+        """Delete all project-scoped resources before hard-deleting the project.
 
         Uses bulk SQL for efficiency. Ordering respects FK constraints.
-
-        Files and service accounts are intentionally retained after project
-        deletion (not cascaded here). Callers observe the orphaned state via
-        ``is_project_deleted`` on their read models. After soft-delete,
-        project-scoped ``files:delete`` cannot authorize orphan cleanup;
-        only system-scope ``files:delete`` with a known UUID can.
+        External side-effects (Temporal schedules, file storage) are best-effort.
         """
-        from sqlalchemy import func as sa_func  # noqa: PLC0415
-        from sqlmodel import col  # noqa: PLC0415
-
+        from syntara.agent_orchestrator.models.invocation import Invocation  # noqa: PLC0415
         from syntara.approvals.models.approval_request import ApprovalRequest  # noqa: PLC0415
         from syntara.authz.models.policy import Policy  # noqa: PLC0415
         from syntara.authz.models.role import Role  # noqa: PLC0415
         from syntara.core.models.secret import EncryptedSecret, Secret  # noqa: PLC0415
         from syntara.credentials.models.credential import Credential  # noqa: PLC0415
-        from syntara.workflows.exceptions import WorkflowHasActiveExecutionsError  # noqa: PLC0415
-        from syntara.workflows.models.execution import TERMINAL_EXECUTION_STATUSES, Execution  # noqa: PLC0415
+        from syntara.files.models.file_metadata import FileMetadata  # noqa: PLC0415
+        from syntara.integrations.models.integration import IntegrationProjectAssignment  # noqa: PLC0415
+        from syntara.service_accounts.models.service_account import ServiceAccount  # noqa: PLC0415
+        from syntara.service_accounts.models.service_account_credential import ServiceAccountCredential  # noqa: PLC0415
+        from syntara.workflows.models.execution import Execution  # noqa: PLC0415
         from syntara.workflows.models.webhook_trigger import WebhookTrigger  # noqa: PLC0415
         from syntara.workflows.models.workflow import Workflow  # noqa: PLC0415
+        from syntara.workflows.models.workflow_version import WorkflowVersion  # noqa: PLC0415
 
-        # Step 1: Fail fast — guard against deleting a project with in-flight executions.
-        workflow_ids_subq = select(Workflow.id).where(Workflow.project_id == project_id).scalar_subquery()
-        non_terminal_count = await self.session.scalar(
-            select(sa_func.count())
-            .select_from(Execution)
-            .where(
-                Execution.workflow_id.in_(workflow_ids_subq),  # type: ignore[attr-defined]
-                col(Execution.status).not_in(TERMINAL_EXECUTION_STATUSES),
-            )
-        )
-        if non_terminal_count:
-            raise WorkflowHasActiveExecutionsError(non_terminal_count, project_id=project_id)
+        # --- External cleanup (best-effort, must run BEFORE DB deletes) ---
+        # _cleanup_file_storage reads FileMetadata rows to get storage paths,
+        # so it must precede the file_metadata DELETE in step 6 below.
+        await self._cleanup_temporal_schedules(project_id)
+        await self._cleanup_file_storage(project_id)
 
-        # Step 2: Hard-delete approval requests
+        # --- Delete child resources (order respects FK constraints) ---
+
+        # 1. Approval requests
         await self.session.exec(
             delete(ApprovalRequest).where(ApprovalRequest.project_id == project_id)  # type: ignore[arg-type]
         )
 
-        # Step 3: Delete webhook triggers for workflows in this project.
+        # 2. Invocations
         await self.session.exec(
-            delete(WebhookTrigger).where(WebhookTrigger.workflow_id.in_(workflow_ids_subq))  # type: ignore[attr-defined]
+            delete(Invocation).where(Invocation.project_id == project_id)  # type: ignore[arg-type]
         )
 
-        # Step 4: Null out published_version_id to avoid self-referential FK issues,
-        # then hard-delete workflows (executions and versions cascade via DB FK).
+        # 3. Executions (must precede workflow deletion)
+        await self.session.exec(
+            delete(Execution).where(Execution.project_id == project_id)  # type: ignore[arg-type]
+        )
+
+        # 4. Workflows (clear published_version_id first to avoid self-ref FK,
+        #    delete webhook triggers, then versions before workflows — FK is RESTRICT, not CASCADE)
         await self.session.exec(
             update(Workflow)
             .where(Workflow.project_id == project_id)  # type: ignore[arg-type]
             .values(published_version_id=None, is_enabled=False)
         )
+        wf_ids_subq = select(Workflow.id).where(Workflow.project_id == project_id).scalar_subquery()
+        await self.session.exec(
+            delete(WebhookTrigger).where(WebhookTrigger.workflow_id.in_(wf_ids_subq))  # type: ignore[attr-defined]
+        )
+        await self.session.exec(delete(WorkflowVersion).where(col(WorkflowVersion.workflow_id).in_(wf_ids_subq)))
         await self.session.exec(
             delete(Workflow).where(Workflow.project_id == project_id)  # type: ignore[arg-type]
         )
 
-        # Step 5: Collect secret IDs, null FK, delete secrets, then hard-delete credentials
+        # 5. Credentials + secrets
         secret_ids_result = await self.session.exec(
             select(Credential.secret_id).where(
                 Credential.project_id == project_id,
@@ -334,42 +357,106 @@ class ProjectService(BaseService):
         )
         secret_ids = list(secret_ids_result.all())
 
-        # Null secret_id (breaks FK before secret deletion)
-        await self.session.exec(
-            update(Credential)
-            .where(Credential.project_id == project_id)  # type: ignore[arg-type]
-            .values(secret_id=None)
-        )
-
-        # Delete secrets
-        if secret_ids:
-            await self.session.exec(
-                delete(EncryptedSecret).where(
-                    EncryptedSecret.secret_id.in_(secret_ids)  # type: ignore[attr-defined]
-                )
-            )
-            await self.session.exec(
-                delete(Secret).where(Secret.id.in_(secret_ids))  # type: ignore[attr-defined]
-            )
-
-        # Hard-delete credentials
         await self.session.exec(
             delete(Credential).where(Credential.project_id == project_id)  # type: ignore[arg-type]
         )
+        if secret_ids:
+            await self.session.exec(delete(EncryptedSecret).where(col(EncryptedSecret.secret_id).in_(secret_ids)))
+            await self.session.exec(delete(Secret).where(col(Secret.id).in_(secret_ids)))
 
-        # Step 6: Hard-delete role assignments
+        # 6. File metadata
+        await self.session.exec(
+            delete(FileMetadata).where(FileMetadata.project_id == project_id)  # type: ignore[arg-type]
+        )
+
+        # 7. Integration project assignments (junction table)
+        await self.session.exec(
+            delete(IntegrationProjectAssignment).where(IntegrationProjectAssignment.project_id == project_id)  # type: ignore[arg-type]
+        )
+
+        # 8. Service account credentials (must precede service_accounts — FK has no CASCADE)
+        sa_ids_subq = select(ServiceAccount.id).where(ServiceAccount.project_id == project_id).scalar_subquery()
+        await self.session.exec(
+            delete(ServiceAccountCredential).where(col(ServiceAccountCredential.service_account_id).in_(sa_ids_subq))
+        )
+
+        # 8b. Service accounts
+        await self.session.exec(
+            delete(ServiceAccount).where(ServiceAccount.project_id == project_id)  # type: ignore[arg-type]
+        )
+
+        # 9. Role assignments
         await self.session.exec(
             delete(RoleAssignment).where(RoleAssignment.project_id == project_id)  # type: ignore[arg-type]
         )
 
-        # Step 7: Hard-delete custom roles
+        # 10. Custom roles
         await self.session.exec(
             delete(Role).where(Role.project_id == project_id)  # type: ignore[arg-type]
         )
 
-        # Step 8: Hard-delete custom policies
+        # 11. Custom policies
         await self.session.exec(
             delete(Policy).where(Policy.project_id == project_id)  # type: ignore[arg-type]
         )
 
-        logger.info("Cascade-cleaned project resources", project_id=str(project_id))
+        logger.info("Cascade-deleted project resources", project_id=str(project_id))
+
+    async def _cleanup_temporal_schedules(self, project_id: UUID) -> None:
+        """Best-effort cleanup of Temporal scheduled triggers for all project workflows."""
+        try:
+            from syntara.workflows.exceptions import ScheduledTriggerSyncError  # noqa: PLC0415
+            from syntara.workflows.models.workflow import Workflow  # noqa: PLC0415
+            from syntara.workflows.services.scheduled_trigger_service import ScheduledTriggerService  # noqa: PLC0415
+
+            result = await self.session.exec(select(Workflow.id).where(Workflow.project_id == project_id))
+            workflow_ids = list(result.all())
+            if workflow_ids:
+                trigger_svc = ScheduledTriggerService()
+                for wf_id in workflow_ids:
+                    try:
+                        await trigger_svc.delete_triggers_for_workflow(str(wf_id))
+                    except (OSError, RuntimeError, ScheduledTriggerSyncError):
+                        logger.warning(
+                            "Failed to clean Temporal triggers for workflow",
+                            workflow_id=str(wf_id),
+                            project_id=str(project_id),
+                            exc_info=True,
+                        )
+        except (OSError, RuntimeError, ImportError):
+            logger.warning(
+                "Failed to clean Temporal schedules for project",
+                project_id=str(project_id),
+                exc_info=True,
+            )
+
+    async def _cleanup_file_storage(self, project_id: UUID) -> None:
+        """Best-effort cleanup of files from object storage."""
+        try:
+            from syntara.files.exceptions import FileError, FileStorageUnavailableError  # noqa: PLC0415
+            from syntara.files.file_manager import FileManager  # noqa: PLC0415
+            from syntara.files.models.file_metadata import FileMetadata  # noqa: PLC0415
+
+            result = await self.session.exec(select(FileMetadata).where(FileMetadata.project_id == project_id))
+            files = list(result.all())
+            if files:
+                fm = FileManager()
+                retriever = fm.get_retriever()
+                for f in files:
+                    try:
+                        await retriever.delete_file(f.file_path)
+                        if f.converted_content_path:
+                            await retriever.delete_file(f.converted_content_path)
+                    except (OSError, FileError):
+                        logger.warning(
+                            "Failed to delete file from storage",
+                            file_id=str(f.id),
+                            path=f.file_path,
+                            exc_info=True,
+                        )
+        except (OSError, ImportError, FileError, FileStorageUnavailableError):
+            logger.warning(
+                "Failed to clean file storage for project",
+                project_id=str(project_id),
+                exc_info=True,
+            )

--- a/backend/src/syntara/projects/service.py
+++ b/backend/src/syntara/projects/service.py
@@ -423,7 +423,7 @@ class ProjectService(BaseService):
                             project_id=str(project_id),
                             exc_info=True,
                         )
-        except (OSError, RuntimeError, ImportError):
+        except (OSError, RuntimeError, ImportError, ScheduledTriggerSyncError):
             logger.warning(
                 "Failed to clean Temporal schedules for project",
                 project_id=str(project_id),

--- a/backend/src/syntara/schemas/openapi-public.json
+++ b/backend/src/syntara/schemas/openapi-public.json
@@ -19128,7 +19128,7 @@
       },
       "delete": {
         "summary": "Delete project",
-        "description": "Delete a project (soft-delete). Requires: project:delete permission scoped to this project.",
+        "description": "Delete a project (hard-delete). Requires: project:delete permission scoped to this project.",
         "operationId": "delete_project",
         "x-app-permission": {
           "resource": "project",

--- a/backend/src/syntara/schemas/openapi-public.yaml
+++ b/backend/src/syntara/schemas/openapi-public.yaml
@@ -13206,7 +13206,7 @@ paths:
         - bearerAuth: []
     delete:
       summary: Delete project
-      description: 'Delete a project (soft-delete). Requires: project:delete permission scoped to this project.'
+      description: 'Delete a project (hard-delete). Requires: project:delete permission scoped to this project.'
       operationId: delete_project
       x-app-permission:
         resource: project

--- a/backend/src/syntara/schemas/openapi.yaml
+++ b/backend/src/syntara/schemas/openapi.yaml
@@ -13851,7 +13851,7 @@ paths:
         - bearerAuth: []
     delete:
       summary: Delete project
-      description: 'Delete a project (soft-delete). Requires: project:delete permission scoped to this project.'
+      description: 'Delete a project (hard-delete). Requires: project:delete permission scoped to this project.'
       operationId: delete_project
       x-app-permission:
         resource: project

--- a/backend/src/syntara/schemas/projects/openapi.yaml
+++ b/backend/src/syntara/schemas/projects/openapi.yaml
@@ -271,7 +271,7 @@ paths:
     delete:
       summary: Delete project
       description: |-
-        Delete a project (soft-delete). Requires: project:delete permission scoped to this project.
+        Delete a project (hard-delete). Requires: project:delete permission scoped to this project.
       operationId: delete_project
       x-app-permission:
         resource: project

--- a/backend/src/syntara/service_accounts/services/service_account_service.py
+++ b/backend/src/syntara/service_accounts/services/service_account_service.py
@@ -102,25 +102,24 @@ class ServiceAccountService(BaseService):
 
     async def _resolve_project_info(self, project_id: UUID) -> tuple[str, bool] | None:
         result = await self.session.exec(
-            select(Project.name, Project.deleted_at).where(
+            select(Project.name).where(
                 Project.id == project_id,
             )
         )
-        row = result.first()
-        if row is None:
+        name = result.first()
+        if name is None:
             return None
-        name, deleted_at = row
-        return name, deleted_at is not None
+        return name, False
 
     async def _resolve_project_infos(self, project_ids: set[UUID]) -> dict[UUID, tuple[str, bool]]:
         if not project_ids:
             return {}
         result = await self.session.exec(
-            select(Project.id, Project.name, Project.deleted_at).where(
+            select(Project.id, Project.name).where(
                 Project.id.in_(project_ids),  # type: ignore[attr-defined]
             )
         )
-        return {row_id: (name, deleted_at is not None) for row_id, name, deleted_at in result.all()}
+        return {row_id: (name, False) for row_id, name in result.all()}
 
     async def get_service_account(self, service_account_id: UUID) -> ServiceAccount:
         """Get a service account by ID.

--- a/backend/src/syntara/workflows/executions_router.py
+++ b/backend/src/syntara/workflows/executions_router.py
@@ -188,9 +188,7 @@ async def create_execution(
     wf_project_id = wf_result.first()
     resource_project = ""
     if wf_project_id:
-        proj_result = await db.exec(
-            select(Project.name).where(Project.id == wf_project_id, Project.deleted_at.is_(None))  # type: ignore[union-attr]
-        )
+        proj_result = await db.exec(select(Project.name).where(Project.id == wf_project_id))
         resource_project = proj_result.first() or ""
 
     evaluator = get_authz_evaluator(http_request)

--- a/backend/src/syntara/workflows/seed_builtin.py
+++ b/backend/src/syntara/workflows/seed_builtin.py
@@ -190,7 +190,6 @@ async def seed_builtin_workflows(session: AsyncSession) -> None:
         select(Project).where(
             Project.name == BUILTIN_PROJECT_NAME,
             Project.is_builtin == True,  # noqa: E712
-            Project.deleted_at.is_(None),  # type: ignore[union-attr]
         )
     )
     system_project = project_result.first()

--- a/backend/src/syntara/workflows/services/execution_service.py
+++ b/backend/src/syntara/workflows/services/execution_service.py
@@ -562,7 +562,6 @@ class ExecutionService(BaseService):
                 == select(Project.id)
                 .where(
                     Project.name == project_name,
-                    Project.deleted_at.is_(None),  # type: ignore[union-attr]
                 )
                 .scalar_subquery(),
             )

--- a/backend/src/syntara/workflows/services/workflow_service.py
+++ b/backend/src/syntara/workflows/services/workflow_service.py
@@ -458,9 +458,7 @@ class WorkflowService(BaseService):
         if not new_credentials:
             return
 
-        proj_result = await self.session.exec(
-            select(Project.name).where(Project.id == project_id, Project.deleted_at.is_(None))  # type: ignore[union-attr]
-        )
+        proj_result = await self.session.exec(select(Project.name).where(Project.id == project_id))
         project_name = proj_result.first() or ""
 
         for cred_id in new_credentials:

--- a/backend/tests/integration/api/test_list_projects.py
+++ b/backend/tests/integration/api/test_list_projects.py
@@ -303,18 +303,23 @@ async def test_authenticated_user_gets_default_project_access(
 
 
 @pytest.mark.asyncio
-async def test_soft_deleted_default_project_does_not_break_new_user(
+async def test_deleted_default_project_does_not_break_new_user(
     auth_client: AsyncClient,
     test_db_session: AsyncSession,
     test_user: User,
     user_factory: Callable[..., Awaitable[User]],
 ) -> None:
-    """When the default project is soft-deleted, new users can still be created and list projects."""
-    # Soft-delete the default project directly in the DB
+    """When the default project is deleted, new users can still be created and list projects."""
+    from syntara.projects.service import ProjectService
+
+    # Clear the is_default flag so the service allows deletion, then cascade-delete
     default_project = (await test_db_session.exec(select(Project).where(Project.name == "default"))).one()
-    default_project.soft_delete(test_user.id)
+    default_project.is_default = False
     test_db_session.add(default_project)
-    await test_db_session.commit()
+    await test_db_session.flush()
+
+    service = ProjectService(session=test_db_session, user=test_user)
+    await service.delete_project(default_project.id)
 
     # Create a new user — should not error
     new_user = await user_factory(username="post-delete-user", email="post-delete@example.com")

--- a/backend/tests/integration/api/test_orphaned_project_resources.py
+++ b/backend/tests/integration/api/test_orphaned_project_resources.py
@@ -1,7 +1,7 @@
-"""Tests that creating resources against a soft-deleted project is rejected.
+"""Tests that creating resources against a deleted project is rejected.
 
 Validates the fix for AAP-74611 / AAP-74612: workflows, credentials, roles,
-and policies must not be creatable against a project whose deleted_at is set.
+and policies must not be creatable against a project that has been deleted.
 """
 
 from __future__ import annotations
@@ -57,7 +57,7 @@ async def _create_and_delete_project(client: AsyncClient) -> str:
 
 @pytest.mark.asyncio
 async def test_create_workflow_against_deleted_project_returns_404(jwt_client: AsyncClient) -> None:
-    """POST /workflows with a soft-deleted project_id must return 404."""
+    """POST /workflows with a deleted project_id must return 404."""
     project_id = await _create_and_delete_project(jwt_client)
 
     resp = await jwt_client.post(
@@ -80,7 +80,7 @@ async def test_create_credential_against_deleted_project_returns_404(
     jwt_client: AsyncClient,
     bearer_type: CredentialType,
 ) -> None:
-    """POST /credentials with a soft-deleted project_id must return 404."""
+    """POST /credentials with a deleted project_id must return 404."""
     project_id = await _create_and_delete_project(jwt_client)
 
     resp = await jwt_client.post(
@@ -101,7 +101,7 @@ async def test_create_credential_against_deleted_project_returns_404(
 
 @pytest.mark.asyncio
 async def test_create_role_against_deleted_project_is_rejected(admin_client: AsyncClient) -> None:
-    """POST /projects/{id}/roles with a soft-deleted project must be rejected.
+    """POST /projects/{id}/roles with a deleted project must be rejected.
 
     Uses admin_client to bypass authz and test the service-layer check.
     """
@@ -123,7 +123,7 @@ async def test_create_role_against_deleted_project_is_rejected(admin_client: Asy
 
 @pytest.mark.asyncio
 async def test_create_policy_against_deleted_project_is_rejected(admin_client: AsyncClient) -> None:
-    """POST /projects/{id}/policies with a soft-deleted project must be rejected.
+    """POST /projects/{id}/policies with a deleted project must be rejected.
 
     Uses admin_client to bypass authz and test the service-layer check.
     """
@@ -145,7 +145,7 @@ async def test_create_policy_against_deleted_project_is_rejected(admin_client: A
 
 @pytest.mark.asyncio
 async def test_create_role_toplevel_against_deleted_project_is_rejected(admin_client: AsyncClient) -> None:
-    """POST /roles with a soft-deleted project_id in the body must return 404.
+    """POST /roles with a deleted project_id in the body must return 404.
 
     Tests the top-level /roles endpoint (separate from /projects/{id}/roles).
     """
@@ -168,7 +168,7 @@ async def test_create_role_toplevel_against_deleted_project_is_rejected(admin_cl
 
 @pytest.mark.asyncio
 async def test_create_policy_toplevel_against_deleted_project_is_rejected(admin_client: AsyncClient) -> None:
-    """POST /policies with a soft-deleted project_id in the body must return 404.
+    """POST /policies with a deleted project_id in the body must return 404.
 
     Tests the top-level /policies endpoint (separate from /projects/{id}/policies).
     """
@@ -194,7 +194,7 @@ async def test_create_role_assignment_toplevel_against_deleted_project_is_reject
     admin_client: AsyncClient,
     test_user: User,
 ) -> None:
-    """POST /role_assignments with a soft-deleted project_id must return 404."""
+    """POST /role_assignments with a deleted project_id must return 404."""
     project_id = await _create_and_delete_project(admin_client)
 
     resp = await admin_client.post(
@@ -221,11 +221,7 @@ async def test_create_role_assignment_toplevel_against_deleted_project_is_reject
 
 @pytest.mark.asyncio
 async def test_permchecker_path_param_deleted_project_returns_404(jwt_client: AsyncClient) -> None:
-    """PermissionChecker with project_param rejects deleted projects with 404.
-
-    Covers path-based project_id (e.g. /projects/{id}/roles).
-    A non-admin user should get 404, not 403.
-    """
+    """PermissionChecker with project_param rejects deleted projects with 404."""
     project_id = await _create_and_delete_project(jwt_client)
 
     resp = await jwt_client.post(
@@ -239,11 +235,7 @@ async def test_permchecker_path_param_deleted_project_returns_404(jwt_client: As
 
 @pytest.mark.asyncio
 async def test_permchecker_body_field_deleted_project_returns_404(jwt_client: AsyncClient) -> None:
-    """PermissionChecker with body_project_field rejects deleted projects with 404.
-
-    Covers body-based project_id (e.g. POST /workflows with project_id in body).
-    A non-admin user should get 404, not 403.
-    """
+    """PermissionChecker with body_project_field rejects deleted projects with 404."""
     project_id = await _create_and_delete_project(jwt_client)
 
     resp = await jwt_client.post(

--- a/backend/tests/integration/api/test_projects.py
+++ b/backend/tests/integration/api/test_projects.py
@@ -298,7 +298,6 @@ async def test_admin_cannot_delete_default_project(
     assert body["title"] == "Default Project Protected"
 
     await test_db_session.refresh(default_project)
-    assert default_project.deleted_at is None
     assert default_project.is_default is True
 
     _auth_as(test_user)

--- a/backend/tests/integration/projects/services/test_project_service.py
+++ b/backend/tests/integration/projects/services/test_project_service.py
@@ -55,7 +55,6 @@ async def test_create_project(seeded_db: AsyncSession, test_user: User) -> None:
     assert project.name == "test-project"
     assert project.description == "A test project"
     assert project.labels == {"env": "dev"}
-    assert project.deleted_at is None
 
     # Creator should be assigned project-admin
     assignments = (await seeded_db.exec(select(RoleAssignment).where(RoleAssignment.project_id == project.id))).all()
@@ -94,7 +93,7 @@ async def test_get_project_not_found(seeded_db: AsyncSession, test_user: User) -
 
 @pytest.mark.asyncio
 async def test_get_deleted_project_not_found(seeded_db: AsyncSession, test_user: User) -> None:
-    """Getting a soft-deleted project raises SafeValueError."""
+    """Getting a hard-deleted project raises ProjectNotFoundError."""
     svc = ProjectService(seeded_db, test_user)
     project = await svc.create_project(name="deleted-project")
     await svc.delete_project(project.id)
@@ -253,7 +252,7 @@ async def test_update_project_partial(seeded_db: AsyncSession, test_user: User) 
 
 @pytest.mark.asyncio
 async def test_delete_project(seeded_db: AsyncSession, test_user: User) -> None:
-    """Soft-delete a project."""
+    """Hard-delete a project."""
     svc = ProjectService(seeded_db, test_user)
     project = await svc.create_project(name="delete-me")
     await svc.delete_project(project.id)
@@ -378,8 +377,8 @@ async def test_delete_project_hard_deletes_workflows(seeded_db: AsyncSession, te
 
 
 @pytest.mark.asyncio
-async def test_delete_project_cascades_executions(seeded_db: AsyncSession, test_user: User) -> None:
-    """Deleting a project cascade-deletes all executions with their workflows."""
+async def test_delete_project_hard_deletes_executions(seeded_db: AsyncSession, test_user: User) -> None:
+    """Deleting a project hard-deletes all executions within it."""
     svc = ProjectService(seeded_db, test_user)
     user_id = test_user.id
     project = await svc.create_project(name="cascade-executions")
@@ -416,62 +415,58 @@ async def test_delete_project_cascades_executions(seeded_db: AsyncSession, test_
     seeded_db.add(execution)
     await seeded_db.commit()
     exec_id = execution.id
-    version_id = wf_version.id
 
     await svc.delete_project(project.id)
 
     seeded_db.expire_all()
     ex = (await seeded_db.exec(select(Execution).where(Execution.id == exec_id))).first()
-    assert ex is None, "Execution should cascade-delete with its workflow when project is deleted"
-    ver = (await seeded_db.exec(select(WorkflowVersion).where(WorkflowVersion.id == version_id))).first()
-    assert ver is None, "WorkflowVersion should cascade-delete with its workflow when project is deleted"
+    assert ex is None
 
 
 @pytest.mark.asyncio
-async def test_delete_project_blocked_by_active_execution(seeded_db: AsyncSession, test_user: User) -> None:
-    """Deleting a project is blocked when one of its workflows has a non-terminal execution."""
-    from syntara.workflows.exceptions import WorkflowHasActiveExecutionsError
+async def test_delete_project_blocked_by_active_executions(seeded_db: AsyncSession, test_user: User) -> None:
+    """Deleting a project with non-terminal executions raises ProjectHasActiveExecutionsError."""
+    from syntara.authz.exceptions import ProjectHasActiveExecutionsError
 
     svc = ProjectService(seeded_db, test_user)
     user_id = test_user.id
-    project = await svc.create_project(name="cascade-blocked-active-exec")
+    project = await svc.create_project(name="active-execs-project")
 
-    workflow = Workflow(name="active-exec-workflow", project_id=project.id, created_by=user_id, labels={})
-    seeded_db.add(workflow)
-    await seeded_db.flush()
-
-    version = WorkflowVersion(
-        workflow_id=workflow.id,
-        version=1,
-        schema_version="2.0.0",
-        workflow_definition=create_minimal_workflow_definition(name="active-exec"),
+    workflow = Workflow(
+        name="active-workflow",
+        project_id=project.id,
         created_by=user_id,
         labels={},
     )
-    seeded_db.add(version)
+    seeded_db.add(workflow)
+    await seeded_db.flush()
+
+    wf_version = WorkflowVersion(
+        workflow_id=workflow.id,
+        version=1,
+        schema_version="2.0.0",
+        workflow_definition=create_minimal_workflow_definition(name="test-guard"),
+        created_by=user_id,
+        labels={},
+    )
+    seeded_db.add(wf_version)
     await seeded_db.flush()
 
     execution = Execution(
         workflow_id=workflow.id,
-        workflow_version_id=version.id,
+        workflow_version_id=wf_version.id,
         project_id=project.id,
-        created_by=user_id,
-        status="running",
         temporal_workflow_id=f"temporal-{uuid4().hex[:8]}",
+        status="running",
+        created_by=user_id,
         labels={},
     )
     seeded_db.add(execution)
     await seeded_db.commit()
-    workflow_id, execution_id = workflow.id, execution.id
 
-    with pytest.raises(WorkflowHasActiveExecutionsError):
+    with pytest.raises(ProjectHasActiveExecutionsError) as exc_info:
         await svc.delete_project(project.id)
-
-    seeded_db.expire_all()
-    wf = (await seeded_db.exec(select(Workflow).where(Workflow.id == workflow_id))).first()
-    assert wf is not None, "Workflow should still exist after blocked delete"
-    ex = (await seeded_db.exec(select(Execution).where(Execution.id == execution_id))).first()
-    assert ex is not None, "Execution should still exist after blocked delete"
+    assert exc_info.value.active_count == 1
 
 
 @pytest.mark.asyncio
@@ -711,7 +706,7 @@ async def test_delete_project_does_not_affect_other_projects(seeded_db: AsyncSes
     await svc.delete_project(p1_id)
 
     seeded_db.expire_all()
-    # p1 resources should be gone (hard-deleted)
+    # p1 resources should be fully deleted
     assert (await seeded_db.exec(select(Role).where(Role.project_id == p1_id))).all() == []
     wf1_row = (await seeded_db.exec(select(Workflow).where(Workflow.project_id == p1_id))).first()
     assert wf1_row is None
@@ -785,7 +780,6 @@ async def test_delete_default_project_raises(seeded_db: AsyncSession, test_user:
 
     # Still present and still the default after rejected delete
     await seeded_db.refresh(default_project)
-    assert default_project.deleted_at is None
     assert default_project.is_default is True
 
 

--- a/backend/tests/integration/websocket/test_websocket_project_scoped_auth.py
+++ b/backend/tests/integration/websocket/test_websocket_project_scoped_auth.py
@@ -216,24 +216,30 @@ class TestProjectScopedExecutionWebSocketAuthorization:
         self,
         test_db_session: AsyncSession,
         test_user: User,
-        test_project_id: UUID,
         sync_test_client: TestClient,
     ) -> None:
-        """WebSocket must reject when execution's project doesn't exist.
+        """WebSocket must reject when execution's project has been hard-deleted.
 
-        This tests the edge case where execution.project_id points to a
-        non-existent or soft-deleted project.
+        Create a real project + execution, then cascade-delete the project
+        (which removes the execution too). The stale execution ID should
+        cause the WebSocket to reject the connection.
         """
-        execution = await _create_execution(test_db_session, project_id=test_project_id, created_by=test_user.id)
+        from syntara.projects.service import ProjectService
 
-        # Soft-delete the project so the JOIN in resolve_resource_project returns no rows
-        project = await test_db_session.get(Project, test_project_id)
-        assert project is not None
-        from datetime import UTC, datetime
-
-        project.deleted_at = datetime.now(tz=UTC)
+        project = Project(name=f"ws-test-{uuid4().hex[:8]}", created_by=test_user.id)
         test_db_session.add(project)
+        await test_db_session.flush()
+
+        execution = await _create_execution(test_db_session, project_id=project.id, created_by=test_user.id)
+        stale_execution_id = execution.id
+
+        # Mark execution as terminal so _check_no_active_executions allows deletion
+        execution.status = ExecutionStatus.COMPLETED
+        test_db_session.add(execution)
         await test_db_session.commit()
+
+        service = ProjectService(session=test_db_session, user=test_user)
+        await service.delete_project(project.id)
 
         fake_user = User(
             id=uuid4(),
@@ -246,7 +252,7 @@ class TestProjectScopedExecutionWebSocketAuthorization:
         with (
             patch(_PATCH_AUTHN, AsyncMock(return_value=fake_user)),
             pytest.raises(WebSocketDisconnect) as exc_info,
-            sync_test_client.websocket_connect(f"{EXECUTION_WS_PATH}/{execution.id}?ticket=valid"),
+            sync_test_client.websocket_connect(f"{EXECUTION_WS_PATH}/{stale_execution_id}?ticket=valid"),
         ):
             pytest.fail("Connection should have been rejected - project not found")
 
@@ -337,20 +343,20 @@ class TestProjectScopedInvocationWebSocketAuthorization:
         self,
         test_db_session: AsyncSession,
         test_user: User,
-        test_project_id: UUID,
         sync_test_client: TestClient,
     ) -> None:
-        """WebSocket must reject when invocation's project doesn't exist or is soft-deleted."""
-        invocation = await _create_invocation(test_db_session, project_id=test_project_id, created_by=test_user.id)
+        """WebSocket must reject when invocation's project has been hard-deleted."""
+        from syntara.projects.service import ProjectService
 
-        # Soft-delete the project so the JOIN returns no rows
-        project = await test_db_session.get(Project, test_project_id)
-        assert project is not None
-        from datetime import UTC, datetime
-
-        project.deleted_at = datetime.now(tz=UTC)
+        project = Project(name=f"ws-test-{uuid4().hex[:8]}", created_by=test_user.id)
         test_db_session.add(project)
-        await test_db_session.commit()
+        await test_db_session.flush()
+
+        invocation = await _create_invocation(test_db_session, project_id=project.id, created_by=test_user.id)
+        stale_invocation_id = invocation.id
+
+        service = ProjectService(session=test_db_session, user=test_user)
+        await service.delete_project(project.id)
 
         fake_user = User(
             id=uuid4(),
@@ -363,7 +369,7 @@ class TestProjectScopedInvocationWebSocketAuthorization:
         with (
             patch(_PATCH_AUTHN, AsyncMock(return_value=fake_user)),
             pytest.raises(WebSocketDisconnect) as exc_info,
-            sync_test_client.websocket_connect(f"{INVOCATION_WS_PATH}/{invocation.id}?ticket=valid"),
+            sync_test_client.websocket_connect(f"{INVOCATION_WS_PATH}/{stale_invocation_id}?ticket=valid"),
         ):
             pytest.fail("Connection should have been rejected - project not found")
 

--- a/backend/tests/unit/files/test_file_manager_delete.py
+++ b/backend/tests/unit/files/test_file_manager_delete.py
@@ -173,22 +173,8 @@ class TestFileManagerIsProjectDeleted:
     """Tests for FileManager.is_project_deleted orphan detection."""
 
     @pytest.mark.asyncio
-    async def test_is_project_deleted_true_when_deleted_at_set(self, file_manager_with_retriever: FileManager) -> None:
-        from datetime import UTC, datetime
-
+    async def test_is_project_deleted_false_when_project_exists(self, file_manager_with_retriever: FileManager) -> None:
         project = Mock()
-        project.deleted_at = datetime.now(UTC)
-        session = AsyncMock()
-        result = Mock()
-        result.one_or_none = Mock(return_value=project)
-        session.exec = AsyncMock(return_value=result)
-
-        assert await file_manager_with_retriever.is_project_deleted(uuid4(), session) is True
-
-    @pytest.mark.asyncio
-    async def test_is_project_deleted_false_when_active(self, file_manager_with_retriever: FileManager) -> None:
-        project = Mock()
-        project.deleted_at = None
         session = AsyncMock()
         result = Mock()
         result.one_or_none = Mock(return_value=project)
@@ -224,19 +210,11 @@ class TestFileManagerBatchIsProjectDeleted:
         file_manager_with_retriever: FileManager,
         scenario: str,
     ) -> None:
-        from datetime import UTC, datetime
-
-        active_id = uuid4()
-        soft_id = uuid4()
+        existing_id = uuid4()
         missing_id = uuid4()
 
-        active = Mock()
-        active.id = active_id
-        active.deleted_at = None
-
-        soft = Mock()
-        soft.id = soft_id
-        soft.deleted_at = datetime.now(UTC)
+        existing = Mock()
+        existing.id = existing_id
 
         session = AsyncMock()
         query_result = Mock()
@@ -248,15 +226,15 @@ class TestFileManagerBatchIsProjectDeleted:
             return
 
         if scenario == "mapped":
-            query_result.all = Mock(return_value=[active, soft])
+            query_result.all = Mock(return_value=[existing])
             session.exec = AsyncMock(return_value=query_result)
-            result = await file_manager_with_retriever.batch_is_project_deleted({active_id, soft_id}, session)
-            assert result == {active_id: False, soft_id: True}
+            result = await file_manager_with_retriever.batch_is_project_deleted({existing_id}, session)
+            assert result == {existing_id: False}
             session.exec.assert_awaited_once()
             return
 
-        query_result.all = Mock(return_value=[active])
+        query_result.all = Mock(return_value=[existing])
         session.exec = AsyncMock(return_value=query_result)
-        result = await file_manager_with_retriever.batch_is_project_deleted({active_id, missing_id}, session)
-        assert result == {active_id: False, missing_id: True}
+        result = await file_manager_with_retriever.batch_is_project_deleted({existing_id, missing_id}, session)
+        assert result == {existing_id: False, missing_id: True}
         session.exec.assert_awaited_once()

--- a/backend/tests/unit/integrations/services/test_integration_project_assignment.py
+++ b/backend/tests/unit/integrations/services/test_integration_project_assignment.py
@@ -1,7 +1,6 @@
 """Unit tests for integration project assignment operations."""
 
 from collections.abc import Generator
-from datetime import UTC, datetime
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -114,21 +113,6 @@ class TestAssignProject:
         fake_project_id = uuid4()
         with pytest.raises(ProjectNotFoundError):
             await integration_service.assign_project(integration_id, fake_project_id)
-
-    @pytest.mark.asyncio
-    async def test_assign_soft_deleted_project_raises(
-        self, test_db_session: AsyncSession, integration_service: IntegrationService
-    ) -> None:
-        project = await _create_project(test_db_session)
-        created = await integration_service.create_integration(_mcp_create(scope=IntegrationScope.PROJECT))
-        integration_id, project_id = created.id, project.id
-
-        project.deleted_at = datetime.now(UTC)
-        test_db_session.add(project)
-        await test_db_session.flush()
-
-        with pytest.raises(ProjectNotFoundError):
-            await integration_service.assign_project(integration_id, project_id)
 
     @pytest.mark.asyncio
     async def test_assign_multiple_projects(

--- a/backend/tests/unit/service_accounts/test_service_account_service.py
+++ b/backend/tests/unit/service_accounts/test_service_account_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import UTC
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
@@ -300,27 +299,12 @@ class TestToReadConversion:
         sa = ServiceAccount(name="test", project_id=project_id, created_by=uuid4())
 
         mock_result = MagicMock()
-        mock_result.first.return_value = ("My Project", None)
+        mock_result.first.return_value = "My Project"
         mock_session.exec.return_value = mock_result
 
         read = await service.to_read(sa)
         assert read.project_name == "My Project"
         assert read.is_project_deleted is False
-
-    @pytest.mark.asyncio
-    async def test_to_read_marks_deleted_project(self, service: ServiceAccountService, mock_session: AsyncMock) -> None:
-        from datetime import datetime
-
-        project_id = uuid4()
-        sa = ServiceAccount(name="test", project_id=project_id, created_by=uuid4())
-
-        mock_result = MagicMock()
-        mock_result.first.return_value = ("Old Project", datetime(2026, 1, 1, tzinfo=UTC))
-        mock_session.exec.return_value = mock_result
-
-        read = await service.to_read(sa)
-        assert read.project_name == "Old Project"
-        assert read.is_project_deleted is True
 
     @pytest.mark.asyncio
     async def test_to_read_handles_missing_project(
@@ -354,8 +338,8 @@ class TestResolveProjectInfosBatch:
         proj_b = uuid4()
         mock_result = MagicMock()
         mock_result.all.return_value = [
-            (proj_a, "Project A", None),
-            (proj_b, "Project B", None),
+            (proj_a, "Project A"),
+            (proj_b, "Project B"),
         ]
         mock_session.exec.return_value = mock_result
 
@@ -364,26 +348,12 @@ class TestResolveProjectInfosBatch:
         assert result[proj_b] == ("Project B", False)
 
     @pytest.mark.asyncio
-    async def test_marks_deleted_projects(self, service: ServiceAccountService, mock_session: AsyncMock) -> None:
-        from datetime import datetime
-
-        proj_id = uuid4()
-        mock_result = MagicMock()
-        mock_result.all.return_value = [
-            (proj_id, "Deleted Project", datetime(2026, 1, 1, tzinfo=UTC)),
-        ]
-        mock_session.exec.return_value = mock_result
-
-        result = await service._resolve_project_infos({proj_id})
-        assert result[proj_id] == ("Deleted Project", True)
-
-    @pytest.mark.asyncio
     async def test_missing_projects_omitted(self, service: ServiceAccountService, mock_session: AsyncMock) -> None:
         existing = uuid4()
         missing = uuid4()
         mock_result = MagicMock()
         mock_result.all.return_value = [
-            (existing, "Exists", None),
+            (existing, "Exists"),
         ]
         mock_session.exec.return_value = mock_result
 
@@ -421,7 +391,7 @@ class TestListServiceAccounts:
             mp.setattr(service, "list_resources", AsyncMock(return_value=mock_response))
 
             mock_result = MagicMock()
-            mock_result.all.return_value = [(proj_id, "My Project", None)]
+            mock_result.all.return_value = [(proj_id, "My Project")]
             mock_session.exec.return_value = mock_result
 
             response = await service.list_service_accounts()
@@ -430,14 +400,12 @@ class TestListServiceAccounts:
         assert response.resources[0].is_project_deleted is False
 
     @pytest.mark.asyncio
-    async def test_list_marks_deleted_project(
+    async def test_list_handles_hard_deleted_project(
         self,
         service: ServiceAccountService,
         mock_session: AsyncMock,
         override_runtime_settings: Callable[..., AbstractContextManager[object]],
     ) -> None:
-        from datetime import datetime
-
         proj_id = uuid4()
         sa_read = ServiceAccountRead(
             id=uuid4(),
@@ -457,13 +425,13 @@ class TestListServiceAccounts:
             mp.setattr(service, "list_resources", AsyncMock(return_value=mock_response))
 
             mock_result = MagicMock()
-            mock_result.all.return_value = [(proj_id, "Old Project", datetime(2026, 1, 1, tzinfo=UTC))]
+            mock_result.all.return_value = []
             mock_session.exec.return_value = mock_result
 
             response = await service.list_service_accounts()
 
-        assert response.resources[0].project_name == "Old Project"
-        assert response.resources[0].is_project_deleted is True
+        assert response.resources[0].project_name is None
+        assert response.resources[0].is_project_deleted is False
 
     @pytest.mark.asyncio
     async def test_list_handles_missing_project(

--- a/frontend/packages/syntara-contracts/src/projects-api.ts
+++ b/frontend/packages/syntara-contracts/src/projects-api.ts
@@ -52,7 +52,7 @@ export interface paths {
     post?: never
     /**
      * Delete project
-     * @description Delete a project (soft-delete). Requires: project:delete permission scoped to this project.
+     * @description Delete a project (hard-delete). Requires: project:delete permission scoped to this project.
      */
     delete: operations['delete_project']
     options?: never

--- a/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows-project-actions.spec.ts
@@ -145,8 +145,8 @@ test.describe('Workflows Page - Project Actions in All Projects View', () => {
       const deleteDialog = app.getByRole('dialog', { name: /Delete project/i })
       await expect(deleteDialog).toBeVisible()
       await expect(deleteDialog.getByText(projectName)).toBeVisible()
-      await expect(deleteDialog.getByText(/workflows.*permanently deleted/i)).toBeVisible()
-      await expect(deleteDialog.getByText(/role assignments.*removed/i)).toBeVisible()
+      await expect(deleteDialog.getByText(/Workflows, executions, and approval requests/i)).toBeVisible()
+      await expect(deleteDialog.getByText(/Role assignments, project roles, and policies/i)).toBeVisible()
 
       // Verify destructive acknowledgement checkbox is required
       const confirmButton = deleteDialog.getByRole('button', { name: 'Delete' })

--- a/frontend/packages/syntara-ui/src/routes/access-management/ProjectsTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/ProjectsTab.test.tsx
@@ -320,10 +320,10 @@ describe('ProjectsTab', () => {
 
       const dialog = screen.getByRole('dialog')
       expect(within(dialog).getByText('Alpha')).toBeInTheDocument()
-      expect(within(dialog).getByText(/will be deleted/)).toBeInTheDocument()
+      expect(within(dialog).getByText(/will be deleted\. This cannot be undone\./)).toBeInTheDocument()
       expect(
         within(dialog).getByRole('checkbox', {
-          name: 'I understand this project, its workflows, and role assignments will be permanently deleted or removed.',
+          name: 'I understand this project and the resources listed above will be permanently deleted.',
         })
       ).toBeInTheDocument()
     })
@@ -341,7 +341,7 @@ describe('ProjectsTab', () => {
 
       const dialog = await screen.findByRole('dialog')
       expect(within(dialog).getByText('Beta')).toBeInTheDocument()
-      expect(within(dialog).getByText(/will be deleted/)).toBeInTheDocument()
+      expect(within(dialog).getByText(/will be deleted\. This cannot be undone\./)).toBeInTheDocument()
     })
   })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/ProjectsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/ProjectsTab.tsx
@@ -1,4 +1,4 @@
-import { Button, Content, List, ListItem, Stack, StackItem, Truncate } from '@patternfly/react-core'
+import { Button, Content, Truncate } from '@patternfly/react-core'
 import { RhUiAddIcon, RhUiEditFillIcon, RhUiTrashIcon } from '@patternfly/react-icons'
 import { ActionsColumn, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import type { IAction, ThProps } from '@patternfly/react-table'
@@ -6,7 +6,6 @@ import { useNavigate } from '@tanstack/react-router'
 import { useCallback, useMemo } from 'react'
 
 import { AppRoute } from '../../app/AppRoute'
-import { SynConfirmationDialog } from '../../components/dialogs/SynConfirmationDialog'
 import { DisabledWithTooltip } from '../../components/DisabledWithTooltip'
 import { IconLabel } from '../../components/IconLabel'
 import { SynListPanelTable, SynListPanelToolbar, SynListPanelView } from '../../components/panels/list/SynListPanel'
@@ -24,6 +23,7 @@ import { accessClient } from '../access/accessClient'
 import type { ProjectRead } from '../access/types'
 
 import { ProjectFormModal } from './ProjectFormModal'
+import { ProjectDeleteDialog } from './projects/ProjectDeleteDialog'
 import { useProjectPermissions } from './useProjectPermissions'
 
 const filterFieldDefinitions: FilterFieldDefinition[] = [
@@ -141,50 +141,6 @@ function ProjectsTable({
         ))}
       </Tbody>
     </>
-  )
-}
-
-function DeleteProjectDialog({
-  project,
-  isOpen,
-  onClose,
-  onDelete,
-}: Readonly<{
-  project: ProjectRead | null
-  isOpen: boolean
-  onClose: () => void
-  onDelete: () => void
-}>) {
-  return (
-    <SynConfirmationDialog
-      isOpen={isOpen}
-      onClose={onClose}
-      onConfirm={onDelete}
-      title="Delete project?"
-      confirmLabel="Delete"
-      confirmVariant="danger"
-      titleIconVariant="warning"
-      destructiveAcknowledgement={{
-        checkboxId: 'delete-project-ack',
-        label: 'I understand this project, its workflows, and role assignments will be permanently deleted or removed.',
-      }}
-    >
-      <Stack hasGutter>
-        <StackItem>
-          The project <strong>{project?.name}</strong> will be deleted. This cannot be undone.
-        </StackItem>
-        <StackItem>
-          <List>
-            <ListItem>All workflows in this project will be permanently deleted.</ListItem>
-            <ListItem>All project role assignments will be removed.</ListItem>
-            <ListItem>
-              Uploaded files are kept after the project is deleted. There is no in-product list or delete flow for them
-              yet.
-            </ListItem>
-          </List>
-        </StackItem>
-      </Stack>
-    </SynConfirmationDialog>
   )
 }
 
@@ -329,11 +285,11 @@ export function ProjectsTab() {
         onSuccess={refetch}
       />
 
-      <DeleteProjectDialog
-        project={deleteDialog.item}
+      <ProjectDeleteDialog
+        projectName={deleteDialog.item?.name}
         isOpen={deleteDialog.isOpen}
         onClose={deleteDialog.close}
-        onDelete={handleDelete}
+        onConfirm={handleDelete}
       />
     </>
   )

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectDeleteDialog.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectDeleteDialog.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { ProjectDeleteDialog } from './ProjectDeleteDialog'
+
+describe('ProjectDeleteDialog', () => {
+  it('has no accessibility violations when open', async () => {
+    const { baseElement } = render(
+      <ProjectDeleteDialog isOpen projectName="My Project" onClose={vi.fn()} onConfirm={vi.fn()} />
+    )
+
+    expect(await axe(baseElement)).toHaveNoViolations()
+  })
+
+  it('renders project name and cascade consequence list', () => {
+    render(<ProjectDeleteDialog isOpen projectName="My Project" onClose={vi.fn()} onConfirm={vi.fn()} />)
+
+    expect(screen.getByText('Delete project?')).toBeInTheDocument()
+    expect(screen.getByText('My Project')).toBeInTheDocument()
+    expect(screen.getByText(/will be deleted\. This cannot be undone\./)).toBeInTheDocument()
+    expect(screen.getByText('Resources that will be deleted:')).toBeInTheDocument()
+    expect(screen.getByText('Workflows, executions, and approval requests')).toBeInTheDocument()
+    expect(screen.getByText('Credentials and service accounts')).toBeInTheDocument()
+    expect(screen.getByText('Uploaded files')).toBeInTheDocument()
+    expect(screen.getByText('Role assignments, project roles, and policies')).toBeInTheDocument()
+    expect(screen.getByText('Integration assignments for this project')).toBeInTheDocument()
+  })
+
+  it('keeps Delete disabled until acknowledgement is checked, then calls onConfirm', async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+    const onClose = vi.fn()
+
+    render(<ProjectDeleteDialog isOpen projectName="My Project" onClose={onClose} onConfirm={onConfirm} />)
+
+    const dialog = screen.getByRole('dialog')
+    const deleteButton = within(dialog).getByRole('button', { name: 'Delete' })
+
+    expect(deleteButton).toBeDisabled()
+
+    await user.click(
+      within(dialog).getByRole('checkbox', {
+        name: /I understand this project and the resources listed above will be permanently deleted/,
+      })
+    )
+
+    expect(deleteButton).toBeEnabled()
+    await user.click(deleteButton)
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectDeleteDialog.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectDeleteDialog.tsx
@@ -1,0 +1,60 @@
+import { List, ListItem, Stack, StackItem } from '@patternfly/react-core'
+import { useId } from 'react'
+
+import { SynConfirmationDialog } from '../../../components/dialogs/SynConfirmationDialog'
+
+const DESTRUCTIVE_ACK_LABEL = 'I understand this project and the resources listed above will be permanently deleted.'
+
+export type ProjectDeleteDialogProps = Readonly<{
+  isOpen: boolean
+  projectName: string | undefined
+  onClose: () => void
+  onConfirm: () => void
+  confirmLoading?: boolean
+}>
+
+/**
+ * Delete confirmation for a project — shared by ProjectsTab, ProjectDetail, and WorkflowDialogs.
+ */
+export function ProjectDeleteDialog({
+  isOpen,
+  projectName,
+  onClose,
+  onConfirm,
+  confirmLoading,
+}: ProjectDeleteDialogProps) {
+  const ackCheckboxId = useId()
+
+  return (
+    <SynConfirmationDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title="Delete project?"
+      confirmLabel="Delete"
+      confirmVariant="danger"
+      titleIconVariant="warning"
+      confirmLoading={confirmLoading}
+      destructiveAcknowledgement={{
+        checkboxId: ackCheckboxId,
+        label: DESTRUCTIVE_ACK_LABEL,
+      }}
+    >
+      <Stack hasGutter>
+        <StackItem>
+          The project <strong>{projectName}</strong> will be deleted. This cannot be undone.
+        </StackItem>
+        <StackItem>Resources that will be deleted:</StackItem>
+        <StackItem>
+          <List>
+            <ListItem>Workflows, executions, and approval requests</ListItem>
+            <ListItem>Credentials and service accounts</ListItem>
+            <ListItem>Uploaded files</ListItem>
+            <ListItem>Role assignments, project roles, and policies</ListItem>
+            <ListItem>Integration assignments for this project</ListItem>
+          </List>
+        </StackItem>
+      </Stack>
+    </SynConfirmationDialog>
+  )
+}

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectDetail.tsx
@@ -8,10 +8,6 @@ import {
   FlexItem,
   Label,
   LabelGroup,
-  List,
-  ListItem,
-  Stack,
-  StackItem,
   Tab,
   TabTitleText,
 } from '@patternfly/react-core'
@@ -21,7 +17,6 @@ import { useMemo, useState } from 'react'
 
 import { AppRoute } from '../../../app/AppRoute'
 import { breadcrumbsProjectDetail, breadcrumbsProjectDetailEarlyShell } from '../../../app/breadcrumbBuilders'
-import { SynConfirmationDialog } from '../../../components/dialogs/SynConfirmationDialog'
 import { DisabledWithTooltip } from '../../../components/DisabledWithTooltip'
 import { IconLabel } from '../../../components/IconLabel'
 import { SynLabel } from '../../../components/labels/SynLabel'
@@ -43,6 +38,7 @@ import { DetailPageShell } from '../DetailPageShell'
 import { ProjectFormModal } from '../ProjectFormModal'
 import { useProjectPermissions } from '../useProjectPermissions'
 
+import { ProjectDeleteDialog } from './ProjectDeleteDialog'
 import { ProjectNotFoundState } from './ProjectNotFoundState'
 import { ProjectRoleAssignmentsTab } from './ProjectRoleAssignmentsTab'
 import { useProjectDetailPermissions } from './useProjectDetailPermissions'
@@ -261,36 +257,12 @@ export function ProjectDetail() {
         }}
       />
 
-      <SynConfirmationDialog
+      <ProjectDeleteDialog
+        projectName={deleteDialog.item?.name}
         isOpen={deleteDialog.isOpen}
         onClose={deleteDialog.close}
         onConfirm={() => handleDelete(deleteDialog.item)}
-        title="Delete project?"
-        confirmLabel="Delete"
-        confirmVariant="danger"
-        titleIconVariant="warning"
-        destructiveAcknowledgement={{
-          checkboxId: 'delete-project-detail-ack',
-          label:
-            'I understand this project, its workflows, and role assignments will be permanently deleted or removed.',
-        }}
-      >
-        <Stack hasGutter>
-          <StackItem>
-            The project <strong>{deleteDialog.item?.name}</strong> will be deleted. This cannot be undone.
-          </StackItem>
-          <StackItem>
-            <List>
-              <ListItem>All workflows in this project will be permanently deleted.</ListItem>
-              <ListItem>All project role assignments will be removed.</ListItem>
-              <ListItem>
-                Uploaded files are kept after the project is deleted. There is no in-product list or delete flow for
-                them yet.
-              </ListItem>
-            </List>
-          </StackItem>
-        </Stack>
-      </SynConfirmationDialog>
+      />
     </SynPage>
   )
 }

--- a/frontend/packages/syntara-ui/src/routes/workflows/WorkflowDialogs.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/WorkflowDialogs.tsx
@@ -1,4 +1,3 @@
-import { List, ListItem, Stack, StackItem } from '@patternfly/react-core'
 import type { WorkflowAPI } from '@syntara/contracts'
 import { useCallback, useState } from 'react'
 
@@ -8,6 +7,7 @@ import { useAlerts } from '../../providers/alerts'
 import { detachPromise } from '../../utils/detachPromise'
 import type { ProjectRead } from '../access/types'
 import { ProjectFormModal } from '../access-management/ProjectFormModal'
+import { ProjectDeleteDialog } from '../access-management/projects/ProjectDeleteDialog'
 import { RunWorkflowModal } from '../builder/components/RunWorkflowModal'
 import { PublishWorkflowDialog } from '../builder/PublishWorkflowDialog'
 import { hasNonEmptyInputSchema } from '../builder/utils/triggerReferenceCheck'
@@ -224,42 +224,17 @@ export function WorkflowDialogs({
         }}
       />
 
-      <SynConfirmationDialog
+      <ProjectDeleteDialog
+        projectName={projectDeleteDialog.item?.name}
         isOpen={projectDeleteDialog.isOpen}
         onClose={projectDeleteDialog.close}
         onConfirm={() => {
           if (projectDeleteDialog.item) {
             onDeleteProject(projectDeleteDialog.item)
           }
-          // Dialog closes in onSettled callback passed to useProjectActions
         }}
-        title="Delete project?"
-        confirmLabel="Delete"
-        confirmVariant="danger"
-        titleIconVariant="warning"
         confirmLoading={isDeletingProject}
-        destructiveAcknowledgement={{
-          checkboxId: 'delete-project-ack',
-          label:
-            'I understand this project, its workflows, and role assignments will be permanently deleted or removed.',
-        }}
-      >
-        <Stack hasGutter>
-          <StackItem>
-            The project <strong>{projectDeleteDialog.item?.name}</strong> will be deleted. This cannot be undone.
-          </StackItem>
-          <StackItem>
-            <List>
-              <ListItem>All workflows in this project will be permanently deleted.</ListItem>
-              <ListItem>All project role assignments will be removed.</ListItem>
-              <ListItem>
-                Uploaded files are kept after the project is deleted. There is no in-product list or delete flow for
-                them yet.
-              </ListItem>
-            </List>
-          </StackItem>
-        </Stack>
-      </SynConfirmationDialog>
+      />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Convert the `Project` model from soft delete to hard delete, per the cascade-everything decision from the 2026-08-20 meeting
- `delete_project()` now permanently removes the project and cascade-deletes all child resources (workflows, executions, invocations, credentials, files, service accounts, role assignments, roles, policies)
- External side-effects (Temporal schedules, file storage) are cleaned up best-effort before deletion
- The audit log (OTEL/Hotel) serves as the historical record

## Changes

**Model** (`authz/models/project.py`):
- Removed `SoftDeletableResource` inheritance
- Replaced partial unique index (`WHERE deleted_at IS NULL`) with plain `UniqueConstraint("name")`

**Service** (`projects/service.py`):
- Rewrote `delete_project()` to hard-delete via `session.delete()`
- Rewrote `_cascade_cleanup_project_resources()` to cascade-delete all children
- Added `_cleanup_temporal_schedules()` and `_cleanup_file_storage()` for best-effort external cleanup
- Preserved credential-integration guard (`_check_credentials_not_referenced_by_integrations`)

**Migration** (`f1b3c7d9e2a4_project_hard_delete.py`):
- Purges any existing soft-deleted project rows (with child cascade)
- Drops partial unique index, creates plain unique constraint
- Drops `deleted_at` / `deleted_by` columns from `projects` table

**14 source files**: Removed `Project.deleted_at.is_(None)` filter conditions from all queries

**6 test files**: Updated assertions from soft-delete to hard-delete behavior

## Related
- Jira: [AAP-72954](https://redhat.atlassian.net/browse/AAP-72954)
- Depends on PR #35 (workflow hard delete) being merged
- Follow up PR #485 (user/group hard delete) depends on this

## Test plan
- [ ] Integration tests for project deletion pass (`test_project_service.py`)
- [ ] Orphaned resource tests updated (`test_orphaned_project_resources.py`)
- [ ] WebSocket auth tests pass with hard-deleted projects
- [ ] Migration upgrades and downgrades cleanly
- [ ] Verify no remaining `Project.deleted_at` references in codebase


Made with [Cursor](https://cursor.com)