### PR TITLE
chore(deps): align typescript-eslint to ^8.61.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4394,17 +4394,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
+      "integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/type-utils": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/type-utils": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4417,20 +4417,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/parser": "^8.69.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4445,14 +4445,14 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4463,9 +4463,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4480,9 +4480,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4494,16 +4494,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.69.0",
+        "@typescript-eslint/tsconfig-utils": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4522,16 +4522,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+      "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4546,13 +4546,13 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.69.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4574,16 +4574,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+      "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4599,14 +4599,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4621,14 +4621,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4639,9 +4639,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4656,9 +4656,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4670,16 +4670,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.69.0",
+        "@typescript-eslint/tsconfig-utils": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4698,13 +4698,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.69.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4773,15 +4773,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
+      "integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4798,14 +4798,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4820,14 +4820,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4838,9 +4838,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4855,9 +4855,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4869,16 +4869,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.69.0",
+        "@typescript-eslint/tsconfig-utils": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4897,16 +4897,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+      "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4921,13 +4921,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.69.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -15529,16 +15529,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
-      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
+      "integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.2",
-        "@typescript-eslint/parser": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2"
+        "@typescript-eslint/eslint-plugin": "8.69.0",
+        "@typescript-eslint/parser": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15553,14 +15553,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -15575,14 +15575,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15593,9 +15593,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15610,9 +15610,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15624,16 +15624,16 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.69.0",
+        "@typescript-eslint/tsconfig-utils": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -15652,16 +15652,16 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+      "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15676,13 +15676,13 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.69.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -16616,7 +16616,7 @@
         "@eslint/js": "^10.0.1",
         "eslint": "^10.9.0",
         "openapi-typescript": "^7.13.0",
-        "typescript-eslint": "~8.58.1"
+        "typescript-eslint": "^8.61.0"
       }
     },
     "packages/syntara-mock-api": {
@@ -16636,119 +16636,6 @@
         "@types/node": "^25.6.0",
         "eslint": "^10.9.0",
         "typescript-eslint": "^8.61.0"
-      }
-    },
-    "packages/syntara-mock-api/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/type-utils": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
-        "ignore": "^7.0.5",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.65.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "packages/syntara-mock-api/node_modules/@typescript-eslint/parser": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "packages/syntara-mock-api/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "debug": "^4.4.3",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "packages/syntara-mock-api/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "packages/syntara-mock-api/node_modules/typescript-eslint": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
-      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.65.0",
-        "@typescript-eslint/parser": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "packages/syntara-ui": {
@@ -16827,7 +16714,7 @@
         "storybook": "^10.5.10",
         "tsx": "^4.22.3",
         "typescript": "~5.9.3",
-        "typescript-eslint": "~8.58.1",
+        "typescript-eslint": "^8.61.0",
         "vite": "^7.3.2",
         "vite-plugin-svgr": "^4.5.0",
         "vitest": "^4.1.10",

--- a/frontend/packages/syntara-contracts/package.json
+++ b/frontend/packages/syntara-contracts/package.json
@@ -39,6 +39,6 @@
     "@eslint/js": "^10.0.1",
     "eslint": "^10.9.0",
     "openapi-typescript": "^7.13.0",
-    "typescript-eslint": "~8.58.1"
+    "typescript-eslint": "^8.61.0"
   }
 }

--- a/frontend/packages/syntara-mock-api/package.json
+++ b/frontend/packages/syntara-mock-api/package.json
@@ -11,8 +11,8 @@
     "podman:run": "podman run --rm -p 3000:3000 syntara-mock-api"
   },
   "dependencies": {
-    "@syntara/contracts": "file:../syntara-contracts",
     "@mswjs/http-middleware": "^0.10.3",
+    "@syntara/contracts": "file:../syntara-contracts",
     "jmespath": "^0.16.0",
     "js-yaml": "^4.1.1",
     "msw": "^2.14.6",

--- a/frontend/packages/syntara-ui/e2e/helpers/approvals.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/approvals.ts
@@ -81,5 +81,5 @@ export async function navigateToApprovalAndOpen(app: Page, approvalName: string)
   await expect(approvalLink).toBeVisible({ timeout: 15_000 })
   await approvalLink.click()
 
-  await waitForApprovalPanel(app)
+  await waitForApprovalPanel(app, 30_000)
 }

--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -8,7 +8,7 @@
  */
 import { type Page } from '../fixtures'
 import { test, expect, toAppUrl } from '../fixtures'
-import { applyApprovalNameFilter } from '../helpers/approvals'
+import { applyApprovalNameFilter, dismissConnectionBanner, navigateToApprovalAndOpen } from '../helpers/approvals'
 import { APP_TITLE } from '../helpers/appTitle'
 import { addApprovalNodeWithBranch } from '../helpers/v2-nodes'
 import { runWorkflowFromBuilder, waitForExecutionPaused } from '../helpers/workflow-run'
@@ -371,120 +371,54 @@ test.describe('Approval Workflow Operations', () => {
   })
 
   test('user changes decision from approve to reject (undo)', async ({ app }) => {
-    // Create a pending approval to test undo behavior
+    test.slow()
     const approval = await createPendingApproval(app)
 
     try {
-      // Navigate to approvals page
-      await app.goto(toAppUrl('/approvals'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+      await navigateToApprovalAndOpen(app, approval.approvalName)
+      await dismissConnectionBanner(app)
 
-      const table = app.getByRole('grid', { name: 'Approvals table' })
-      await table.waitFor({ state: 'visible', timeout: 15_000 })
-
-      // Filter to show only our test approval
-      await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      // Wait for filter chip to confirm filter was applied and table to refresh
-      await expect(app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })).toBeVisible({
-        timeout: 15_000,
-      })
-
-      // Step 1: Click on the pending approval to open side panel
-      const approvalLink = table.getByRole('link', { name: approval.approvalName })
-      await approvalLink.waitFor({ state: 'visible', timeout: 10_000 })
-      await approvalLink.click()
-
-      // Step 2: Verify navigation to execution detail with side panel
-      await expect(app).toHaveURL(/\/executions\/[^?]+\?approval=/, { timeout: 15_000 })
-      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
-
-      // Step 3: Click "Approve" button
       const approveButton = app.getByRole('button', { name: 'Approve', exact: true })
-      await expect(approveButton).toBeVisible({ timeout: 15_000 })
-      await approveButton.click()
-
-      // Step 4: Verify approval notes field appears
-      const approvalNotesInput = app.getByPlaceholder(/explain.*reason.*approving|optional.*note/i)
-      await expect(approvalNotesInput).toBeVisible({ timeout: 10_000 })
-
-      // Step 5: Click "Reject" to undo the approve decision
       const rejectButton = app.getByRole('button', { name: 'Reject', exact: true })
+      await expect(approveButton).not.toHaveAttribute('aria-disabled', 'true', { timeout: 20_000 })
+
+      await approveButton.click()
+      await expect(app.getByPlaceholder(/Explain the reason for approving/i)).toBeVisible({ timeout: 10_000 })
+      // Pending approve hides the action buttons; undo clears the draft before choosing reject.
+      await expect(rejectButton).not.toBeVisible()
+
+      await app.getByRole('button', { name: 'Undo decision' }).click()
+      await expect(approveButton).toBeVisible({ timeout: 10_000 })
       await expect(rejectButton).toBeVisible({ timeout: 10_000 })
+      await expect(rejectButton).not.toHaveAttribute('aria-disabled', 'true', { timeout: 20_000 })
+
       await rejectButton.click()
-
-      // Step 6: Verify rejection notes field appears (approval notes replaced)
-      const rejectionNotesInput = app.getByPlaceholder(/explain.*reason.*rejecting|optional.*note/i)
-      await expect(rejectionNotesInput).toBeVisible({ timeout: 10_000 })
-
-      // Step 7: Verify approval notes field is no longer visible
-      await expect(approvalNotesInput).not.toBeVisible()
-
-      // Step 8: Verify "Submit decision" button is available for rejection
-      const submitButton = app.getByRole('button', { name: 'Submit decision' })
-      await expect(submitButton).toBeVisible({ timeout: 10_000 })
-
-      // NOTE: This test verifies undo behavior (switching between approve/reject)
-      // without actually submitting to avoid mutating approval state
+      await expect(app.getByPlaceholder(/Explain the reason for rejecting/i)).toBeVisible({ timeout: 10_000 })
+      await expect(app.getByRole('button', { name: 'Submit decision' })).toBeVisible({ timeout: 10_000 })
     } finally {
-      // Cleanup: delete created workflow
       await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
     }
   })
 
   test('user clears decision with explicit undo button', async ({ app }) => {
-    // Create a pending approval to test undo/clear behavior
+    test.slow()
     const approval = await createPendingApproval(app)
 
     try {
-      // Navigate to approvals page
-      await app.goto(toAppUrl('/approvals'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+      await navigateToApprovalAndOpen(app, approval.approvalName)
+      await dismissConnectionBanner(app)
 
-      const table = app.getByRole('grid', { name: 'Approvals table' })
-      await table.waitFor({ state: 'visible', timeout: 15_000 })
-
-      // Filter to show only our test approval
-      await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      // Click on the pending approval
-      const approvalLink = table.getByRole('link', { name: approval.approvalName })
-      await approvalLink.waitFor({ state: 'visible', timeout: 10_000 })
-      await approvalLink.click()
-      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
-
-      // Step 1: Click "Approve"
       const approveButton = app.getByRole('button', { name: 'Approve', exact: true })
+      await expect(approveButton).not.toHaveAttribute('aria-disabled', 'true', { timeout: 20_000 })
       await approveButton.click()
-      await expect(app.getByPlaceholder(/explain.*reason.*approving/i)).toBeVisible()
+      await expect(app.getByPlaceholder(/Explain the reason for approving/i)).toBeVisible({ timeout: 10_000 })
 
-      // Step 2: Look for "Undo decision" or "Clear" button
-      const undoButton = app.getByRole('button', { name: /undo.*decision|clear.*selection/i })
-      const hasUndoButton = await undoButton.isVisible().catch(() => false)
+      await app.getByRole('button', { name: 'Undo decision' }).click()
 
-      if (hasUndoButton) {
-        await undoButton.click()
-
-        // Step 3: Verify both approve and reject buttons are visible again
-        await expect(app.getByRole('button', { name: 'Approve', exact: true })).toBeVisible()
-        await expect(app.getByRole('button', { name: 'Reject', exact: true })).toBeVisible()
-
-        // Step 4: Verify notes field is cleared
-        const notesField = app.getByPlaceholder(/explain.*reason/i)
-        await expect(notesField).not.toBeVisible()
-      } else {
-        // If no explicit undo button exists, verify switching between approve/reject acts as undo
-        const rejectButton = app.getByRole('button', { name: 'Reject', exact: true })
-        await expect(rejectButton).toBeVisible()
-
-        // Clicking reject after approve is the undo mechanism
-        await rejectButton.click()
-        await expect(app.getByPlaceholder(/explain.*reason.*rejecting/i)).toBeVisible()
-      }
+      await expect(approveButton).toBeVisible({ timeout: 10_000 })
+      await expect(app.getByRole('button', { name: 'Reject', exact: true })).toBeVisible()
+      await expect(app.getByPlaceholder(/Explain the reason for approving/i)).not.toBeVisible()
     } finally {
-      // Cleanup: delete created workflow
       await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
     }
   })
@@ -549,8 +483,10 @@ test.describe('Approval Workflow Operations', () => {
   })
 
   test('UI-29: self-contained approve flow via approvals queue', async ({ app }) => {
-    // Create a workflow with an approval node so we control the approval name
-    const workflowName = buildUniqueName('e2e-approve')
+    // Create a workflow with an approval node so we control the approval name.
+    // Avoid 'approve' in the workflow name — getByRole({ name: 'Approve' }) is a
+    // substring match and collides with the workflow link button on execution detail.
+    const workflowName = buildUniqueName('e2e-ui29')
     const approvalNodeName = buildUniqueName('gate')
     const { id: workflowId } = await createWorkflowViaApi(app, workflowName, [
       { id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} },
@@ -586,8 +522,8 @@ test.describe('Approval Workflow Operations', () => {
       await expect(app).toHaveURL(/\/executions\/[^?]+\?approval=/)
       await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
 
-      // Approve with notes
-      await app.getByRole('button', { name: 'Approve' }).click()
+      // Approve with notes (exact: true — workflow link names must not substring-match)
+      await app.getByRole('button', { name: 'Approve', exact: true }).click()
       await app.getByPlaceholder(/Explain the reason for approving/i).fill('Approved in E2E test')
       await app.getByRole('button', { name: 'Submit decision' }).click()
 

--- a/frontend/packages/syntara-ui/package.json
+++ b/frontend/packages/syntara-ui/package.json
@@ -99,7 +99,7 @@
     "storybook": "^10.5.10",
     "tsx": "^4.22.3",
     "typescript": "~5.9.3",
-    "typescript-eslint": "~8.58.1",
+    "typescript-eslint": "^8.61.0",
     "vite": "^7.3.2",
     "vite-plugin-svgr": "^4.5.0",
     "vitest": "^4.1.10",

--- a/frontend/packages/syntara-ui/src/app/AppDockedNav.test.tsx
+++ b/frontend/packages/syntara-ui/src/app/AppDockedNav.test.tsx
@@ -104,7 +104,7 @@ describe('AppDockedNav', () => {
     mockLocation = '/workflows'
     vi.mocked(authClient.useQuery).mockReturnValue({
       data: { id: 'user-1', username: 'testuser' },
-    } as never)
+    })
     mockUseDockState.mockReturnValue({
       isDockExpanded: false,
       isDockTextExpanded: false,
@@ -447,7 +447,7 @@ describe('AppDockedNav', () => {
   })
 
   it('renders user menu as "User" when currentUser is not loaded', () => {
-    vi.mocked(authClient.useQuery).mockReturnValue({ data: undefined } as never)
+    vi.mocked(authClient.useQuery).mockReturnValue({ data: undefined })
     renderDockedNav()
     expect(screen.getByText('User')).toBeInTheDocument()
   })

--- a/frontend/packages/syntara-ui/src/components/SynKebabMenu.tsx
+++ b/frontend/packages/syntara-ui/src/components/SynKebabMenu.tsx
@@ -79,10 +79,10 @@ export function SynKebabMenu({ actions, 'aria-label': ariaLabel }: SynKebabMenuP
     (ref: React.Ref<MenuToggleElement>) => (
       <KebabToggle
         toggleRef={(node: MenuToggleElement | null) => {
-          ;(toggleRef as React.MutableRefObject<MenuToggleElement | null>).current = node
+          ;(toggleRef).current = node
           if (typeof ref === 'function') ref(node)
           else if (ref && typeof ref === 'object')
-            (ref as React.MutableRefObject<MenuToggleElement | null>).current = node
+            (ref).current = node
         }}
         isExpanded={isOpen}
         ariaLabel={ariaLabel}

--- a/frontend/packages/syntara-ui/src/components/SynKebabMenu.tsx
+++ b/frontend/packages/syntara-ui/src/components/SynKebabMenu.tsx
@@ -79,10 +79,9 @@ export function SynKebabMenu({ actions, 'aria-label': ariaLabel }: SynKebabMenuP
     (ref: React.Ref<MenuToggleElement>) => (
       <KebabToggle
         toggleRef={(node: MenuToggleElement | null) => {
-          ;(toggleRef).current = node
+          toggleRef.current = node
           if (typeof ref === 'function') ref(node)
-          else if (ref && typeof ref === 'object')
-            (ref).current = node
+          else if (ref && typeof ref === 'object') ref.current = node
         }}
         isExpanded={isOpen}
         ariaLabel={ariaLabel}

--- a/frontend/packages/syntara-ui/src/components/SynLink.tsx
+++ b/frontend/packages/syntara-ui/src/components/SynLink.tsx
@@ -9,10 +9,7 @@ type RouterLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement>
 /** Bridge PF Button's `href` convention to TanStack Router's `to` prop. */
 function RouterLink({ href, children, ...rest }: RouterLinkProps) {
   return (
-    <TanStackLink
-      to={(href ?? '/')}
-      {...(rest as Omit<ComponentProps<typeof TanStackLink>, 'to' | 'children'>)}
-    >
+    <TanStackLink to={href ?? '/'} {...(rest as Omit<ComponentProps<typeof TanStackLink>, 'to' | 'children'>)}>
       {children}
     </TanStackLink>
   )

--- a/frontend/packages/syntara-ui/src/components/SynLink.tsx
+++ b/frontend/packages/syntara-ui/src/components/SynLink.tsx
@@ -5,13 +5,12 @@ import type { ComponentProps, ReactNode } from 'react'
 type ButtonOnClick = ComponentProps<typeof Button>['onClick']
 
 type RouterLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement>
-type TanStackTo = ComponentProps<typeof TanStackLink>['to']
 
 /** Bridge PF Button's `href` convention to TanStack Router's `to` prop. */
 function RouterLink({ href, children, ...rest }: RouterLinkProps) {
   return (
     <TanStackLink
-      to={(href ?? '/') as TanStackTo}
+      to={(href ?? '/')}
       {...(rest as Omit<ComponentProps<typeof TanStackLink>, 'to' | 'children'>)}
     >
       {children}

--- a/frontend/packages/syntara-ui/src/components/WorkflowName.test.tsx
+++ b/frontend/packages/syntara-ui/src/components/WorkflowName.test.tsx
@@ -21,7 +21,7 @@ describe('WorkflowName', () => {
       data: { id: 'workflow-1', name: 'Test Workflow' },
       isLoading: false,
       isError: false,
-    } as never)
+    })
 
     render(<WorkflowName workflowId="workflow-1" />)
 
@@ -33,7 +33,7 @@ describe('WorkflowName', () => {
       data: undefined,
       isLoading: true,
       isError: false,
-    } as never)
+    })
 
     render(<WorkflowName workflowId="workflow-1" />)
 
@@ -45,7 +45,7 @@ describe('WorkflowName', () => {
       data: undefined,
       isLoading: false,
       isError: true,
-    } as never)
+    })
 
     render(<WorkflowName workflowId="workflow-1" />)
 
@@ -57,7 +57,7 @@ describe('WorkflowName', () => {
       data: undefined,
       isLoading: true,
       isError: false,
-    } as never)
+    })
 
     render(<WorkflowName workflowId="workflow-1" fallback="Loading..." />)
 
@@ -69,7 +69,7 @@ describe('WorkflowName', () => {
       data: { id: 'workflow-1' },
       isLoading: false,
       isError: false,
-    } as never)
+    })
 
     render(<WorkflowName workflowId="workflow-1" />)
 

--- a/frontend/packages/syntara-ui/src/components/layout/SynPageBreadcrumbs.tsx
+++ b/frontend/packages/syntara-ui/src/components/layout/SynPageBreadcrumbs.tsx
@@ -1,7 +1,6 @@
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core'
 import type { BreadcrumbItemRenderArgs } from '@patternfly/react-core'
 import { Link } from '@tanstack/react-router'
-import type { ComponentProps } from 'react'
 import { useSyncExternalStore } from 'react'
 
 import type { AppBreadcrumbItem } from '../../app/breadcrumbs/appBreadcrumbItem'
@@ -10,12 +9,10 @@ import { SynPageBreadcrumbsCollapsedMiddle } from './SynPageBreadcrumbsCollapsed
 
 export type { AppBreadcrumbItem }
 
-type TanStackTo = ComponentProps<typeof Link>['to']
-
 function renderBreadcrumbLink(href: string, label: string) {
   return ({ className, ariaCurrent }: BreadcrumbItemRenderArgs) => (
     // TanStack Router expects literal route strings; breadcrumb hrefs are dynamic
-    <Link to={href as TanStackTo} className={className} aria-current={ariaCurrent}>
+    <Link to={href} className={className} aria-current={ariaCurrent}>
       {label}
     </Link>
   )

--- a/frontend/packages/syntara-ui/src/hooks/routing/Link.tsx
+++ b/frontend/packages/syntara-ui/src/hooks/routing/Link.tsx
@@ -5,14 +5,12 @@ type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   href: string
 }
 
-type TanStackTo = ComponentProps<typeof TanStackLink>['to']
-
 /**
  * @deprecated Use `Link` from `@tanstack/react-router` directly.
  */
 export function Link({ href, children, ...rest }: Readonly<LinkProps>) {
   return (
-    <TanStackLink to={href as TanStackTo} {...(rest as Omit<ComponentProps<typeof TanStackLink>, 'to' | 'children'>)}>
+    <TanStackLink to={href} {...(rest as Omit<ComponentProps<typeof TanStackLink>, 'to' | 'children'>)}>
       {children}
     </TanStackLink>
   )

--- a/frontend/packages/syntara-ui/src/hooks/useActiveAdminCount.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useActiveAdminCount.test.ts
@@ -58,14 +58,14 @@ describe('useActiveAdminCount', () => {
   it('returns 0 when no admins group is found', () => {
     // First call: groups query returns no groups
     // Second call: members query returns empty (no group id)
-    mockUseQuery.mockReturnValueOnce(emptyResult as never).mockReturnValueOnce(emptyResult as never)
+    mockUseQuery.mockReturnValueOnce(emptyResult).mockReturnValueOnce(emptyResult)
 
     const { result } = renderHook(() => useActiveAdminCount())
     expect(result.current).toBe(0)
   })
 
   it('returns 0 when groups data is undefined', () => {
-    mockUseQuery.mockReturnValueOnce(undefinedResult as never).mockReturnValueOnce(undefinedResult as never)
+    mockUseQuery.mockReturnValueOnce(undefinedResult).mockReturnValueOnce(undefinedResult)
 
     const { result } = renderHook(() => useActiveAdminCount())
     expect(result.current).toBe(0)
@@ -73,13 +73,13 @@ describe('useActiveAdminCount', () => {
 
   it('returns the count of enabled members in the admins group', () => {
     mockUseQuery
-      .mockReturnValueOnce(groupsResult([{ id: 'admins-id', name: 'admins', is_builtin: true }]) as never)
+      .mockReturnValueOnce(groupsResult([{ id: 'admins-id', name: 'admins', is_builtin: true }]))
       .mockReturnValueOnce(
         membersResult([
           { id: 'user-1', is_enabled: true },
           { id: 'user-2', is_enabled: true },
           { id: 'user-3', is_enabled: true },
-        ]) as never
+        ])
       )
 
     const { result } = renderHook(() => useActiveAdminCount())
@@ -88,14 +88,14 @@ describe('useActiveAdminCount', () => {
 
   it('filters out disabled members from the count', () => {
     mockUseQuery
-      .mockReturnValueOnce(groupsResult([{ id: 'admins-id', name: 'admins', is_builtin: true }]) as never)
+      .mockReturnValueOnce(groupsResult([{ id: 'admins-id', name: 'admins', is_builtin: true }]))
       .mockReturnValueOnce(
         membersResult([
           { id: 'user-1', is_enabled: true },
           { id: 'user-2', is_enabled: false },
           { id: 'user-3', is_enabled: true },
           { id: 'user-4', is_enabled: false },
-        ]) as never
+        ])
       )
 
     const { result } = renderHook(() => useActiveAdminCount())
@@ -103,7 +103,7 @@ describe('useActiveAdminCount', () => {
   })
 
   it('skips queries when enabled is false', () => {
-    mockUseQuery.mockReturnValue(undefinedResult as never)
+    mockUseQuery.mockReturnValue(undefinedResult)
 
     renderHook(() => useActiveAdminCount(false))
 
@@ -117,8 +117,8 @@ describe('useActiveAdminCount', () => {
 
   it('ignores non-builtin groups named admins', () => {
     mockUseQuery
-      .mockReturnValueOnce(groupsResult([{ id: 'custom-id', name: 'admins', is_builtin: false }]) as never)
-      .mockReturnValueOnce(emptyResult as never)
+      .mockReturnValueOnce(groupsResult([{ id: 'custom-id', name: 'admins', is_builtin: false }]))
+      .mockReturnValueOnce(emptyResult)
 
     const { result } = renderHook(() => useActiveAdminCount())
     // No builtin admins group found, so members query gets empty group_id

--- a/frontend/packages/syntara-ui/src/hooks/useApiErrorAlert.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useApiErrorAlert.test.ts
@@ -104,8 +104,10 @@ describe('useApiErrorAlert', () => {
   })
 
   it('resets deduplication when error becomes null', () => {
-    const { rerender } = renderHook(({ e }) => useApiErrorAlert(e), {
-      initialProps: { e: { detail: 'Error' } },
+    type ErrorProps = { e: { detail: string } | null }
+    const initialProps: ErrorProps = { e: { detail: 'Error' } }
+    const { rerender } = renderHook(({ e }: ErrorProps) => useApiErrorAlert(e), {
+      initialProps,
     })
 
     expect(mockShowError).toHaveBeenCalledTimes(1)

--- a/frontend/packages/syntara-ui/src/hooks/useApiErrorAlert.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useApiErrorAlert.test.ts
@@ -94,7 +94,7 @@ describe('useApiErrorAlert', () => {
 
   it('shows alert for different errors', () => {
     const { rerender } = renderHook(({ e }) => useApiErrorAlert(e), {
-      initialProps: { e: { detail: 'Error 1' } as unknown },
+      initialProps: { e: { detail: 'Error 1' } },
     })
 
     expect(mockShowError).toHaveBeenCalledTimes(1)
@@ -105,7 +105,7 @@ describe('useApiErrorAlert', () => {
 
   it('resets deduplication when error becomes null', () => {
     const { rerender } = renderHook(({ e }) => useApiErrorAlert(e), {
-      initialProps: { e: { detail: 'Error' } as unknown },
+      initialProps: { e: { detail: 'Error' } },
     })
 
     expect(mockShowError).toHaveBeenCalledTimes(1)

--- a/frontend/packages/syntara-ui/src/hooks/useFileStorageStatus.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useFileStorageStatus.test.ts
@@ -40,7 +40,7 @@ const loadingResult: MockQueryResult = { data: undefined, isLoading: true, isErr
 const errorResult: MockQueryResult = { data: undefined, isLoading: false, isError: true }
 
 function mockResult(result: MockQueryResult) {
-  mockUseQuery.mockReturnValue(result as unknown as ReturnType<typeof filesClient.useQuery>)
+  mockUseQuery.mockReturnValue(result)
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/packages/syntara-ui/src/hooks/useMonacoBlur.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useMonacoBlur.test.ts
@@ -103,13 +103,13 @@ describe('useMonacoBlur', () => {
     const onBlur = vi.fn()
     type Props = { onBlur?: (value: string) => void }
     const { result, rerender } = renderHook(({ onBlur: ob }: Props) => useMonacoBlur('code', ob), {
-      initialProps: { onBlur: undefined } as Props,
+      initialProps: { onBlur: undefined },
     })
     const editor = createMockEditor()
     act(() => {
       result.current.handleEditorDidMount(editor as unknown as MonacoEditor)
     })
-    rerender({ onBlur } as Props)
+    rerender({ onBlur })
     const calls = editor.onDidBlurEditorText.mock.calls as unknown[][]
     const blurCallback = calls[0]?.[0] as (() => void) | undefined
     expect(blurCallback).toBeTypeOf('function')

--- a/frontend/packages/syntara-ui/src/hooks/useMonacoBlur.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useMonacoBlur.test.ts
@@ -102,8 +102,9 @@ describe('useMonacoBlur', () => {
   it('useEffect sets up blur listener when onBlur is added after editor mount', () => {
     const onBlur = vi.fn()
     type Props = { onBlur?: (value: string) => void }
+    const initialProps: Props = { onBlur: undefined }
     const { result, rerender } = renderHook(({ onBlur: ob }: Props) => useMonacoBlur('code', ob), {
-      initialProps: { onBlur: undefined },
+      initialProps,
     })
     const editor = createMockEditor()
     act(() => {

--- a/frontend/packages/syntara-ui/src/hooks/usePaginatedProjects.test.tsx
+++ b/frontend/packages/syntara-ui/src/hooks/usePaginatedProjects.test.tsx
@@ -57,7 +57,7 @@ describe('usePaginatedProjects', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     queryClient.clear()
-    vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1) as never)
+    vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1))
   })
 
   afterEach(() => {
@@ -92,7 +92,7 @@ describe('usePaginatedProjects', () => {
         isPending: true,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const { result } = renderHook(() => usePaginatedProjects(), { wrapper })
 
@@ -213,11 +213,11 @@ describe('usePaginatedProjects', () => {
 
   describe('clearTypeaheadOnly', () => {
     it('clears filter text without collapsing merged pages', () => {
-      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2') as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2'))
       const { result, rerender } = renderHook(() => usePaginatedProjects(), { wrapper })
 
       act(() => result.current.loadMore())
-      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page2) as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page2))
       rerender()
 
       expect(result.current.projects).toHaveLength(4)
@@ -233,7 +233,7 @@ describe('usePaginatedProjects', () => {
 
   describe('hasMore and loadMore', () => {
     it('hasMore is true when query returns a next cursor', () => {
-      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2') as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2'))
       const { result } = renderHook(() => usePaginatedProjects(), { wrapper })
 
       expect(result.current.hasMore).toBe(true)
@@ -251,7 +251,7 @@ describe('usePaginatedProjects', () => {
     })
 
     it('accumulates page 2 projects after loadMore', () => {
-      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2') as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2'))
       const { result, rerender } = renderHook(() => usePaginatedProjects(), { wrapper })
 
       act(() => {
@@ -259,14 +259,14 @@ describe('usePaginatedProjects', () => {
       })
 
       // Simulate the query returning page 2 after the cursor is set
-      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page2) as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page2))
       rerender()
 
       expect(result.current.projects).toEqual([...page1, ...page2])
     })
 
     it('deduplicates projects that appear in both extraPages and the new page', () => {
-      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2') as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2'))
       const { result, rerender } = renderHook(() => usePaginatedProjects(), { wrapper })
 
       act(() => {
@@ -275,7 +275,7 @@ describe('usePaginatedProjects', () => {
 
       // page 2 overlaps: p1 is a duplicate
       const overlapPage = [page1[0], ...page2]
-      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(overlapPage) as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(overlapPage))
       rerender()
 
       const ids = result.current.projects.map((p) => p.id)
@@ -288,7 +288,7 @@ describe('usePaginatedProjects', () => {
 
   describe('isLoadingMore', () => {
     it('is true when a cursor is set and the query is still fetching', () => {
-      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2') as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2'))
       const { result, rerender } = renderHook(() => usePaginatedProjects(), { wrapper })
 
       act(() => {
@@ -296,7 +296,7 @@ describe('usePaginatedProjects', () => {
       })
 
       // Simulate in-flight refetch with the cursor
-      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2', true) as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(makeQueryData(page1, 'cursor-2', true))
       rerender()
 
       expect(result.current.isLoadingMore).toBe(true)

--- a/frontend/packages/syntara-ui/src/hooks/usePermissionAnywhere.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/usePermissionAnywhere.test.ts
@@ -34,7 +34,7 @@ describe('usePermissionAnywhere', () => {
   })
 
   it('returns true when can_i with check_any_project allows', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => usePermissionAnywhere('read', 'role-assignment'), {
       wrapper: createWrapper(),
@@ -49,7 +49,7 @@ describe('usePermissionAnywhere', () => {
   })
 
   it('returns false when can_i denies', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } })
 
     const { result } = renderHook(() => usePermissionAnywhere('read', 'role-assignment'), {
       wrapper: createWrapper(),

--- a/frontend/packages/syntara-ui/src/hooks/usePermissionChecks.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/usePermissionChecks.test.ts
@@ -125,7 +125,7 @@ describe('usePermissionChecks', () => {
 
     const wrapper = createWrapper()
     const { result, rerender } = renderHook(({ checks }) => usePermissionChecks(checks), {
-      initialProps: { checks: CHECKS as readonly PermissionRequirement[] },
+      initialProps: { checks: CHECKS },
       wrapper,
     })
 

--- a/frontend/packages/syntara-ui/src/hooks/useSortableTable.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useSortableTable.ts
@@ -1,7 +1,7 @@
 import type { ThProps } from '@patternfly/react-table'
 import { useCallback, useMemo } from 'react'
 
-import type { SortableColumn, SortConfig, SortDirection } from '../types/sorting'
+import type { SortableColumn, SortConfig } from '../types/sorting'
 import { buildSortParam } from '../utils/sortUtils'
 
 import type { UseSortStateOptions, UseSortStateResult } from './useSortState'
@@ -98,7 +98,7 @@ export function useSortableTableControls(
           defaultDirection: 'asc',
         },
         onSort: (_event, _index, direction) => {
-          setSort({ field: columnField, direction: direction as SortDirection })
+          setSort({ field: columnField, direction: direction })
         },
         columnIndex,
       }

--- a/frontend/packages/syntara-ui/src/hooks/useTableSort.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useTableSort.test.ts
@@ -57,7 +57,7 @@ describe('useTableSort', () => {
 
       const sortParams = result.current.getSortParams(2)
       act(() => {
-        sortParams?.onSort?.(null as never, 2, 'desc' as SortByDirection, {} as never)
+        sortParams?.onSort?.(null as never, 2, 'desc' as SortByDirection, {})
       })
 
       expect(result.current.activeSortIndex).toBe(2)
@@ -70,7 +70,7 @@ describe('useTableSort', () => {
 
       const sortParams = result.current.getSortParams(1)
       act(() => {
-        sortParams?.onSort?.(null as never, 1, 'desc' as SortByDirection, {} as never)
+        sortParams?.onSort?.(null as never, 1, 'desc' as SortByDirection, {})
       })
 
       expect(onSortChange).toHaveBeenCalledTimes(1)
@@ -82,7 +82,7 @@ describe('useTableSort', () => {
       const sortParams = result.current.getSortParams(1)
       expect(() => {
         act(() => {
-          sortParams?.onSort?.(null as never, 1, 'desc' as SortByDirection, {} as never)
+          sortParams?.onSort?.(null as never, 1, 'desc' as SortByDirection, {})
         })
       }).not.toThrow()
     })

--- a/frontend/packages/syntara-ui/src/hooks/useTableSort.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useTableSort.ts
@@ -27,7 +27,7 @@ export function useTableSort(options: UseTableSortOptions = {}) {
       },
       onSort: (_event, _index, direction) => {
         setActiveSortIndex(columnIndex)
-        setSortDirection(direction as SortDirection)
+        setSortDirection(direction)
         onSortChange?.()
       },
       columnIndex,

--- a/frontend/packages/syntara-ui/src/routes/access-management/AccessManagement.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/AccessManagement.test.tsx
@@ -58,11 +58,11 @@ describe('AccessManagement', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
     vi.mocked(usersClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
     vi.mocked(accessClient.useQuery).mockReturnValue({
       data: { resources: [] },
       isPending: false,
@@ -70,15 +70,15 @@ describe('AccessManagement', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
     vi.mocked(accessClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
     vi.mocked(adminClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
     vi.mocked(accessFetchClient.POST).mockImplementation((path: string) => {
       if (path === '/authz/what_can_i') {
         return Promise.resolve({ data: { resources: [], next: null } } as never)

--- a/frontend/packages/syntara-ui/src/routes/access-management/GroupsTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/GroupsTab.test.tsx
@@ -94,7 +94,7 @@ describe('GroupsTab Component', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     vi.mocked(usersClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
@@ -113,7 +113,7 @@ describe('GroupsTab Component', () => {
       variables: undefined,
       status: 'idle',
       isPaused: false,
-    } as never)
+    })
   })
 
   describe('Rendering', () => {
@@ -168,7 +168,7 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -329,7 +329,7 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -352,7 +352,7 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -375,7 +375,7 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -396,7 +396,7 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -420,7 +420,7 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -500,7 +500,7 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -567,12 +567,12 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(usersClient.useMutation).mockReturnValue({
         mutate: mockDeleteMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -607,12 +607,12 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(usersClient.useMutation).mockReturnValue({
         mutate: mockDeleteMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -650,7 +650,7 @@ describe('GroupsTab Component', () => {
       vi.mocked(usersClient.useMutation).mockReturnValue({
         mutate: mockDeleteMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -714,7 +714,7 @@ describe('GroupsTab Component', () => {
       vi.mocked(usersClient.useMutation).mockReturnValue({
         mutate: mockDeleteMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -746,7 +746,7 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 
@@ -772,7 +772,7 @@ describe('GroupsTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupsTab />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/ProjectsTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/ProjectsTab.test.tsx
@@ -107,7 +107,7 @@ function setupMocks(projects = mockProjects) {
     isError: false,
     error: null,
     refetch: mockRefetch,
-  } as never)
+  })
 
   vi.mocked(accessClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
@@ -126,7 +126,7 @@ function setupMocks(projects = mockProjects) {
     variables: undefined,
     status: 'idle',
     isPaused: false,
-  } as never)
+  })
 }
 
 const DELETE_PROJECT_LABEL = 'Delete project'
@@ -214,7 +214,7 @@ describe('ProjectsTab', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       render(<ProjectsTab />, { wrapper })
 
@@ -229,7 +229,7 @@ describe('ProjectsTab', () => {
         isError: true,
         error: new Error('Failed to load'),
         refetch: mockRefetch,
-      } as never)
+      })
 
       render(<ProjectsTab />, { wrapper })
 
@@ -359,7 +359,7 @@ describe('ProjectsTab', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockDeleteMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<ProjectsTab />, { wrapper })
 
@@ -386,7 +386,7 @@ describe('ProjectsTab', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockDeleteMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<ProjectsTab />, { wrapper })
 
@@ -417,7 +417,7 @@ describe('ProjectsTab', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockDeleteMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<ProjectsTab />, { wrapper })
 
@@ -505,7 +505,7 @@ describe('ProjectsTab', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockCreateMutate,
         isPending: false,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<ProjectsTab />, { wrapper })
@@ -534,7 +534,7 @@ describe('ProjectsTab', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockCreateMutate,
         isPending: false,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<ProjectsTab />, { wrapper })

--- a/frontend/packages/syntara-ui/src/routes/access-management/UsersTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/UsersTab.test.tsx
@@ -175,12 +175,12 @@ describe('UsersTab Component', () => {
       variables: undefined,
       status: 'idle',
       isPaused: false,
-    } as never)
+    })
 
     vi.mocked(adminClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
   })
 
   describe('Built-in Administrator Account', () => {
@@ -250,7 +250,7 @@ describe('UsersTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<UsersTab />, { wrapper })
 
@@ -450,7 +450,7 @@ describe('UsersTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<UsersTab />, { wrapper })
 
@@ -630,7 +630,7 @@ describe('UsersTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<UsersTab />, { wrapper })
 
@@ -646,7 +646,7 @@ describe('UsersTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<UsersTab />, { wrapper })
 
@@ -662,7 +662,7 @@ describe('UsersTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<UsersTab />, { wrapper })
 
@@ -757,12 +757,12 @@ describe('UsersTab Component', () => {
         error: null,
         isFetching: false,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockDeleteMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<UsersTab />, { wrapper })
 
@@ -792,12 +792,12 @@ describe('UsersTab Component', () => {
         error: null,
         isFetching: false,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockDeleteMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<UsersTab />, { wrapper })
 
@@ -857,12 +857,12 @@ describe('UsersTab Component', () => {
         error: null,
         isFetching: false,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockDeleteMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<UsersTab />, { wrapper })
 
@@ -899,7 +899,7 @@ describe('UsersTab Component', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<UsersTab />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/Authentication.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/Authentication.test.tsx
@@ -99,14 +99,14 @@ function setupProviders(providers: (typeof mockProvider)[] = [mockProvider]) {
     error: null,
     isPending: false,
     refetch: vi.fn(),
-  } as never)
+  })
   vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
-  } as never)
+  })
   vi.mocked(adminClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
 }
 
 function setupEmptyProviders() {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/IdentityProvidersTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/IdentityProvidersTab.test.tsx
@@ -89,14 +89,14 @@ function setupProviders(providers = [mockProvider]) {
     error: null,
     isPending: false,
     refetch: vi.fn(),
-  } as never)
+  })
   vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
-  } as never)
+  })
   vi.mocked(adminClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
 }
 
 function setupEmptyProviders() {
@@ -110,7 +110,7 @@ describe('IdentityProvidersTab', () => {
     vi.mocked(adminClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
   })
 
   describe('loading state', () => {
@@ -122,10 +122,10 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: true,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
-      } as never)
+      })
 
       render(<IdentityProvidersTab />, { wrapper })
 
@@ -142,10 +142,10 @@ describe('IdentityProvidersTab', () => {
         error: new Error('Network error'),
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
-      } as never)
+      })
 
       render(<IdentityProvidersTab />, { wrapper })
 
@@ -164,10 +164,10 @@ describe('IdentityProvidersTab', () => {
         error: retryableError,
         isPending: false,
         refetch: mockRefetch,
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
-      } as never)
+      })
 
       render(<IdentityProvidersTab />, { wrapper })
 
@@ -335,10 +335,10 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
-      } as never)
+      })
 
       render(<IdentityProvidersTab />, { wrapper })
 
@@ -415,7 +415,7 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((_method: string, path: string) => {
         if (path === '/identity_providers/{provider_id}' && _method === 'delete') {
           return { mutate: mockDeleteMutate }
@@ -461,7 +461,7 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: mockRefetch,
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((_method: string, path: string) => {
         if (path === '/identity_providers/{provider_id}' && _method === 'delete') {
           return { mutate: mockDeleteMutate }
@@ -557,14 +557,14 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
-      } as never)
+      })
       vi.mocked(adminClient.useMutation).mockReturnValue({
         mutate: mockRevokeMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<IdentityProvidersTab />, { wrapper })
 
@@ -592,10 +592,10 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
-      } as never)
+      })
 
       render(<IdentityProvidersTab />, { wrapper })
 
@@ -617,7 +617,7 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((_method: string, path: string) => {
         if (_method === 'patch' && path === '/identity_providers/{provider_id}') {
           return { mutate: mockPatchMutate }
@@ -653,7 +653,7 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((_method: string, path: string) => {
         if (_method === 'patch' && path === '/identity_providers/{provider_id}') {
           return { mutate: mockPatchMutate }
@@ -688,7 +688,7 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: mockRefetch,
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((_method: string, path: string) => {
         if (_method === 'patch' && path === '/identity_providers/{provider_id}') {
           return { mutate: mockPatchMutate }
@@ -721,7 +721,7 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: mockRefetch,
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((_method: string, path: string) => {
         if (_method === 'patch' && path === '/identity_providers/{provider_id}') {
           return { mutate: mockPatchMutate }
@@ -753,7 +753,7 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((_method: string, path: string) => {
         if (_method === 'patch' && path === '/identity_providers/{provider_id}') {
           return { mutate: mockPatchMutate }
@@ -785,7 +785,7 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((_method: string, path: string) => {
         if (_method === 'patch' && path === '/identity_providers/{provider_id}') {
           return { mutate: mockPatchMutate }
@@ -814,7 +814,7 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((_method: string, path: string) => {
         if (_method === 'patch' && path === '/identity_providers/{provider_id}') {
           return { mutate: mockPatchMutate }
@@ -854,10 +854,10 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
-      } as never)
+      })
 
       render(<IdentityProvidersTab />, { wrapper })
 
@@ -877,10 +877,10 @@ describe('IdentityProvidersTab', () => {
         error: null,
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
-      } as never)
+      })
 
       render(<IdentityProvidersTab />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/AAPSetupModal.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/AAPSetupModal.test.tsx
@@ -57,7 +57,7 @@ describe('AAPSetupModal', () => {
       variables: undefined,
       status: 'idle',
       isPaused: false,
-    } as never)
+    })
   })
 
   function renderModal(isOpen = true) {
@@ -257,7 +257,7 @@ describe('AAPSetupModal', () => {
         variables: undefined,
         status: 'pending',
         isPaused: false,
-      } as never)
+      })
 
       renderModal()
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/AddIdentityProvider.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/AddIdentityProvider.test.tsx
@@ -57,11 +57,11 @@ function setupMocks() {
     isError: false,
     error: null,
     refetch: vi.fn(),
-  } as never)
+  })
   vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
 }
 
 describe('AddIdentityProvider', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/EditGroupMapping.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/EditGroupMapping.test.tsx
@@ -141,7 +141,7 @@ describe('EditGroupMapping', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn().mockResolvedValue({ data: { resources: mockMappedGroups } }),
-    } as never)
+    })
 
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue({
       data: mockProvider,
@@ -150,12 +150,12 @@ describe('EditGroupMapping', () => {
       error: null,
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
   })
 
   it('renders Add group mapping title when there are no server mappings', async () => {
@@ -179,7 +179,7 @@ describe('EditGroupMapping', () => {
       error: null,
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     render(<EditGroupMapping />, { wrapper })
     await waitFor(() => {
@@ -213,7 +213,7 @@ describe('EditGroupMapping', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
 
     mockSearchRef.current = '?new=1'
     const user = userEvent.setup()
@@ -234,7 +234,7 @@ describe('EditGroupMapping', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
 
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue({
       data: {
@@ -250,7 +250,7 @@ describe('EditGroupMapping', () => {
       error: null,
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const user = userEvent.setup()
     render(<EditGroupMapping />, { wrapper })
@@ -277,7 +277,7 @@ describe('EditGroupMapping', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
 
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue({
       data: {
@@ -292,7 +292,7 @@ describe('EditGroupMapping', () => {
       error: null,
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const user = userEvent.setup()
     render(<EditGroupMapping />, { wrapper })
@@ -311,7 +311,7 @@ describe('EditGroupMapping', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
 
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue({
       data: {
@@ -326,7 +326,7 @@ describe('EditGroupMapping', () => {
       error: null,
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const user = userEvent.setup()
     render(<EditGroupMapping />, { wrapper })
@@ -380,7 +380,7 @@ describe('EditGroupMapping', () => {
       error: { response: { status: 404 } },
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     render(<EditGroupMapping />, { wrapper })
     await waitFor(() => {
@@ -396,7 +396,7 @@ describe('EditGroupMapping', () => {
       error: { response: { status: 404 } },
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const user = userEvent.setup()
     render(<EditGroupMapping />, { wrapper })
@@ -418,7 +418,7 @@ describe('EditGroupMapping', () => {
       error: new Error('Server error'),
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     render(<EditGroupMapping />, { wrapper })
     expect(screen.getAllByText('Error loading identity provider').length).toBeGreaterThan(0)
@@ -545,7 +545,7 @@ describe('EditGroupMapping', () => {
         error: { response: { status: 404 } },
         isPending: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const { container } = render(<EditGroupMapping />, { wrapper })
       await waitFor(() => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/EditIdentityProvider.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/EditIdentityProvider.test.tsx
@@ -70,11 +70,11 @@ function setupMocks() {
     isError: false,
     error: null,
     refetch: vi.fn(),
-  } as never)
+  })
   vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
 }
 
 describe('EditIdentityProvider', () => {
@@ -111,11 +111,11 @@ describe('EditIdentityProvider', () => {
       isError: true,
       error: notFoundError,
       refetch: vi.fn(),
-    } as never)
+    })
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
 
     render(<EditIdentityProvider />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingFormEditor.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingFormEditor.test.tsx
@@ -109,11 +109,11 @@ describe('GroupMappingFormEditor', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
   })
 
   it('uses identityProviderMapping documentation key', async () => {
@@ -133,7 +133,7 @@ describe('GroupMappingFormEditor', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: true,
-    } as never)
+    })
 
     render(<GroupMappingFormEditor metadata={buildMetadata()} openTestSignInRef={createRef()} />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingStep.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingStep.test.tsx
@@ -89,7 +89,7 @@ describe('GroupMappingStep', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
   })
 
   describe('Rendering', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/GroupMappingTab.test.tsx
@@ -69,7 +69,7 @@ describe('GroupMappingTab', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
   })
 
   describe('Empty state', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderDetail.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderDetail.test.tsx
@@ -108,9 +108,9 @@ function mockQueryReturn(overrides: Record<string, unknown> = {}): ReturnType<ty
 describe('IdentityProviderDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(identityProvidersClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
-    vi.mocked(adminClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(identityProvidersClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false })
+    vi.mocked(adminClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false })
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
     vi.mocked(useParams).mockReturnValue({ providerId: VALID_PROVIDER_ID })
     mockIdpPermissions.canCreate = true
     mockIdpPermissions.canUpdate = true
@@ -503,7 +503,7 @@ describe('IdentityProviderDetail', () => {
 
   it('opens disable dialog when toggling an enabled provider', async () => {
     const user = userEvent.setup()
-    vi.mocked(identityProvidersClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+    vi.mocked(identityProvidersClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false })
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue(mockQueryReturn())
 
     render(<IdentityProviderDetail />, { wrapper: createWrapper() })
@@ -517,10 +517,10 @@ describe('IdentityProviderDetail', () => {
   it('calls patchProvider to disable after confirming dialog', async () => {
     const user = userEvent.setup()
     const mockPatch = vi.fn()
-    vi.mocked(identityProvidersClient.useMutation).mockImplementation(((method: string) => {
+    vi.mocked(identityProvidersClient.useMutation).mockImplementation((method: string) => {
       if (method === 'patch') return { mutate: mockPatch, isPending: false }
       return { mutate: vi.fn(), isPending: false }
-    }) as unknown as typeof identityProvidersClient.useMutation)
+    })
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue(mockQueryReturn())
 
     render(<IdentityProviderDetail />, { wrapper: createWrapper() })
@@ -547,10 +547,10 @@ describe('IdentityProviderDetail', () => {
     const mockPatch = vi.fn((_params: unknown, callbacks: MutationCallbacks) => {
       callbacks.onSuccess?.()
     })
-    vi.mocked(identityProvidersClient.useMutation).mockImplementation(((method: string) => {
+    vi.mocked(identityProvidersClient.useMutation).mockImplementation((method: string) => {
       if (method === 'patch') return { mutate: mockPatch, isPending: false }
       return { mutate: vi.fn(), isPending: false }
-    }) as unknown as typeof identityProvidersClient.useMutation)
+    })
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue(mockQueryReturn({ refetch: mockRefetch }))
 
     render(<IdentityProviderDetail />, { wrapper: createWrapper() })
@@ -567,10 +567,10 @@ describe('IdentityProviderDetail', () => {
     const mockPatch = vi.fn((_params: unknown, callbacks: MutationCallbacks) => {
       callbacks.onError?.(new Error('Toggle failed'))
     })
-    vi.mocked(identityProvidersClient.useMutation).mockImplementation(((method: string) => {
+    vi.mocked(identityProvidersClient.useMutation).mockImplementation((method: string) => {
       if (method === 'patch') return { mutate: mockPatch, isPending: false }
       return { mutate: vi.fn(), isPending: false }
-    }) as unknown as typeof identityProvidersClient.useMutation)
+    })
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue(mockQueryReturn())
 
     render(<IdentityProviderDetail />, { wrapper: createWrapper() })
@@ -587,10 +587,10 @@ describe('IdentityProviderDetail', () => {
   it('does not call patchProvider when provider has no id', async () => {
     const user = userEvent.setup()
     const mockPatch = vi.fn()
-    vi.mocked(identityProvidersClient.useMutation).mockImplementation(((method: string) => {
+    vi.mocked(identityProvidersClient.useMutation).mockImplementation((method: string) => {
       if (method === 'patch') return { mutate: mockPatch, isPending: false }
       return { mutate: vi.fn(), isPending: false }
-    }) as unknown as typeof identityProvidersClient.useMutation)
+    })
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue(
       mockQueryReturn({ data: { ...mockProvider, id: undefined } })
     )
@@ -666,7 +666,7 @@ describe('IdentityProviderDetail', () => {
   it('calls revoke mutation when confirming revocation', async () => {
     const user = userEvent.setup()
     const mockRevoke = vi.fn()
-    vi.mocked(adminClient.useMutation).mockReturnValue({ mutate: mockRevoke, isPending: false } as never)
+    vi.mocked(adminClient.useMutation).mockReturnValue({ mutate: mockRevoke, isPending: false })
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue(mockQueryReturn())
 
     render(<IdentityProviderDetail />, { wrapper: createWrapper() })
@@ -682,10 +682,10 @@ describe('IdentityProviderDetail', () => {
   it('calls delete mutation when confirming deletion', async () => {
     const user = userEvent.setup()
     const mockDelete = vi.fn()
-    vi.mocked(identityProvidersClient.useMutation).mockImplementation(((method: string) => {
+    vi.mocked(identityProvidersClient.useMutation).mockImplementation((method: string) => {
       if (method === 'delete') return { mutate: mockDelete, isPending: false }
       return { mutate: vi.fn(), isPending: false }
-    }) as unknown as typeof identityProvidersClient.useMutation)
+    })
     vi.mocked(identityProvidersClient.useQuery).mockReturnValue(mockQueryReturn())
 
     render(<IdentityProviderDetail />, { wrapper: createWrapper() })

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderForm.test.tsx
@@ -78,11 +78,11 @@ function setupMocks() {
     isError: false,
     error: null,
     refetch: vi.fn(),
-  } as never)
+  })
   vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
 }
 
 describe('IdentityProviderForm', () => {
@@ -195,11 +195,11 @@ describe('IdentityProviderForm', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
         isPending: false,
-      } as never)
+      })
     }
 
     it('renders the edit form with Save button on last step', async () => {
@@ -241,11 +241,11 @@ describe('IdentityProviderForm', () => {
         isError: true,
         error: notFoundError,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
         isPending: false,
-      } as never)
+      })
 
       const { container } = render(<IdentityProviderForm mode="edit" />, { wrapper })
 
@@ -267,11 +267,11 @@ describe('IdentityProviderForm', () => {
         refetch: vi.fn(),
         status: 'pending',
         fetchStatus: 'fetching',
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
         isPending: false,
-      } as never)
+      })
 
       render(<IdentityProviderForm mode="edit" />, { wrapper })
 
@@ -289,7 +289,7 @@ describe('IdentityProviderForm', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((method: string) => {
         if (method === 'patch') {
@@ -339,7 +339,7 @@ describe('IdentityProviderForm', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((method: string) => {
         if (method === 'patch') {
@@ -384,7 +384,7 @@ describe('IdentityProviderForm', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((method: string) => {
         if (method === 'patch') {
@@ -437,11 +437,11 @@ describe('IdentityProviderForm', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
         isPending: false,
-      } as never)
+      })
 
       // Should render without crashing — null mapped_group_id defaults to ''
       render(<IdentityProviderForm mode="edit" />, { wrapper })
@@ -471,11 +471,11 @@ describe('IdentityProviderForm', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
         isPending: false,
-      } as never)
+      })
 
       render(<IdentityProviderForm mode="edit" />, { wrapper })
 
@@ -508,7 +508,7 @@ describe('IdentityProviderForm', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(identityProvidersClient.useMutation).mockImplementation(((method: string) => {
         if (method === 'patch') {
           return { mutate: mockPatch, isPending: false }

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/WizardNavFooter.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/WizardNavFooter.test.tsx
@@ -13,7 +13,7 @@ const mockContext = {
   goToNextStep: mockGoToNextStep,
   goToPrevStep: mockGoToPrevStep,
   goToStepById: mockGoToStepById,
-  activeStep: { index: 1 } as { index: number },
+  activeStep: { index: 1 },
   steps: [{}, {}],
 }
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useGroupMappingForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/useGroupMappingForm.test.tsx
@@ -88,7 +88,7 @@ describe('useGroupMappingFormMetadata', () => {
       error: null,
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
   })
 
   it('reports invalid provider id', () => {
@@ -128,7 +128,7 @@ describe('useGroupMappingFormMetadata', () => {
       error: null,
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useGroupMappingFormMetadata(VALID_PROVIDER_ID, ''), { wrapper })
 
@@ -145,7 +145,7 @@ describe('useGroupMappingFormMetadata', () => {
       error: { response: { status: 404 } },
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useGroupMappingFormMetadata(VALID_PROVIDER_ID, ''), { wrapper })
     expect(result.current.isNotFound).toBe(true)
@@ -159,7 +159,7 @@ describe('useGroupMappingFormMetadata', () => {
       error: null,
       isPending: true,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useGroupMappingFormMetadata(VALID_PROVIDER_ID, ''), { wrapper })
     expect(result.current.breadcrumbs.some((item) => item.label === 'Identity provider')).toBe(true)
@@ -187,7 +187,7 @@ describe('useGroupMappingFormMetadata', () => {
       error: null,
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useGroupMappingFormMetadata(VALID_PROVIDER_ID, ''), { wrapper })
 
@@ -214,7 +214,7 @@ describe('useGroupMappingEditForm', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
   })
 
   it('initializes one blank entry when provider has no mappings', async () => {
@@ -241,7 +241,7 @@ describe('useGroupMappingEditForm', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>
@@ -274,7 +274,7 @@ describe('useGroupMappingEditForm', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>
@@ -309,7 +309,7 @@ describe('useGroupMappingEditForm', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>
@@ -618,7 +618,7 @@ describe('useGroupMappingEditForm', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/useIdentityProviderPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/useIdentityProviderPermissions.test.ts
@@ -50,7 +50,7 @@ describe('useIdentityProviderPermissions', () => {
   })
 
   it('returns all true when API grants all permissions', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useIdentityProviderPermissions(), { wrapper: createWrapper() })
 
@@ -65,7 +65,7 @@ describe('useIdentityProviderPermissions', () => {
   })
 
   it('calls can_i with correct action and resource_type', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     renderHook(() => useIdentityProviderPermissions(), { wrapper: createWrapper() })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/useIdentityProviderToggle.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/useIdentityProviderToggle.test.ts
@@ -49,7 +49,7 @@ describe('useIdentityProviderToggle', () => {
     vi.mocked(identityProvidersClient.useMutation).mockReturnValue({
       mutate: mockPatchMutate,
       isPending: false,
-    } as never)
+    })
     mockErrorHandler.mockReturnValue(vi.fn())
     vi.mocked(useMutationErrorHandler).mockReturnValue(mockErrorHandler)
     mockPatchMutate.mockClear()

--- a/frontend/packages/syntara-ui/src/routes/access-management/groups/GroupDetail.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/groups/GroupDetail.test.tsx
@@ -198,7 +198,7 @@ function mockSuccessQueries(group = mockGroup, members = mockMembersData, roleAs
   vi.mocked(accessClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -211,7 +211,7 @@ describe('GroupDetail', () => {
     routerTestState.navigate.mockClear()
     mockLocationValue = `/system-administration/access-management/groups/${VALID_GROUP_ID}`
     mockUseParams.mockReturnValue({ groupId: VALID_GROUP_ID })
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
     vi.mocked(useGroupPermissions).mockReturnValue({
       canCreate: true,
       canUpdate: true,

--- a/frontend/packages/syntara-ui/src/routes/access-management/groups/GroupMembersPanel.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/groups/GroupMembersPanel.test.tsx
@@ -109,12 +109,12 @@ describe('GroupMembersPanel', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn().mockResolvedValue({}),
-    } as never)
+    })
 
     vi.mocked(accessClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
   })
 
   describe('Rendering', () => {
@@ -176,7 +176,7 @@ describe('GroupMembersPanel', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupMembersPanel {...defaultProps} />, { wrapper })
 
@@ -207,7 +207,7 @@ describe('GroupMembersPanel', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupMembersPanel {...defaultProps} />, { wrapper })
 
@@ -224,7 +224,7 @@ describe('GroupMembersPanel', () => {
         isPending: true,
         isError: false,
         error: null,
-      } as never)
+      })
 
       render(<GroupMembersPanel {...defaultProps} />, { wrapper })
 
@@ -239,7 +239,7 @@ describe('GroupMembersPanel', () => {
         isPending: false,
         isError: true,
         error: new Error('Failed'),
-      } as never)
+      })
 
       render(<GroupMembersPanel {...defaultProps} />, { wrapper })
 
@@ -305,7 +305,7 @@ describe('GroupMembersPanel', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockMutate,
         isPending: false,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<GroupMembersPanel {...defaultProps} />, { wrapper })
@@ -369,7 +369,7 @@ describe('GroupMembersPanel', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<GroupMembersPanel {...defaultProps} />, { wrapper })
 
@@ -411,7 +411,7 @@ describe('GroupMembersPanel', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<GroupMembersPanel {...defaultProps} />, { wrapper })
@@ -477,7 +477,7 @@ describe('GroupMembersPanel', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockMutate,
         isPending: false,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<GroupMembersPanel {...defaultProps} />, { wrapper })
@@ -507,7 +507,7 @@ describe('GroupMembersPanel', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockMutate,
         isPending: false,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<GroupMembersPanel groupId="group-123" onMembershipChange={onMembershipChange} />, { wrapper })
@@ -550,7 +550,7 @@ describe('GroupMembersPanel', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn().mockResolvedValue({}),
-      } as never)
+      })
 
       render(<GroupMembersPanel {...defaultProps} />, { wrapper })
 
@@ -577,7 +577,7 @@ describe('GroupMembersPanel', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn().mockResolvedValue({}),
-      } as never)
+      })
 
       render(<GroupMembersPanel {...defaultProps} />, { wrapper })
 
@@ -630,7 +630,7 @@ describe('GroupMembersPanel', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const { container } = render(<GroupMembersPanel {...defaultProps} />, { wrapper })
       const results = await axe(container)

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/AssignProjectRoleModal.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/AssignProjectRoleModal.tsx
@@ -80,7 +80,7 @@ function TypeaheadFormField<T extends FieldValues>({
               id={fieldId}
               ariaLabel={ariaLabel}
               options={options}
-              selected={field.value as string}
+              selected={field.value}
               onChange={(value) => {
                 field.onChange(value)
                 onValueChange?.()

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectDetail.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectDetail.test.tsx
@@ -117,7 +117,7 @@ describe('ProjectDetail', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
   }
 
   beforeEach(() => {
@@ -126,7 +126,7 @@ describe('ProjectDetail', () => {
     mockRefetch.mockResolvedValue({})
     mockDetailTab.mockReturnValue(['details', mockGoToTab])
     mockUseParams.mockReturnValue({ projectId: 'proj-1' })
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
     vi.mocked(useProjectPermissions).mockReturnValue({
       canCreate: true,
       canUpdate: true,
@@ -137,7 +137,7 @@ describe('ProjectDetail', () => {
     vi.mocked(accessClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
     setupMocks()
   })
 
@@ -255,7 +255,7 @@ describe('ProjectDetail', () => {
       isError: true,
       error: new Error('Not found'),
       refetch: mockRefetch,
-    } as never)
+    })
 
     render(<ProjectDetail />, { wrapper })
 
@@ -272,7 +272,7 @@ describe('ProjectDetail', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     render(<ProjectDetail />, { wrapper })
 
@@ -288,7 +288,7 @@ describe('ProjectDetail', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     const { container } = render(<ProjectDetail />, { wrapper })
 
@@ -303,7 +303,7 @@ describe('ProjectDetail', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     render(<ProjectDetail />, { wrapper })
 
@@ -318,7 +318,7 @@ describe('ProjectDetail', () => {
       isError: true,
       error: new Error('Not found'),
       refetch: mockRefetch,
-    } as never)
+    })
 
     render(<ProjectDetail />, { wrapper })
 
@@ -335,7 +335,7 @@ describe('ProjectDetail', () => {
       isError: true,
       error: new Error('Not found'),
       refetch: mockRefetch,
-    } as never)
+    })
 
     render(<ProjectDetail />, { wrapper })
 
@@ -352,7 +352,7 @@ describe('ProjectDetail', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     render(<ProjectDetail />, { wrapper })
 
@@ -412,7 +412,7 @@ describe('ProjectDetail', () => {
       isError: true,
       error: { message: 'Not found', retryable: true },
       refetch: rejectingRefetch,
-    } as never)
+    })
 
     render(<ProjectDetail />, { wrapper })
 
@@ -432,7 +432,7 @@ describe('ProjectDetail', () => {
       isError: true,
       error: new Error('Not found'),
       refetch: rejectingRefetch,
-    } as never)
+    })
 
     render(<ProjectDetail />, { wrapper })
 
@@ -449,7 +449,7 @@ describe('ProjectDetail', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     const { container } = render(<ProjectDetail />, { wrapper })
 
@@ -465,7 +465,7 @@ describe('ProjectDetail', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     render(<ProjectDetail />, { wrapper })
 
@@ -482,7 +482,7 @@ describe('ProjectDetail', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     render(<ProjectDetail />, { wrapper })
 
@@ -495,7 +495,7 @@ describe('ProjectDetail', () => {
         const body = (opts as { body?: { resource_type?: string } })?.body
         const resourceType = body?.resource_type ?? ''
         const allowed = permissions[resourceType] ?? true
-        return Promise.resolve({ data: { allowed } } as never)
+        return Promise.resolve({ data: { allowed } })
       })
     }
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPoliciesTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPoliciesTab.test.tsx
@@ -101,7 +101,7 @@ describe('ProjectPoliciesTab', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     vi.mocked(accessClient.useMutation).mockReturnValue(mockMutationReturn)
   }
@@ -162,7 +162,7 @@ describe('ProjectPoliciesTab', () => {
       isError: true,
       error: new Error('Network error'),
       refetch: vi.fn(),
-    } as never)
+    })
 
     render(<ProjectPoliciesTab projectId="proj-1" />, { wrapper })
 
@@ -176,7 +176,7 @@ describe('ProjectPoliciesTab', () => {
       isError: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     render(<ProjectPoliciesTab projectId="proj-1" />, { wrapper })
 
@@ -312,7 +312,7 @@ describe('ProjectPoliciesTab', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     const user = userEvent.setup()
     render(<ProjectPoliciesTab projectId="proj-1" />, { wrapper })

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPolicySelect.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectPolicySelect.test.tsx
@@ -77,7 +77,7 @@ describe('ProjectPolicySelect', () => {
       data: { resources: policies },
       isLoading,
       isFetching,
-    } as never)
+    })
   }
 
   beforeEach(() => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectRoleAssignmentsTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectRoleAssignmentsTab.test.tsx
@@ -189,7 +189,7 @@ function setupMutationMock(callbackToInvoke: 'onSuccess' | 'onError', errorValue
     isPending: false,
     isError: false,
     error: null,
-  } as never)
+  })
   return mutate
 }
 
@@ -237,7 +237,7 @@ async function openUnassignDialog(user: UserEvent, principalName: string, roleNa
 describe('ProjectRoleAssignmentsTab', () => {
   const mockRefetch = vi.fn().mockResolvedValue({})
 
-  function setupMocks(assignments: RoleAssignmentRead[] = mockAllAssignments as unknown as RoleAssignmentRead[]) {
+  function setupMocks(assignments: RoleAssignmentRead[] = mockAllAssignments) {
     vi.mocked(accessClient.useQuery).mockReturnValue({
       data: { resources: assignments, total: assignments.length, next: null, prev: null },
       isPending: false,
@@ -245,7 +245,7 @@ describe('ProjectRoleAssignmentsTab', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     vi.mocked(accessClient.useMutation).mockReturnValue(mockMutationReturn)
   }
@@ -315,7 +315,7 @@ describe('ProjectRoleAssignmentsTab', () => {
         created_at: '2024-04-01T00:00:00Z',
         project_id: 'proj-1',
         project_name: 'Test Project',
-      } as RoleAssignmentRead,
+      },
     ])
     render(<ProjectRoleAssignmentsTab projectId="proj-1" />, { wrapper })
 
@@ -357,7 +357,7 @@ describe('ProjectRoleAssignmentsTab', () => {
       isError: true,
       error: new Error('Network error'),
       refetch: vi.fn(),
-    } as never)
+    })
 
     render(<ProjectRoleAssignmentsTab projectId="proj-1" />, { wrapper })
 
@@ -372,7 +372,7 @@ describe('ProjectRoleAssignmentsTab', () => {
       isError: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     render(<ProjectRoleAssignmentsTab projectId="proj-1" />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectWorkflowsTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectWorkflowsTab.test.tsx
@@ -125,8 +125,8 @@ function mockQueries(options?: {
     error: options?.error ?? null,
     refetch,
   }
-  vi.mocked(accessClient.useQuery).mockReturnValue(returnValue as never)
-  vi.mocked(workflowClient.useQuery).mockReturnValue(returnValue as never)
+  vi.mocked(accessClient.useQuery).mockReturnValue(returnValue)
+  vi.mocked(workflowClient.useQuery).mockReturnValue(returnValue)
   return refetch
 }
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/CredentialsTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/CredentialsTab.test.tsx
@@ -128,7 +128,7 @@ describe('CredentialsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     for (const action of ['create', 'update', 'delete', 'rotate_secret']) {
       queryClient.setQueryData(['authz', 'can_i', { action, resource_type: 'service_account' }], {
@@ -137,7 +137,7 @@ describe('CredentialsTab', () => {
     }
 
     vi.mocked(accessClient.useQuery).mockReturnValue(
-      buildQueryResult({ resources: mockCredentials, max_lifetime_days: 180 }) as never
+      buildQueryResult({ resources: mockCredentials, max_lifetime_days: 180 })
     )
 
     mockMutations = setupMutationMocks()
@@ -165,7 +165,7 @@ describe('CredentialsTab', () => {
   })
 
   it('shows empty state when there are no credentials', () => {
-    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ resources: [] }) as never)
+    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ resources: [] }))
 
     render(<CredentialsTab serviceAccountId="sa-1" serviceAccountName="deploy-bot" resourceProject="proj-1" />, {
       wrapper,
@@ -350,7 +350,7 @@ describe('CredentialsTab', () => {
           grace_period_seconds: 3600,
         },
       ]
-      vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ resources: credsWithGracePeriod }) as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ resources: credsWithGracePeriod }))
 
       const user = userEvent.setup()
       render(<CredentialsTab serviceAccountId="sa-1" resourceProject="proj-1" />, { wrapper })
@@ -474,7 +474,7 @@ describe('CredentialsTab', () => {
       }))
 
       vi.mocked(accessClient.useQuery).mockReturnValue(
-        buildQueryResult({ resources: maxCreds, max_credentials: 10, total_credentials: 10 }) as never
+        buildQueryResult({ resources: maxCreds, max_credentials: 10, total_credentials: 10 })
       )
 
       render(<CredentialsTab serviceAccountId="sa-1" serviceAccountName="deploy-bot" resourceProject="proj-1" />, {
@@ -493,7 +493,7 @@ describe('CredentialsTab', () => {
       }))
 
       vi.mocked(accessClient.useQuery).mockReturnValue(
-        buildQueryResult({ resources: maxCreds, max_credentials: 10, total_credentials: 10 }) as never
+        buildQueryResult({ resources: maxCreds, max_credentials: 10, total_credentials: 10 })
       )
 
       const user = userEvent.setup()
@@ -582,7 +582,7 @@ describe('CredentialsTab', () => {
           isSuccess: false,
           error: new Error('Network error'),
           data: undefined,
-        }) as never
+        })
       )
 
       render(<CredentialsTab serviceAccountId="sa-1" serviceAccountName="deploy-bot" resourceProject="proj-1" />, {
@@ -614,7 +614,7 @@ describe('CredentialsTab', () => {
       }))
 
       vi.mocked(accessClient.useQuery).mockReturnValue(
-        buildQueryResult({ resources: maxCreds, max_credentials: 10, total_credentials: 10 }) as never
+        buildQueryResult({ resources: maxCreds, max_credentials: 10, total_credentials: 10 })
       )
 
       const { container } = render(
@@ -629,7 +629,7 @@ describe('CredentialsTab', () => {
     })
 
     it('has no accessibility violations in empty state', async () => {
-      vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ resources: [] }) as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ resources: [] }))
 
       const { container } = render(
         <CredentialsTab serviceAccountId="sa-1" serviceAccountName="deploy-bot" resourceProject="proj-1" />,

--- a/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/EditServiceAccountModal.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/EditServiceAccountModal.test.tsx
@@ -71,7 +71,7 @@ describe('EditServiceAccountModal', () => {
       variables: undefined,
       status: 'idle',
       isPaused: false,
-    } as never)
+    })
   })
 
   it('renders with "Edit service account" title', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountDetail.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountDetail.test.tsx
@@ -304,7 +304,7 @@ describe('ServiceAccountDetail', () => {
 
   it('renders owning project as a link when project_name is present', () => {
     vi.mocked(accessClient.useQuery).mockReturnValue(
-      buildQueryResult({ ...mockServiceAccount, project_name: 'my-project' }) as never
+      buildQueryResult({ ...mockServiceAccount, project_name: 'my-project' })
     )
 
     render(<ServiceAccountDetail />, { wrapper })

--- a/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountDetail.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountDetail.test.tsx
@@ -114,9 +114,9 @@ describe('ServiceAccountDetail', () => {
       tooltips: { create: '', update: '', delete: '', rotateSecret: '' },
     })
 
-    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult(mockServiceAccount) as never)
+    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult(mockServiceAccount))
 
-    vi.mocked(accessClient.useMutation).mockReturnValue(buildMutationResult() as never)
+    vi.mocked(accessClient.useMutation).mockReturnValue(buildMutationResult())
   })
 
   it('renders the service account name as heading', () => {
@@ -223,9 +223,7 @@ describe('ServiceAccountDetail', () => {
       return buildMutationResult()
     }) as never)
 
-    vi.mocked(accessClient.useQuery).mockReturnValue(
-      buildQueryResult({ ...mockServiceAccount, status: 'disabled' }) as never
-    )
+    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ ...mockServiceAccount, status: 'disabled' }))
 
     const user = userEvent.setup()
     render(<ServiceAccountDetail />, { wrapper })
@@ -253,7 +251,7 @@ describe('ServiceAccountDetail', () => {
         isError: true,
         error: new Error('Not found'),
         data: undefined,
-      }) as never
+      })
     )
 
     render(<ServiceAccountDetail />, { wrapper })
@@ -269,7 +267,7 @@ describe('ServiceAccountDetail', () => {
         error: new Error('Not found'),
         data: undefined,
         refetch: mockRefetch,
-      }) as never
+      })
     )
 
     const user = userEvent.setup()
@@ -282,9 +280,7 @@ describe('ServiceAccountDetail', () => {
   })
 
   it('shows outline disabled state label on details tab', () => {
-    vi.mocked(accessClient.useQuery).mockReturnValue(
-      buildQueryResult({ ...mockServiceAccount, status: 'disabled' }) as never
-    )
+    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ ...mockServiceAccount, status: 'disabled' }))
 
     render(<ServiceAccountDetail />, { wrapper })
 
@@ -292,9 +288,7 @@ describe('ServiceAccountDetail', () => {
   })
 
   it('shows Disabled state for disabled service accounts', () => {
-    vi.mocked(accessClient.useQuery).mockReturnValue(
-      buildQueryResult({ ...mockServiceAccount, status: 'disabled' }) as never
-    )
+    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ ...mockServiceAccount, status: 'disabled' }))
 
     render(<ServiceAccountDetail />, { wrapper })
 
@@ -315,9 +309,7 @@ describe('ServiceAccountDetail', () => {
   })
 
   it('renders owning project as plain text when project_name is null', () => {
-    vi.mocked(accessClient.useQuery).mockReturnValue(
-      buildQueryResult({ ...mockServiceAccount, project_name: null }) as never
-    )
+    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ ...mockServiceAccount, project_name: null }))
 
     render(<ServiceAccountDetail />, { wrapper })
 
@@ -327,7 +319,7 @@ describe('ServiceAccountDetail', () => {
 
   it('shows Never for last authenticated when never used', () => {
     vi.mocked(accessClient.useQuery).mockReturnValue(
-      buildQueryResult({ ...mockServiceAccount, last_authenticated_at: null }) as never
+      buildQueryResult({ ...mockServiceAccount, last_authenticated_at: null })
     )
 
     render(<ServiceAccountDetail />, { wrapper })
@@ -382,7 +374,7 @@ describe('ServiceAccountDetail', () => {
         isLoading: true,
         isSuccess: false,
         data: undefined,
-      }) as never
+      })
     )
 
     render(<ServiceAccountDetail />, { wrapper })
@@ -391,9 +383,7 @@ describe('ServiceAccountDetail', () => {
   })
 
   it('hides description row when description is null', () => {
-    vi.mocked(accessClient.useQuery).mockReturnValue(
-      buildQueryResult({ ...mockServiceAccount, description: null }) as never
-    )
+    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ ...mockServiceAccount, description: null }))
 
     render(<ServiceAccountDetail />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountsTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountsTab.test.tsx
@@ -129,7 +129,7 @@ describe('ServiceAccountsTab', () => {
     })
 
     vi.mocked(accessClient.useQuery).mockReturnValue(
-      buildQueryResult({ resources: mockServiceAccounts, next_cursor: null }) as never
+      buildQueryResult({ resources: mockServiceAccounts, next_cursor: null })
     )
 
     vi.mocked(accessClient.useMutation).mockReturnValue(buildMutationResult() as never)

--- a/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountsTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountsTab.test.tsx
@@ -132,7 +132,7 @@ describe('ServiceAccountsTab', () => {
       buildQueryResult({ resources: mockServiceAccounts, next_cursor: null })
     )
 
-    vi.mocked(accessClient.useMutation).mockReturnValue(buildMutationResult() as never)
+    vi.mocked(accessClient.useMutation).mockReturnValue(buildMutationResult())
   })
 
   it('renders service accounts in a table', () => {
@@ -165,7 +165,7 @@ describe('ServiceAccountsTab', () => {
       buildQueryResult({
         resources: [{ ...mockServiceAccounts[0], project_name: null }],
         next_cursor: null,
-      }) as never
+      })
     )
 
     render(<ServiceAccountsTab />, { wrapper })
@@ -181,7 +181,7 @@ describe('ServiceAccountsTab', () => {
   })
 
   it('renders empty state when no service accounts exist', () => {
-    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ resources: [], next_cursor: null }) as never)
+    vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ resources: [], next_cursor: null }))
 
     render(<ServiceAccountsTab />, { wrapper })
 
@@ -429,7 +429,7 @@ describe('ServiceAccountsTab', () => {
     })
 
     it('has no accessibility violations in empty state', async () => {
-      vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ resources: [], next_cursor: null }) as never)
+      vi.mocked(accessClient.useQuery).mockReturnValue(buildQueryResult({ resources: [], next_cursor: null }))
 
       const { container } = render(<ServiceAccountsTab />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/useServiceAccountPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/useServiceAccountPermissions.test.ts
@@ -47,7 +47,7 @@ describe('useServiceAccountPermissions', () => {
   })
 
   it('hub chrome only checks create with check_any_project', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useServiceAccountPermissions(), { wrapper: createWrapper() })
 
@@ -65,7 +65,7 @@ describe('useServiceAccountPermissions', () => {
   })
 
   it('scopes destructive actions to resourceProject on detail/row screens', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useServiceAccountPermissions({ resourceProject: 'proj-1' }), {
       wrapper: createWrapper(),

--- a/frontend/packages/syntara-ui/src/routes/access-management/token-revocation/TokenRevocation.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/token-revocation/TokenRevocation.test.tsx
@@ -55,7 +55,7 @@ describe('TokenRevocationTab', () => {
       mutate: mockMutate,
       isPending: false,
     } as ReturnType<typeof adminClient.useMutation>)
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
   })
 
   function renderWithQuery(data: { revoked_before: string | null; updated_at: string | null }) {
@@ -65,7 +65,7 @@ describe('TokenRevocationTab', () => {
       isError: false,
       error: null,
       refetch: vi.fn(),
-    } as unknown as ReturnType<typeof adminClient.useQuery>)
+    })
     return render(<TokenRevocationTab />, { wrapper })
   }
 
@@ -166,7 +166,7 @@ describe('TokenRevocationTab', () => {
   })
 
   it('disables revoke button when user lacks revoke permission', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } })
     renderWithQuery({ revoked_before: null, updated_at: null })
 
     await waitFor(() => {
@@ -192,7 +192,7 @@ describe('TokenRevocationTab', () => {
   })
 
   it('should have no accessibility violations when button is disabled', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } })
     const { container } = renderWithQuery({ revoked_before: null, updated_at: null })
     let results: Awaited<ReturnType<typeof axe>>
     await act(async () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/useAccessManagementPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/useAccessManagementPermissions.test.ts
@@ -71,7 +71,7 @@ describe('useAccessManagementPermissions', () => {
   })
 
   it('updates to true when API confirms access', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useAccessManagementPermissions(), { wrapper: createWrapper() })
 
@@ -81,7 +81,7 @@ describe('useAccessManagementPermissions', () => {
   })
 
   it('updates to false when API denies all access', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } })
 
     const { result } = renderHook(() => useAccessManagementPermissions(), { wrapper: createWrapper() })
 
@@ -173,7 +173,7 @@ describe('useAccessManagementPermissions', () => {
   })
 
   it('calls can_i with check_any_project for project-aware resources', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     renderHook(() => useAccessManagementPermissions(), { wrapper: createWrapper() })
 
@@ -204,7 +204,7 @@ describe('useAccessManagementPermissions', () => {
   })
 
   it('deduplicates queries across multiple consumers', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const wrapper = createWrapper()
     renderHook(() => useAccessManagementPermissions(), { wrapper })

--- a/frontend/packages/syntara-ui/src/routes/access-management/useAdminToggle.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/useAdminToggle.test.ts
@@ -65,7 +65,7 @@ function setupMocks({
   vi.mocked(accessClient.useMutation).mockReturnValue({
     mutate: mockMutate,
     isPending: false,
-  } as never)
+  })
   vi.mocked(useActiveAdminCount).mockReturnValue(activeAdminCount)
   vi.mocked(useMutationErrorHandler).mockReturnValue(mockErrorHandler)
   vi.mocked(useAuthStore).mockImplementation((selector: unknown) =>

--- a/frontend/packages/syntara-ui/src/routes/access-management/useGroupPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/useGroupPermissions.test.ts
@@ -48,7 +48,7 @@ describe('useGroupPermissions', () => {
   })
 
   it('returns all true when API grants all permissions', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useGroupPermissions(), { wrapper: createWrapper() })
 
@@ -62,7 +62,7 @@ describe('useGroupPermissions', () => {
   })
 
   it('calls can_i with correct action and resource_type', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     renderHook(() => useGroupPermissions(), { wrapper: createWrapper() })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/useProjectPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/useProjectPermissions.test.ts
@@ -47,7 +47,7 @@ describe('useProjectPermissions', () => {
   })
 
   it('hub chrome only checks project:create', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useProjectPermissions(), { wrapper: createWrapper() })
 
@@ -64,7 +64,7 @@ describe('useProjectPermissions', () => {
   })
 
   it('scopes update/delete to a concrete resourceProject', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useProjectPermissions({ resourceProject: 'proj-a' }), {
       wrapper: createWrapper(),

--- a/frontend/packages/syntara-ui/src/routes/access-management/useRevokeUserTokens.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/useRevokeUserTokens.test.ts
@@ -29,7 +29,7 @@ function setupMocks() {
   vi.mocked(adminClient.useMutation).mockReturnValue({
     mutate: mockMutate,
     isPending: false,
-  } as never)
+  })
   vi.mocked(useMutationErrorHandler).mockReturnValue(mockErrorHandler)
 }
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/useUserPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/useUserPermissions.test.ts
@@ -48,7 +48,7 @@ describe('useUserPermissions', () => {
   })
 
   it('returns all true when API grants all permissions', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useUserPermissions(), { wrapper: createWrapper() })
 
@@ -62,7 +62,7 @@ describe('useUserPermissions', () => {
   })
 
   it('returns all false when API denies all permissions', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } })
 
     const { result } = renderHook(() => useUserPermissions(), { wrapper: createWrapper() })
 
@@ -76,7 +76,7 @@ describe('useUserPermissions', () => {
   })
 
   it('calls can_i with correct action and resource_type', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     renderHook(() => useUserPermissions(), { wrapper: createWrapper() })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/useUsersEnabledToggle.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/useUsersEnabledToggle.test.ts
@@ -89,7 +89,7 @@ function setupMocks({
     mutateAsync: mockMutateAsync,
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
   vi.mocked(accessClient.useQuery).mockImplementation((...args: unknown[]) => {
     const endpoint = args[1] as string
     if (endpoint === '/groups') {

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/CreateUser.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/CreateUser.test.tsx
@@ -56,11 +56,11 @@ describe('CreateUser', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
     vi.mocked(usersClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
 
     render(<CreateUser />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/EditUser.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/EditUser.test.tsx
@@ -77,7 +77,7 @@ function setupSuccessMocks() {
     error: null,
     isFetching: false,
     refetch: vi.fn(),
-  } as never)
+  })
   vi.mocked(accessClient.useQuery).mockReturnValue({
     data: mockUserData,
     isPending: false,
@@ -85,11 +85,11 @@ function setupSuccessMocks() {
     error: null,
     isFetching: false,
     refetch: vi.fn(),
-  } as never)
+  })
   vi.mocked(accessClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
 }
 
 describe('EditUser', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/IdentityDialogs.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/IdentityDialogs.test.tsx
@@ -70,12 +70,12 @@ function setupMocks() {
     isError: false,
     error: null,
     refetch: vi.fn(),
-  } as never)
+  })
 
   vi.mocked(usersClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
 }
 
 const defaultDialogProps = {

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/TransferIdentityWizard.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/TransferIdentityWizard.test.tsx
@@ -184,7 +184,7 @@ function setupMocks({
   vi.mocked(usersClient.useMutation).mockReturnValue({
     mutate: mockMutate,
     isPending: false,
-  } as never)
+  })
 }
 
 describe('TransferIdentityWizard', () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserDetail.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserDetail.test.tsx
@@ -191,7 +191,7 @@ function mockQueryByPath(pathResults: Record<string, unknown>) {
   vi.mocked(accessClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
 }
 
 /** Default mock return for a successful user + groups + identities + role-assignments query set. */
@@ -237,7 +237,7 @@ function mockSuccessQueries(roleAssignments = mockRoleAssignmentsData) {
   vi.mocked(accessClient.useMutation).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
-  } as never)
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -269,7 +269,7 @@ describe('computeRoleAssignmentCount', () => {
 describe('UserDetail', () => {
   beforeEach(() => {
     mockAuthQuery.mockReturnValue({ data: { id: 'me-id' }, isPending: false, isError: false, error: null })
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
     vi.mocked(useUserPermissions).mockReturnValue({
       canCreate: true,
       canUpdate: true,
@@ -380,7 +380,7 @@ describe('UserDetail', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const { container } = render(<UserDetail />, { wrapper })
 
@@ -1499,7 +1499,7 @@ describe('UserDetail', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<UserDetail isMyProfile />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserForm.test.tsx
@@ -89,7 +89,7 @@ function setupCreateMocks(mutateOverrides?: Partial<ReturnType<typeof vi.fn>>) {
     error: null,
     isFetching: false,
     refetch: vi.fn(),
-  } as never)
+  })
   vi.mocked(accessClient.useQuery).mockReturnValue({
     data: undefined,
     isPending: false,
@@ -97,13 +97,13 @@ function setupCreateMocks(mutateOverrides?: Partial<ReturnType<typeof vi.fn>>) {
     error: null,
     isFetching: false,
     refetch: vi.fn(),
-  } as never)
+  })
   const mockMutate = vi.fn()
   vi.mocked(accessClient.useMutation).mockReturnValue({
     mutate: mockMutate,
     isPending: false,
     ...mutateOverrides,
-  } as never)
+  })
   return { mockMutate }
 }
 
@@ -125,7 +125,7 @@ function setupEditMocks(mutateOverrides?: Partial<ReturnType<typeof vi.fn>>) {
     error: null,
     isFetching: false,
     refetch: vi.fn(),
-  } as never)
+  })
   vi.mocked(accessClient.useQuery).mockReturnValue({
     data: mockUserData,
     isPending: false,
@@ -133,13 +133,13 @@ function setupEditMocks(mutateOverrides?: Partial<ReturnType<typeof vi.fn>>) {
     error: null,
     isFetching: false,
     refetch: vi.fn(),
-  } as never)
+  })
   const mockMutate = vi.fn()
   vi.mocked(accessClient.useMutation).mockReturnValue({
     mutate: mockMutate,
     isPending: false,
     ...mutateOverrides,
-  } as never)
+  })
   return { mockMutate }
 }
 
@@ -288,7 +288,7 @@ describe('UserForm', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(accessClient.useQuery).mockReturnValue({
         data: undefined,
         isPending: false,
@@ -296,11 +296,11 @@ describe('UserForm', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
         isPending: true,
-      } as never)
+      })
 
       render(<UserForm mode="create" />, { wrapper })
 
@@ -391,7 +391,7 @@ describe('UserForm', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<UserForm mode="edit" />, { wrapper })
 
@@ -494,7 +494,7 @@ describe('UserForm', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(accessClient.useQuery).mockReturnValue({
         data: undefined,
         isPending: false,
@@ -502,11 +502,11 @@ describe('UserForm', () => {
         error: new Error('Not found'),
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
         isPending: false,
-      } as never)
+      })
 
       render(<UserForm mode="edit" />, { wrapper })
 
@@ -526,7 +526,7 @@ describe('UserForm', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(accessClient.useQuery).mockReturnValue({
         data: undefined,
         isPending: false,
@@ -534,11 +534,11 @@ describe('UserForm', () => {
         error: new Error('Not found'),
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
         isPending: false,
-      } as never)
+      })
 
       render(<UserForm mode="edit" />, { wrapper })
 
@@ -560,7 +560,7 @@ describe('UserForm', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(accessClient.useQuery).mockReturnValue({
         data: undefined,
         isPending: false,
@@ -568,11 +568,11 @@ describe('UserForm', () => {
         error: new Error('Not found'),
         isFetching: false,
         refetch: mockRefetch,
-      } as never)
+      })
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
         isPending: false,
-      } as never)
+      })
 
       render(<UserForm mode="edit" />, { wrapper })
 
@@ -590,7 +590,7 @@ describe('UserForm', () => {
         error: null,
         isFetching: false,
         refetch: vi.fn(),
-      } as never)
+      })
       vi.mocked(accessClient.useQuery).mockReturnValue({
         data: undefined,
         isPending: true,
@@ -600,11 +600,11 @@ describe('UserForm', () => {
         refetch: vi.fn(),
         status: 'pending',
         fetchStatus: 'fetching',
-      } as never)
+      })
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: vi.fn(),
         isPending: false,
-      } as never)
+      })
 
       render(<UserForm mode="edit" />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserGroupsPanel.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserGroupsPanel.test.tsx
@@ -128,7 +128,7 @@ describe('UserGroupsPanel', () => {
     vi.mocked(accessClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
   })
 
   describe('Rendering', () => {
@@ -548,7 +548,7 @@ describe('UserGroupsPanel', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockRemoveMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<UserGroupsPanel userId="user-123" />, { wrapper })
 
@@ -620,7 +620,7 @@ describe('UserGroupsPanel', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockRemoveMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<UserGroupsPanel userId="user-123" />, { wrapper })
 
@@ -838,7 +838,7 @@ describe('UserGroupsPanel', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         mutate: mockAddMutate,
         isPending: false,
-      } as never)
+      })
 
       return { mockRefetch }
     }

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserIdentitiesPanel.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserIdentitiesPanel.test.tsx
@@ -126,19 +126,19 @@ function setupMocks(identities: unknown[] = [], queryOverrides: Record<string, u
     error: null,
     refetch: vi.fn(),
     ...queryOverrides,
-  } as never)
+  })
 
   vi.mocked(usersClient.useMutation).mockReturnValue({
     mutate: mockMutate,
     isPending: false,
-  } as never)
+  })
 
   vi.mocked(identityProvidersClient.useQuery).mockReturnValue({
     data: { resources: mockFullProviders, next: null, prev: null },
     isPending: false,
     isError: false,
     error: null,
-  } as never)
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -158,7 +158,7 @@ describe('UserIdentitiesPanel', () => {
       isPending: false,
       isError: false,
       error: null,
-    } as never)
+    })
   })
 
   // ---- Empty state --------------------------------------------------------
@@ -319,12 +319,12 @@ describe('UserIdentitiesPanel', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(usersClient.useMutation).mockReturnValue({
         mutate: mockMutate,
         isPending: false,
-      } as never)
+      })
 
       render(<UserIdentitiesPanel userId="user-1" hasPassword={false} />, { wrapper })
 
@@ -685,7 +685,7 @@ describe('UserIdentitiesPanel', () => {
         isPending: false,
         isError: false,
         error: null,
-      } as never)
+      })
 
       render(<UserIdentitiesPanel userId="user-1" currentUserId="user-1" hasPassword={false} />, { wrapper })
 
@@ -775,7 +775,7 @@ describe('UserIdentitiesPanel', () => {
         isPending: false,
         isError: true,
         error: new Error('Network error'),
-      } as never)
+      })
 
       render(<UserIdentitiesPanel userId="user-1" hasPassword={false} />, { wrapper })
 
@@ -1007,7 +1007,7 @@ describe('useDetachIdentity', () => {
     vi.mocked(usersClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
   })
 
   const hookWrapper = ({ children }: { children: ReactNode }) => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/useTransferIdentityData.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/useTransferIdentityData.test.tsx
@@ -112,7 +112,7 @@ describe('useIdentitiesData', () => {
       isError: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useIdentitiesData(undefined), { wrapper })
 
@@ -126,7 +126,7 @@ describe('useIdentitiesData', () => {
       isError: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useIdentitiesData('user-2'), { wrapper })
 
@@ -142,7 +142,7 @@ describe('useIdentitiesData', () => {
       isError: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useIdentitiesData('user-2'), { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/useUserIdentityPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/useUserIdentityPermissions.test.ts
@@ -44,7 +44,7 @@ describe('useUserIdentityPermissions', () => {
   })
 
   it('returns all true when API grants all permissions', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useUserIdentityPermissions(), { wrapper: createWrapper() })
 
@@ -56,7 +56,7 @@ describe('useUserIdentityPermissions', () => {
   })
 
   it('calls can_i with correct action and resource_type', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     renderHook(() => useUserIdentityPermissions(), { wrapper: createWrapper() })
 

--- a/frontend/packages/syntara-ui/src/routes/access/AssignRoleDialog.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/AssignRoleDialog.test.tsx
@@ -200,7 +200,7 @@ function setupDefaultMocks() {
     }
     return { ...defaultQueryReturn } as never
   })
-  vi.mocked(accessClient.useMutation).mockReturnValue(mockMutationReturn as never)
+  vi.mocked(accessClient.useMutation).mockReturnValue(mockMutationReturn)
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -410,7 +410,7 @@ describe('AssignRoleDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutate: mockMutate,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<AssignRoleDialog {...defaultProps} />, { wrapper })
@@ -427,7 +427,7 @@ describe('AssignRoleDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutate: mockMutate,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<AssignRoleDialog {...defaultProps} />, { wrapper })
@@ -467,7 +467,7 @@ describe('AssignRoleDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutate: mockMutate,
-      } as never)
+      })
 
       const onSuccess = vi.fn()
       const onClose = vi.fn()
@@ -501,7 +501,7 @@ describe('AssignRoleDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutate: mockMutate,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<AssignRoleDialog {...defaultProps} />, { wrapper })
@@ -538,7 +538,7 @@ describe('AssignRoleDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutate: mockMutate,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<AssignRoleDialog {...defaultProps} />, { wrapper })
@@ -576,7 +576,7 @@ describe('AssignRoleDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutate: mockMutate,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<AssignRoleDialog {...defaultProps} />, { wrapper })
@@ -680,7 +680,7 @@ describe('AssignRoleDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutate: mockMutate,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<AssignRoleDialog {...defaultProps} />, { wrapper })
@@ -774,7 +774,7 @@ describe('AssignRoleDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutate: mockMutate,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<AssignRoleDialog {...defaultProps} />, { wrapper })

--- a/frontend/packages/syntara-ui/src/routes/access/AssignmentsTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/AssignmentsTab.test.tsx
@@ -193,7 +193,7 @@ describe('AssignmentsTab', () => {
       variables: undefined,
       status: 'idle',
       isPaused: false,
-    } as never)
+    })
 
     vi.mocked(accessFetchClient.GET).mockResolvedValue({ data: { resources: [] } } as never)
   })
@@ -1227,7 +1227,7 @@ describe('AssignmentsTab', () => {
           project_name: null,
           created_at: '2024-06-01T00:00:00Z',
         },
-      ] as unknown as RoleAssignmentRead[]
+      ]
       setupAssignmentsQuery(fullRow)
       const user = userEvent.setup()
       render(<AssignmentsTab />, { wrapper })
@@ -1257,7 +1257,7 @@ describe('AssignmentsTab', () => {
           project_name: null,
           created_at: '2024-01-01T00:00:00Z',
         },
-      ] as unknown as RoleAssignmentRead[]
+      ]
       setupAssignmentsQuery(minimalRow)
       render(<AssignmentsTab />, { wrapper })
 
@@ -1412,7 +1412,7 @@ describe('AssignmentsTab', () => {
           project_name: undefined,
           created_at: '2024-01-01T00:00:00Z',
         },
-      ] as unknown as RoleAssignmentRead[]
+      ]
       setupAssignmentsQuery(systemOnly)
       render(<AssignmentsTab />, { wrapper })
 
@@ -1435,7 +1435,7 @@ describe('AssignmentsTab', () => {
           project_name: 'Project Alpha',
           created_at: '2024-05-01T00:00:00Z',
         },
-      ] as unknown as RoleAssignmentRead[]
+      ]
       setupAssignmentsQuery(groupRow)
       const user = userEvent.setup()
       render(<AssignmentsTab />, { wrapper })

--- a/frontend/packages/syntara-ui/src/routes/access/CheckAccessView.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/CheckAccessView.test.tsx
@@ -75,7 +75,7 @@ function mockMutationState(overrides: Record<string, unknown>) {
     variables: undefined,
     isPaused: false,
     ...overrides,
-  } as never)
+  })
 }
 
 /** Helper to fill the form with resource type "project" and action "read" */
@@ -135,7 +135,7 @@ describe('CheckAccessView', () => {
       submittedAt: 0,
       variables: undefined,
       isPaused: false,
-    } as never)
+    })
   })
 
   it('renders the empty state initially', () => {

--- a/frontend/packages/syntara-ui/src/routes/access/EditAssignmentDialog.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/EditAssignmentDialog.test.tsx
@@ -175,7 +175,7 @@ function setupDefaultMocks() {
     refetch: vi.fn(),
   })
 
-  vi.mocked(accessClient.useMutation).mockReturnValue(mockMutationReturn as never)
+  vi.mocked(accessClient.useMutation).mockReturnValue(mockMutationReturn)
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -285,7 +285,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const onSuccess = vi.fn()
       const onClose = vi.fn()
@@ -316,7 +316,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const onSuccess = vi.fn()
       const onClose = vi.fn()
@@ -346,7 +346,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const onClose = vi.fn()
       const onSuccess = vi.fn()
@@ -375,7 +375,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const onClose = vi.fn()
       const onSuccess = vi.fn()
@@ -403,7 +403,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const onSuccess = vi.fn()
       const onClose = vi.fn()
@@ -432,7 +432,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined)
       const user = userEvent.setup()
@@ -514,7 +514,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<EditAssignmentDialog {...defaultProps} row={projectRow} />, { wrapper })
@@ -536,7 +536,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const onClose = vi.fn()
       const onSuccess = vi.fn()
@@ -567,7 +567,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const onSuccess = vi.fn()
       const onClose = vi.fn()
@@ -601,7 +601,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const onSuccess = vi.fn()
       const onClose = vi.fn()
@@ -632,7 +632,7 @@ describe('EditAssignmentDialog', () => {
       vi.mocked(accessClient.useMutation).mockReturnValue({
         ...mockMutationReturn,
         mutateAsync: mutateAsyncSpy,
-      } as never)
+      })
 
       const onSuccess = vi.fn()
       const onClose = vi.fn()

--- a/frontend/packages/syntara-ui/src/routes/access/EditRoleDialog.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/EditRoleDialog.test.tsx
@@ -72,7 +72,7 @@ describe('EditRoleDialog', () => {
       isFetching: false,
       isLoading: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     vi.mocked(accessClient.useMutation).mockReturnValue({
       mutate: mockMutate,
@@ -91,7 +91,7 @@ describe('EditRoleDialog', () => {
       variables: undefined,
       status: 'idle',
       isPaused: false,
-    } as never)
+    })
   })
 
   function renderDialog(role: RoleRead = mockRole) {

--- a/frontend/packages/syntara-ui/src/routes/access/MyPermissionsView.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/MyPermissionsView.tsx
@@ -164,7 +164,7 @@ export function MyPermissionsView() {
       },
       onSort: (_event, index, direction) => {
         setActiveSortIndex(index)
-        setSortDirection(direction as SortDirection)
+        setSortDirection(direction)
         setPage(1)
       },
       columnIndex,

--- a/frontend/packages/syntara-ui/src/routes/access/PoliciesTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PoliciesTab.test.tsx
@@ -96,7 +96,7 @@ function setupPoliciesQuery(policies: PolicyRead[], options?: { total?: number; 
     isError: false,
     error: null,
     refetch: mockRefetch,
-  } as never)
+  })
 }
 
 describe('PoliciesTab', () => {
@@ -123,7 +123,7 @@ describe('PoliciesTab', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     render(<PoliciesTab />, { wrapper })
 
@@ -138,7 +138,7 @@ describe('PoliciesTab', () => {
       isError: true,
       error: new Error('Network error'),
       refetch: mockRefetch,
-    } as never)
+    })
 
     render(<PoliciesTab />, { wrapper })
 
@@ -410,7 +410,7 @@ describe('PoliciesTab', () => {
     const user = userEvent.setup()
     let returnEmpty = false
 
-    vi.mocked(accessClient.useQuery).mockImplementation((() => ({
+    vi.mocked(accessClient.useQuery).mockImplementation(() => ({
       data: {
         resources: returnEmpty ? [] : samplePolicies,
         total: returnEmpty ? 0 : samplePolicies.length,
@@ -422,7 +422,7 @@ describe('PoliciesTab', () => {
       isError: false,
       error: null,
       refetch: mockRefetch,
-    })) as unknown as typeof accessClient.useQuery)
+    }))
 
     render(<PoliciesTab />, { wrapper })
 
@@ -468,7 +468,7 @@ describe('PoliciesTab', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
       render(<PoliciesTab />, { wrapper })
 
       expect(screen.getByText('No policies yet')).toBeInTheDocument()
@@ -482,7 +482,7 @@ describe('PoliciesTab', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
       render(<PoliciesTab />, { wrapper })
 
       expect(screen.getByText('No policies yet')).toBeInTheDocument()
@@ -577,7 +577,7 @@ describe('PoliciesTab', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
       render(<PoliciesTab />, { wrapper })
 
       expect(screen.getByText('admin-policy')).toBeInTheDocument()

--- a/frontend/packages/syntara-ui/src/routes/access/PolicyDetailSidebar.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicyDetailSidebar.test.tsx
@@ -257,7 +257,7 @@ describe('PolicyDetailSidebar', () => {
   it('renders scope as "Any" when policy.scope is undefined', () => {
     const policyWithUndefinedScope: PolicyRead = {
       ...customPolicy,
-      scope: undefined as unknown as string,
+      scope: undefined,
       project_id: null,
     }
     render(<PolicyDetailSidebar policy={policyWithUndefinedScope} onClose={onClose} />)

--- a/frontend/packages/syntara-ui/src/routes/access/PolicySelect.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PolicySelect.test.tsx
@@ -91,8 +91,8 @@ describe('PolicySelect', () => {
       isFetching: false,
       isLoading: false,
       refetch: vi.fn(),
-    } as never)
-    vi.mocked(fetchAllPoliciesForSelect).mockResolvedValue(mockPolicies as never)
+    })
+    vi.mocked(fetchAllPoliciesForSelect).mockResolvedValue(mockPolicies)
   })
 
   describe('Accessibility', () => {
@@ -207,7 +207,7 @@ describe('PolicySelect', () => {
         isFetching: true,
         isLoading: true,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const user = userEvent.setup()
       renderPolicySelect()
@@ -228,7 +228,7 @@ describe('PolicySelect', () => {
         isFetching: false,
         isLoading: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const user = userEvent.setup()
       renderPolicySelect()
@@ -343,7 +343,7 @@ describe('PolicySelect', () => {
         isFetching: false,
         isLoading: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const user = userEvent.setup()
       renderPolicySelect()
@@ -367,7 +367,7 @@ describe('PolicySelect', () => {
         isFetching: false,
         isLoading: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const user = userEvent.setup()
       renderPolicySelect()
@@ -420,7 +420,7 @@ describe('PolicySelect', () => {
         isFetching: false,
         isLoading: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const user = userEvent.setup()
       renderPolicySelect({ selected: ['orphan-policy'] })

--- a/frontend/packages/syntara-ui/src/routes/access/RolesTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/RolesTab.test.tsx
@@ -166,7 +166,7 @@ describe('RolesTab', () => {
       variables: undefined,
       status: 'idle',
       isPaused: false,
-    } as never)
+    })
   })
 
   describe('Accessibility', () => {
@@ -184,7 +184,7 @@ describe('RolesTab', () => {
         error: null,
         isFetching: false,
         refetch: mockRefetch,
-      } as never)
+      })
 
       const { container } = render(<RolesTab />, { wrapper: createWrapper() })
       const results = await axe(container)
@@ -257,7 +257,7 @@ describe('RolesTab', () => {
         error: null,
         isFetching: false,
         refetch: mockRefetch,
-      } as never)
+      })
 
       render(<RolesTab />, { wrapper: createWrapper() })
 

--- a/frontend/packages/syntara-ui/src/routes/access/WhoCanView.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/WhoCanView.test.tsx
@@ -71,7 +71,7 @@ function mockMutationState(overrides: Record<string, unknown>) {
     variables: undefined,
     isPaused: false,
     ...overrides,
-  } as never)
+  })
 }
 
 describe('WhoCanView', () => {
@@ -82,7 +82,7 @@ describe('WhoCanView', () => {
       data: { resources: [], next: null },
       isPending: false,
       error: null,
-    } as never)
+    })
     vi.mocked(accessFetchClient.GET).mockResolvedValue({ data: { resources: [] } } as never)
     vi.mocked(dynamicFetchClient.GET).mockResolvedValue({ data: { resources: [] } } as never)
     const projectsMockValue = {
@@ -121,7 +121,7 @@ describe('WhoCanView', () => {
       submittedAt: 0,
       variables: undefined,
       isPaused: false,
-    } as never)
+    })
   })
 
   it('renders empty state initially', () => {

--- a/frontend/packages/syntara-ui/src/routes/access/editAssignmentMutations.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/editAssignmentMutations.ts
@@ -7,7 +7,7 @@ function assertAssignmentId(data: unknown): string {
     data !== null &&
     typeof data === 'object' &&
     'id' in data &&
-    typeof (data).id === 'string' &&
+    typeof data.id === 'string' &&
     (data as { id: string }).id.length > 0
   ) {
     return (data as { id: string }).id

--- a/frontend/packages/syntara-ui/src/routes/access/editAssignmentMutations.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/editAssignmentMutations.ts
@@ -7,7 +7,7 @@ function assertAssignmentId(data: unknown): string {
     data !== null &&
     typeof data === 'object' &&
     'id' in data &&
-    typeof (data as { id: unknown }).id === 'string' &&
+    typeof (data).id === 'string' &&
     (data as { id: string }).id.length > 0
   ) {
     return (data as { id: string }).id

--- a/frontend/packages/syntara-ui/src/routes/access/fetchAllPoliciesForSelect.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/fetchAllPoliciesForSelect.test.ts
@@ -68,7 +68,7 @@ describe('fetchAllPoliciesForSelect', () => {
       { name: 'workflow-admin', is_project_eligible: false },
       { name: 'policy:update:project', is_project_eligible: true },
     ]
-    vi.mocked(fetchAllPages).mockResolvedValue(policies as never)
+    vi.mocked(fetchAllPages).mockResolvedValue(policies)
 
     const result = await fetchAllPoliciesForSelect({})
 
@@ -87,7 +87,7 @@ describe('fetchAllProjectPoliciesForSelect', () => {
       { id: '1', name: 'read-policy' },
       { id: '2', name: 'write-policy' },
     ]
-    vi.mocked(fetchAllPages).mockResolvedValue(policies as never)
+    vi.mocked(fetchAllPages).mockResolvedValue(policies)
 
     const result = await fetchAllProjectPoliciesForSelect('proj-1')
 

--- a/frontend/packages/syntara-ui/src/routes/access/useAllPermissions.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/useAllPermissions.test.tsx
@@ -42,7 +42,7 @@ describe('useAllPermissions', () => {
     vi.mocked(accessFetchClient.POST).mockResolvedValue({
       data: { resources: mockPermissions, next: null },
       error: null,
-    } as never)
+    })
 
     const { result } = renderHook(() => useAllPermissions(), { wrapper })
 
@@ -59,8 +59,8 @@ describe('useAllPermissions', () => {
     const page2 = [{ policy_name: 'policy-b', effect: 'deny', actions: ['delete'], scope: 'project', project: 'prod' }]
 
     vi.mocked(accessFetchClient.POST)
-      .mockResolvedValueOnce({ data: { resources: page1, next: 'cursor-1' }, error: null } as never)
-      .mockResolvedValueOnce({ data: { resources: page2, next: null }, error: null } as never)
+      .mockResolvedValueOnce({ data: { resources: page1, next: 'cursor-1' }, error: null })
+      .mockResolvedValueOnce({ data: { resources: page2, next: null }, error: null })
 
     const { result } = renderHook(() => useAllPermissions(), { wrapper })
 
@@ -76,7 +76,7 @@ describe('useAllPermissions', () => {
     vi.mocked(accessFetchClient.POST).mockResolvedValue({
       data: undefined,
       error: { detail: 'Forbidden' },
-    } as never)
+    })
 
     const { result } = renderHook(() => useAllPermissions(), { wrapper })
 
@@ -100,7 +100,7 @@ describe('useAllPermissions', () => {
     vi.mocked(accessFetchClient.POST).mockResolvedValue({
       data: { resources: [], next: null },
       error: null,
-    } as never)
+    })
 
     renderHook(() => useAllPermissions(), { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/access/useAssignmentPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/useAssignmentPermissions.test.ts
@@ -43,7 +43,7 @@ describe('useAssignmentPermissions', () => {
   })
 
   it('uses check_any_project when no resourceProject is provided', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     renderHook(() => useAssignmentPermissions(), { wrapper: createWrapper() })
 
@@ -58,7 +58,7 @@ describe('useAssignmentPermissions', () => {
   })
 
   it('scopes can_i to resourceProject when provided', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useAssignmentPermissions({ resourceProject: 'proj-1' }), {
       wrapper: createWrapper(),

--- a/frontend/packages/syntara-ui/src/routes/access/useRolePermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access/useRolePermissions.test.ts
@@ -46,7 +46,7 @@ describe('useRolePermissions', () => {
   })
 
   it('returns all true when API grants all permissions', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useRolePermissions(), { wrapper: createWrapper() })
 
@@ -59,7 +59,7 @@ describe('useRolePermissions', () => {
   })
 
   it('uses system-scoped can_i when no resourceProject is provided', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     renderHook(() => useRolePermissions(), { wrapper: createWrapper() })
 
@@ -78,7 +78,7 @@ describe('useRolePermissions', () => {
   })
 
   it('scopes can_i to resourceProject when provided', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     renderHook(() => useRolePermissions({ resourceProject: 'proj-1' }), { wrapper: createWrapper() })
 

--- a/frontend/packages/syntara-ui/src/routes/approvals/ApprovalDetailContent.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/approvals/ApprovalDetailContent.test.tsx
@@ -104,7 +104,7 @@ describe('ApprovalDetailContent', () => {
       mutate: vi.fn(),
       isPending: false,
       isSuccess: false,
-    } as never)
+    })
   })
 
   it('renders the approval summary with workflow name', () => {
@@ -223,7 +223,7 @@ describe('ApprovalDetailContent', () => {
       mutate,
       isPending: false,
       isSuccess: false,
-    } as never)
+    })
 
     const user = userEvent.setup()
     render(<ApprovalDetailContent approval={mockApproval} />, { wrapper })
@@ -250,7 +250,7 @@ describe('ApprovalDetailContent', () => {
       mutate,
       isPending: false,
       isSuccess: false,
-    } as never)
+    })
 
     const user = userEvent.setup()
     render(<ApprovalDetailContent approval={mockApproval} />, { wrapper })
@@ -275,7 +275,7 @@ describe('ApprovalDetailContent', () => {
       mutate,
       isPending: false,
       isSuccess: false,
-    } as never)
+    })
 
     const onDecisionSubmitted = vi.fn()
     const user = userEvent.setup()
@@ -342,7 +342,7 @@ describe('ApprovalDetailContent', () => {
       mutate,
       isPending: false,
       isSuccess: false,
-    } as never)
+    })
 
     const user = userEvent.setup()
     const { rerender } = render(<ApprovalDetailContent approval={mockApproval} />, { wrapper })
@@ -355,7 +355,7 @@ describe('ApprovalDetailContent', () => {
       mutate,
       isPending: true,
       isSuccess: false,
-    } as never)
+    })
 
     rerender(<ApprovalDetailContent approval={mockApproval} />)
 
@@ -369,7 +369,7 @@ describe('ApprovalDetailContent', () => {
       mutate,
       isPending: false,
       isSuccess: false,
-    } as never)
+    })
 
     render(<ApprovalDetailContent approval={mockApproval} />, { wrapper })
 
@@ -385,7 +385,7 @@ describe('ApprovalDetailContent', () => {
       mutate,
       isPending: false,
       isSuccess: false,
-    } as never)
+    })
 
     const approvalNoId = { ...mockApproval, id: undefined as unknown as string }
     const user = userEvent.setup()

--- a/frontend/packages/syntara-ui/src/routes/approvals/Approvals.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/approvals/Approvals.test.tsx
@@ -289,7 +289,7 @@ describe('Approvals Component', () => {
       error: null,
       isError: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     mockUseProjectSelector.mockReturnValue({
       selectedProject: null,
@@ -308,7 +308,7 @@ describe('Approvals Component', () => {
       error,
       isError: !!error,
       refetch: vi.fn(),
-    } as never)
+    })
   }
 
   it('renders the approvals table with data', () => {
@@ -369,7 +369,7 @@ describe('Approvals Component', () => {
       isError: true,
       error: { message: 'Failed to load', retryable: true },
       refetch: mockRefetch,
-    } as never)
+    })
 
     const user = userEvent.setup()
     render(<Approvals />)
@@ -697,7 +697,7 @@ describe('Approvals Component', () => {
         error: null,
         isError: false,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<Approvals />)
 
@@ -748,7 +748,7 @@ describe('Approvals Component', () => {
         },
         isPending: false,
         error: null,
-      } as never)
+      })
 
       render(<Approvals />)
 
@@ -767,7 +767,7 @@ describe('Approvals Component', () => {
         },
         isPending: false,
         error: null,
-      } as never)
+      })
 
       render(<Approvals />)
 
@@ -788,7 +788,7 @@ describe('Approvals Component', () => {
         },
         isPending: false,
         error: null,
-      } as never)
+      })
 
       render(<Approvals />)
 
@@ -816,7 +816,7 @@ describe('Approvals Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       const { rerender } = render(<Approvals />)
 
@@ -850,7 +850,7 @@ describe('Approvals Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       // Rerender to trigger useEffect with fetching state
       rerender(<Approvals />)
@@ -879,7 +879,7 @@ describe('Approvals Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       rerender(<Approvals />)
 
@@ -918,7 +918,7 @@ describe('Approvals Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       const { rerender } = render(<Approvals />)
 
@@ -949,7 +949,7 @@ describe('Approvals Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       rerender(<Approvals />)
 
@@ -983,7 +983,7 @@ describe('Approvals Component', () => {
           workflow_id: undefined,
         },
       }
-      mockApprovalsQuery([approvalWithoutWorkflow] as unknown as Approval[])
+      mockApprovalsQuery([approvalWithoutWorkflow])
 
       render(<Approvals />)
 
@@ -1052,7 +1052,7 @@ describe('Approvals Component', () => {
         ...a,
         project_id: i === 0 ? 'proj-1' : 'proj-2',
       }))
-      mockApprovalsQuery(approvalsWithProjects as Approval[])
+      mockApprovalsQuery(approvalsWithProjects)
 
       render(<Approvals />)
 
@@ -1074,7 +1074,7 @@ describe('Approvals Component', () => {
       mockAllProjectsSelector([{ id: 'proj-1', name: 'Project Alpha' }])
 
       const approvalsWithProject = [{ ...mockApprovals[0], project_id: 'proj-1' }]
-      mockApprovalsQuery(approvalsWithProject as Approval[])
+      mockApprovalsQuery(approvalsWithProject)
 
       render(<Approvals />)
 
@@ -1129,7 +1129,7 @@ describe('Approvals Component', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       vi.mocked(approvalsClient.useQuery).mockReturnValue({
         data: undefined,
@@ -1137,7 +1137,7 @@ describe('Approvals Component', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<Approvals />)
 
@@ -1164,7 +1164,7 @@ describe('Approvals Component', () => {
         isPending: false,
         isError: false,
         error: null,
-      } as never)
+      })
     })
 
     async function selectFirstPendingApproval(user: ReturnType<typeof userEvent.setup>) {
@@ -1231,7 +1231,7 @@ describe('Approvals Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<Approvals />)
@@ -1261,7 +1261,7 @@ describe('Approvals Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<Approvals />)

--- a/frontend/packages/syntara-ui/src/routes/approvals/ApprovalsTableBody.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/approvals/ApprovalsTableBody.test.tsx
@@ -52,7 +52,7 @@ function makeProject(overrides: Partial<ProjectRead> = {}): ProjectRead {
     id: 'proj-1',
     name: 'Project Alpha',
     ...overrides,
-  } as ProjectRead
+  }
 }
 
 describe('FlatApprovalsTableBody', () => {

--- a/frontend/packages/syntara-ui/src/routes/approvals/useApprovalSelection.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/approvals/useApprovalSelection.test.ts
@@ -358,7 +358,7 @@ describe('useApprovalSelection', () => {
           selectableApprovalIds: mockSelectableApprovalIds,
         }),
       {
-        initialProps: { sortParam: '-created_at' as string | undefined },
+        initialProps: { sortParam: '-created_at' },
       }
     )
 

--- a/frontend/packages/syntara-ui/src/routes/approvals/useApprovalsData.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/approvals/useApprovalsData.test.tsx
@@ -81,7 +81,7 @@ describe('useApprovalsData', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     vi.mocked(accessClient.useQuery).mockReturnValue({
       data: { resources: [] },
@@ -90,7 +90,7 @@ describe('useApprovalsData', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
   })
 
   it('enriches approvals with approval name, workflow name, and workflow ID', async () => {
@@ -103,7 +103,7 @@ describe('useApprovalsData', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>
@@ -150,7 +150,7 @@ describe('useApprovalsData', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>
@@ -189,7 +189,7 @@ describe('useApprovalsData', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>
@@ -221,7 +221,7 @@ describe('useApprovalsData', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>
@@ -258,7 +258,7 @@ describe('useApprovalsData', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>
@@ -294,7 +294,7 @@ describe('useApprovalsData', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>
@@ -323,7 +323,7 @@ describe('useApprovalsData', () => {
       error: null,
       isFetching: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(
       () =>

--- a/frontend/packages/syntara-ui/src/routes/approvals/useCanApprovalAction.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/approvals/useCanApprovalAction.test.ts
@@ -155,7 +155,7 @@ describe('useCanApprovalAction', () => {
 
     type ActionProps = { action: 'decide' | 'read' }
     const { result, rerender } = renderHook(({ action }: ActionProps) => useCanApprovalAction(action), {
-      initialProps: { action: 'decide' } as ActionProps,
+      initialProps: { action: 'decide' },
     })
 
     await waitFor(() => {
@@ -173,7 +173,7 @@ describe('useCanApprovalAction', () => {
     // Change action
     mockPost.mockClear()
     mockPost.mockResolvedValue({ data: { allowed: false } })
-    rerender({ action: 'read' } as ActionProps)
+    rerender({ action: 'read' })
 
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalledWith('/authz/can_i', {

--- a/frontend/packages/syntara-ui/src/routes/approvals/useSelectableApprovalIds.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/approvals/useSelectableApprovalIds.test.tsx
@@ -52,7 +52,7 @@ describe('useSelectableApprovalIds', () => {
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: { resources: [] },
       isLoading: false,
-    } as never)
+    })
 
     const approvals = [mockApproval('1', 'pending')]
     const approvalPermissions = new Map([['1', true]])
@@ -67,12 +67,12 @@ describe('useSelectableApprovalIds', () => {
   it('returns empty set when loading user groups', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: 'alice', userId: 'user-1' }
-      return selector(state as never) as never
+      return selector(state as never)
     })
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as never)
+    })
 
     const approvals = [mockApproval('1', 'pending')]
     const approvalPermissions = new Map([['1', true]])
@@ -87,12 +87,12 @@ describe('useSelectableApprovalIds', () => {
   it('includes approval when user has RBAC permission and no approvers configured', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: 'alice', userId: 'user-1' }
-      return selector(state as never) as never
+      return selector(state as never)
     })
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: { resources: [] },
       isLoading: false,
-    } as never)
+    })
 
     const approvals = [mockApproval('1', 'pending')]
     const approvalPermissions = new Map([['1', true]])
@@ -107,12 +107,12 @@ describe('useSelectableApprovalIds', () => {
   it('includes approval when user is in approver_users', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: 'alice', userId: 'user-1' }
-      return selector(state as never) as never
+      return selector(state as never)
     })
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: { resources: [] },
       isLoading: false,
-    } as never)
+    })
 
     const approvals = [mockApproval('1', 'pending', [{ id: '1', username: 'alice' }])]
     const approvalPermissions = new Map([['1', true]])
@@ -127,12 +127,12 @@ describe('useSelectableApprovalIds', () => {
   it('excludes approval when user is not in approver_users', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: 'charlie', userId: 'user-3' }
-      return selector(state as never) as never
+      return selector(state as never)
     })
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: { resources: [] },
       isLoading: false,
-    } as never)
+    })
 
     const approvals = [mockApproval('1', 'pending', [{ id: '1', username: 'alice' }])]
     const approvalPermissions = new Map([['1', true]])
@@ -147,14 +147,14 @@ describe('useSelectableApprovalIds', () => {
   it('includes approval when user is in approver_groups', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: 'alice', userId: 'user-1' }
-      return selector(state as never) as never
+      return selector(state as never)
     })
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: {
         resources: [{ id: 'group-1', name: 'Admins' }],
       },
       isLoading: false,
-    } as never)
+    })
 
     const approvals = [mockApproval('1', 'pending', undefined, [{ id: 'group-1', name: 'Admins' }])]
     const approvalPermissions = new Map([['1', true]])
@@ -169,14 +169,14 @@ describe('useSelectableApprovalIds', () => {
   it('excludes approval when user is not in approver_groups', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: 'alice', userId: 'user-1' }
-      return selector(state as never) as never
+      return selector(state as never)
     })
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: {
         resources: [{ id: 'group-2', name: 'Other' }],
       },
       isLoading: false,
-    } as never)
+    })
 
     const approvals = [mockApproval('1', 'pending', undefined, [{ id: 'group-1', name: 'Admins' }])]
     const approvalPermissions = new Map([['1', true]])
@@ -191,12 +191,12 @@ describe('useSelectableApprovalIds', () => {
   it('excludes approval when status is not pending', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: 'alice', userId: 'user-1' }
-      return selector(state as never) as never
+      return selector(state as never)
     })
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: { resources: [] },
       isLoading: false,
-    } as never)
+    })
 
     const approvals = [mockApproval('1', 'approved')]
     const approvalPermissions = new Map([['1', true]])
@@ -211,12 +211,12 @@ describe('useSelectableApprovalIds', () => {
   it('excludes approval when user lacks RBAC permission', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: 'alice', userId: 'user-1' }
-      return selector(state as never) as never
+      return selector(state as never)
     })
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: { resources: [] },
       isLoading: false,
-    } as never)
+    })
 
     const approvals = [mockApproval('1', 'pending')]
     const approvalPermissions = new Map([['1', false]])
@@ -231,7 +231,7 @@ describe('useSelectableApprovalIds', () => {
   it('filters out user groups with missing id or name', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: 'alice', userId: 'user-1' }
-      return selector(state as never) as never
+      return selector(state as never)
     })
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: {
@@ -243,7 +243,7 @@ describe('useSelectableApprovalIds', () => {
         ],
       },
       isLoading: false,
-    } as never)
+    })
 
     const approvals = [mockApproval('1', 'pending', undefined, [{ id: 'group-1', name: 'Valid Group' }])]
     const approvalPermissions = new Map([['1', true]])
@@ -258,14 +258,14 @@ describe('useSelectableApprovalIds', () => {
   it('handles multiple approvals with mixed selectability', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: 'alice', userId: 'user-1' }
-      return selector(state as never) as never
+      return selector(state as never)
     })
     vi.mocked(usersClient.useQuery).mockReturnValue({
       data: {
         resources: [{ id: 'group-1', name: 'Admins' }],
       },
       isLoading: false,
-    } as never)
+    })
 
     const approvals = [
       mockApproval('1', 'pending'), // selectable - no approvers
@@ -293,7 +293,7 @@ describe('useSelectableApprovalIds', () => {
   it('skips query when currentUserId is null', () => {
     vi.mocked(useAuthStore).mockImplementation((selector) => {
       const state = { username: null, userId: null }
-      return selector(state as never) as never
+      return selector(state as never)
     })
 
     const mockUseQuery = vi.fn().mockReturnValue({

--- a/frontend/packages/syntara-ui/src/routes/builder/AddNodePanel.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/AddNodePanel.test.tsx
@@ -165,7 +165,7 @@ describe('AddNodePanel Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockNodeRegistryGetAll.mockReturnValue(mockNodeTypes as never[])
+    mockNodeRegistryGetAll.mockReturnValue(mockNodeTypes)
     mockNodeRegistryGet.mockImplementation((id: string) => mockNodeTypes.find((node) => node.id === id) as never)
   })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.duplicate.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.duplicate.test.tsx
@@ -180,12 +180,12 @@ describe('BuilderContent - Duplicate Workflow', () => {
       error: null,
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     vi.mocked(executionsClient.useMutation).mockReturnValue({
       mutate: mockExecuteMutate,
       isPending: false,
-    } as never)
+    })
 
     vi.mocked(approvalsClient.useQuery).mockReturnValue({
       data: undefined,
@@ -193,7 +193,7 @@ describe('BuilderContent - Duplicate Workflow', () => {
       error: null,
       isPending: false,
       refetch: vi.fn(),
-    } as never)
+    })
 
     vi.mocked(workflowClient.useMutation).mockImplementation((method: string, path: string) => {
       if (method === 'post' && path === '/workflows') {

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.roundTrip.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.roundTrip.test.tsx
@@ -33,11 +33,7 @@ function roundTrip(
     flattenedActivities,
     edges: loadedEdges,
     triggers: loadedTriggers,
-  } = convertV2Definition(
-    v2Def.nodes,
-    v2Def.edges,
-    v2Def.triggers
-  )
+  } = convertV2Definition(v2Def.nodes, v2Def.edges, v2Def.triggers)
 
   const rebuilt = buildWorkflowDefinition(name, description, flattenedActivities, loadedTriggers, {
     edges: loadedEdges,

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.roundTrip.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.roundTrip.test.tsx
@@ -6,10 +6,8 @@ import type { EdgeConnection } from './types/edge'
 import { convertV2Definition, parseNodePositions } from './utils/processExistingWorkflow'
 import { buildWorkflowDefinition } from './utils/workflowDefinitionBuilder'
 
-type V2Edge = { from: string; to: string; from_port?: string; to_port?: string }
-
 function makeActivity(overrides: Partial<Activity> & { id: string; type: string }): Activity {
-  return { name: overrides.id, parameters: {}, ...overrides } as Activity
+  return { name: overrides.id, parameters: {}, ...overrides }
 }
 
 function makeEdge(source: string, target: string, sourceHandle?: string, targetHandle?: string): EdgeConnection {
@@ -36,9 +34,9 @@ function roundTrip(
     edges: loadedEdges,
     triggers: loadedTriggers,
   } = convertV2Definition(
-    v2Def.nodes as Activity[],
-    v2Def.edges as V2Edge[],
-    v2Def.triggers as Array<Record<string, unknown>>
+    v2Def.nodes,
+    v2Def.edges,
+    v2Def.triggers
   )
 
   const rebuilt = buildWorkflowDefinition(name, description, flattenedActivities, loadedTriggers, {

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.test.tsx
@@ -301,7 +301,7 @@ describe('BuilderContent', () => {
     vi.mocked(executionsClient.useMutation).mockReturnValue(createMockMutation())
 
     vi.mocked(workflowFetchClient.GET).mockResolvedValue({
-      data: { current_version: 1, version: { version: 1 } } as WorkflowWithVersion,
+      data: { current_version: 1, version: { version: 1 } },
       error: undefined,
       response: new Response(),
     })
@@ -1522,7 +1522,7 @@ describe('BuilderContent', () => {
         act(() => {
           useWorkflowStore.getState().markDirty()
         })
-        const event = new Event('beforeunload', { cancelable: true }) as BeforeUnloadEvent
+        const event = new Event('beforeunload', { cancelable: true })
         act(() => {
           handler(event)
         })
@@ -1586,7 +1586,7 @@ describe('BuilderContent', () => {
       }
 
       await renderBuilder({
-        workflow: workflowNoDescription as WorkflowWithVersion,
+        workflow: workflowNoDescription,
         isNew: false,
         workflowId: 'workflow-1',
       })
@@ -3149,7 +3149,7 @@ describe('BuilderContent', () => {
         ...mockWorkflow.version,
         version: 3,
       },
-    } as unknown as WorkflowWithVersion
+    }
 
     function setupConflictOnSave() {
       const mockUpdateMutate = vi.fn((_params: unknown, callbacks?: MutationCallbacks) => {
@@ -3518,7 +3518,7 @@ describe('BuilderContent', () => {
       const workflowWithProject = {
         ...mockWorkflow,
         project_id: 'project-1',
-      } as unknown as WorkflowWithVersion
+      }
 
       await renderBuilder({ workflow: workflowWithProject, isNew: false, workflowId: 'workflow-1' })
 
@@ -3554,7 +3554,7 @@ describe('BuilderContent', () => {
       const workflowWithProject = {
         ...mockWorkflow,
         project_id: 'project-1',
-      } as unknown as WorkflowWithVersion
+      }
 
       await renderBuilder({ workflow: workflowWithProject, isNew: false, workflowId: 'workflow-1' })
 
@@ -3581,7 +3581,7 @@ describe('BuilderContent', () => {
       const workflowWithProject = {
         ...mockWorkflow,
         project_id: 'project-1',
-      } as unknown as WorkflowWithVersion
+      }
 
       await renderBuilder({ workflow: workflowWithProject, isNew: false, workflowId: 'workflow-1' })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
@@ -40,7 +40,7 @@ import { useBuilderDerivedUiFlags } from './hooks/useBuilderDerivedUiFlags'
 import { useBuilderDialogProps } from './hooks/useBuilderDialogProps'
 import { useBuilderFlowInteractionHandlers } from './hooks/useBuilderFlowInteractionHandlers'
 import { useBuilderLiveRunPanel } from './hooks/useBuilderLiveRunPanel'
-import { useBuilderSaveWorkflow, type UseBuilderSaveWorkflowParams } from './hooks/useBuilderSaveWorkflow'
+import { useBuilderSaveWorkflow } from './hooks/useBuilderSaveWorkflow'
 import { useBuilderToolbarHandlers } from './hooks/useBuilderToolbarHandlers'
 import { useBuilderValidation } from './hooks/useBuilderValidation'
 import { useBuilderVersionPanel } from './hooks/useBuilderVersionPanel'
@@ -254,7 +254,7 @@ export function BuilderContent(props: BuilderContentProps) {
       dispatch({ type: 'SET_VALIDATION_ERRORS', payload: errors, source: 'save' })
       useWorkflowStore.getState().setValidationErrorCount(errors.length)
     },
-    createWorkflow: createWorkflow as UseBuilderSaveWorkflowParams['createWorkflow'],
+    createWorkflow: createWorkflow,
     updateWorkflow,
   })
   const guardedSaveWorkflow = useGuardedSaveWorkflow(
@@ -307,7 +307,7 @@ export function BuilderContent(props: BuilderContentProps) {
     handleToggleHistory,
     handleToggleVersionHistory: baseHandleToggleVersionHistory,
   } = useBuilderToolbarHandlers({
-    workflow: workflow as { id: string } | undefined,
+    workflow: workflow,
     workflowName,
     detailsOpen,
     historyCardOpen,
@@ -566,7 +566,7 @@ export function BuilderContent(props: BuilderContentProps) {
     pendingImport,
     setPendingImport,
     selectedProject: stableProjectId ? { id: stableProjectId } : null,
-    createWorkflow: createWorkflow as UseBuilderSaveWorkflowParams['createWorkflow'],
+    createWorkflow: createWorkflow,
     setLocation,
     pinnedMockDataForDialog,
   })
@@ -681,9 +681,7 @@ export function BuilderContent(props: BuilderContentProps) {
                         <ExecutionDetailsPanelWrapper
                           executionId={mostRecentExecutionId}
                           workflowDefinition={
-                            workflow?.version?.workflow_definition as Parameters<
-                              typeof ExecutionDetailsPanelWrapper
-                            >[0]['workflowDefinition']
+                            workflow?.version?.workflow_definition
                           }
                           selectedNodeId={mostRecentSelectedNodeId}
                           selectedNodeName={mostRecentSelectedNodeName}

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
@@ -680,9 +680,7 @@ export function BuilderContent(props: BuilderContentProps) {
                       {showMostRecentRunPanelInEditor && mostRecentExecutionId && (
                         <ExecutionDetailsPanelWrapper
                           executionId={mostRecentExecutionId}
-                          workflowDefinition={
-                            workflow?.version?.workflow_definition
-                          }
+                          workflowDefinition={workflow?.version?.workflow_definition}
                           selectedNodeId={mostRecentSelectedNodeId}
                           selectedNodeName={mostRecentSelectedNodeName}
                           onNodeSelect={handleMostRecentNodeSelect}

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderEdit.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderEdit.tsx
@@ -1,4 +1,3 @@
-import type { WorkflowWithVersion } from '@syntara/contracts'
 import { useParams, useRouterState } from '@tanstack/react-router'
 import { ReactFlowProvider } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
@@ -107,7 +106,7 @@ export default function BuilderEdit() {
   return (
     <ReactFlowProvider key={workflowId}>
       <BuilderContent
-        workflow={workflowQuery.data as WorkflowWithVersion}
+        workflow={workflowQuery.data}
         isNew={false}
         workflowId={workflowId}
         executionCopy={executionCopy}

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.test.tsx
@@ -14,7 +14,7 @@ function resetStoreState() {
     workflowVersion: 1,
     _positionUndoVersion: 0,
     edges: [] as Array<Record<string, unknown>>,
-    nodePositions: {} as Record<string, { x: number; y: number }>,
+    nodePositions: {},
     triggers: [] as Array<Record<string, unknown>>,
     activities: [] as Array<Record<string, unknown>>,
   }

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.tsx
@@ -515,7 +515,7 @@ export function BuilderFlow(props: BuilderFlowProps) {
           const triggerRealId = triggers[Number.parseInt(node.id.split('-')[1], 10)]?.id
           const enriched = executionStateEnricher.enrichTriggerNode(
             triggerRealId,
-            node.data as Record<string, unknown>,
+            node.data,
             effectiveExecutionStatus,
             activityStates
           )

--- a/frontend/packages/syntara-ui/src/routes/builder/ExecutionDetailsPanel.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/ExecutionDetailsPanel.test.tsx
@@ -112,13 +112,13 @@ describe('ExecutionDetailsPanel', () => {
       vi.mocked(executionsClient.useQuery).mockReturnValue({
         ...EXECUTION,
         data: { ...EXECUTION.data, status: 'completed', completed_at: '2024-01-01T00:05:00Z' },
-      } as never)
+      })
 
       const { container } = renderPanel(WORKFLOW_DEF)
 
       expect(container.textContent).toContain(' - ')
 
-      vi.mocked(executionsClient.useQuery).mockReturnValue(EXECUTION as never)
+      vi.mocked(executionsClient.useQuery).mockReturnValue(EXECUTION)
     })
 
     it('shows elapsed time that ticks while running', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/HistoryListItemLink.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/HistoryListItemLink.tsx
@@ -1,7 +1,5 @@
 import { Link } from '@tanstack/react-router'
-import type { ComponentProps, MouseEvent, ReactNode } from 'react'
-
-type TanStackTo = ComponentProps<typeof Link>['to']
+import type { MouseEvent, ReactNode } from 'react'
 
 type HistoryListItemLinkProps = Readonly<{
   to: string
@@ -45,7 +43,7 @@ export function HistoryListItemLink({
   return (
     <Link
       // TanStack Router expects literal route strings; history hrefs are dynamic
-      to={to as TanStackTo}
+      to={to}
       className={`${pfClass}${selectedClass}${extraClass}`.trim()}
       aria-current={isSelected ? 'page' : undefined}
       aria-label={ariaLabel}

--- a/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.test.tsx
@@ -757,7 +757,7 @@ describe('NodeDetailsPanel', () => {
       id,
       type: 'task',
       position: { x: 0, y: 0 },
-      data: { id, type: 'script', name: id, parameters: {} },
+      data: { id, type: 'script', name: id, parameters: { language: 'python', code: '' } },
     })
 
     const { rerender } = render(

--- a/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.test.tsx
@@ -135,7 +135,7 @@ describe('NodeDetailsPanel', () => {
         </button>
       ),
       onSubmit: mockOnSubmit,
-    } as never)
+    })
 
     render(<NodeDetailsPanel mode="add" nodeTypeId="action" nodeSubtypeId={null} onClose={mockOnClose} />)
 
@@ -174,7 +174,7 @@ describe('NodeDetailsPanel', () => {
         </button>
       ),
       onSubmit: mockOnSubmit,
-    } as never)
+    })
 
     render(
       <NodeDetailsPanel
@@ -229,7 +229,7 @@ describe('NodeDetailsPanel', () => {
         </button>
       ),
       onSubmit: mockOnSubmit,
-    } as never)
+    })
 
     render(
       <NodeDetailsPanel
@@ -266,7 +266,7 @@ describe('NodeDetailsPanel', () => {
         </button>
       ),
       onSubmit: mockOnSubmit,
-    } as never)
+    })
 
     render(<NodeDetailsPanel mode="add" nodeTypeId="action" nodeSubtypeId={null} onClose={mockOnClose} />)
 
@@ -297,7 +297,7 @@ describe('NodeDetailsPanel', () => {
         </button>
       ),
       onSubmit: mockOnSubmit,
-    } as never)
+    })
 
     render(<NodeDetailsPanel mode="add" nodeTypeId="action" nodeSubtypeId={null} onClose={mockOnClose} />)
 
@@ -325,7 +325,7 @@ describe('NodeDetailsPanel', () => {
         </button>
       ),
       onSubmit: mockOnSubmit,
-    } as never)
+    })
 
     render(
       <NodeDetailsPanel
@@ -355,7 +355,7 @@ describe('NodeDetailsPanel', () => {
       category: 'task',
       formComponent: () => <div>Form</div>,
       onSubmit: vi.fn(),
-    } as never)
+    })
 
     render(<NodeDetailsPanel mode="add" nodeTypeId="action" nodeSubtypeId={null} onClose={mockOnClose} />)
 
@@ -369,7 +369,7 @@ describe('NodeDetailsPanel', () => {
       id: 'task-1',
       type: 'task',
       position: { x: 0, y: 0 },
-      data: { id: 'task-1', type: 'task', name: 'Task', task: { executor: 'script', parameters: {} } } as never,
+      data: { id: 'task-1', type: 'task', name: 'Task', task: { executor: 'script', parameters: {} } },
     }
 
     render(<NodeDetailsPanel mode="edit" node={taskNode} onClose={mockOnClose} />)
@@ -383,7 +383,7 @@ describe('NodeDetailsPanel', () => {
       id: 'trigger-0',
       type: 'trigger',
       position: { x: 0, y: 0 },
-      data: { id: 'trigger-0', type: 'trigger', name: 'Trigger' } as never,
+      data: { id: 'trigger-0', type: 'trigger', name: 'Trigger' },
     }
 
     render(<NodeDetailsPanel mode="edit" node={triggerNode} onClose={mockOnClose} />)
@@ -404,7 +404,7 @@ describe('NodeDetailsPanel', () => {
       id: 'task-1',
       type: 'task',
       position: { x: 0, y: 0 },
-      data: { id: 'task-1', type: 'task', name: 'Task', task: { executor: 'script', parameters: {} } } as never,
+      data: { id: 'task-1', type: 'task', name: 'Task', task: { executor: 'script', parameters: {} } },
     }
 
     render(<NodeDetailsPanel mode="edit" node={taskNode} onClose={mockOnClose} />)
@@ -426,13 +426,13 @@ describe('NodeDetailsPanel', () => {
         id: 'condition-1',
         type: 'condition',
         position: { x: 0, y: 0 },
-        data: { id: 'condition-1', type: 'condition', name: 'Condition', condition: 'true' } as never,
+        data: { id: 'condition-1', type: 'condition', name: 'Condition', condition: 'true' },
       },
       loop: {
         id: 'loop-1',
         type: 'loop',
         position: { x: 0, y: 0 },
-        data: { id: 'loop-1', type: 'loop', name: 'Loop', loop: { type: 'forEach', items: 'x', do: [] } } as never,
+        data: { id: 'loop-1', type: 'loop', name: 'Loop', loop: { type: 'forEach', items: 'x', do: [] } },
       },
       converge: {
         id: 'converge-1',
@@ -443,7 +443,7 @@ describe('NodeDetailsPanel', () => {
           type: 'converge',
           name: 'Converge',
           converge: { branches: [], strategy: 'all' },
-        } as never,
+        },
       },
       approval: {
         id: 'approval-1',
@@ -454,7 +454,7 @@ describe('NodeDetailsPanel', () => {
           type: 'approval',
           name: 'Approval',
           task: { executor: 'approval', parameters: {} },
-        } as never,
+        },
       },
     }
 
@@ -483,7 +483,7 @@ describe('NodeDetailsPanel', () => {
       category: 'trigger',
       formComponent: () => <div>Form</div>,
       onSubmit: vi.fn(),
-    } as never)
+    })
 
     render(<NodeDetailsPanel mode="add" nodeTypeId="trigger" nodeSubtypeId={null} onClose={mockOnClose} />)
 
@@ -501,7 +501,7 @@ describe('NodeDetailsPanel', () => {
       workflow: {
         activities: [],
       },
-    } as never
+    }
 
     mockNodeRegistryGet.mockReturnValue({
       id: 'action',
@@ -523,7 +523,7 @@ describe('NodeDetailsPanel', () => {
         </button>
       ),
       onSubmit: mockOnSubmit,
-    } as never)
+    })
 
     render(
       <NodeDetailsPanel
@@ -557,7 +557,7 @@ describe('NodeDetailsPanel', () => {
       workflow: {
         activities: [],
       },
-    } as never
+    }
 
     mockNodeRegistryGet.mockReturnValue({
       id: 'action',
@@ -579,7 +579,7 @@ describe('NodeDetailsPanel', () => {
         </button>
       ),
       onSubmit: mockOnSubmit,
-    } as never)
+    })
 
     render(
       <NodeDetailsPanel
@@ -631,7 +631,7 @@ describe('NodeDetailsPanel', () => {
         </button>
       ),
       onSubmit: mockOnSubmit,
-    } as never)
+    })
 
     render(<NodeDetailsPanel mode="add" nodeTypeId="logic" nodeSubtypeId="condition" onClose={mockOnClose} />)
 
@@ -659,7 +659,7 @@ describe('NodeDetailsPanel', () => {
       ],
       formComponent: () => <div>AAP Form</div>,
       onSubmit: vi.fn(),
-    } as never)
+    })
 
     render(<NodeDetailsPanel mode="add" nodeTypeId="aap" nodeSubtypeId="job_template" onClose={mockOnClose} />)
 
@@ -684,7 +684,7 @@ describe('NodeDetailsPanel', () => {
       category: 'trigger',
       formComponent: () => <div data-testid="trigger-form">Trigger Form</div>,
       onSubmit: vi.fn(),
-    } as never)
+    })
 
     render(<NodeDetailsPanel mode="add" nodeTypeId="trigger" nodeSubtypeId={null} onClose={mockOnClose} />)
 
@@ -697,7 +697,7 @@ describe('NodeDetailsPanel', () => {
       id: 'trigger-0',
       type: 'trigger',
       position: { x: 0, y: 0 },
-      data: { id: 'trigger-0', type: 'trigger', name: 'Trigger' } as never,
+      data: { id: 'trigger-0', type: 'trigger', name: 'Trigger' },
     }
 
     render(<NodeDetailsPanel mode="edit" node={triggerNode} onClose={mockOnClose} />)
@@ -715,7 +715,7 @@ describe('NodeDetailsPanel', () => {
         <div data-testid="project-id">{projectId ?? 'none'}</div>
       ),
       onSubmit: vi.fn(),
-    } as never)
+    })
 
     render(
       <NodeDetailsPanel
@@ -735,7 +735,7 @@ describe('NodeDetailsPanel', () => {
       id: 'task-1',
       type: 'task',
       position: { x: 0, y: 0 },
-      data: { id: 'task-1', type: 'task', name: 'Task', task: { executor: 'script', parameters: {} } } as never,
+      data: { id: 'task-1', type: 'task', name: 'Task', task: { executor: 'script', parameters: {} } },
     }
 
     render(
@@ -757,7 +757,7 @@ describe('NodeDetailsPanel', () => {
       id,
       type: 'task',
       position: { x: 0, y: 0 },
-      data: { id, type: 'script', name: id, parameters: {} } as never,
+      data: { id, type: 'script', name: id, parameters: {} },
     })
 
     const { rerender } = render(

--- a/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.tsx
@@ -65,7 +65,7 @@ function cleanMetadata(metadata: ActivityMetadata | undefined): ActivityMetadata
   if (!metadata) return undefined
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { __isGeneric: _isGeneric, ...rest } = metadata
-  return Object.keys(rest).length > 0 ? (rest) : undefined
+  return Object.keys(rest).length > 0 ? rest : undefined
 }
 
 /** Get formId for add mode based on node type and subtype */

--- a/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.tsx
@@ -65,7 +65,7 @@ function cleanMetadata(metadata: ActivityMetadata | undefined): ActivityMetadata
   if (!metadata) return undefined
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { __isGeneric: _isGeneric, ...rest } = metadata
-  return Object.keys(rest).length > 0 ? (rest as ActivityMetadata) : undefined
+  return Object.keys(rest).length > 0 ? (rest) : undefined
 }
 
 /** Get formId for add mode based on node type and subtype */
@@ -164,7 +164,7 @@ function resolveMenuNodeType(flowNodeType: string | undefined): MenuNodeTypeUnio
 }
 
 function getNodeDisabledState(node: Node<NodeType['data']> | undefined): boolean {
-  const nodeData = node?.data as Record<string, unknown> | undefined
+  const nodeData = node?.data
   const nodeSettings = nodeData?.settings as { disabled?: boolean } | undefined
   return nodeSettings?.disabled ?? false
 }

--- a/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.tsx
@@ -164,8 +164,8 @@ function resolveMenuNodeType(flowNodeType: string | undefined): MenuNodeTypeUnio
 }
 
 function getNodeDisabledState(node: Node<NodeType['data']> | undefined): boolean {
-  const nodeData = node?.data
-  const nodeSettings = nodeData?.settings as { disabled?: boolean } | undefined
+  if (!node?.data) return false
+  const nodeSettings = Reflect.get(node.data, 'settings') as { disabled?: boolean } | undefined
   return nodeSettings?.disabled ?? false
 }
 

--- a/frontend/packages/syntara-ui/src/routes/builder/NodeRawDataView.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/NodeRawDataView.test.tsx
@@ -16,7 +16,7 @@ describe('NodeRawDataView Component', () => {
         type: 'converge',
         id: 'test-node-1',
         name: 'Test Converge Node',
-      } as unknown as NodeType['data'],
+      },
     }
 
     render(<NodeRawDataView node={node} />)
@@ -30,7 +30,7 @@ describe('NodeRawDataView Component', () => {
       id: 'my-custom-id',
       type: 'parallel',
       position: { x: 0, y: 0 },
-      data: {} as unknown as NodeType['data'],
+      data: {},
     }
 
     render(<NodeRawDataView node={node} />)
@@ -49,7 +49,7 @@ describe('NodeRawDataView Component', () => {
         id: 'data-test',
         name: 'Test Data',
         customField: 'custom value',
-      } as unknown as NodeType['data'],
+      },
     }
 
     render(<NodeRawDataView node={node} />)
@@ -69,7 +69,7 @@ describe('NodeRawDataView Component', () => {
       id: 'test',
       type: 'trigger',
       position: { x: 0, y: 0 },
-      data: {} as unknown as NodeType['data'],
+      data: {},
     }
 
     render(<NodeRawDataView node={node} />)
@@ -83,7 +83,7 @@ describe('NodeRawDataView Component', () => {
       id: 'monospace-test',
       type: 'task',
       position: { x: 0, y: 0 },
-      data: {} as unknown as NodeType['data'],
+      data: {},
     }
 
     render(<NodeRawDataView node={node} />)
@@ -99,7 +99,7 @@ describe('NodeRawDataView Component', () => {
       id: 'empty-data',
       type: 'converge',
       position: { x: 0, y: 0 },
-      data: {} as unknown as NodeType['data'],
+      data: {},
     }
 
     render(<NodeRawDataView node={node} />)
@@ -134,7 +134,7 @@ describe('NodeRawDataView Component', () => {
           },
         ],
         else: [],
-      } as unknown as NodeType['data'],
+      },
     }
 
     render(<NodeRawDataView node={node} />)
@@ -150,7 +150,7 @@ describe('NodeRawDataView Component', () => {
       id: 'style-test',
       type: 'task',
       position: { x: 0, y: 0 },
-      data: {} as unknown as NodeType['data'],
+      data: {},
     }
 
     render(<NodeRawDataView node={node} />)

--- a/frontend/packages/syntara-ui/src/routes/builder/components/BuilderDialogs.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/BuilderDialogs.test.tsx
@@ -74,8 +74,8 @@ describe('BuilderDialogs', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(useWorkflowStore).mockImplementation((selector: (s: any) => unknown) => selector({ isDirty: false }))
 
-    vi.mocked(approvalsClient.useQuery).mockReturnValue({ data: undefined, refetch: vi.fn() } as never)
-    vi.mocked(approvalsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+    vi.mocked(approvalsClient.useQuery).mockReturnValue({ data: undefined, refetch: vi.fn() })
+    vi.mocked(approvalsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false })
   })
 
   it('renders nothing visible when all dialogs are closed', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/components/CredentialSelector.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/CredentialSelector.test.tsx
@@ -151,7 +151,7 @@ function mockUseQuery(
     credentials: (listData?.resources ?? []) as Credential[],
     isLoading: credentialsOverride.isPending ?? false,
     error: null,
-    refetch: vi.fn() as unknown as ReturnType<typeof useAllCredentials>['refetch'],
+    refetch: vi.fn(),
   })
 
   const typesResponse = {

--- a/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.test.tsx
@@ -75,7 +75,7 @@ describe('NodeEditorOverlay', () => {
             type: 'task',
             position: { x: 0, y: 0 },
             data: { id: 'task-1', type: ExecutorTypeEnum.HTTP_REQUEST, name: 'Task' },
-          } as never
+          }
         }
       />
     )

--- a/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/NodeEditorOverlay.test.tsx
@@ -69,14 +69,12 @@ describe('NodeEditorOverlay', () => {
     render(
       <NodeEditorOverlay
         {...baseProps}
-        selectedNode={
-          {
-            id: 'task-1',
-            type: 'task',
-            position: { x: 0, y: 0 },
-            data: { id: 'task-1', type: ExecutorTypeEnum.HTTP_REQUEST, name: 'Task' },
-          }
-        }
+        selectedNode={{
+          id: 'task-1',
+          type: 'task',
+          position: { x: 0, y: 0 },
+          data: { id: 'task-1', type: ExecutorTypeEnum.HTTP_REQUEST, name: 'Task' },
+        }}
       />
     )
     expect(useDocLinkMock).toHaveBeenCalledWith('restApi')

--- a/frontend/packages/syntara-ui/src/routes/builder/components/RunWorkflowModal.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/RunWorkflowModal.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { axe } from 'vitest-axe'
 
 import { ColorSchemeProvider } from '../../../providers/theme/ColorSchemeProvider'
+import { expectStringContaining } from '../../../test/test-helpers'
 
 import { RunWorkflowModal } from './RunWorkflowModal'
 
@@ -40,7 +41,7 @@ vi.mock('../../../providers/alerts', () => ({
 const mockUseQuery = vi.fn<(...args: unknown[]) => { data: unknown; isLoading: boolean }>()
 vi.mock('../../../client', () => ({
   executionsClient: {
-    useQuery: (...args: unknown[]) => mockUseQuery(...args) as { data: unknown; isLoading: boolean },
+    useQuery: (...args: unknown[]) => mockUseQuery(...args),
   },
 }))
 
@@ -184,7 +185,7 @@ describe('RunWorkflowModal', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Validation failed',
-        description: expect.stringContaining('Missing required field: "name"') as unknown as string,
+        description: expectStringContaining('Missing required field: "name"'),
       })
       expect(props.onConfirm).not.toHaveBeenCalled()
     })
@@ -198,7 +199,7 @@ describe('RunWorkflowModal', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Validation failed',
-        description: expect.stringContaining('Field "name" should be string') as unknown as string,
+        description: expectStringContaining('Field "name" should be string'),
       })
       expect(props.onConfirm).not.toHaveBeenCalled()
     })
@@ -244,7 +245,7 @@ describe('RunWorkflowModal', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Validation failed',
-        description: expect.stringContaining('Field "qty" should be integer') as unknown as string,
+        description: expectStringContaining('Field "qty" should be integer'),
       })
       expect(props.onConfirm).not.toHaveBeenCalled()
     })
@@ -279,7 +280,7 @@ describe('RunWorkflowModal', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Validation failed',
-        description: expect.stringContaining('Field "enabled" should be boolean') as unknown as string,
+        description: expectStringContaining('Field "enabled" should be boolean'),
       })
       expect(props.onConfirm).not.toHaveBeenCalled()
     })
@@ -314,7 +315,7 @@ describe('RunWorkflowModal', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Validation failed',
-        description: expect.stringContaining('Field "tags" should be array') as unknown as string,
+        description: expectStringContaining('Field "tags" should be array'),
       })
       expect(props.onConfirm).not.toHaveBeenCalled()
     })
@@ -349,7 +350,7 @@ describe('RunWorkflowModal', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Validation failed',
-        description: expect.stringContaining('Field "parameters" should be object') as unknown as string,
+        description: expectStringContaining('Field "parameters" should be object'),
       })
       expect(props.onConfirm).not.toHaveBeenCalled()
     })

--- a/frontend/packages/syntara-ui/src/routes/builder/components/RunWorkflowModal.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/components/RunWorkflowModal.tsx
@@ -158,7 +158,7 @@ export function RunWorkflowModal({
     const activities = activitiesQuery.data.resources ?? []
     const triggerActivity = activities.find((a) => a.activity_name === triggerNodeId)
     if (triggerActivity?.output_data && typeof triggerActivity.output_data === 'object') {
-      return triggerActivity.output_data as Record<string, unknown>
+      return triggerActivity.output_data
     }
     return null
   }, [activitiesQuery.data, triggerNodeId])

--- a/frontend/packages/syntara-ui/src/routes/builder/duplicateNodePosition.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/duplicateNodePosition.test.ts
@@ -13,7 +13,7 @@ function node(id: string, pos: { x: number; y: number }, measured?: { width: num
     position: pos,
     data: {},
     measured: measured ?? { width: DEFAULT_W, height: DEFAULT_H },
-  } as Node
+  }
 }
 
 describe('findDuplicatePosition', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderApproval.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderApproval.test.ts
@@ -75,7 +75,7 @@ function makeNode(type: string, executionStatus?: string): Node<NodeType['data']
       name: 'Test Node',
       __executionState: executionStatus ? { status: executionStatus } : undefined,
     },
-  } as unknown as Node<NodeType['data']>
+  }
 }
 
 describe('useBuilderApproval', () => {
@@ -86,8 +86,8 @@ describe('useBuilderApproval', () => {
     approvalState.pending = null
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
-    vi.mocked(approvalsClient.useQuery).mockReturnValue({ data: undefined, refetch: mockFetchForNode } as never)
-    vi.mocked(approvalsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+    vi.mocked(approvalsClient.useQuery).mockReturnValue({ data: undefined, refetch: mockFetchForNode })
+    vi.mocked(approvalsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false })
   })
 
   it('returns approvalViewOpen as false initially', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderApproval.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderApproval.ts
@@ -106,7 +106,7 @@ export function useBuilderApproval({
       if (showMostRecentRunPanelInEditor) {
         const target = event.target as HTMLElement | null
         const clickedBadge = target?.closest?.(EXECUTION_BADGE_SELECTOR) != null
-        const execNode: ExecutionNode = { id: node.id, type: node.type, data: node.data as Record<string, unknown> }
+        const execNode: ExecutionNode = { id: node.id, type: node.type, data: node.data }
         if (clickedBadge && isWaitingApprovalNode(execNode)) {
           handleApprovalNodeClick(event, execNode)
           setApprovalViewOpen(true)

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderConflict.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderConflict.test.ts
@@ -412,7 +412,7 @@ describe('useBuilderConflict', () => {
       const reloadMock = vi.fn()
       const originalLocation = window.location
       Object.defineProperty(window, 'location', {
-        value: { ...originalLocation, reload: reloadMock } as Location,
+        value: { ...originalLocation, reload: reloadMock },
         writable: true,
       })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderConflict.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderConflict.ts
@@ -216,7 +216,7 @@ export function useBuilderConflict(params: UseBuilderConflictParams) {
     conflictDialogProps: {
       isOpen: conflictDialog.isOpen,
       onClose: conflictDialog.close,
-      conflictAction: conflictDialog.item?.action ?? ('save'),
+      conflictAction: conflictDialog.item?.action ?? 'save',
       conflictInfo: conflictDialog.item?.info,
       onSaveAsNewest: handleSaveAsNewest,
       onDuplicate: handleDuplicateWorkflow,

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderConflict.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderConflict.ts
@@ -216,7 +216,7 @@ export function useBuilderConflict(params: UseBuilderConflictParams) {
     conflictDialogProps: {
       isOpen: conflictDialog.isOpen,
       onClose: conflictDialog.close,
-      conflictAction: conflictDialog.item?.action ?? ('save' as ConflictAction),
+      conflictAction: conflictDialog.item?.action ?? ('save'),
       conflictInfo: conflictDialog.item?.info,
       onSaveAsNewest: handleSaveAsNewest,
       onDuplicate: handleDuplicateWorkflow,

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderFlowInteractionHandlers.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderFlowInteractionHandlers.test.tsx
@@ -2,8 +2,6 @@ import { act, renderHook } from '@testing-library/react'
 import type { Edge, Node, ReactFlowInstance } from '@xyflow/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
-import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
-
 import { useBuilderFlowInteractionHandlers } from './useBuilderFlowInteractionHandlers'
 
 const moveActivityBefore = vi.fn()
@@ -77,7 +75,7 @@ describe('useBuilderFlowInteractionHandlers', () => {
       data: { __isGeneric: true },
     } as unknown as Node
     act(() => {
-      result.current.handleNodeClick({} as React.MouseEvent, node as unknown as Node<NodeType['data']>)
+      result.current.handleNodeClick({} as React.MouseEvent, node)
     })
     expect(dispatch).toHaveBeenCalledWith({
       type: 'NODE_CLICK',

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderFlowInteractionHandlers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderFlowInteractionHandlers.ts
@@ -99,7 +99,7 @@ export function useBuilderFlowInteractionHandlers({
       dispatch({
         type: 'NODE_CLICK',
         // React Flow widens getNode().data; builder state expects Node<NodeType['data']>
-        payload: { node: node as Node<NodeType['data']>, isGeneric },
+        payload: { node: node, isGeneric },
       })
     },
     [dispatch, reactFlowInstance]

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderImportHandlers.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderImportHandlers.test.ts
@@ -133,7 +133,7 @@ describe('useBuilderImportHandlers', () => {
 
       const createCall = vi.mocked(params.createWorkflow).mock.calls[0]
       const onSuccess = createCall[1]?.onSuccess as (data: { id: string }) => void
-      act(() => onSuccess({ id: 'new-wf-1' } as never))
+      act(() => onSuccess({ id: 'new-wf-1' }))
 
       expect(setPendingImport).toHaveBeenCalledWith(null)
       expect(params.showSuccess).toHaveBeenCalledWith({
@@ -160,7 +160,7 @@ describe('useBuilderImportHandlers', () => {
             warning_count: 1,
             findings: [{ severity: 'warning', category: 'invalid_reference', message: 'LLM model was removed' }],
           },
-        } as never)
+        })
       )
 
       expect(params.showAlert).toHaveBeenCalledWith({

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderImportHandlers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderImportHandlers.ts
@@ -1,4 +1,3 @@
-import type { WorkflowAPI } from '@syntara/contracts'
 import { useCallback } from 'react'
 
 import type { AlertConfig, AlertMessage } from '../../../providers/alerts'
@@ -8,8 +7,6 @@ import { applyImportToCanvas, type PendingImportData } from '../useWorkflowImpor
 import { buildWorkflowDefinition } from '../utils/workflowDefinitionBuilder'
 
 import type { UseBuilderSaveWorkflowParams } from './useBuilderSaveWorkflow'
-
-type CreateWorkflowBody = WorkflowAPI.paths['/workflows']['post']['requestBody']['content']['application/json']
 
 export type UseBuilderImportHandlersParams = {
   dispatch: (action: BuilderAction) => void
@@ -66,7 +63,7 @@ export function useBuilderImportHandlers(
         body: {
           name: importName,
           description: importDescription,
-          workflow_definition: fullDefinition as unknown as CreateWorkflowBody['workflow_definition'],
+          workflow_definition: fullDefinition,
           project_id: projectId,
           is_import: true,
         },

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi, beforeEach, type MockedFunction } from 'vites
 
 import { useWorkflowStore } from '../../../stores/useWorkflowStore'
 import type { WorkflowDefinition } from '../../../stores/workflowStoreTypes'
+import { expectStringContaining } from '../../../test/test-helpers'
 import { detachPromise } from '../../../utils/detachPromise'
 
 import type { UseBuilderSaveWorkflowParams } from './useBuilderSaveWorkflow'
@@ -98,7 +99,7 @@ describe('useBuilderSaveWorkflow', () => {
     const { result } = renderHook(() => useBuilderSaveWorkflow(buildParams({ currentWorkflow: null, showError })))
 
     await expect(result.current()).resolves.toBe(false)
-    expect(showError).toHaveBeenCalledWith({ title: 'Failed to save workflow', description: 'No workflow to save' })
+    expect(showError).toHaveBeenCalledWith({ title: 'Save failed', description: 'No workflow to save' })
   })
 
   it('returns false and shows danger toast when create path has no project', async () => {
@@ -209,13 +210,13 @@ describe('useBuilderSaveWorkflow', () => {
 
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith({
-      title: 'Failed to create workflow',
-      description: expect.stringContaining('Failed to create workflow') as unknown as string,
+      title: 'Create failed',
+      description: expectStringContaining('Failed to create workflow'),
     })
   })
 
   it('does not call create when update path is used', async () => {
-    const createWorkflow = vi.fn() as MockedFunction<CreateWorkflow>
+    const createWorkflow = vi.fn()
     const updateWorkflow = vi.fn((...args: Parameters<UpdateWorkflow>) => {
       detachPromise(args[1]?.onSuccess?.(updateResponse()))
     }) as MockedFunction<UpdateWorkflow>
@@ -267,7 +268,7 @@ describe('useBuilderSaveWorkflow', () => {
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Failed to create workflow',
+        title: 'Create failed',
         description: expect.stringContaining('has warnings') as unknown as string,
       })
     )
@@ -287,7 +288,7 @@ describe('useBuilderSaveWorkflow', () => {
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Failed to update workflow',
+        title: 'Update failed',
         description: expect.stringContaining('has warnings') as unknown as string,
       })
     )
@@ -426,7 +427,7 @@ describe('useBuilderSaveWorkflow', () => {
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Failed to update workflow',
+        title: 'Update failed',
         description: expect.stringContaining(
           'Step "Orphan Script" is unreachable from any trigger'
         ) as unknown as string,

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.test.tsx
@@ -99,7 +99,7 @@ describe('useBuilderSaveWorkflow', () => {
     const { result } = renderHook(() => useBuilderSaveWorkflow(buildParams({ currentWorkflow: null, showError })))
 
     await expect(result.current()).resolves.toBe(false)
-    expect(showError).toHaveBeenCalledWith({ title: 'Save failed', description: 'No workflow to save' })
+    expect(showError).toHaveBeenCalledWith({ title: 'Failed to save workflow', description: 'No workflow to save' })
   })
 
   it('returns false and shows danger toast when create path has no project', async () => {
@@ -210,7 +210,7 @@ describe('useBuilderSaveWorkflow', () => {
 
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith({
-      title: 'Create failed',
+      title: 'Failed to create workflow',
       description: expectStringContaining('Failed to create workflow'),
     })
   })
@@ -268,7 +268,7 @@ describe('useBuilderSaveWorkflow', () => {
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Create failed',
+        title: 'Failed to create workflow',
         description: expect.stringContaining('has warnings') as unknown as string,
       })
     )
@@ -288,7 +288,7 @@ describe('useBuilderSaveWorkflow', () => {
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Update failed',
+        title: 'Failed to update workflow',
         description: expect.stringContaining('has warnings') as unknown as string,
       })
     )
@@ -427,7 +427,7 @@ describe('useBuilderSaveWorkflow', () => {
     await expect(result.current()).resolves.toBe(false)
     expect(showError).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Update failed',
+        title: 'Failed to update workflow',
         description: expect.stringContaining(
           'Step "Orphan Script" is unreachable from any trigger'
         ) as unknown as string,

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.ts
@@ -49,7 +49,7 @@ function syncToolSelectionsFromResponse(responseData: SaveResponseData | undefin
       } else {
         delete newParams.tool_selections
       }
-      store.updateActivity(activity.id, { parameters: newParams } as Partial<typeof activity>)
+      store.updateActivity(activity.id, { parameters: newParams })
       updated = true
     }
   }
@@ -92,13 +92,13 @@ function buildSavePayloads(opts: {
   const createPayload: CreateWorkflowBodyExtended = {
     name: nameToSave,
     description: workflowDescription,
-    workflow_definition: workflowDef as unknown as CreateWorkflowBody['workflow_definition'],
+    workflow_definition: workflowDef,
     project_id: selectedProjectId,
   }
   const patchPayload: PatchWorkflowBody = {
     name: nameToSave,
     description: workflowDescription,
-    workflow_definition: workflowDef as unknown as PatchWorkflowBody['workflow_definition'],
+    workflow_definition: workflowDef,
     ...(expectedVersion != null ? { expected_version: expectedVersion } : {}),
   }
   return { createPayload, patchPayload }

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderToolbarHandlers.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderToolbarHandlers.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi, beforeEach, type MockedFunction } from 'vites
 
 import { useWorkflowStore } from '../../../stores/useWorkflowStore'
 import type { WorkflowDefinition } from '../../../stores/workflowStoreTypes'
+import { expectStringContaining } from '../../../test/test-helpers'
 
 import type { UseBuilderToolbarHandlersOptions } from './useBuilderToolbarHandlers'
 import { useBuilderToolbarHandlers } from './useBuilderToolbarHandlers'
@@ -94,7 +95,7 @@ describe('useBuilderToolbarHandlers', () => {
   })
 
   it('handleRunWorkflow does not call executeWorkflow when workflow is missing', async () => {
-    const executeWorkflow = vi.fn() as MockedFunction<ExecuteWorkflow>
+    const executeWorkflow = vi.fn()
     const { result } = renderHook(() =>
       useBuilderToolbarHandlers(buildOptions({ workflow: undefined, executeWorkflow }))
     )
@@ -138,7 +139,7 @@ describe('useBuilderToolbarHandlers', () => {
     // Then validation error shown
     expect(showError).toHaveBeenCalledWith({
       title: 'Cannot run workflow',
-      description: expect.stringContaining('at least one trigger') as unknown as string,
+      description: expectStringContaining('at least one trigger'),
     })
     expect(dispatch).toHaveBeenCalledWith({ type: 'SET_CONFIRM_DIALOG', payload: false })
     // But execution should not happen
@@ -179,7 +180,7 @@ describe('useBuilderToolbarHandlers', () => {
     // Then validation error shown
     expect(showError).toHaveBeenCalledWith({
       title: 'Cannot run workflow',
-      description: expect.stringContaining('at least one step') as unknown as string,
+      description: expectStringContaining('at least one step'),
     })
     expect(dispatch).toHaveBeenCalledWith({ type: 'SET_CONFIRM_DIALOG', payload: false })
     // But execution should not happen
@@ -209,7 +210,7 @@ describe('useBuilderToolbarHandlers', () => {
     // Then validation error shown
     expect(showError).toHaveBeenCalledWith({
       title: 'Cannot run workflow',
-      description: expect.stringContaining('at least one connection') as unknown as string,
+      description: expectStringContaining('at least one connection'),
     })
     expect(dispatch).toHaveBeenCalledWith({ type: 'SET_CONFIRM_DIALOG', payload: false })
     // But execution should not happen
@@ -345,7 +346,7 @@ describe('useBuilderToolbarHandlers', () => {
   })
 
   it('handleDeleteWorkflow does not call deleteWorkflow when workflow is missing', () => {
-    const deleteWorkflow = vi.fn() as MockedFunction<DeleteWorkflow>
+    const deleteWorkflow = vi.fn()
     const { result } = renderHook(() =>
       useBuilderToolbarHandlers(buildOptions({ workflow: undefined, deleteWorkflow }))
     )
@@ -433,7 +434,7 @@ describe('useBuilderToolbarHandlers', () => {
 
   it('handleRunWorkflow dispatches SET_CONFIRM_DIALOG:false when save throws', async () => {
     const handleSaveWorkflow = vi.fn().mockRejectedValue(new Error('network'))
-    const executeWorkflow = vi.fn() as MockedFunction<ExecuteWorkflow>
+    const executeWorkflow = vi.fn()
     const dispatch = vi.fn()
 
     // Mock isDirty state with edges for validation
@@ -524,7 +525,7 @@ describe('useBuilderToolbarHandlers', () => {
   })
 
   it('handleRunWorkflow passes triggerNodeId in the execution body', async () => {
-    const executeWorkflow = vi.fn() as MockedFunction<ExecuteWorkflow>
+    const executeWorkflow: MockedFunction<ExecuteWorkflow> = vi.fn()
 
     const { result } = renderHook(() => useBuilderToolbarHandlers(buildOptions({ executeWorkflow })))
     await result.current.handleRunWorkflow({ key: 'val' }, 'trigger-node-1')
@@ -535,7 +536,7 @@ describe('useBuilderToolbarHandlers', () => {
   })
 
   it('handleRunWorkflow always sends trigger_node_id in body', async () => {
-    const executeWorkflow = vi.fn() as MockedFunction<ExecuteWorkflow>
+    const executeWorkflow: MockedFunction<ExecuteWorkflow> = vi.fn()
 
     const { result } = renderHook(() => useBuilderToolbarHandlers(buildOptions({ executeWorkflow })))
     await result.current.handleRunWorkflow()
@@ -546,7 +547,7 @@ describe('useBuilderToolbarHandlers', () => {
   })
 
   it('handleRunWorkflow shows error when currentWorkflow is null', async () => {
-    const executeWorkflow = vi.fn() as MockedFunction<ExecuteWorkflow>
+    const executeWorkflow = vi.fn()
     const showError = vi.fn()
     const dispatch = vi.fn()
 
@@ -565,7 +566,7 @@ describe('useBuilderToolbarHandlers', () => {
   })
 
   it('handleRunWorkflow handles wait node with no name (falls back to Untitled)', async () => {
-    const executeWorkflow = vi.fn() as MockedFunction<ExecuteWorkflow>
+    const executeWorkflow = vi.fn()
     const showError = vi.fn()
     const dispatch = vi.fn()
     const currentWorkflow = minimalWorkflow({
@@ -590,13 +591,13 @@ describe('useBuilderToolbarHandlers', () => {
 
     expect(showError).toHaveBeenCalledWith({
       title: 'Cannot run workflow',
-      description: expect.stringContaining('Untitled') as unknown as string,
+      description: expectStringContaining('Untitled'),
     })
     expect(executeWorkflow).not.toHaveBeenCalled()
   })
 
   it('handleRunWorkflow shows error when wait node exceeds max duration', async () => {
-    const executeWorkflow = vi.fn() as MockedFunction<ExecuteWorkflow>
+    const executeWorkflow = vi.fn()
     const showError = vi.fn()
     const dispatch = vi.fn()
     const currentWorkflow = minimalWorkflow({
@@ -626,7 +627,7 @@ describe('useBuilderToolbarHandlers', () => {
 
     expect(showError).toHaveBeenCalledWith({
       title: 'Cannot run workflow',
-      description: expect.stringContaining('exceeds maximum allowed') as unknown as string,
+      description: expectStringContaining('exceeds maximum allowed'),
     })
     expect(executeWorkflow).not.toHaveBeenCalled()
   })
@@ -682,7 +683,7 @@ describe('useBuilderToolbarHandlers', () => {
   describe('pre-flight version conflict check', () => {
     it('calls onRunConflict when server has a newer version', async () => {
       const onRunConflict = vi.fn()
-      const executeWorkflow = vi.fn() as MockedFunction<ExecuteWorkflow>
+      const executeWorkflow = vi.fn()
       const dispatch = vi.fn()
 
       mockWorkflowFetchClientGET.mockResolvedValue({

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderWorkflowLifecycle.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderWorkflowLifecycle.test.tsx
@@ -2,7 +2,6 @@ import type { WorkflowAPI } from '@syntara/contracts'
 import { renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
-import type { WorkflowDefinition } from '../../../stores/workflowStoreTypes'
 import type { BuilderAction } from '../builderReducer'
 import type { EdgeConnection } from '../types/edge'
 import { DEFAULT_WORKFLOW_NAME } from '../utils/workflowNaming'
@@ -19,7 +18,7 @@ const processExistingWorkflowMock = vi.hoisted(() =>
       name: 'processed',
       description: '',
       workflow: { activities: [] },
-    } as WorkflowDefinition,
+    },
     generatedEdges: [] as EdgeConnection[],
     initPayload: { name: 'processed', description: 'd' },
   }))
@@ -169,7 +168,7 @@ describe('useBuilderWorkflowLifecycle', () => {
         name: wf.name,
         description: wf.description ?? '',
         workflow: { activities: [] },
-      } as WorkflowDefinition,
+      },
       generatedEdges: [] as EdgeConnection[],
       initPayload: {
         name: wf.name,

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useButtonEdgeMaintenance.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useButtonEdgeMaintenance.test.tsx
@@ -191,7 +191,7 @@ describe('useButtonEdgeMaintenance', () => {
       if (typeof updater === 'function') {
         capturedEdges = updater([
           { id: 'edge-1', source: 'node-1', target: 'node-2', sourceHandle: 'source' },
-        ] as unknown as EdgeType[])
+        ])
       }
       return capturedEdges
     })
@@ -834,7 +834,7 @@ describe('useButtonEdgeMaintenance', () => {
             targetHandle: 'target',
             data: { isActive: false },
           },
-        ] as unknown as EdgeType[])
+        ])
         edgesCalls.push(result)
         return result
       }
@@ -888,7 +888,7 @@ describe('useButtonEdgeMaintenance', () => {
             targetHandle: 'target',
             data: { isActive: false },
           },
-        ] as unknown as EdgeType[])
+        ])
         edgesCalls.push(result)
         return result
       }
@@ -1024,7 +1024,7 @@ describe('useButtonEdgeMaintenance', () => {
           edges,
           executionStatus,
         }),
-      { initialProps: { executionStatus: 'running' as string | null } }
+      { initialProps: { executionStatus: 'running' } }
     )
 
     // In execution mode, no button edges should be created

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useButtonEdgeMaintenance.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useButtonEdgeMaintenance.test.tsx
@@ -189,9 +189,7 @@ describe('useButtonEdgeMaintenance', () => {
     let capturedEdges: unknown[] = []
     mockSetEdges.mockImplementation((updater) => {
       if (typeof updater === 'function') {
-        capturedEdges = updater([
-          { id: 'edge-1', source: 'node-1', target: 'node-2', sourceHandle: 'source' },
-        ])
+        capturedEdges = updater([{ id: 'edge-1', source: 'node-1', target: 'node-2', sourceHandle: 'source' }])
       }
       return capturedEdges
     })

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useButtonEdgeMaintenance.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useButtonEdgeMaintenance.test.tsx
@@ -1012,17 +1012,19 @@ describe('useButtonEdgeMaintenance', () => {
   it('resets signature when transitioning from execution to edit mode', () => {
     const nodes = [{ id: 'node-1', type: 'task', position: { x: 100, y: 100 } }] as never[]
     const edges = [] as never[]
+    type StatusProps = { executionStatus: string | null }
+    const initialProps: StatusProps = { executionStatus: 'running' }
 
     // Start in execution mode
     const { rerender } = renderHook(
-      ({ executionStatus }: { executionStatus: string | null }) =>
+      ({ executionStatus }: StatusProps) =>
         useButtonEdgeMaintenance({
           ...defaultOptions,
           nodes,
           edges,
           executionStatus,
         }),
-      { initialProps: { executionStatus: 'running' } }
+      { initialProps }
     )
 
     // In execution mode, no button edges should be created

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useEdgeExecutionStatus.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useEdgeExecutionStatus.test.ts
@@ -58,8 +58,10 @@ describe('useEdgeExecutionStatus', () => {
 
     it('does not clear edge statuses when not initialized even on truthy→null transition', () => {
       const setEdges = vi.fn()
+      type StatusProps = { status: string | null }
+      const initialProps: StatusProps = { status: 'running' }
       const { rerender } = renderHook(
-        ({ status }: { status: string | null }) =>
+        ({ status }: StatusProps) =>
           useEdgeExecutionStatus({
             effectiveExecutionStatus: status,
             isInitialized: false,
@@ -68,7 +70,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'running' } }
+        { initialProps }
       )
       rerender({ status: null })
       expect(setEdges).not.toHaveBeenCalled()
@@ -79,9 +81,11 @@ describe('useEdgeExecutionStatus', () => {
     it('clears executionStatus from edges when execution ends', () => {
       const setEdges = vi.fn()
       const edgeWithStatus = makeEdge('e1', 'running')
+      type StatusProps = { status: string | null }
+      const initialProps: StatusProps = { status: 'running' }
 
       const { rerender } = renderHook(
-        ({ status }: { status: string | null }) =>
+        ({ status }: StatusProps) =>
           useEdgeExecutionStatus({
             effectiveExecutionStatus: status,
             isInitialized: true,
@@ -90,7 +94,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'running' } }
+        { initialProps }
       )
 
       setEdges.mockClear()
@@ -105,9 +109,11 @@ describe('useEdgeExecutionStatus', () => {
     it('returns the same edges reference when none have executionStatus (no-op)', () => {
       const setEdges = vi.fn()
       const cleanEdge = makeEdge('e1')
+      type StatusProps = { status: string | null }
+      const initialProps: StatusProps = { status: 'running' }
 
       const { rerender } = renderHook(
-        ({ status }: { status: string | null }) =>
+        ({ status }: StatusProps) =>
           useEdgeExecutionStatus({
             effectiveExecutionStatus: status,
             isInitialized: true,
@@ -116,7 +122,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'running' } }
+        { initialProps }
       )
 
       setEdges.mockClear()

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useEdgeExecutionStatus.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useEdgeExecutionStatus.test.ts
@@ -68,7 +68,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'running' as string | null } }
+        { initialProps: { status: 'running' } }
       )
       rerender({ status: null })
       expect(setEdges).not.toHaveBeenCalled()
@@ -90,7 +90,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'running' as string | null } }
+        { initialProps: { status: 'running' } }
       )
 
       setEdges.mockClear()
@@ -116,7 +116,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'running' as string | null } }
+        { initialProps: { status: 'running' } }
       )
 
       setEdges.mockClear()
@@ -244,7 +244,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'running' as string | null } }
+        { initialProps: { status: 'running' } }
       )
 
       setEdges.mockClear()
@@ -270,7 +270,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'running' as string | null } }
+        { initialProps: { status: 'running' } }
       )
 
       setEdges.mockClear()
@@ -296,7 +296,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'running' as string | null } }
+        { initialProps: { status: 'running' } }
       )
 
       setEdges.mockClear()
@@ -323,7 +323,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'running' as string | null } }
+        { initialProps: { status: 'running' } }
       )
 
       setEdges.mockClear()
@@ -351,7 +351,7 @@ describe('useEdgeExecutionStatus', () => {
             storedEdges: [],
             setEdges,
           }),
-        { initialProps: { status: 'completed' as string | null } }
+        { initialProps: { status: 'completed' } }
       )
 
       setEdges.mockClear()

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useEdgeSynchronization.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useEdgeSynchronization.test.tsx
@@ -31,7 +31,7 @@ describe('useEdgeSynchronization', () => {
 
     renderHook(() =>
       useEdgeSynchronization({
-        edges: edges as never[],
+        edges: edges,
         isInitialized: false,
         setStoredEdges: mockSetStoredEdges,
         workflowVersion: 1,
@@ -46,7 +46,7 @@ describe('useEdgeSynchronization', () => {
 
     renderHook(() =>
       useEdgeSynchronization({
-        edges: edges as never[],
+        edges: edges,
         isInitialized: true,
         setStoredEdges: mockSetStoredEdges,
         workflowVersion: 1,
@@ -65,7 +65,7 @@ describe('useEdgeSynchronization', () => {
     const { rerender } = renderHook(
       ({ edges }) =>
         useEdgeSynchronization({
-          edges: edges as never[],
+          edges: edges,
           isInitialized: true,
           setStoredEdges: mockSetStoredEdges,
           workflowVersion: 1,
@@ -96,7 +96,7 @@ describe('useEdgeSynchronization', () => {
     const { rerender } = renderHook(
       ({ edges }) =>
         useEdgeSynchronization({
-          edges: edges as never[],
+          edges: edges,
           isInitialized: true,
           setStoredEdges: mockSetStoredEdges,
           workflowVersion: 1,
@@ -124,7 +124,7 @@ describe('useEdgeSynchronization', () => {
 
     const { result } = renderHook(() =>
       useEdgeSynchronization({
-        edges: edges as never[],
+        edges: edges,
         isInitialized: true,
         setStoredEdges: mockSetStoredEdges,
         workflowVersion: 1,
@@ -141,7 +141,7 @@ describe('useEdgeSynchronization', () => {
     const { rerender } = renderHook(
       ({ edges }) =>
         useEdgeSynchronization({
-          edges: edges as never[],
+          edges: edges,
           isInitialized: true,
           setStoredEdges: mockSetStoredEdges,
           workflowVersion: 1,
@@ -170,7 +170,7 @@ describe('useEdgeSynchronization', () => {
     const { rerender } = renderHook(
       ({ edges }) =>
         useEdgeSynchronization({
-          edges: edges as never[],
+          edges: edges,
           isInitialized: true,
           setStoredEdges: mockSetStoredEdges,
           workflowVersion: 1,
@@ -201,7 +201,7 @@ describe('useEdgeSynchronization', () => {
     const { rerender } = renderHook(
       ({ edges }) =>
         useEdgeSynchronization({
-          edges: edges as never[],
+          edges: edges,
           isInitialized: true,
           setStoredEdges: mockSetStoredEdges,
           workflowVersion: 1,
@@ -232,7 +232,7 @@ describe('useEdgeSynchronization', () => {
     const { rerender } = renderHook(
       ({ edges }) =>
         useEdgeSynchronization({
-          edges: edges as never[],
+          edges: edges,
           isInitialized: true,
           setStoredEdges: mockSetStoredEdges,
           workflowVersion: 1,
@@ -260,7 +260,7 @@ describe('useEdgeSynchronization', () => {
     const { result, rerender } = renderHook(
       ({ edges }) =>
         useEdgeSynchronization({
-          edges: edges as never[],
+          edges: edges,
           isInitialized: true,
           setStoredEdges: mockSetStoredEdges,
           workflowVersion: 1,
@@ -297,7 +297,7 @@ describe('useEdgeSynchronization', () => {
     const { rerender } = renderHook(
       ({ edges }) =>
         useEdgeSynchronization({
-          edges: edges as never[],
+          edges: edges,
           isInitialized: true,
           setStoredEdges: mockSetStoredEdges,
           workflowVersion: 1,

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useLoopBackNodeTypes.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useLoopBackNodeTypes.test.ts
@@ -52,7 +52,7 @@ describe('useLoopBackNodeTypes', () => {
       if (typeof updater === 'function') {
         currentNodes = updater(currentNodes)
       }
-    }) as unknown as Dispatch<SetStateAction<NodeType[]>>
+    })
   })
 
   it('does nothing when not initialized', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodeDeletion.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodeDeletion.test.tsx
@@ -709,7 +709,7 @@ describe('useNodeDeletion', () => {
         ...(Array.from({ length: nodeCount }, (_, i) => ({
           id: `node-${i}`,
           type: 'task' as const,
-          data: { label: `Task ${i}` } as unknown,
+          data: { label: `Task ${i}` },
           position: { x: 0, y: i * 100 },
         })) as NodeType[]),
       ]

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodeDeletion.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodeDeletion.test.tsx
@@ -711,7 +711,7 @@ describe('useNodeDeletion', () => {
           type: 'task' as const,
           data: { label: `Task ${i}` },
           position: { x: 0, y: i * 100 },
-        })) as NodeType[]),
+        })) as unknown as NodeType[]),
       ]
 
       const edges: EdgeConnection[] = [

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodePanelNavigation.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodePanelNavigation.ts
@@ -1,10 +1,9 @@
-import type { Node, ReactFlowInstance } from '@xyflow/react'
+import type { ReactFlowInstance } from '@xyflow/react'
 import { useCallback, type Dispatch } from 'react'
 
 import { getActivityMetadata, useWorkflowStore } from '../../../stores/useWorkflowStore'
 import { selectTriggers } from '../../../stores/workflowStoreSelectors'
 import { toReactFlowNodeId } from '../../../utils/triggerNodeIds'
-import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
 import type { BuilderAction } from '../builderReducer'
 
 const EMPTY_TRIGGERS: Array<{ id: string }> = []
@@ -23,7 +22,7 @@ export function useNodePanelNavigation(
       const isGeneric = getActivityMetadata(node.data)?.__isGeneric === true
       dispatch({
         type: 'NODE_CLICK',
-        payload: { node: node as Node<NodeType['data']>, isGeneric },
+        payload: { node: node, isGeneric },
       })
     },
     [reactFlowInstance, dispatch, triggers]

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/usePendingEdgeManagement.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/usePendingEdgeManagement.ts
@@ -72,7 +72,7 @@ export function usePendingEdgeManagement({
                 isPending: true,
                 isActive: true,
               },
-            } as EdgeType,
+            },
           ]
         }
         return withoutPendingEdges

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/usePublishWorkflow.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/usePublishWorkflow.ts
@@ -29,7 +29,7 @@ function getDirtyWorkflowDefinition(
     currentWorkflow.workflow.activities ?? [],
     currentWorkflow.triggers ?? [],
     { edges, nodePositions }
-  ) as unknown as Record<string, unknown>
+  )
 }
 
 type UsePublishWorkflowOptions = {
@@ -73,7 +73,7 @@ export function usePublishWorkflow(
             change_description: description ?? null,
             ...(workflowDefinition ? { workflow_definition: workflowDefinition } : {}),
             ...(expectedVersion != null ? { expected_version: expectedVersion } : {}),
-          } as { name: string | null; change_description: string | null },
+          },
         },
         {
           onSuccess: (data) => {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useVersionHistory.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useVersionHistory.ts
@@ -75,10 +75,7 @@ export function useVersionHistory({ workflowId, isNew, onVersionUpdated }: UseVe
   const updateMetadataMutation = workflowClient.useMutation('patch', '/workflows/{workflow_id}/versions/{version}')
 
   const allVersions = versionsQuery.data?.resources
-  const publishedVersionName = useMemo(
-    () => resolvePublishedVersionName(allVersions),
-    [allVersions]
-  )
+  const publishedVersionName = useMemo(() => resolvePublishedVersionName(allVersions), [allVersions])
   const filteredVersions = useMemo((): WorkflowVersion[] => {
     if (!allVersions) return []
     if (statusFilter.length === 0) return allVersions

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useVersionHistory.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useVersionHistory.ts
@@ -76,12 +76,12 @@ export function useVersionHistory({ workflowId, isNew, onVersionUpdated }: UseVe
 
   const allVersions = versionsQuery.data?.resources
   const publishedVersionName = useMemo(
-    () => resolvePublishedVersionName(allVersions as WorkflowVersion[] | undefined),
+    () => resolvePublishedVersionName(allVersions),
     [allVersions]
   )
   const filteredVersions = useMemo((): WorkflowVersion[] => {
     if (!allVersions) return []
-    if (statusFilter.length === 0) return allVersions as WorkflowVersion[]
+    if (statusFilter.length === 0) return allVersions
     return (allVersions as WorkflowVersion[]).filter((v) => statusFilter.includes(v.status as VersionStatus))
   }, [allVersions, statusFilter])
 

--- a/frontend/packages/syntara-ui/src/routes/builder/node-details/ApprovalNodeDetails.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-details/ApprovalNodeDetails.tsx
@@ -55,7 +55,7 @@ export function ApprovalNodeDetails({
           ...(data.decision_window !== undefined && { decision_window: data.decision_window }),
         },
         settings: data.settings,
-      } as Partial<Activity>)
+      })
       onClose()
     } catch (error) {
       showError({

--- a/frontend/packages/syntara-ui/src/routes/builder/node-details/ConditionNodeDetails.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-details/ConditionNodeDetails.tsx
@@ -38,7 +38,7 @@ export function ConditionNodeDetails({
         parameters: {
           condition: data.condition ?? '',
         },
-      } as ConditionActivity
+      }
 
       updateActivity(nodeId, updatedActivity)
       onClose()

--- a/frontend/packages/syntara-ui/src/routes/builder/node-details/ConvergeNodeDetails.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-details/ConvergeNodeDetails.tsx
@@ -48,7 +48,7 @@ export function ConvergeNodeDetails({
           ...(data.wait_duration !== undefined && { wait_duration: data.wait_duration }),
         },
         settings: data.settings,
-      } as ConvergeActivity
+      }
 
       updateActivity(nodeId, updatedActivity)
       onClose()

--- a/frontend/packages/syntara-ui/src/routes/builder/node-details/TaskNodeDetails.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-details/TaskNodeDetails.tsx
@@ -279,7 +279,7 @@ function buildAAPInitialData(taskName: string, config: Record<string, unknown>):
     job_slice_count: c.job_slice_count ?? c.jobSlicing,
     diff_mode: getField(c.diff_mode, c.diffMode, false),
     execution_environment: getField(c.execution_environment, c.executionEnvironment, ''),
-    instance_group: getField(c.instance_group_name, c.instanceGroupName, '') as string | undefined,
+    instance_group: getField(c.instance_group_name, c.instanceGroupName, ''),
     instance_group_id: c.instance_group_id ?? c.instanceGroupId,
     labels: c.labels ?? [],
     use_input_variables: resolveUseInputVariables(c, organizationName, jobTemplateName, inventoryName, extraVars),

--- a/frontend/packages/syntara-ui/src/routes/builder/node-details/TriggerNodeDetails.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-details/TriggerNodeDetails.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { axe } from 'vitest-axe'
 
 import type { Trigger } from '../../../stores/workflowStoreTypes'
+import { expectStringContaining } from '../../../test/test-helpers'
 import * as TriggerNodeFormModule from '../node-forms/TriggerNodeForm'
 
 import { TriggerNodeDetails } from './TriggerNodeDetails'
@@ -473,7 +474,7 @@ describe('TriggerNodeDetails Component', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Update failed',
-        description: expect.stringContaining('Invalid interval format') as unknown as string,
+        description: expectStringContaining('Invalid interval format'),
       })
       expect(mockOnClose).not.toHaveBeenCalled()
 
@@ -513,7 +514,7 @@ describe('TriggerNodeDetails Component', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Update failed',
-        description: expect.stringContaining('Invalid interval format') as unknown as string,
+        description: expectStringContaining('Invalid interval format'),
       })
       expect(mockOnClose).not.toHaveBeenCalled()
 
@@ -627,7 +628,7 @@ describe('TriggerNodeDetails Component', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Update failed',
-        description: expect.stringContaining('Invalid interval format') as unknown as string,
+        description: expectStringContaining('Invalid interval format'),
       })
       expect(mockOnClose).not.toHaveBeenCalled()
 
@@ -667,7 +668,7 @@ describe('TriggerNodeDetails Component', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Update failed',
-        description: expect.stringContaining('Invalid interval format') as unknown as string,
+        description: expectStringContaining('Invalid interval format'),
       })
       expect(mockOnClose).not.toHaveBeenCalled()
 
@@ -1145,7 +1146,7 @@ describe('TriggerNodeDetails Component', () => {
 
       expect(mockShowError).toHaveBeenCalledWith({
         title: 'Update failed',
-        description: expect.stringContaining('Invalid JSON schema') as unknown as string,
+        description: expectStringContaining('Invalid JSON schema'),
       })
 
       formSpy.mockRestore()

--- a/frontend/packages/syntara-ui/src/routes/builder/node-details/taskNodeSubmitHelpers.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-details/taskNodeSubmitHelpers.test.ts
@@ -10,7 +10,7 @@ const baseTask: TaskActivity = {
   name: 'Task',
   type: ExecutorTypeEnum.SCRIPT,
   parameters: { language: 'python', code: 'print(1)' },
-} as TaskActivity
+}
 
 describe('taskNodeSubmitHelpers', () => {
   describe('safeJSONReviver', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/node-details/taskNodeSubmitHelpers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-details/taskNodeSubmitHelpers.ts
@@ -79,7 +79,7 @@ export function buildRegistryActivityUpdate(taskData: TaskActivity, data: Regist
             ...(scriptEnv && { environment: scriptEnv }),
           }
         : {
-            method: data.method as 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+            method: data.method,
             url: data.url ?? '',
             ...(apiHeaders && { headers: apiHeaders }),
             ...(data.body && {
@@ -87,7 +87,7 @@ export function buildRegistryActivityUpdate(taskData: TaskActivity, data: Regist
             }),
             ...(data.credential_id && { credential_id: data.credential_id }),
           },
-  } as Activity
+  }
 }
 
 function parseHttpBodyField(body: string): unknown {

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPNodeForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPNodeForm.test.tsx
@@ -218,7 +218,7 @@ describe('AAPNodeForm', () => {
       ],
       isLoading: false,
       error: null,
-      refetch: vi.fn() as unknown as ReturnType<typeof useAllCredentials>['refetch'],
+      refetch: vi.fn(),
     })
   })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPWorkflowTemplateForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPWorkflowTemplateForm.test.tsx
@@ -191,7 +191,7 @@ describe('AAPWorkflowTemplateForm', () => {
       ],
       isLoading: false,
       error: null,
-      refetch: vi.fn() as unknown as ReturnType<typeof useAllCredentials>['refetch'],
+      refetch: vi.fn(),
     })
   })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/AIAgentNodeForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/AIAgentNodeForm.test.tsx
@@ -151,11 +151,11 @@ describe('AIAgentNodeForm', () => {
       isPending: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
     vi.mocked(credentialsClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
     vi.mocked(useAllProjects).mockReturnValue({ projects: [], isLoading: false, error: null, refetch: vi.fn() })
     vi.mocked(useSelectableProjects).mockReturnValue({ projects: [], isLoading: false, error: null, refetch: vi.fn() })
     vi.mocked(useFileStorageStatus).mockReturnValue({
@@ -742,7 +742,7 @@ describe('AIAgentNodeForm', () => {
         isLoading: true,
         isError: false,
         refetch: vi.fn().mockResolvedValue({}),
-      } as never)
+      })
 
       renderWithHeader(<AIAgentNodeForm onSubmit={mockOnSubmit} />)
 
@@ -824,14 +824,14 @@ describe('AIAgentNodeForm', () => {
           isLoading: true,
           isError: false,
           refetch: vi.fn().mockResolvedValue({}),
-        } as never)
+        })
 
         vi.mocked(useAllEnabledMcpIntegrations).mockReturnValue({
           integrations: [],
           isLoading: true,
           isError: false,
           refetch: vi.fn().mockResolvedValue({}),
-        } as never)
+        })
 
         renderWithHeader(
           <AIAgentNodeForm

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/ActionNodeForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/ActionNodeForm.test.tsx
@@ -65,7 +65,7 @@ describe('ActionNodeForm', () => {
       isPending: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
     vi.mocked(useAllCredentials).mockReturnValue({
       credentials: [],
       isLoading: false,
@@ -75,7 +75,7 @@ describe('ActionNodeForm', () => {
     vi.mocked(credentialsClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
     vi.mocked(useAllProjects).mockReturnValue({ projects: [], isLoading: false, error: null, refetch: vi.fn() })
     vi.mocked(useSelectableProjects).mockReturnValue({ projects: [], isLoading: false, error: null, refetch: vi.fn() })
   })

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/ActionNodeForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/ActionNodeForm.test.tsx
@@ -70,7 +70,7 @@ describe('ActionNodeForm', () => {
       credentials: [],
       isLoading: false,
       error: null,
-      refetch: vi.fn() as unknown as ReturnType<typeof useAllCredentials>['refetch'],
+      refetch: vi.fn(),
     })
     vi.mocked(credentialsClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
@@ -396,7 +396,7 @@ describe('ActionNodeForm', () => {
         credentials: [mockSecretUrlCredential],
         isLoading: false,
         error: null,
-        refetch: vi.fn() as unknown as ReturnType<typeof useAllCredentials>['refetch'],
+        refetch: vi.fn(),
       })
     }
 
@@ -425,7 +425,7 @@ describe('ActionNodeForm', () => {
         credentials: [mockSecretUrlCredential, mockBearerCredential],
         isLoading: false,
         error: null,
-        refetch: vi.fn() as unknown as ReturnType<typeof useAllCredentials>['refetch'],
+        refetch: vi.fn(),
       })
     }
 
@@ -536,7 +536,7 @@ describe('ActionNodeForm', () => {
         credentials: [mockBearerCredential],
         isLoading: false,
         error: null,
-        refetch: vi.fn() as unknown as ReturnType<typeof useAllCredentials>['refetch'],
+        refetch: vi.fn(),
       })
       renderWithHeader(<ActionNodeForm onSubmit={mockOnSubmit} initialData={{ executor: 'http_request' }} />)
 
@@ -579,7 +579,7 @@ describe('ActionNodeForm', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
       renderWithHeader(
         <ActionNodeForm
           onSubmit={mockOnSubmit}

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/ConnectionsSection.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/ConnectionsSection.test.tsx
@@ -87,7 +87,7 @@ beforeEach(() => {
     credentials: [],
     isLoading: false,
     error: null,
-    refetch: vi.fn() as unknown as ReturnType<typeof useAllCredentials>['refetch'],
+    refetch: vi.fn(),
   })
 })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/LogicNodeForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/LogicNodeForm.tsx
@@ -118,7 +118,7 @@ export function LogicNodeForm({ onSubmit, initialData, onHeaderContentChange }: 
       strategy: initialData?.strategy,
       requiredPathCount: initialData?.requiredPathCount,
       wait_duration: initialData?.wait_duration,
-      settings: initialData?.settings as ConvergeFormData['settings'],
+      settings: initialData?.settings,
     } satisfies Partial<ConvergeFormData>
     const convergeData: Partial<ConvergeFormData> = Object.fromEntries(
       Object.entries(convergeSource).filter(([, v]) => v !== undefined)

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/RightSidePill.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/RightSidePill.test.tsx
@@ -16,7 +16,7 @@ function createMockNode(type: string, data?: Partial<NodeType['data']>): Node<No
     id: 'test-node-1',
     type,
     position: { x: 0, y: 0 },
-    data: data ?? ({ name: 'Test Node' }),
+    data: data ?? { name: 'Test Node' },
   }
 }
 

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/RightSidePill.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/RightSidePill.test.tsx
@@ -16,7 +16,7 @@ function createMockNode(type: string, data?: Partial<NodeType['data']>): Node<No
     id: 'test-node-1',
     type,
     position: { x: 0, y: 0 },
-    data: data ?? ({ name: 'Test Node' } as NodeType['data']),
+    data: data ?? ({ name: 'Test Node' }),
   }
 }
 

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/hooks/getAdjacentNodesFromFlow.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/hooks/getAdjacentNodesFromFlow.ts
@@ -1,7 +1,6 @@
 import type { Edge, Node } from '@xyflow/react'
 
 import { getCanvasNodeIconDescriptor } from '../../../workflows/canvas/nodes/nodeIconResolver'
-import type { NodeType } from '../../../workflows/canvas/nodes/NodeType'
 
 import type { UpstreamNodeInfo } from './useUpstreamNodes'
 
@@ -27,7 +26,7 @@ function toNodeInfo(node: Node): UpstreamNodeInfo {
   const { icon, id: iconId } = getCanvasNodeIconDescriptor({
     id: node.id,
     type: node.type,
-    data: node.data as NodeType['data'],
+    data: node.data,
   })
   return {
     id: node.id,

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/hooks/useNodeExecutionData.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/hooks/useNodeExecutionData.test.ts
@@ -7,7 +7,7 @@ const mockUseQuery = vi.fn<(...args: unknown[]) => { data: unknown; isLoading: b
 
 vi.mock('../../../../client', () => ({
   executionsClient: {
-    useQuery: (...args: unknown[]) => mockUseQuery(...args) as { data: unknown; isLoading: boolean },
+    useQuery: (...args: unknown[]) => mockUseQuery(...args),
   },
 }))
 

--- a/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerLogicNode.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerLogicNode.test.ts
@@ -303,7 +303,7 @@ describe('registerLogicNode', () => {
     it('calls onError for invalid logicType', () => {
       const onSuccess = vi.fn()
       const onError = vi.fn()
-      getHandler()({ logicType: 'invalid', name: 'Bad' } as unknown as Record<string, unknown>, onSuccess, onError)
+      getHandler()({ logicType: 'invalid', name: 'Bad' }, onSuccess, onError)
 
       expect(onError).toHaveBeenCalledWith('Invalid logic type')
       expect(onSuccess).not.toHaveBeenCalled()

--- a/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerLogicNodeSubmit.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerLogicNodeSubmit.test.ts
@@ -87,7 +87,7 @@ describe('registerLogicNodeSubmit', () => {
         buildLogicStepName({
           logicType: ActivityTypeEnum.CONDITION,
           name: 'My Branch',
-        } as Parameters<typeof buildLogicStepName>[0])
+        })
       ).toBe('My Branch')
     })
 
@@ -96,7 +96,7 @@ describe('registerLogicNodeSubmit', () => {
         buildLogicStepName({
           logicType: ActivityTypeEnum.CONVERGE,
           name: 'Join',
-        } as Parameters<typeof buildLogicStepName>[0])
+        })
       ).toBe('Join')
     })
 
@@ -105,7 +105,7 @@ describe('registerLogicNodeSubmit', () => {
         buildLogicStepName({
           logicType: ActivityTypeEnum.WAIT,
           name: 'Pause',
-        } as Parameters<typeof buildLogicStepName>[0])
+        })
       ).toBe('Pause')
     })
 
@@ -115,14 +115,14 @@ describe('registerLogicNodeSubmit', () => {
           logicType: ActivityTypeEnum.LOOP,
           name: 'Iter',
           type: 'while',
-        } as Parameters<typeof buildLogicStepName>[0])
+        })
       ).toBe('Iter')
     })
   })
 
   describe('submitConditionLogic', () => {
     it('returns true and adds activity when condition missing', () => {
-      expect(submitConditionLogic('id', 'n', { logicType: ActivityTypeEnum.CONDITION, name: 'x' } as never)).toBe(true)
+      expect(submitConditionLogic('id', 'n', { logicType: ActivityTypeEnum.CONDITION, name: 'x' })).toBe(true)
       expect(mockAddActivity).toHaveBeenCalled()
     })
 
@@ -132,7 +132,7 @@ describe('registerLogicNodeSubmit', () => {
           logicType: ActivityTypeEnum.CONDITION,
           name: 'x',
           condition: 'true',
-        } as never)
+        })
       ).toBe(true)
       expect(mockAddActivity).toHaveBeenCalled()
     })
@@ -146,7 +146,7 @@ describe('registerLogicNodeSubmit', () => {
         submitLoopLogic({
           activityId: 'l1',
           name: 'L',
-          data: { logicType: ActivityTypeEnum.LOOP, name: 'L', type: 'invalid' } as never,
+          data: { logicType: ActivityTypeEnum.LOOP, name: 'L', type: 'invalid' },
           generateId: () => 'x',
           onSuccess,
           onError,
@@ -162,7 +162,7 @@ describe('registerLogicNodeSubmit', () => {
         submitLoopLogic({
           activityId: 'l1',
           name: 'L',
-          data: { logicType: ActivityTypeEnum.LOOP, name: 'L', type: 'forEach' } as never,
+          data: { logicType: ActivityTypeEnum.LOOP, name: 'L', type: 'forEach' },
           generateId: () => 'x',
           onSuccess,
           onError: vi.fn(),
@@ -177,7 +177,7 @@ describe('registerLogicNodeSubmit', () => {
         submitLoopLogic({
           activityId: 'l1',
           name: 'L',
-          data: { logicType: ActivityTypeEnum.LOOP, name: 'L', type: 'while' } as never,
+          data: { logicType: ActivityTypeEnum.LOOP, name: 'L', type: 'while' },
           generateId: () => 'x',
           onSuccess,
           onError: vi.fn(),
@@ -197,7 +197,7 @@ describe('registerLogicNodeSubmit', () => {
             name: 'Each',
             type: 'forEach',
             items: 'ctx.items',
-          } as never,
+          },
           generateId: () => 'abc',
           onSuccess,
           onError: vi.fn(),
@@ -218,7 +218,7 @@ describe('registerLogicNodeSubmit', () => {
             name: 'While',
             type: 'while',
             condition: 'true',
-          } as never,
+          },
           generateId: () => 'xyz',
           onSuccess,
           onError: vi.fn(),
@@ -231,7 +231,7 @@ describe('registerLogicNodeSubmit', () => {
 
   describe('submitConvergeLogic', () => {
     it('creates activity even when strategy missing', () => {
-      expect(submitConvergeLogic('c1', 'C', { logicType: ActivityTypeEnum.CONVERGE, name: 'C' } as never)).toBe(true)
+      expect(submitConvergeLogic('c1', 'C', { logicType: ActivityTypeEnum.CONVERGE, name: 'C' })).toBe(true)
       expect(mockAddActivity).toHaveBeenCalled()
     })
 
@@ -275,12 +275,12 @@ describe('registerLogicNodeSubmit', () => {
 
   describe('submitSwitchLogic', () => {
     it('creates activity when cases are missing', () => {
-      expect(submitSwitchLogic('s1', 'S', { logicType: ActivityTypeEnum.SWITCH, name: 'S' } as never)).toBe(true)
+      expect(submitSwitchLogic('s1', 'S', { logicType: ActivityTypeEnum.SWITCH, name: 'S' })).toBe(true)
       expect(mockAddActivity).toHaveBeenCalled()
     })
 
     it('creates activity when cases array is empty', () => {
-      expect(submitSwitchLogic('s1', 'S', { logicType: ActivityTypeEnum.SWITCH, name: 'S', cases: [] } as never)).toBe(
+      expect(submitSwitchLogic('s1', 'S', { logicType: ActivityTypeEnum.SWITCH, name: 'S', cases: [] })).toBe(
         true
       )
       expect(mockAddActivity).toHaveBeenCalled()
@@ -292,7 +292,7 @@ describe('registerLogicNodeSubmit', () => {
           logicType: ActivityTypeEnum.SWITCH,
           name: 'Route',
           cases: [{ caseId: 'c1', condition: '${status} == "approved"' }],
-        } as never)
+        })
       ).toBe(true)
       expect(mockAddActivity).toHaveBeenCalled()
       const activity = mockAddActivity.mock.calls[0][0] as {
@@ -312,7 +312,7 @@ describe('registerLogicNodeSubmit', () => {
             { caseId: 'c1', condition: '${priority} > 7' },
             { caseId: 'c2', condition: 'not(${status} == "rejected")' },
           ],
-        } as never)
+        })
       ).toBe(true)
       expect(mockAddActivity).toHaveBeenCalled()
       const activity = mockAddActivity.mock.calls[0][0] as {
@@ -331,7 +331,7 @@ describe('registerLogicNodeSubmit', () => {
           { caseId: 'c1', label: 'High Priority', condition: '${priority} > 7' },
           { caseId: 'c2', label: 'Low Priority', condition: '${priority} < 3' },
         ],
-      } as never)
+      })
       expect(mockAddActivity).toHaveBeenCalled()
       const activity = mockAddActivity.mock.calls[0][0] as {
         cases: Array<{ port: string; label: string; condition: string }>
@@ -360,7 +360,7 @@ describe('registerLogicNodeSubmit', () => {
       const result = submitWaitLogic('w2', 'Minimal', {
         logicType: ActivityTypeEnum.WAIT,
         name: 'Minimal',
-      } as never)
+      })
 
       expect(result).toBe(true)
       expect(mockAddActivity).toHaveBeenCalled()

--- a/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerLogicNodeSubmit.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerLogicNodeSubmit.test.ts
@@ -280,9 +280,7 @@ describe('registerLogicNodeSubmit', () => {
     })
 
     it('creates activity when cases array is empty', () => {
-      expect(submitSwitchLogic('s1', 'S', { logicType: ActivityTypeEnum.SWITCH, name: 'S', cases: [] })).toBe(
-        true
-      )
+      expect(submitSwitchLogic('s1', 'S', { logicType: ActivityTypeEnum.SWITCH, name: 'S', cases: [] })).toBe(true)
       expect(mockAddActivity).toHaveBeenCalled()
     })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/useActivityFilters.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/useActivityFilters.test.ts
@@ -1,7 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
-import type { FilterConfig } from '../../types/filters'
 import { FilterOperatorEnum } from '../../types/filters'
 import type { ActivityState } from '../workflows/execution/types'
 
@@ -139,7 +138,7 @@ describe('useActivityFilters', () => {
     const { result } = renderHook(() => useActivityFilters(ACTIVITIES, states))
 
     act(() => {
-      result.current.handleFilterChange([{ key: 'unknown_key', value: 'something' } as FilterConfig])
+      result.current.handleFilterChange([{ key: 'unknown_key', value: 'something' }])
     })
 
     expect(result.current.filteredActivityOrder).toEqual(ACTIVITIES)

--- a/frontend/packages/syntara-ui/src/routes/builder/useWorkflowImportExport.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/useWorkflowImportExport.ts
@@ -118,7 +118,7 @@ export function useWorkflowImportExport({
         edges,
         nodePositions,
       })
-      downloadWorkflowDefinition(definition as Record<string, unknown>, name)
+      downloadWorkflowDefinition(definition, name)
     } catch (err: unknown) {
       showError({ title: 'Failed to export workflow', description: getErrorMessage(err) })
     }

--- a/frontend/packages/syntara-ui/src/routes/builder/useWorkflowVerification.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/useWorkflowVerification.ts
@@ -198,7 +198,7 @@ export function useWorkflowVerification({ dispatch }: UseWorkflowVerificationOpt
           },
         })
         .then((resp) => {
-          processValidateResponse(resp as ValidateResponse, dispatch, {
+          processValidateResponse(resp, dispatch, {
             frontendErrors: allFrontendErrors,
             onValid,
             silent,

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/EdgeFactory.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/EdgeFactory.test.ts
@@ -142,7 +142,7 @@ describe('EdgeFactory', () => {
   describe('addEdge', () => {
     it('adds edge to existing edges array', () => {
       const existingEdges: EdgeType[] = [
-        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' } as EdgeType,
+        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' },
       ]
       const newEdge = EdgeFactory.createEdge({
         source: 'node-2',
@@ -171,7 +171,7 @@ describe('EdgeFactory', () => {
   describe('createAndAdd', () => {
     it('creates and adds edge in one operation', () => {
       const existingEdges: EdgeType[] = [
-        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' } as EdgeType,
+        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' },
       ]
 
       const result = EdgeFactory.createAndAdd(
@@ -191,8 +191,8 @@ describe('EdgeFactory', () => {
   describe('replaceEdge', () => {
     it('replaces an existing edge', () => {
       const existingEdges: EdgeType[] = [
-        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' } as EdgeType,
-        { id: 'edge-2', source: 'node-2', target: 'node-3', type: 'default' } as EdgeType,
+        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' },
+        { id: 'edge-2', source: 'node-2', target: 'node-3', type: 'default' },
       ]
 
       const result = EdgeFactory.replaceEdge(
@@ -211,7 +211,7 @@ describe('EdgeFactory', () => {
 
     it('handles replacing non-existent edge', () => {
       const existingEdges: EdgeType[] = [
-        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' } as EdgeType,
+        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' },
       ]
 
       const result = EdgeFactory.replaceEdge(
@@ -230,8 +230,8 @@ describe('EdgeFactory', () => {
   describe('removeButtonEdge', () => {
     it('removes button edge for regular node', () => {
       const edges: EdgeType[] = [
-        { id: 'button-node-1', source: 'node-1', target: 'placeholder-node-1', type: 'buttonEdge' } as EdgeType,
-        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' } as EdgeType,
+        { id: 'button-node-1', source: 'node-1', target: 'placeholder-node-1', type: 'buttonEdge' },
+        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' },
       ]
 
       const result = EdgeFactory.removeButtonEdge('node-1', edges)
@@ -242,15 +242,15 @@ describe('EdgeFactory', () => {
 
     it('removes all button edge variants for a node without specific handle', () => {
       const edges: EdgeType[] = [
-        { id: 'button-condition-1', source: 'condition-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
-        { id: 'button-condition-1-true', source: 'condition-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
+        { id: 'button-condition-1', source: 'condition-1', target: 'placeholder', type: 'buttonEdge' },
+        { id: 'button-condition-1-true', source: 'condition-1', target: 'placeholder', type: 'buttonEdge' },
         {
           id: 'button-condition-1-false',
           source: 'condition-1',
           target: 'placeholder',
           type: 'buttonEdge',
-        } as EdgeType,
-        { id: 'edge-1', source: 'condition-1', target: 'task-1', type: 'default' } as EdgeType,
+        },
+        { id: 'edge-1', source: 'condition-1', target: 'task-1', type: 'default' },
       ]
 
       const result = EdgeFactory.removeButtonEdge('condition-1', edges)
@@ -261,13 +261,13 @@ describe('EdgeFactory', () => {
 
     it('removes specific true handle button edge', () => {
       const edges: EdgeType[] = [
-        { id: 'button-condition-1-true', source: 'condition-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
+        { id: 'button-condition-1-true', source: 'condition-1', target: 'placeholder', type: 'buttonEdge' },
         {
           id: 'button-condition-1-false',
           source: 'condition-1',
           target: 'placeholder',
           type: 'buttonEdge',
-        } as EdgeType,
+        },
       ]
 
       const result = EdgeFactory.removeButtonEdge('condition-1', edges, 'true')
@@ -278,13 +278,13 @@ describe('EdgeFactory', () => {
 
     it('removes specific false handle button edge', () => {
       const edges: EdgeType[] = [
-        { id: 'button-condition-1-true', source: 'condition-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
+        { id: 'button-condition-1-true', source: 'condition-1', target: 'placeholder', type: 'buttonEdge' },
         {
           id: 'button-condition-1-false',
           source: 'condition-1',
           target: 'placeholder',
           type: 'buttonEdge',
-        } as EdgeType,
+        },
       ]
 
       const result = EdgeFactory.removeButtonEdge('condition-1', edges, 'false')
@@ -295,8 +295,8 @@ describe('EdgeFactory', () => {
 
     it('removes specific done handle button edge for loop', () => {
       const edges: EdgeType[] = [
-        { id: 'button-loop-1-done', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
-        { id: 'button-loop-1-loop', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
+        { id: 'button-loop-1-done', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' },
+        { id: 'button-loop-1-loop', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' },
       ]
 
       const result = EdgeFactory.removeButtonEdge('loop-1', edges, 'done')
@@ -307,8 +307,8 @@ describe('EdgeFactory', () => {
 
     it('removes specific loop handle button edge for loop', () => {
       const edges: EdgeType[] = [
-        { id: 'button-loop-1-done', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
-        { id: 'button-loop-1-loop', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
+        { id: 'button-loop-1-done', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' },
+        { id: 'button-loop-1-loop', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' },
       ]
 
       const result = EdgeFactory.removeButtonEdge('loop-1', edges, 'loop')
@@ -319,10 +319,10 @@ describe('EdgeFactory', () => {
 
     it('removes all loop button edges when no handle specified', () => {
       const edges: EdgeType[] = [
-        { id: 'button-loop-1', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
-        { id: 'button-loop-1-done', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
-        { id: 'button-loop-1-loop', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' } as EdgeType,
-        { id: 'edge-1', source: 'loop-1', target: 'task-1', type: 'default' } as EdgeType,
+        { id: 'button-loop-1', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' },
+        { id: 'button-loop-1-done', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' },
+        { id: 'button-loop-1-loop', source: 'loop-1', target: 'placeholder', type: 'buttonEdge' },
+        { id: 'edge-1', source: 'loop-1', target: 'task-1', type: 'default' },
       ]
 
       const result = EdgeFactory.removeButtonEdge('loop-1', edges)
@@ -338,13 +338,13 @@ describe('EdgeFactory', () => {
           source: 'approval-1',
           target: 'placeholder',
           type: 'buttonEdge',
-        } as EdgeType,
+        },
         {
           id: 'button-approval-1-rejected',
           source: 'approval-1',
           target: 'placeholder',
           type: 'buttonEdge',
-        } as EdgeType,
+        },
       ]
 
       const result = EdgeFactory.removeButtonEdge('approval-1', edges, 'approved')
@@ -360,13 +360,13 @@ describe('EdgeFactory', () => {
           source: 'approval-1',
           target: 'placeholder',
           type: 'buttonEdge',
-        } as EdgeType,
+        },
         {
           id: 'button-approval-1-rejected',
           source: 'approval-1',
           target: 'placeholder',
           type: 'buttonEdge',
-        } as EdgeType,
+        },
       ]
 
       const result = EdgeFactory.removeButtonEdge('approval-1', edges, 'rejected')
@@ -409,7 +409,7 @@ describe('EdgeFactory', () => {
         source: 'node-1',
         target: 'node-2',
         type: 'default',
-      } as EdgeType
+      }
 
       const result = EdgeFactory.toEdgeConnection(edge)
 
@@ -433,7 +433,7 @@ describe('EdgeFactory', () => {
           sourceHandle: 'source',
           targetHandle: 'target',
           type: 'default',
-        } as EdgeType,
+        },
         {
           id: 'edge-2',
           source: 'node-2',
@@ -441,7 +441,7 @@ describe('EdgeFactory', () => {
           sourceHandle: 'source',
           targetHandle: 'target',
           type: 'default',
-        } as EdgeType,
+        },
       ]
 
       const result = EdgeFactory.toEdgeConnections(edges)

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/EdgeFactory.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/EdgeFactory.test.ts
@@ -141,9 +141,7 @@ describe('EdgeFactory', () => {
 
   describe('addEdge', () => {
     it('adds edge to existing edges array', () => {
-      const existingEdges: EdgeType[] = [
-        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' },
-      ]
+      const existingEdges: EdgeType[] = [{ id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' }]
       const newEdge = EdgeFactory.createEdge({
         source: 'node-2',
         target: 'node-3',
@@ -170,9 +168,7 @@ describe('EdgeFactory', () => {
 
   describe('createAndAdd', () => {
     it('creates and adds edge in one operation', () => {
-      const existingEdges: EdgeType[] = [
-        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' },
-      ]
+      const existingEdges: EdgeType[] = [{ id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' }]
 
       const result = EdgeFactory.createAndAdd(
         {
@@ -210,9 +206,7 @@ describe('EdgeFactory', () => {
     })
 
     it('handles replacing non-existent edge', () => {
-      const existingEdges: EdgeType[] = [
-        { id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' },
-      ]
+      const existingEdges: EdgeType[] = [{ id: 'edge-1', source: 'node-1', target: 'node-2', type: 'default' }]
 
       const result = EdgeFactory.replaceEdge(
         'non-existent',

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/EdgeFactory.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/EdgeFactory.ts
@@ -76,7 +76,7 @@ export class EdgeFactory {
       type: edgeType,
       markerEnd,
       ...(onAddNode ? { data: { onAddNode } } : {}),
-    } as EdgeType
+    }
   }
 
   /**

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/executionState/ExecutionStateEnricher.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/executionState/ExecutionStateEnricher.ts
@@ -171,7 +171,7 @@ export class ExecutionStateEnricher {
 
     // If not in execution view, return as-is
     if (!executionStatus) {
-      return activity as ActivityWithMetadata
+      return activity
     }
 
     // Step 1: Add direct backend state if available.
@@ -182,7 +182,7 @@ export class ExecutionStateEnricher {
 
     // Nodes added after copy-to-editor were never part of the run — no status indicators
     if (!activityState && skipInferenceActivityIds && !skipInferenceActivityIds.has(activity.id)) {
-      return activity as ActivityWithMetadata
+      return activity
     }
 
     // Add execution badge flag to metadata

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/panelMenuActions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/panelMenuActions.test.ts
@@ -16,7 +16,7 @@ describe('buildPanelMenuActions', () => {
       id: 'task-1',
       type: 'task',
       position: { x: 0, y: 0 },
-      data: { id: 'task-1', type: 'task', name: 'Task' } as never,
+      data: { id: 'task-1', type: 'task', name: 'Task' },
     }
 
     const actions = buildPanelMenuActions(
@@ -40,7 +40,7 @@ describe('buildPanelMenuActions', () => {
       id: 'task-1',
       type: 'task',
       position: { x: 0, y: 0 },
-      data: { id: 'task-1', type: 'task', name: 'Task' } as never,
+      data: { id: 'task-1', type: 'task', name: 'Task' },
     }
 
     const actions = buildPanelMenuActions(

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/processExistingWorkflow.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/processExistingWorkflow.ts
@@ -56,7 +56,7 @@ export function convertV2Definition(
     if (meta) return { ...a, metadata: meta }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructuring to strip metadata
     const { metadata: _unsanitized, ...rest } = a as Activity & { metadata?: unknown }
-    return rest as Activity
+    return rest
   })
 
   const triggerIdToDisplayId = new Map<string, string>()

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/resolveStepDocKey.test.ts
@@ -12,7 +12,7 @@ function makeNode(type: string, data: Record<string, unknown> = {}): Node<NodeTy
     id: 'node-1',
     type,
     position: { x: 0, y: 0 },
-    data: data as NodeType['data'],
+    data: data,
   }
 }
 

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/triggerIndexRemapping.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/triggerIndexRemapping.ts
@@ -91,7 +91,7 @@ export function remapTriggerIdsInEdges<T extends EdgeConnection>(
         id: edgeId,
         source: updatedSource,
         target: updatedTarget,
-      } as T
+      }
     }
 
     return edge

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/validation/__tests__/validateConditionConnections.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/validation/__tests__/validateConditionConnections.test.ts
@@ -33,12 +33,10 @@ describe('validateConditionConnections', () => {
 
     const result = validateConditionConnections(activities, edges)
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      severity: 'error',
-      rule: 'condition-connections',
-      nodeId: 'C1',
-      message: expect.stringContaining('Then') as unknown as string,
-    })
+    expect(result[0]?.severity).toBe('error')
+    expect(result[0]?.rule).toBe('condition-connections')
+    expect(result[0]?.nodeId).toBe('C1')
+    expect(result[0]?.message).toContain('Then')
   })
 
   it('allows missing Else branch connection (else is optional)', () => {
@@ -64,12 +62,10 @@ describe('validateConditionConnections', () => {
 
     const result = validateConditionConnections(activities, edges)
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      severity: 'error',
-      rule: 'condition-connections',
-      nodeId: 'C1',
-      message: expect.stringContaining('Then') as unknown as string,
-    })
+    expect(result[0]?.severity).toBe('error')
+    expect(result[0]?.rule).toBe('condition-connections')
+    expect(result[0]?.nodeId).toBe('C1')
+    expect(result[0]?.message).toContain('Then')
   })
 
   it('handles multiple condition nodes', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/validation/__tests__/validateConvergeInputs.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/validation/__tests__/validateConvergeInputs.test.ts
@@ -42,14 +42,13 @@ describe('validateConvergeInputs', () => {
 
     const result = validateConvergeInputs(activities, edges)
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      severity: 'error',
-      rule: 'converge-inputs',
-      nodeIds: expect.arrayContaining(['J1', 'C1']) as unknown as string[],
-    })
-    expect(result[0].message).toContain('both')
-    expect(result[0].message).toContain('Then')
-    expect(result[0].message).toContain('Else')
+    expect(result[0]?.severity).toBe('error')
+    expect(result[0]?.rule).toBe('converge-inputs')
+    expect(result[0]?.nodeIds).toContain('J1')
+    expect(result[0]?.nodeIds).toContain('C1')
+    expect(result[0]?.message).toContain('both')
+    expect(result[0]?.message).toContain('Then')
+    expect(result[0]?.message).toContain('Else')
   })
 
   it('handles converge with direct connections from condition (no intermediate tasks)', () => {
@@ -89,8 +88,9 @@ describe('validateConvergeInputs', () => {
 
     const result = validateConvergeInputs(activities, edges)
     expect(result).toHaveLength(1)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    expect(result[0]).toMatchObject({ severity: 'error', nodeIds: expect.arrayContaining(['J1', 'C1']) })
+    expect(result[0]?.severity).toBe('error')
+    expect(result[0]?.nodeIds).toContain('J1')
+    expect(result[0]?.nodeIds).toContain('C1')
   })
 
   it('allows converge with only one branch from a condition', () => {
@@ -139,8 +139,8 @@ describe('validateConvergeInputs', () => {
 
   it('uses condition ID as name when name is missing', () => {
     const activities: Activity[] = [
-      { type: 'condition', id: 'C1', parameters: { condition: 'x > 10' } } as Activity,
-      { type: 'converge', id: 'J1', parameters: { strategy: 'all' } } as Activity,
+      { type: 'condition', id: 'C1', parameters: { condition: 'x > 10' } },
+      { type: 'converge', id: 'J1', parameters: { strategy: 'all' } },
     ]
 
     const edges: EdgeConnection[] = [

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/validation/__tests__/validateNoDanglingNodes.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/validation/__tests__/validateNoDanglingNodes.test.ts
@@ -34,12 +34,10 @@ describe('validateNoDanglingNodes', () => {
 
     const result = validateNoDanglingNodes(activities, edges)
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      severity: 'error',
-      rule: 'no-dangling-nodes',
-      nodeId: 'C',
-      message: expect.stringContaining('Task C') as unknown as string,
-    })
+    expect(result[0]?.severity).toBe('error')
+    expect(result[0]?.rule).toBe('no-dangling-nodes')
+    expect(result[0]?.nodeId).toBe('C')
+    expect(result[0]?.message).toContain('Task C')
   })
 
   it('detects multiple dangling nodes', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/workflowDefinitionBuilder.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/workflowDefinitionBuilder.test.ts
@@ -124,7 +124,7 @@ describe('buildWorkflowDefinition', () => {
           type: 'script',
           parameters: {},
           inputs: { param1: 'value1', param2: 'value2' },
-        } as Activity & { inputs: Record<string, unknown> },
+        },
       ]
 
       const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
@@ -511,7 +511,7 @@ describe('buildWorkflowDefinition', () => {
           name: 'Process Item',
           parameters: { code: 'print(item)' },
           inputs: { item: '$.current_item' },
-        } as Activity & { inputs: Record<string, unknown> },
+        },
       ]
 
       const edges: EdgeConnection[] = [

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialDetail.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialDetail.test.tsx
@@ -17,7 +17,7 @@ const { mockNavigate } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
 }))
 
-const wouterMock = vi.hoisted(() => ({
+const wouterMock = vi.hoisted((): { credentialId: string | undefined } => ({
   credentialId: '1',
 }))
 

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialDetail.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialDetail.test.tsx
@@ -18,7 +18,7 @@ const { mockNavigate } = vi.hoisted(() => ({
 }))
 
 const wouterMock = vi.hoisted(() => ({
-  credentialId: '1' as string | undefined,
+  credentialId: '1',
 }))
 
 const mockCredential = {
@@ -235,7 +235,7 @@ describe('CredentialDetail', () => {
     queryClient.clear()
     mockMutate = vi.fn()
     vi.mocked(useParams).mockReturnValue({ credentialId: '1' })
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery())
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -802,7 +802,7 @@ describe('CredentialDetail', () => {
 
   it('renders em-dash for workflow count when null', () => {
     const credWithNullCount = { ...mockCredential, workflow_count: null }
-    vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(credWithNullCount as never))
+    vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(credWithNullCount))
 
     render(<CredentialDetail />, { wrapper })
 
@@ -814,7 +814,7 @@ describe('CredentialDetail', () => {
 
   it('renders workflow count as badge on Workflows tab when greater than zero', async () => {
     const credWithCount = { ...mockCredential, workflow_count: 5 }
-    vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(credWithCount as never))
+    vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(credWithCount))
 
     render(<CredentialDetail />, { wrapper })
 
@@ -836,7 +836,7 @@ describe('CredentialDetail', () => {
 
   it('renders em-dash for integration count when null', () => {
     const credWithNullIntegrationCount = { ...mockCredential, integration_count: null }
-    vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(credWithNullIntegrationCount as never))
+    vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(credWithNullIntegrationCount))
 
     render(<CredentialDetail />, { wrapper })
 
@@ -846,7 +846,7 @@ describe('CredentialDetail', () => {
 
   it('renders integration count as badge on Integrations tab when greater than zero', async () => {
     const credWithIntegrationCount = { ...mockCredential, integration_count: 7 }
-    vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(credWithIntegrationCount as never))
+    vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(credWithIntegrationCount))
 
     render(<CredentialDetail />, { wrapper })
 
@@ -858,7 +858,7 @@ describe('CredentialDetail', () => {
 
   describe('Permission-based tab gating', () => {
     it('hides Workflows tab when workflow:read is denied', async () => {
-      vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } } as never)
+      vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: false } })
       render(<CredentialDetail />, { wrapper })
 
       await act(async () => {
@@ -870,7 +870,7 @@ describe('CredentialDetail', () => {
     })
 
     it('shows Workflows tab when workflow:read is granted', async () => {
-      vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+      vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
       render(<CredentialDetail />, { wrapper })
 
       expect(await screen.findByRole('tab', { name: /Workflows/ })).toBeInTheDocument()

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/Credentials.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/Credentials.test.tsx
@@ -230,7 +230,7 @@ describe('Credentials', () => {
       mutate: mockMutate,
       mutateAsync: mockMutateAsync,
       isPending: false,
-    } as never)
+    })
   })
 
   it('has no accessibility violations', async () => {
@@ -653,7 +653,7 @@ describe('Credentials', () => {
   it('renders empty state when no credentials exist (with project selected)', () => {
     mockSelectedProject.current = { id: 'proj-1', name: 'Project Alpha' }
     vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery([]))
-    vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+    vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false })
     render(<Credentials />, { wrapper })
 
     expect(screen.getByText('No credentials yet')).toBeInTheDocument()
@@ -664,7 +664,7 @@ describe('Credentials', () => {
   it('renders grouped table body when viewing all projects', () => {
     mockSelectedProject.current = null
     vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(mockCredentials))
-    vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+    vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false })
     render(<Credentials />, { wrapper })
 
     expect(screen.getByText('Project Alpha')).toBeInTheDocument()
@@ -681,7 +681,7 @@ describe('Credentials', () => {
     const user = userEvent.setup()
     mockSelectedProject.current = null
     vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(mockCredentials))
-    vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+    vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false })
     render(<Credentials />, { wrapper })
 
     expect(screen.getByText('GitHub API Token')).toBeInTheDocument()
@@ -697,7 +697,7 @@ describe('Credentials', () => {
     mockSelectedProject.current = null
     const credWithUnknownProject = [{ ...mockCredentials[0], project_id: 'unknown-id' }]
     vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(credWithUnknownProject))
-    vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+    vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false })
     render(<Credentials />, { wrapper })
 
     expect(screen.getByText('unknown-id')).toBeInTheDocument()
@@ -706,7 +706,7 @@ describe('Credentials', () => {
   it('renders flat table body when a project is selected', () => {
     mockSelectedProject.current = { id: 'proj-1', name: 'Project Alpha' }
     vi.mocked(credentialsClient.useQuery).mockImplementation(mockQuery(mockCredentials))
-    vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+    vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: vi.fn(), isPending: false })
     render(<Credentials />, { wrapper })
 
     expect(screen.queryByText('Project Alpha')).not.toBeInTheDocument()

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialsTableBody.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialsTableBody.test.tsx
@@ -31,7 +31,7 @@ const sampleCredential: Credential = {
   enabled: true,
   credential_type_id: 'type-1',
   project_id: 'proj-1',
-} as Credential
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/form/CredentialFormModal.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/form/CredentialFormModal.test.tsx
@@ -117,8 +117,8 @@ describe('CredentialFormModal', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(credentialsClient.useMutation).mockReturnValue({ mutate: mockMutate, isPending: false } as any)
     const projectsMock = { projects: mockProjects, isLoading: false, error: null, refetch: vi.fn() }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-    vi.mocked(useSelectableProjects).mockReturnValue(projectsMock as any)
+
+    vi.mocked(useSelectableProjects).mockReturnValue(projectsMock)
   })
 
   it('has no accessibility violations in create mode', async () => {
@@ -477,8 +477,8 @@ describe('CredentialFormModal', () => {
 
   it('shows loading state for projects', () => {
     const loadingMock = { projects: [], isLoading: true, error: null, refetch: vi.fn() }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-    vi.mocked(useSelectableProjects).mockReturnValue(loadingMock as any)
+
+    vi.mocked(useSelectableProjects).mockReturnValue(loadingMock)
 
     render(<CredentialFormModal isOpen onClose={vi.fn()} />, { wrapper })
 
@@ -488,8 +488,8 @@ describe('CredentialFormModal', () => {
 
   it('shows error when projects fail to load', () => {
     const errorMock = { projects: [], isLoading: false, error: new Error('Network error'), refetch: vi.fn() }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-    vi.mocked(useSelectableProjects).mockReturnValue(errorMock as any)
+
+    vi.mocked(useSelectableProjects).mockReturnValue(errorMock)
 
     render(<CredentialFormModal isOpen onClose={vi.fn()} />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/form/DynamicFieldRenderer.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/form/DynamicFieldRenderer.tsx
@@ -42,6 +42,12 @@ type DynamicFieldRendererProps = {
   error?: string
 }
 
+function toFieldString(value: unknown): string {
+  return value != null && (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean')
+    ? String(value)
+    : ''
+}
+
 function FieldHelperText({ error, helpText }: Readonly<{ error?: string; helpText?: string }>) {
   if (error) {
     return (
@@ -153,7 +159,7 @@ function ChoicesSelect({
 }
 
 function ChoicesField({ field, value, onChange, isRequired, error }: DynamicFieldRendererProps) {
-  const stringValue = value != null ? String(value as string | number | boolean) : ''
+  const stringValue = toFieldString(value)
 
   return (
     <FieldWrapper field={field} isRequired={isRequired} error={error}>
@@ -170,7 +176,7 @@ function ChoicesField({ field, value, onChange, isRequired, error }: DynamicFiel
 }
 
 function MultilineField({ field, value, onChange, isRequired, error }: DynamicFieldRendererProps) {
-  const stringValue = value != null ? String(value as string | number | boolean) : ''
+  const stringValue = toFieldString(value)
   const validated = error ? 'error' : 'default'
 
   return (
@@ -192,7 +198,7 @@ function SecretField({ field, value, onChange, isRequired, isEditMode, error }: 
   const [showSecret, setShowSecret] = useState(false)
   const [secretTouched, setSecretTouched] = useState(false)
 
-  const stringValue = value != null ? String(value as string | number | boolean) : ''
+  const stringValue = toFieldString(value)
   const isEncryptedPlaceholder = isEditMode && !secretTouched && stringValue === ENCRYPTED_SENTINEL
   const displayValue = isEncryptedPlaceholder ? '' : stringValue
   const validated = error ? 'error' : 'default'
@@ -236,7 +242,7 @@ function SecretField({ field, value, onChange, isRequired, isEditMode, error }: 
 }
 
 function PlainTextField({ field, value, onChange, isRequired, error }: DynamicFieldRendererProps) {
-  const stringValue = value != null ? String(value as string | number | boolean) : ''
+  const stringValue = toFieldString(value)
   const validated = error ? 'error' : 'default'
 
   return (

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/form/credentialFormUtils.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/form/credentialFormUtils.test.ts
@@ -23,7 +23,7 @@ import {
 import type { FieldDefinition } from './DynamicFieldRenderer'
 
 function makeCredentialType(overrides: Partial<CredentialType> & { inputs: unknown }): CredentialType {
-  return { id: 'type-1', name: 'Test Type', ...overrides } as CredentialType
+  return { id: 'type-1', name: 'Test Type', ...overrides }
 }
 
 function makeSetError() {

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/useCredentialPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/useCredentialPermissions.test.ts
@@ -52,7 +52,7 @@ describe('useCredentialPermissions', () => {
   })
 
   it('uses check_any_project for create and system-scoped update/delete without resourceProject', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useCredentialPermissions(), { wrapper: createWrapper() })
 
@@ -183,7 +183,7 @@ describe('useCredentialPermissions', () => {
   })
 
   it('skips all checks and reports isLoading when enabled is false', () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useCredentialPermissions({ enabled: false }), {
       wrapper: createWrapper(),

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/EditIntegrationForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/EditIntegrationForm.tsx
@@ -317,7 +317,7 @@ export function EditIntegrationForm() {
       base_url: 'base_url' in config ? String(config.base_url ?? '') : '',
       allow_http: 'allow_http' in config ? Boolean(config.allow_http) : false,
       insecure_skip_tls_verify: 'insecure_skip_tls_verify' in config ? Boolean(config.insecure_skip_tls_verify) : false,
-      ca_certificate: 'ca_certificate' in config ? ((config.ca_certificate as string | null) ?? null) : null,
+      ca_certificate: 'ca_certificate' in config ? ((config.ca_certificate) ?? null) : null,
       scope: (integration.scope as 'global' | 'project') ?? 'global',
       project_ids: projectIds,
       management_credential_id: integration.management_credential_id ?? null,

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/EditIntegrationForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/EditIntegrationForm.tsx
@@ -317,7 +317,7 @@ export function EditIntegrationForm() {
       base_url: 'base_url' in config ? String(config.base_url ?? '') : '',
       allow_http: 'allow_http' in config ? Boolean(config.allow_http) : false,
       insecure_skip_tls_verify: 'insecure_skip_tls_verify' in config ? Boolean(config.insecure_skip_tls_verify) : false,
-      ca_certificate: 'ca_certificate' in config ? ((config.ca_certificate) ?? null) : null,
+      ca_certificate: 'ca_certificate' in config ? (config.ca_certificate ?? null) : null,
       scope: (integration.scope as 'global' | 'project') ?? 'global',
       project_ids: projectIds,
       management_credential_id: integration.management_credential_id ?? null,

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationDetail.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationDetail.test.tsx
@@ -193,7 +193,7 @@ describe('IntegrationDetail', () => {
       isError: overrides?.isError ?? false,
       error: overrides?.isError ? new Error('Load failed') : null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     vi.mocked(credentialsClient.useQuery).mockReturnValue({
       data: integration.management_credential_id
@@ -206,7 +206,7 @@ describe('IntegrationDetail', () => {
       isPending: false,
       isError: false,
       error: null,
-    } as never)
+    })
 
     const baseMutationResult = {
       isPending: false,
@@ -614,22 +614,22 @@ describe('IntegrationDetail', () => {
         isError: true,
         error: retryableError,
         refetch: mockRefetch,
-      } as never)
+      })
       vi.mocked(credentialsClient.useQuery).mockReturnValue({
         data: undefined,
         isPending: false,
         isError: false,
         error: null,
-      } as never)
+      })
       vi.mocked(integrationsClient.useMutation).mockReturnValue({
         mutate: mockMutate,
         isPending: false,
-      } as never)
+      })
       vi.mocked(integrationsClient.useMutation).mockReturnValue({
         mutateAsync: vi.fn().mockResolvedValue({}),
         mutate: vi.fn(),
         isPending: false,
-      } as never)
+      })
       mockRefetch.mockResolvedValue({ data: mockIntegration })
       const user = userEvent.setup()
       render(<IntegrationDetail />, { wrapper })
@@ -646,7 +646,7 @@ describe('IntegrationDetail', () => {
       render(<IntegrationDetail />, { wrapper })
 
       expect(mockRegisterDirtyCheck).toHaveBeenCalledOnce()
-      const opts = mockRegisterDirtyCheck.mock.lastCall?.[0] as unknown as Record<string, unknown> | undefined
+      const opts = mockRegisterDirtyCheck.mock.lastCall?.[0]
       expect(opts).toBeDefined()
       expect(typeof opts!.check).toBe('function')
       expect(typeof opts!.saveAndExit).toBe('function')
@@ -1152,7 +1152,7 @@ describe('IntegrationDetail', () => {
     })
 
     it('shows invalid integration error when integrationId is empty', () => {
-      vi.mocked(useParams).mockReturnValue({ integrationId: '' } as never)
+      vi.mocked(useParams).mockReturnValue({ integrationId: '' })
       render(<IntegrationDetail />, { wrapper })
 
       expect(screen.getByText('Invalid integration')).toBeInTheDocument()

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationProjectsList.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationProjectsList.test.tsx
@@ -194,7 +194,7 @@ function setupMocks(overrides?: {
     isPending: false,
     isError: false,
     error: null,
-  } as never)
+  })
 
   vi.mocked(integrationsClient.useMutation).mockImplementation((_method: string, path: string) => {
     if (path === '/integrations/{integration_id}/tools/bulk_update') {

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationResourcesTab.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationResourcesTab.test.tsx
@@ -86,7 +86,7 @@ describe('IntegrationResourcesTab', () => {
       variables: undefined,
       status: 'idle',
       isPaused: false,
-    } as never)
+    })
   })
 
   function renderTab(overrides?: {

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/Integrations.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/Integrations.test.tsx
@@ -177,7 +177,7 @@ describe('Integrations Component', () => {
       isError: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     vi.mocked(integrationsClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
@@ -196,7 +196,7 @@ describe('Integrations Component', () => {
       variables: undefined,
       status: 'idle',
       isPaused: false,
-    } as never)
+    })
   })
 
   describe('Rendering', () => {
@@ -298,7 +298,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<Integrations />, { wrapper })
 
@@ -317,7 +317,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<Integrations />, { wrapper })
 
@@ -976,7 +976,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(integrationsClient.useMutation).mockImplementation((_method: string, path: string) => {
         if (path.includes('validate')) {
@@ -1014,7 +1014,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(integrationsClient.useMutation).mockImplementation((_method: string, path: string) => {
         if (path.includes('validate')) {
@@ -1070,14 +1070,14 @@ describe('Integrations Component', () => {
           isError: false,
           error: null,
           refetch: mockRefetch,
-        } as never)
+        })
         .mockReturnValue({
           data: { resources: updatedIntegrations },
           isPending: false,
           isError: false,
           error: null,
           refetch: mockRefetch,
-        } as never)
+        })
 
       vi.mocked(integrationsClient.useMutation).mockImplementation((_method: string, path: string) => {
         if (path.includes('validate')) {
@@ -1130,7 +1130,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(integrationsClient.useMutation).mockImplementation((_method: string, path: string) => {
         if (path.includes('validate')) {
@@ -1250,7 +1250,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(integrationsClient.useMutation).mockImplementation((method: string) => {
         if (method === 'delete') {
@@ -1291,7 +1291,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: mockRefetch,
-      } as never)
+      })
 
       vi.mocked(integrationsClient.useMutation).mockImplementation((method: string) => {
         if (method === 'delete') {
@@ -1452,7 +1452,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<Integrations />, { wrapper })
@@ -1525,7 +1525,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       // Make patch call onError
       mockPatchMutate.mockImplementation((_variables: unknown, options?: { onError?: (error: unknown) => void }) => {
@@ -1557,7 +1557,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<Integrations />, { wrapper })
 
@@ -1630,7 +1630,7 @@ describe('Integrations Component', () => {
         isError: false,
         error: null,
         refetch: vi.fn(),
-      } as never)
+      })
 
       render(<Integrations />, { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationDetailsStep.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationDetailsStep.tsx
@@ -383,7 +383,7 @@ export function IntegrationDetailsStep({ control, setValue, onTypeChange }: Inte
               control={control}
               render={({ field }) => (
                 <ProviderHintSelect
-                  value={field.value as string | undefined}
+                  value={field.value}
                   isOpen={isProviderOpen}
                   onOpenChange={setIsProviderOpen}
                   onSelect={(value) => {

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/IntegrationForm.test.tsx
@@ -293,7 +293,7 @@ describe('IntegrationForm', () => {
       mutateAsync: mockMutateAsync,
       isPending: false,
       isError: false,
-    } as never)
+    })
 
     const user = userEvent.setup()
     render(<IntegrationForm />, { wrapper })

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/ProjectMultiSelect.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/ProjectMultiSelect.test.tsx
@@ -19,7 +19,7 @@ const mockProjects = [
 
 function mockProjectsLoaded(projects = mockProjects) {
   vi.mocked(useSelectableProjects).mockReturnValue({
-    projects: projects as ReturnType<typeof useSelectableProjects>['projects'],
+    projects: projects,
     isLoading: false,
     error: null,
     refetch: vi.fn(),

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/ScopeFields.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/form/ScopeFields.tsx
@@ -1,6 +1,6 @@
 import { FormGroup, FormHelperText, HelperText, HelperTextItem, Switch } from '@patternfly/react-core'
 import { RhUiErrorIcon } from '@patternfly/react-icons'
-import { Controller, type Control, type FieldValues, type Path, type PathValue } from 'react-hook-form'
+import { Controller, type Control, type FieldValues, type Path } from 'react-hook-form'
 
 import { integrationHelp } from '../integrationFieldHelp'
 
@@ -38,7 +38,7 @@ export function ScopeFields<T extends FieldValues>({
               isChecked={field.value === 'global'}
               onChange={(_event, checked) => {
                 const newScope = checked ? 'global' : 'project'
-                field.onChange(newScope as PathValue<T, Path<T>>)
+                field.onChange(newScope)
                 onScopeChange?.(newScope)
               }}
             />
@@ -64,7 +64,7 @@ export function ScopeFields<T extends FieldValues>({
               <>
                 <ProjectMultiSelect
                   selectedIds={(field.value as string[]) ?? []}
-                  onChange={(ids) => field.onChange(ids as PathValue<T, Path<T>>)}
+                  onChange={(ids) => field.onChange(ids)}
                   validated={fieldState.error ? 'error' : 'default'}
                 />
                 {fieldState.error && (

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/integrationUtils.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/integrationUtils.test.ts
@@ -76,7 +76,7 @@ describe('integrationUtils', () => {
     })
 
     it('returns empty string when configuration is undefined', () => {
-      expect(getProviderHint(buildIntegration({ configuration: undefined } as never))).toBe('')
+      expect(getProviderHint(buildIntegration({ configuration: undefined }))).toBe('')
     })
   })
 
@@ -98,7 +98,7 @@ describe('integrationUtils', () => {
     })
 
     it('returns empty string when configuration is undefined', () => {
-      expect(getBaseUrl(buildIntegration({ configuration: undefined } as never))).toBe('')
+      expect(getBaseUrl(buildIntegration({ configuration: undefined }))).toBe('')
     })
 
     it('resolves default URL for well-known provider when base_url is null', () => {

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/useIntegrationActions.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/useIntegrationActions.test.tsx
@@ -78,7 +78,7 @@ describe('useIntegrationActions', () => {
       variables: undefined,
       status: 'idle',
       isPaused: false,
-    } as never)
+    })
   })
 
   describe('validateDialog', () => {

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/useIntegrationPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/useIntegrationPermissions.test.ts
@@ -46,7 +46,7 @@ describe('useIntegrationPermissions', () => {
   })
 
   it('returns all true when API grants all permissions', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useIntegrationPermissions(), { wrapper: createWrapper() })
 
@@ -59,7 +59,7 @@ describe('useIntegrationPermissions', () => {
   })
 
   it('calls can_i with correct action and resource_type', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     renderHook(() => useIntegrationPermissions(), { wrapper: createWrapper() })
 

--- a/frontend/packages/syntara-ui/src/routes/configuration/settings/SettingField.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/settings/SettingField.test.tsx
@@ -25,7 +25,7 @@ const baseSetting: RuntimeSetting = {
   value_type: 'integer',
   requires_restart: false,
   cache_ttl_seconds: null,
-  validation_schema: { min: 1 } as unknown as RuntimeSetting['validation_schema'],
+  validation_schema: { min: 1 },
   version: 1,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',

--- a/frontend/packages/syntara-ui/src/routes/configuration/settings/SettingInput.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/settings/SettingInput.tsx
@@ -313,7 +313,7 @@ export function SettingInput({
       return (
         <TextInput
           id={setting.key}
-          value={String(value as string)}
+          value={String(value)}
           readOnlyVariant={readOnlyVariant}
           onChange={(_event, val) => onChange(setting.key, val)}
         />

--- a/frontend/packages/syntara-ui/src/routes/executions/ApprovalReviewView.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/ApprovalReviewView.test.tsx
@@ -117,7 +117,7 @@ describe('ApprovalReviewView', () => {
     vi.mocked(approvalsClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
   })
 
   it('renders approval name, summary list, context, and form', () => {
@@ -253,7 +253,7 @@ describe('ApprovalReviewView', () => {
     vi.mocked(approvalsClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: true,
-    } as never)
+    })
 
     render(<ApprovalReviewView {...defaultProps} />, { wrapper: createWrapper() })
 

--- a/frontend/packages/syntara-ui/src/routes/executions/CancelExecutionButton.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/CancelExecutionButton.test.tsx
@@ -49,7 +49,7 @@ describe('CancelExecutionButton', () => {
     vi.mocked(executionsClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
   })
 
   it('renders an enabled cancel button', () => {
@@ -81,7 +81,7 @@ describe('CancelExecutionButton', () => {
     vi.mocked(executionsClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: true,
-    } as never)
+    })
 
     renderButton()
 

--- a/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetail.tsx
@@ -312,7 +312,7 @@ export default function ExecutionDetail() {
   useSyncActivityStore(execution, activities)
 
   const activityNameMap = useActivityNamesForExecution(
-    execution?.workflow_definition as WorkflowDefShape | undefined,
+    execution?.workflow_definition,
     activities
   )
 
@@ -330,7 +330,7 @@ export default function ExecutionDetail() {
   const isCancellable = isExecutionCancellable(execution?.status)
 
   const { forkAsNewWorkflow, isForkLoading } = useForkWorkflow({
-    workflowDefinition: execution?.workflow_definition as Record<string, unknown> | undefined,
+    workflowDefinition: execution?.workflow_definition,
     workflowName: workflow?.name ?? 'Workflow',
     projectId: execution?.project_id,
   })

--- a/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/ExecutionDetail.tsx
@@ -311,10 +311,7 @@ export default function ExecutionDetail() {
 
   useSyncActivityStore(execution, activities)
 
-  const activityNameMap = useActivityNamesForExecution(
-    execution?.workflow_definition,
-    activities
-  )
+  const activityNameMap = useActivityNamesForExecution(execution?.workflow_definition, activities)
 
   const nodeClick = useExecutionNodeClick(executionId)
   const { approvals, currentIndex, currentApproval, isApprovalLoading, handleNodeClick, navigateToIndex } = nodeClick

--- a/frontend/packages/syntara-ui/src/routes/executions/Executions.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/Executions.test.tsx
@@ -129,7 +129,7 @@ describe('Executions Component', () => {
     vi.mocked(executionsClient.useMutation).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as never)
+    })
 
     // Reset workflowClient mock to default implementation
     vi.mocked(workflowClient.useQuery).mockImplementation(((_method: string, path: string) => {
@@ -163,7 +163,7 @@ describe('Executions Component', () => {
       data: { resources: data },
       isPending,
       error,
-    } as never)
+    })
 
     // Mock the workflows query for fetching workflow names
     vi.mocked(workflowClient.useQuery).mockImplementation(((_method: string, path: string, options?: unknown) => {
@@ -703,7 +703,7 @@ describe('Executions Component', () => {
         data: { resources: [] },
         isPending: false,
         error: null,
-      } as never)
+      })
       // Don't override workflowClient mock - use the one from beforeEach
 
       render(<Executions />, { wrapper: TestWrapper })
@@ -721,7 +721,7 @@ describe('Executions Component', () => {
         data: { resources: [] },
         isPending: false,
         error: null,
-      } as never)
+      })
       vi.mocked(workflowClient.useQuery).mockImplementation(((_method: string, path: string) => {
         if (path === '/workflows') {
           return {
@@ -754,7 +754,7 @@ describe('Executions Component', () => {
         data: { resources: [] },
         isPending: false,
         error: null,
-      } as never)
+      })
       // Don't override workflowClient mock - use the one from beforeEach
 
       render(<Executions />, { wrapper: TestWrapper })
@@ -792,7 +792,7 @@ describe('Executions Component', () => {
         },
         isPending: false,
         error: null,
-      } as never)
+      })
 
       render(<Executions />, { wrapper: TestWrapper })
 
@@ -811,7 +811,7 @@ describe('Executions Component', () => {
         },
         isPending: false,
         error: null,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<Executions />, { wrapper: TestWrapper })
@@ -835,7 +835,7 @@ describe('Executions Component', () => {
         },
         isPending: false,
         error: null,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<Executions />, { wrapper: TestWrapper })
@@ -876,7 +876,7 @@ describe('Executions Component', () => {
         data: { resources: executionsWithProjects },
         isPending: false,
         error: null,
-      } as never)
+      })
 
       vi.mocked(workflowClient.useQuery).mockImplementation(((_method: string, path: string) => {
         if (path === '/workflows') {
@@ -917,7 +917,7 @@ describe('Executions Component', () => {
         data: { resources: executionsWithProjects },
         isPending: false,
         error: null,
-      } as never)
+      })
 
       vi.mocked(workflowClient.useQuery).mockImplementation(((_method: string, path: string) => {
         if (path === '/workflows') {
@@ -967,7 +967,7 @@ describe('Executions Component', () => {
         data: { resources: executionsWithProjects },
         isPending: false,
         error: null,
-      } as never)
+      })
 
       vi.mocked(workflowClient.useQuery).mockImplementation(((_method: string, path: string) => {
         if (path === '/workflows') {
@@ -1028,7 +1028,7 @@ describe('Executions Component', () => {
         data: { resources: [] },
         isPending: false,
         error: null,
-      } as never)
+      })
 
       vi.mocked(workflowClient.useQuery).mockImplementation(((_method: string, path: string) => {
         if (path === '/workflows') {

--- a/frontend/packages/syntara-ui/src/routes/executions/RetryExecutionButton.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/RetryExecutionButton.test.tsx
@@ -63,7 +63,7 @@ describe('RetryExecutionButton', () => {
     vi.mocked(executionsClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
     vi.mocked(useCanI).mockReturnValue({ allowed: true, isChecking: false, isError: false })
   })
 

--- a/frontend/packages/syntara-ui/src/routes/executions/executionFilters.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/executionFilters.ts
@@ -1,4 +1,3 @@
-import type { WorkflowAPI } from '@syntara/contracts'
 import { ExecutionStatusEnum } from '@syntara/contracts'
 
 import { workflowFetchClient } from '../../client'
@@ -55,7 +54,7 @@ export const getExecutionWorkflowFilterDefinition = (): FilterFieldDefinition =>
 
     try {
       const response = await workflowFetchClient.GET('/workflows', {
-        params: { query: params as WorkflowAPI.paths['/workflows']['get']['parameters']['query'] },
+        params: { query: params },
       })
 
       const workflows = response.data?.resources ?? []

--- a/frontend/packages/syntara-ui/src/routes/executions/hooks/useExecutionApprovalPanel.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/hooks/useExecutionApprovalPanel.test.ts
@@ -351,7 +351,7 @@ describe('useExecutionApprovalPanel', () => {
   it('handles URL approval not in fetched list (defaults to first approval)', async () => {
     const { useFetchApprovalForUrlParam } = await import('./useFetchApprovalForUrlParam')
     const urlApproval = { ...mockApproval, id: 'url-approval-not-in-list' }
-    vi.mocked(useFetchApprovalForUrlParam).mockReturnValue(urlApproval as Approval)
+    vi.mocked(useFetchApprovalForUrlParam).mockReturnValue(urlApproval)
     mockFetchApprovals.mockResolvedValue([mockApproval]) // URL approval not in the fetched list
 
     const { result } = renderHook(() =>
@@ -437,7 +437,7 @@ describe('useExecutionApprovalPanel', () => {
     renderHook(() => useExecutionApprovalPanel('exec-1', '', makeNodeClick(), undefined))
 
     await act(async () => {
-      capturedCallback!(detectedApproval as Approval)
+      capturedCallback!(detectedApproval)
       await vi.runAllTimersAsync()
     })
 

--- a/frontend/packages/syntara-ui/src/routes/executions/hooks/useExecutionNodeClick.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/hooks/useExecutionNodeClick.ts
@@ -52,7 +52,7 @@ type ExecutionState = {
 
 function getExecutionState(node: ExecutionNode): ExecutionState | undefined {
   const value = node.data.__executionState
-  if (typeof value === 'object' && value !== null) return value as ExecutionState
+  if (typeof value === 'object' && value !== null) return value
   return undefined
 }
 

--- a/frontend/packages/syntara-ui/src/routes/executions/hooks/useFetchApprovalForNode.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/hooks/useFetchApprovalForNode.test.ts
@@ -39,7 +39,7 @@ describe('useFetchApprovalForNode', () => {
       isPending: false,
       error: null,
       isError: false,
-    } as never)
+    })
   })
 
   it('starts with isLoading false', () => {

--- a/frontend/packages/syntara-ui/src/routes/executions/hooks/useFetchApprovalForUrlParam.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/hooks/useFetchApprovalForUrlParam.test.ts
@@ -33,7 +33,7 @@ describe('useFetchApprovalForUrlParam', () => {
   it('returns undefined when no approval param in URL', () => {
     vi.mocked(approvalsClient.useQuery).mockReturnValue({
       data: undefined,
-    } as never)
+    })
 
     const { result } = renderHook(() => useFetchApprovalForUrlParam(''), {
       wrapper: makeWrapper(queryClient),
@@ -46,7 +46,7 @@ describe('useFetchApprovalForUrlParam', () => {
     const mockApproval = { id: 'approval-1', name: 'Test' }
     vi.mocked(approvalsClient.useQuery).mockReturnValue({
       data: mockApproval,
-    } as never)
+    })
 
     const { result } = renderHook(() => useFetchApprovalForUrlParam('approval=approval-1'), {
       wrapper: makeWrapper(queryClient),
@@ -64,7 +64,7 @@ describe('useFetchApprovalForUrlParam', () => {
   it('passes enabled=false when no approval param', () => {
     vi.mocked(approvalsClient.useQuery).mockReturnValue({
       data: undefined,
-    } as never)
+    })
 
     renderHook(() => useFetchApprovalForUrlParam('history=open'), {
       wrapper: makeWrapper(queryClient),
@@ -81,7 +81,7 @@ describe('useFetchApprovalForUrlParam', () => {
   it('handles searchParams with question mark prefix', () => {
     vi.mocked(approvalsClient.useQuery).mockReturnValue({
       data: undefined,
-    } as never)
+    })
 
     renderHook(() => useFetchApprovalForUrlParam('?approval=test-id'), {
       wrapper: makeWrapper(queryClient),

--- a/frontend/packages/syntara-ui/src/routes/executions/hooks/useFetchPendingApprovals.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/hooks/useFetchPendingApprovals.test.ts
@@ -73,7 +73,7 @@ describe('useFetchPendingApprovals', () => {
       isLoading: false,
       isError: false,
       error: null,
-    } as never)
+    })
   })
 
   it('initializes with not loading', () => {

--- a/frontend/packages/syntara-ui/src/routes/executions/hooks/useForkWorkflow.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/hooks/useForkWorkflow.ts
@@ -1,4 +1,3 @@
-import type { V2WorkflowDefinition } from '@syntara/contracts'
 import { useCallback } from 'react'
 
 import { workflowClient } from '../../../client'
@@ -29,7 +28,7 @@ export function useForkWorkflow({ workflowDefinition, workflowName, projectId }:
         body: {
           name: forkName,
           description: '',
-          workflow_definition: workflowDefinition as unknown as V2WorkflowDefinition,
+          workflow_definition: workflowDefinition,
           project_id: projectId,
         },
       })

--- a/frontend/packages/syntara-ui/src/routes/executions/hooks/useIsCurrentVersion.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/hooks/useIsCurrentVersion.test.tsx
@@ -26,7 +26,7 @@ describe('useIsCurrentVersion', () => {
       data: null,
       isLoading: false,
       error: null,
-    } as never)
+    })
   })
 
   it('returns isCurrentVersion true when no workflow data loaded', () => {
@@ -47,7 +47,7 @@ describe('useIsCurrentVersion', () => {
       data: null,
       isLoading: true,
       error: null,
-    } as never)
+    })
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'v-1', true), { wrapper: Wrapper })
 
@@ -67,8 +67,8 @@ describe('useIsCurrentVersion', () => {
     }
 
     vi.mocked(workflowClient.useQuery)
-      .mockReturnValueOnce(mockWorkflowQuery as never)
-      .mockReturnValueOnce(mockVersionsQuery as never)
+      .mockReturnValueOnce(mockWorkflowQuery)
+      .mockReturnValueOnce(mockVersionsQuery)
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'current-version-id', true), { wrapper: Wrapper })
 
@@ -95,8 +95,8 @@ describe('useIsCurrentVersion', () => {
     }
 
     vi.mocked(workflowClient.useQuery)
-      .mockReturnValueOnce(mockWorkflowQuery as never)
-      .mockReturnValueOnce(mockVersionsQuery as never)
+      .mockReturnValueOnce(mockWorkflowQuery)
+      .mockReturnValueOnce(mockVersionsQuery)
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'old-version-id', true), { wrapper: Wrapper })
 
@@ -119,8 +119,8 @@ describe('useIsCurrentVersion', () => {
     }
 
     vi.mocked(workflowClient.useQuery)
-      .mockReturnValueOnce(mockWorkflowQuery as never)
-      .mockReturnValueOnce(mockVersionsQuery as never)
+      .mockReturnValueOnce(mockWorkflowQuery)
+      .mockReturnValueOnce(mockVersionsQuery)
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'old-version-id', true), { wrapper: Wrapper })
 
@@ -141,8 +141,8 @@ describe('useIsCurrentVersion', () => {
     }
 
     vi.mocked(workflowClient.useQuery)
-      .mockReturnValueOnce(mockWorkflowQuery as never)
-      .mockReturnValueOnce(mockVersionsQuery as never)
+      .mockReturnValueOnce(mockWorkflowQuery)
+      .mockReturnValueOnce(mockVersionsQuery)
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'old-version-id', true), { wrapper: Wrapper })
 
@@ -163,8 +163,8 @@ describe('useIsCurrentVersion', () => {
     }
 
     vi.mocked(workflowClient.useQuery)
-      .mockReturnValueOnce(mockWorkflowQuery as never)
-      .mockReturnValueOnce(mockVersionsQuery as never)
+      .mockReturnValueOnce(mockWorkflowQuery)
+      .mockReturnValueOnce(mockVersionsQuery)
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'missing-version-id', true), { wrapper: Wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/executions/hooks/useIsCurrentVersion.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/hooks/useIsCurrentVersion.test.tsx
@@ -66,9 +66,7 @@ describe('useIsCurrentVersion', () => {
       error: null,
     }
 
-    vi.mocked(workflowClient.useQuery)
-      .mockReturnValueOnce(mockWorkflowQuery)
-      .mockReturnValueOnce(mockVersionsQuery)
+    vi.mocked(workflowClient.useQuery).mockReturnValueOnce(mockWorkflowQuery).mockReturnValueOnce(mockVersionsQuery)
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'current-version-id', true), { wrapper: Wrapper })
 
@@ -94,9 +92,7 @@ describe('useIsCurrentVersion', () => {
       error: null,
     }
 
-    vi.mocked(workflowClient.useQuery)
-      .mockReturnValueOnce(mockWorkflowQuery)
-      .mockReturnValueOnce(mockVersionsQuery)
+    vi.mocked(workflowClient.useQuery).mockReturnValueOnce(mockWorkflowQuery).mockReturnValueOnce(mockVersionsQuery)
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'old-version-id', true), { wrapper: Wrapper })
 
@@ -118,9 +114,7 @@ describe('useIsCurrentVersion', () => {
       error: null,
     }
 
-    vi.mocked(workflowClient.useQuery)
-      .mockReturnValueOnce(mockWorkflowQuery)
-      .mockReturnValueOnce(mockVersionsQuery)
+    vi.mocked(workflowClient.useQuery).mockReturnValueOnce(mockWorkflowQuery).mockReturnValueOnce(mockVersionsQuery)
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'old-version-id', true), { wrapper: Wrapper })
 
@@ -140,9 +134,7 @@ describe('useIsCurrentVersion', () => {
       error: null,
     }
 
-    vi.mocked(workflowClient.useQuery)
-      .mockReturnValueOnce(mockWorkflowQuery)
-      .mockReturnValueOnce(mockVersionsQuery)
+    vi.mocked(workflowClient.useQuery).mockReturnValueOnce(mockWorkflowQuery).mockReturnValueOnce(mockVersionsQuery)
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'old-version-id', true), { wrapper: Wrapper })
 
@@ -162,9 +154,7 @@ describe('useIsCurrentVersion', () => {
       error: null,
     }
 
-    vi.mocked(workflowClient.useQuery)
-      .mockReturnValueOnce(mockWorkflowQuery)
-      .mockReturnValueOnce(mockVersionsQuery)
+    vi.mocked(workflowClient.useQuery).mockReturnValueOnce(mockWorkflowQuery).mockReturnValueOnce(mockVersionsQuery)
 
     const { result } = renderHook(() => useIsCurrentVersion('wf-1', 'missing-version-id', true), { wrapper: Wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/executions/hooks/useNodeExecutionDetails.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/hooks/useNodeExecutionDetails.ts
@@ -61,7 +61,7 @@ export function useNodeExecutionDetails(
     // are arbitrary JSON objects, so we widen to Record<string, unknown>.
     // output_data is already typed as Record<string, unknown> | null in the contract.
     return {
-      inputData: (activity?.input_data as Record<string, unknown> | undefined) ?? null,
+      inputData: (activity?.input_data) ?? null,
       outputData: activity?.output_data ?? null,
       isLoading,
       error,

--- a/frontend/packages/syntara-ui/src/routes/executions/hooks/useNodeExecutionDetails.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/hooks/useNodeExecutionDetails.ts
@@ -61,7 +61,7 @@ export function useNodeExecutionDetails(
     // are arbitrary JSON objects, so we widen to Record<string, unknown>.
     // output_data is already typed as Record<string, unknown> | null in the contract.
     return {
-      inputData: (activity?.input_data) ?? null,
+      inputData: activity?.input_data ?? null,
       outputData: activity?.output_data ?? null,
       isLoading,
       error,

--- a/frontend/packages/syntara-ui/src/routes/executions/useCancelExecution.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/useCancelExecution.test.tsx
@@ -44,7 +44,7 @@ describe('useCancelExecution', () => {
     vi.mocked(executionsClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
   })
 
   it('calls mutate with the correct execution ID and shows success', () => {
@@ -91,7 +91,7 @@ describe('useCancelExecution', () => {
     vi.mocked(executionsClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: true,
-    } as never)
+    })
 
     const { Wrapper } = createWrapper()
     const { result } = renderHook(() => useCancelExecution('exec-abc'), { wrapper: Wrapper })

--- a/frontend/packages/syntara-ui/src/routes/executions/useRetryExecution.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/useRetryExecution.test.tsx
@@ -43,7 +43,7 @@ describe('useRetryExecution', () => {
     vi.mocked(executionsClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: false,
-    } as never)
+    })
   })
 
   it('calls mutate with the correct execution ID and shows success', () => {
@@ -92,7 +92,7 @@ describe('useRetryExecution', () => {
     vi.mocked(executionsClient.useMutation).mockReturnValue({
       mutate: mockMutate,
       isPending: true,
-    } as never)
+    })
 
     const { Wrapper } = createWrapper()
     const { result } = renderHook(() => useRetryExecution('exec-abc'), { wrapper: Wrapper })

--- a/frontend/packages/syntara-ui/src/routes/workflows/Workflows.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/Workflows.test.tsx
@@ -49,12 +49,20 @@ vi.mock('../access/useAllProjects', () => ({
 // Mock useProjectSelector — default to a single selected project so that:
 // 1. projectSelectorReady is true (queries are enabled)
 // 2. the flat table body is rendered (most tests expect flat rows)
-const mockUseProjectSelector = vi.fn(() => ({
-  selectedProject: { id: 'proj-default', name: 'Default Project' },
-  isAllProjects: false,
-  projects: [{ id: 'proj-default', name: 'Default Project' }],
-  ProjectSelector: null,
-}))
+type MockProjectSelector = {
+  selectedProject: { id: string; name: string } | null
+  isAllProjects: boolean
+  projects: { id: string; name: string }[]
+  ProjectSelector: null
+}
+const mockUseProjectSelector = vi.fn(
+  (): MockProjectSelector => ({
+    selectedProject: { id: 'proj-default', name: 'Default Project' },
+    isAllProjects: false,
+    projects: [{ id: 'proj-default', name: 'Default Project' }],
+    ProjectSelector: null,
+  })
+)
 vi.mock('../../hooks/useProjectSelector', () => ({
   useProjectSelector: () => mockUseProjectSelector(),
 }))

--- a/frontend/packages/syntara-ui/src/routes/workflows/Workflows.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/Workflows.test.tsx
@@ -50,7 +50,7 @@ vi.mock('../access/useAllProjects', () => ({
 // 1. projectSelectorReady is true (queries are enabled)
 // 2. the flat table body is rendered (most tests expect flat rows)
 const mockUseProjectSelector = vi.fn(() => ({
-  selectedProject: { id: 'proj-default', name: 'Default Project' } as { id: string; name: string } | null,
+  selectedProject: { id: 'proj-default', name: 'Default Project' },
   isAllProjects: false,
   projects: [{ id: 'proj-default', name: 'Default Project' }],
   ProjectSelector: null,
@@ -179,7 +179,7 @@ describe('Workflows Component', () => {
       isError: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     // Then set up workflow query (mockWorkflowQuery will override accessClient.useQuery)
     const defaultQueryReturn = {
@@ -231,7 +231,7 @@ describe('Workflows Component', () => {
     vi.mocked(executionsFetchClient.POST).mockResolvedValue({
       data: { id: 'exec-default' },
       error: undefined,
-    } as never)
+    })
 
     // Mock workflowClient.useMutation for delete workflow
     vi.mocked(workflowClient.useMutation).mockReturnValue({
@@ -410,7 +410,7 @@ describe('Workflows Component', () => {
       vi.mocked(executionsFetchClient.POST).mockResolvedValue({
         data: { id: 'exec-123' },
         error: undefined,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<Workflows />, { wrapper })
@@ -450,7 +450,7 @@ describe('Workflows Component', () => {
       vi.mocked(executionsFetchClient.POST).mockResolvedValue({
         data: undefined,
         error: { detail: 'Network error' },
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<Workflows />, { wrapper })
@@ -490,7 +490,7 @@ describe('Workflows Component', () => {
       vi.mocked(executionsFetchClient.POST).mockResolvedValue({
         data: undefined,
         error: {},
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<Workflows />, { wrapper })
@@ -633,7 +633,7 @@ describe('Workflows Component', () => {
       vi.mocked(executionsFetchClient.POST).mockResolvedValue({
         data: { id: 'exec-with-inputs' },
         error: undefined,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<Workflows />, { wrapper })
@@ -1270,7 +1270,7 @@ describe('Workflows Component', () => {
       vi.mocked(executionsFetchClient.POST).mockResolvedValue({
         data: { id: 'exec-123' },
         error: undefined,
-      } as never)
+      })
 
       const user = userEvent.setup()
       render(<Workflows />, { wrapper })

--- a/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/detectTaskNodeType.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/common/detectTaskNodeType.test.ts
@@ -35,7 +35,7 @@ describe('detectTaskNodeType', () => {
           prompt: 'Do something',
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>)
+      })
       const result = detectTaskNodeType(task)
 
       expect(result.detectedExecutorType).toBe('agentic')
@@ -46,7 +46,7 @@ describe('detectTaskNodeType', () => {
       const task = createBaseTask({
         type: 'http_request',
         parameters: { method: 'GET', url: 'https://api.example.com' },
-      } as Partial<TaskActivity>)
+      })
       const result = detectTaskNodeType(task)
 
       expect(result.detectedExecutorType).toBe('http_request')
@@ -57,7 +57,7 @@ describe('detectTaskNodeType', () => {
       const task = createBaseTask({
         type: 'aap_job_template',
         parameters: { job_template_id: 123 },
-      } as Partial<TaskActivity>)
+      })
       const result = detectTaskNodeType(task)
 
       expect(result.detectedExecutorType).toBe('aap_job_template')
@@ -84,7 +84,7 @@ describe('detectTaskNodeType', () => {
       const task = createBaseTask({
         type: 'agentic',
         parameters: { prompt: 'test' },
-      } as Partial<TaskActivity>) as TaskActivityWithMetadata
+      }) as TaskActivityWithMetadata
       task.metadata = { __executorType: 'aap_job_template' }
 
       const result = detectTaskNodeType(task)
@@ -97,7 +97,7 @@ describe('detectTaskNodeType', () => {
       const task = createBaseTask({
         type: 'agentic',
         parameters: { prompt: 'test' },
-      } as Partial<TaskActivity>) as TaskActivityWithMetadata
+      }) as TaskActivityWithMetadata
       task.metadata = { __executorType: 'aap' }
 
       const result = detectTaskNodeType(task)
@@ -137,7 +137,7 @@ describe('detectTaskNodeType', () => {
           prompt: JSON.stringify(promptPayload),
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>)
+      })
 
       const result = detectTaskNodeType(task)
 
@@ -154,7 +154,7 @@ describe('detectTaskNodeType', () => {
           prompt: 'Run a job template on AAP',
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>)
+      })
 
       const result = detectTaskNodeType(task)
 
@@ -175,7 +175,7 @@ describe('detectTaskNodeType', () => {
           prompt: JSON.stringify(promptPayload),
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>)
+      })
 
       const result = detectTaskNodeType(task)
 
@@ -195,7 +195,7 @@ describe('detectTaskNodeType', () => {
           prompt: JSON.stringify(promptPayload),
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>)
+      })
 
       const result = detectTaskNodeType(task)
 
@@ -210,7 +210,7 @@ describe('detectTaskNodeType', () => {
           prompt: '{ invalid json',
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>)
+      })
 
       const result = detectTaskNodeType(task)
 
@@ -231,7 +231,7 @@ describe('detectTaskNodeType', () => {
           prompt: JSON.stringify(maliciousPayload),
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>)
+      })
 
       const result = detectTaskNodeType(task)
 
@@ -254,7 +254,7 @@ describe('detectTaskNodeType', () => {
           prompt: JSON.stringify(maliciousPayload),
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>)
+      })
 
       const result = detectTaskNodeType(task)
 
@@ -270,7 +270,7 @@ describe('detectTaskNodeType', () => {
           prompt: '"just a string"',
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>)
+      })
 
       const result = detectTaskNodeType(task)
 
@@ -286,7 +286,7 @@ describe('detectTaskNodeType', () => {
           prompt: 'null',
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>)
+      })
 
       const result = detectTaskNodeType(task)
 
@@ -308,7 +308,7 @@ describe('detectTaskNodeType', () => {
           prompt: JSON.stringify(promptPayload),
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>) as TaskActivityWithMetadata
+      }) as TaskActivityWithMetadata
 
       task.metadata = { __executorType: 'script' }
 
@@ -332,7 +332,7 @@ describe('detectTaskNodeType', () => {
           prompt: JSON.stringify(promptPayload),
           model: 'claude-3-sonnet',
         },
-      } as Partial<TaskActivity>) as TaskActivityWithMetadata
+      }) as TaskActivityWithMetadata
 
       task.metadata = { __executorType: 'invalid-type' }
 

--- a/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/nodeIconResolver.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/nodeIconResolver.test.ts
@@ -192,7 +192,7 @@ describe('nodeIconResolver', () => {
         {
           id: 'task-1',
           type: 'task',
-          data: { type: ExecutorTypeEnum.SCRIPT, id: 'task-1', name: 'Script' } as TaskActivity,
+          data: { type: ExecutorTypeEnum.SCRIPT, id: 'task-1', name: 'Script' },
         },
         null
       )

--- a/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/taskSemanticLabels.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/canvas/nodes/taskSemanticLabels.test.ts
@@ -9,7 +9,7 @@ function makeTask(
   return {
     id: 'a1',
     ...overrides,
-  } as TaskActivity
+  }
 }
 
 describe('getTaskSemanticLabels', () => {

--- a/frontend/packages/syntara-ui/src/routes/workflows/hooks/useExecutionData.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/hooks/useExecutionData.test.tsx
@@ -86,7 +86,7 @@ describe('useExecutionData', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useExecutionData('exec-123'), { wrapper })
 
@@ -106,7 +106,7 @@ describe('useExecutionData', () => {
       isSuccess: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     renderHook(() => useExecutionData('exec-123'), { wrapper })
 
@@ -138,7 +138,7 @@ describe('useExecutionData', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     renderHook(() => useExecutionData('exec-123'), { wrapper })
 
@@ -158,7 +158,7 @@ describe('useExecutionData', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     renderHook(() => useExecutionData('exec-123', { autoLoad: false }), { wrapper })
 
@@ -176,7 +176,7 @@ describe('useExecutionData', () => {
       isSuccess: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     renderHook(() => useExecutionData('exec-123', { enabled: false }), { wrapper })
 
@@ -197,7 +197,7 @@ describe('useExecutionData', () => {
       isSuccess: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useExecutionData('exec-123'), { wrapper })
 
@@ -214,7 +214,7 @@ describe('useExecutionData', () => {
       isSuccess: false,
       error: mockError,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useExecutionData('exec-123'), { wrapper })
 
@@ -236,7 +236,7 @@ describe('useExecutionData', () => {
       isSuccess: false,
       error: null,
       refetch: mockRefetch,
-    } as never)
+    })
 
     const { result } = renderHook(() => useExecutionData('exec-123'), { wrapper })
 
@@ -257,7 +257,7 @@ describe('useExecutionData', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     renderHook(() => useExecutionData('exec-123'), { wrapper })
 
@@ -285,7 +285,7 @@ describe('useExecutionData', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     renderHook(() => useExecutionData('exec-123'), { wrapper })
 
@@ -320,7 +320,7 @@ describe('useExecutionData', () => {
           completed_at: null,
         },
       ],
-    } as Partial<Execution>)
+    })
 
     vi.mocked(executionsClient.useQuery).mockReturnValue({
       data: mockExecution,
@@ -328,7 +328,7 @@ describe('useExecutionData', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     renderHook(() => useExecutionData('exec-123'), { wrapper })
 
@@ -358,7 +358,7 @@ describe('useShouldStreamExecution', () => {
       isSuccess: false,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useShouldStreamExecution('exec-123'), { wrapper })
 
@@ -366,7 +366,7 @@ describe('useShouldStreamExecution', () => {
   })
 
   it('returns true for running execution', () => {
-    const mockExecution = createMockExecution({ status: 'running' } as Partial<Execution>)
+    const mockExecution = createMockExecution({ status: 'running' })
 
     vi.mocked(executionsClient.useQuery).mockReturnValue({
       data: mockExecution,
@@ -374,7 +374,7 @@ describe('useShouldStreamExecution', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useShouldStreamExecution('exec-123'), { wrapper })
 
@@ -382,7 +382,7 @@ describe('useShouldStreamExecution', () => {
   })
 
   it('returns true for pending execution', () => {
-    const mockExecution = createMockExecution({ status: 'pending' } as Partial<Execution>)
+    const mockExecution = createMockExecution({ status: 'pending' })
 
     vi.mocked(executionsClient.useQuery).mockReturnValue({
       data: mockExecution,
@@ -390,7 +390,7 @@ describe('useShouldStreamExecution', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useShouldStreamExecution('exec-123'), { wrapper })
 
@@ -398,7 +398,7 @@ describe('useShouldStreamExecution', () => {
   })
 
   it('returns true for paused execution', () => {
-    const mockExecution = createMockExecution({ status: 'paused' } as Partial<Execution>)
+    const mockExecution = createMockExecution({ status: 'paused' })
 
     vi.mocked(executionsClient.useQuery).mockReturnValue({
       data: mockExecution,
@@ -406,7 +406,7 @@ describe('useShouldStreamExecution', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useShouldStreamExecution('exec-123'), { wrapper })
 
@@ -414,7 +414,7 @@ describe('useShouldStreamExecution', () => {
   })
 
   it('returns false for completed execution', () => {
-    const mockExecution = createMockExecution({ status: 'completed' } as Partial<Execution>)
+    const mockExecution = createMockExecution({ status: 'completed' })
 
     vi.mocked(executionsClient.useQuery).mockReturnValue({
       data: mockExecution,
@@ -422,7 +422,7 @@ describe('useShouldStreamExecution', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useShouldStreamExecution('exec-123'), { wrapper })
 
@@ -430,7 +430,7 @@ describe('useShouldStreamExecution', () => {
   })
 
   it('returns false for failed execution', () => {
-    const mockExecution = createMockExecution({ status: 'failed' } as Partial<Execution>)
+    const mockExecution = createMockExecution({ status: 'failed' })
 
     vi.mocked(executionsClient.useQuery).mockReturnValue({
       data: mockExecution,
@@ -438,7 +438,7 @@ describe('useShouldStreamExecution', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useShouldStreamExecution('exec-123'), { wrapper })
 
@@ -446,7 +446,7 @@ describe('useShouldStreamExecution', () => {
   })
 
   it('returns false for cancelled execution', () => {
-    const mockExecution = createMockExecution({ status: 'cancelled' } as Partial<Execution>)
+    const mockExecution = createMockExecution({ status: 'cancelled' })
 
     vi.mocked(executionsClient.useQuery).mockReturnValue({
       data: mockExecution,
@@ -454,7 +454,7 @@ describe('useShouldStreamExecution', () => {
       isSuccess: true,
       error: null,
       refetch: vi.fn(),
-    } as never)
+    })
 
     const { result } = renderHook(() => useShouldStreamExecution('exec-123'), { wrapper })
 

--- a/frontend/packages/syntara-ui/src/routes/workflows/hooks/useExecutionData.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/hooks/useExecutionData.ts
@@ -145,7 +145,7 @@ export function useExecutionData(executionId: string, options: UseExecutionDataO
     data: data,
     isLoading,
     isSuccess,
-    error: (error) ?? null,
+    error: error ?? null,
     refetch,
   }
 }

--- a/frontend/packages/syntara-ui/src/routes/workflows/hooks/useExecutionData.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/hooks/useExecutionData.ts
@@ -126,7 +126,7 @@ export function useExecutionData(executionId: string, options: UseExecutionDataO
   useEffect(() => {
     if (autoLoad && isSuccess && data) {
       try {
-        setExecution(data as Execution)
+        setExecution(data)
         setError(null)
       } catch (err) {
         setError(err instanceof Error ? err : new Error(getErrorMessage(err)))
@@ -142,10 +142,10 @@ export function useExecutionData(executionId: string, options: UseExecutionDataO
   }, [error, setError])
 
   return {
-    data: data as Execution | undefined,
+    data: data,
     isLoading,
     isSuccess,
-    error: (error as ApiError | null) ?? null,
+    error: (error) ?? null,
     refetch,
   }
 }
@@ -194,7 +194,7 @@ export function useShouldStreamExecution(executionId: string): boolean {
     return false
   }
 
-  const execution = data as Execution
+  const execution = data
   const terminalStatuses = ['completed', 'completed_with_errors', 'failed', 'cancelled']
   return !terminalStatuses.includes(execution.status ?? '')
 }

--- a/frontend/packages/syntara-ui/src/routes/workflows/resolveWorkflowRunTrigger.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/resolveWorkflowRunTrigger.test.ts
@@ -85,7 +85,7 @@ describe('resolveWorkflowRunTrigger', () => {
   })
 
   it('fetches the published version when it differs from the current draft', async () => {
-    vi.mocked(workflowFetchClient.GET).mockImplementation(((path: string) => {
+    vi.mocked(workflowFetchClient.GET).mockImplementation((path: string) => {
       if (path === '/workflows/{workflow_id}/versions/{version}') {
         return Promise.resolve(
           mockGetResponse({
@@ -113,7 +113,7 @@ describe('resolveWorkflowRunTrigger', () => {
           },
         })
       )
-    }))
+    })
 
     await expect(resolveWorkflowRunTrigger(mockWorkflow({ published_version_number: 1 }))).resolves.toEqual({
       triggerNodeId: 'published-trigger',
@@ -164,7 +164,7 @@ describe('resolveWorkflowRunTrigger', () => {
   })
 
   it('keeps draft triggers when published version fetch fails', async () => {
-    vi.mocked(workflowFetchClient.GET).mockImplementation(((path: string) => {
+    vi.mocked(workflowFetchClient.GET).mockImplementation((path: string) => {
       if (path === '/workflows/{workflow_id}/versions/{version}') {
         return Promise.resolve(mockGetResponse(undefined, { detail: 'not found' }))
       }
@@ -180,7 +180,7 @@ describe('resolveWorkflowRunTrigger', () => {
           },
         })
       )
-    }))
+    })
 
     await expect(resolveWorkflowRunTrigger(mockWorkflow({ published_version_number: 1 }))).resolves.toEqual({
       triggerNodeId: 'draft-trigger',

--- a/frontend/packages/syntara-ui/src/routes/workflows/resolveWorkflowRunTrigger.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/resolveWorkflowRunTrigger.test.ts
@@ -113,7 +113,7 @@ describe('resolveWorkflowRunTrigger', () => {
           },
         })
       )
-    }) as never)
+    }))
 
     await expect(resolveWorkflowRunTrigger(mockWorkflow({ published_version_number: 1 }))).resolves.toEqual({
       triggerNodeId: 'published-trigger',
@@ -180,7 +180,7 @@ describe('resolveWorkflowRunTrigger', () => {
           },
         })
       )
-    }) as never)
+    }))
 
     await expect(resolveWorkflowRunTrigger(mockWorkflow({ published_version_number: 1 }))).resolves.toEqual({
       triggerNodeId: 'draft-trigger',

--- a/frontend/packages/syntara-ui/src/routes/workflows/stores/useExecutionStore.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/stores/useExecutionStore.test.ts
@@ -153,7 +153,7 @@ describe('useExecutionStore', () => {
             completed_at: '2025-12-10T15:00:10Z',
           },
         ],
-      } as Partial<Execution>)
+      })
 
       useExecutionStore.getState().setExecution(execution)
 
@@ -165,7 +165,7 @@ describe('useExecutionStore', () => {
     it('handles execution without activities', () => {
       const execution = createMockExecution({
         activities: [],
-      } as Partial<Execution>)
+      })
 
       useExecutionStore.getState().setExecution(execution)
 
@@ -450,7 +450,7 @@ describe('useExecutionStore', () => {
             completed_at: '2025-12-10T15:00:10Z',
           },
         ],
-      } as Partial<Execution>)
+      })
       useExecutionStore.getState().setExecution(execution)
 
       const error = selectActivityError('failed_task')(useExecutionStore.getState())

--- a/frontend/packages/syntara-ui/src/routes/workflows/stores/useExecutionStore.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/stores/useExecutionStore.ts
@@ -665,5 +665,5 @@ export function useExecutionWithLiveStatus<T extends ExecutionRead | undefined>(
     ...data,
     status: liveStatus,
     approval_pending: liveApprovalPending ?? data.approval_pending,
-  } as T
+  }
 }

--- a/frontend/packages/syntara-ui/src/routes/workflows/useWorkflowActions.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/useWorkflowActions.test.tsx
@@ -277,7 +277,7 @@ describe('useWorkflowActions', () => {
       vi.mocked(executionsFetchClient.POST).mockResolvedValue({
         data: { id: 'exec-1' },
         error: undefined,
-      } as never)
+      })
 
       const { result } = renderHook(
         () =>
@@ -318,11 +318,11 @@ describe('useWorkflowActions', () => {
         },
         error: undefined,
         response: new Response(),
-      } as never)
+      })
       vi.mocked(executionsFetchClient.POST).mockResolvedValue({
         data: { id: 'exec-2' },
         error: undefined,
-      } as never)
+      })
 
       const { result } = renderHook(
         () =>
@@ -357,7 +357,7 @@ describe('useWorkflowActions', () => {
         },
         error: undefined,
         response: new Response(),
-      } as never)
+      })
 
       const { result } = renderHook(
         () =>

--- a/frontend/packages/syntara-ui/src/routes/workflows/useWorkflowPermissions.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/useWorkflowPermissions.test.ts
@@ -53,7 +53,7 @@ describe('useWorkflowPermissions', () => {
   })
 
   it('uses check_any_project for create and system-scoped update/delete/run without resourceProject', async () => {
-    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } } as never)
+    vi.mocked(accessFetchClient.POST).mockResolvedValue({ data: { allowed: true } })
 
     const { result } = renderHook(() => useWorkflowPermissions(), { wrapper: createWrapper() })
 

--- a/frontend/packages/syntara-ui/src/stores/useAuthStore.test.ts
+++ b/frontend/packages/syntara-ui/src/stores/useAuthStore.test.ts
@@ -765,7 +765,7 @@ describe('useAuthStore', () => {
         ...window.location,
         origin: 'http://localhost',
         href: 'http://localhost/',
-      } as Location)
+      })
       Object.defineProperty(window.location, 'href', { set: hrefSetter, configurable: true })
 
       mockFetch.mockResolvedValueOnce({

--- a/frontend/packages/syntara-ui/src/stores/useWorkflowStore.ts
+++ b/frontend/packages/syntara-ui/src/stores/useWorkflowStore.ts
@@ -373,7 +373,7 @@ export const useWorkflowStore: UseWorkflowStoreBound = create<WorkflowStore>()(
                   ...existingParameters,
                   branches: branchIds,
                 },
-              } as Activity
+              }
             }
           }
 

--- a/frontend/packages/syntara-ui/src/stores/workflowActivityHelpers.test.ts
+++ b/frontend/packages/syntara-ui/src/stores/workflowActivityHelpers.test.ts
@@ -15,29 +15,26 @@ import type { Activity } from './workflowStoreTypes'
 // v2: all nodes are flat with a config object, no nested structures
 const task = (id: string): Activity => ({ type: ActivityTypeEnum.SCRIPT, id, name: id, parameters: {} })
 
-const condition = (id: string): Activity =>
-  ({
-    type: ActivityTypeEnum.CONDITION,
-    id,
-    name: id,
-    parameters: { condition: 'true' },
-  })
+const condition = (id: string): Activity => ({
+  type: ActivityTypeEnum.CONDITION,
+  id,
+  name: id,
+  parameters: { condition: 'true' },
+})
 
-const loop = (id: string): Activity =>
-  ({
-    type: ActivityTypeEnum.LOOP,
-    id,
-    name: id,
-    parameters: { type: 'for_each', items: 'items' },
-  })
+const loop = (id: string): Activity => ({
+  type: ActivityTypeEnum.LOOP,
+  id,
+  name: id,
+  parameters: { type: 'for_each', items: 'items' },
+})
 
-const converge = (id: string): Activity =>
-  ({
-    type: ActivityTypeEnum.CONVERGE,
-    id,
-    name: id,
-    parameters: { strategy: 'all' },
-  })
+const converge = (id: string): Activity => ({
+  type: ActivityTypeEnum.CONVERGE,
+  id,
+  name: id,
+  parameters: { strategy: 'all' },
+})
 
 describe('findActivityById', () => {
   it('finds top-level activity', () => {

--- a/frontend/packages/syntara-ui/src/stores/workflowActivityHelpers.test.ts
+++ b/frontend/packages/syntara-ui/src/stores/workflowActivityHelpers.test.ts
@@ -13,7 +13,7 @@ import {
 import type { Activity } from './workflowStoreTypes'
 
 // v2: all nodes are flat with a config object, no nested structures
-const task = (id: string): Activity => ({ type: ActivityTypeEnum.SCRIPT, id, name: id, parameters: {} }) as Activity
+const task = (id: string): Activity => ({ type: ActivityTypeEnum.SCRIPT, id, name: id, parameters: {} })
 
 const condition = (id: string): Activity =>
   ({
@@ -21,7 +21,7 @@ const condition = (id: string): Activity =>
     id,
     name: id,
     parameters: { condition: 'true' },
-  }) as Activity
+  })
 
 const loop = (id: string): Activity =>
   ({
@@ -29,7 +29,7 @@ const loop = (id: string): Activity =>
     id,
     name: id,
     parameters: { type: 'for_each', items: 'items' },
-  }) as Activity
+  })
 
 const converge = (id: string): Activity =>
   ({
@@ -37,7 +37,7 @@ const converge = (id: string): Activity =>
     id,
     name: id,
     parameters: { strategy: 'all' },
-  }) as Activity
+  })
 
 describe('findActivityById', () => {
   it('finds top-level activity', () => {

--- a/frontend/packages/syntara-ui/src/stores/workflowActivityHelpers.ts
+++ b/frontend/packages/syntara-ui/src/stores/workflowActivityHelpers.ts
@@ -48,7 +48,7 @@ export function updateActivityInList(
   activityId: string,
   updates: Partial<Activity>
 ): Activity[] {
-  return mapActivityInList(activities, activityId, (activity) => ({ ...activity, ...updates }) as Activity)
+  return mapActivityInList(activities, activityId, (activity) => ({ ...activity, ...updates }))
 }
 
 /**
@@ -57,7 +57,7 @@ export function updateActivityInList(
  * position-dependent consumers (edges, converge nodes) continue to work.
  */
 export function replaceActivityInList(activities: Activity[], activityId: string, newActivity: Activity): Activity[] {
-  return mapActivityInList(activities, activityId, () => ({ ...newActivity, id: activityId }) as Activity)
+  return mapActivityInList(activities, activityId, () => ({ ...newActivity, id: activityId }))
 }
 
 /**

--- a/frontend/packages/syntara-ui/src/test/setup.ts
+++ b/frontend/packages/syntara-ui/src/test/setup.ts
@@ -177,7 +177,7 @@ if (typeof globalThis !== 'undefined' && !globalThis.ResizeObserver) {
     disconnect() {
       // No-op in test environment
     }
-  } as typeof ResizeObserver
+  }
 }
 
 // Polyfill the `[hidden] { display: none }` UA-stylesheet rule (missing in happy-dom,

--- a/frontend/packages/syntara-ui/src/test/test-helpers.ts
+++ b/frontend/packages/syntara-ui/src/test/test-helpers.ts
@@ -1,4 +1,5 @@
 import type { Activity } from '@syntara/contracts'
+import { expect } from 'vitest'
 
 /** Options for creating a condition fixture with flexible config */
 type ConditionOverrides = {
@@ -19,3 +20,13 @@ export const makeCondition = (overrides: ConditionOverrides = {}): Activity => (
     condition: overrides.condition ?? 'x > 10',
   },
 })
+
+/**
+ * Typed wrapper for vitest's `expect.stringContaining` asymmetric matcher.
+ * Vitest types the matcher as `any`; this keeps call-site object literals type-safe.
+ */
+export function expectStringContaining(expected: string): string {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- vitest asymmetric matchers are typed as any
+  const matcher: string = expect.stringContaining(expected)
+  return matcher
+}

--- a/frontend/packages/syntara-ui/src/utils/apiErrors.ts
+++ b/frontend/packages/syntara-ui/src/utils/apiErrors.ts
@@ -156,18 +156,18 @@ export function getErrorStatus(error: unknown): number | undefined {
 
   const err = error as ApiError
 
-  const direct = extractNumericStatus(err as unknown as Record<string, unknown>)
+  const direct = extractNumericStatus(err)
   if (direct !== undefined) return direct
 
   // openapi-fetch/openapi-react-query stores status in response.status
   if (err.response && typeof err.response === 'object') {
-    const responseStatus = extractNumericStatus(err.response as Record<string, unknown>)
+    const responseStatus = extractNumericStatus(err.response)
     if (responseStatus !== undefined) return responseStatus
   }
 
   // openapi-fetch nested cause wrapper
   if (err.cause && typeof err.cause === 'object') {
-    const causeStatus = extractNumericStatus(err.cause as Record<string, unknown>)
+    const causeStatus = extractNumericStatus(err.cause)
     if (causeStatus !== undefined) return causeStatus
   }
 
@@ -583,7 +583,7 @@ function extractEmbeddedErrorTitle(err: ApiError): string | undefined {
 
 export function getErrorTitle(error: unknown): string {
   if (error && typeof error === 'object') {
-    const embedded = extractEmbeddedErrorTitle(error as ApiError)
+    const embedded = extractEmbeddedErrorTitle(error)
     if (embedded) {
       return embedded
     }

--- a/frontend/packages/syntara-ui/src/utils/appMode.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/appMode.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
 
 describe('resolveAppMode', () => {
   it('returns community when VITE_EXTENDED is unset', () => {
-    vi.stubEnv('VITE_EXTENDED', undefined as unknown as string)
+    vi.stubEnv('VITE_EXTENDED', undefined)
 
     expect(resolveAppMode()).toBe('community')
   })
@@ -51,7 +51,7 @@ describe('isCommunityMode / isExtendedMode', () => {
   })
 
   it('defaults to resolveAppMode() when mode is omitted', () => {
-    vi.stubEnv('VITE_EXTENDED', undefined as unknown as string)
+    vi.stubEnv('VITE_EXTENDED', undefined)
 
     expect(isCommunityMode()).toBe(true)
     expect(isExtendedMode()).toBe(false)

--- a/frontend/packages/syntara-ui/src/utils/appTitle.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/appTitle.test.ts
@@ -33,7 +33,7 @@ describe('APP_TITLE module', () => {
   })
 
   it('ignores VITE_APP_TITLE when VITE_EXTENDED is unset', async () => {
-    vi.stubEnv('VITE_EXTENDED', undefined as unknown as string)
+    vi.stubEnv('VITE_EXTENDED', undefined)
     vi.stubEnv('VITE_APP_TITLE', 'Custom Extended Title')
     vi.resetModules()
     const mod = (await import('./appTitle')) as { APP_TITLE: string }
@@ -50,7 +50,7 @@ describe('APP_TITLE module', () => {
 
   it('falls back to Syntara when extended but title is missing', async () => {
     vi.stubEnv('VITE_EXTENDED', 'true')
-    vi.stubEnv('VITE_APP_TITLE', undefined as unknown as string)
+    vi.stubEnv('VITE_APP_TITLE', undefined)
     vi.resetModules()
     const mod = (await import('./appTitle')) as { APP_TITLE: string }
     expect(mod.APP_TITLE).toBe('Syntara')
@@ -64,16 +64,16 @@ describe('CI upstream mode (VITE_APP_TITLE unset)', () => {
   })
 
   it('resolves community title when neither VITE_EXTENDED nor VITE_APP_TITLE is set', async () => {
-    vi.stubEnv('VITE_EXTENDED', undefined as unknown as string)
-    vi.stubEnv('VITE_APP_TITLE', undefined as unknown as string)
+    vi.stubEnv('VITE_EXTENDED', undefined)
+    vi.stubEnv('VITE_APP_TITLE', undefined)
     vi.resetModules()
     const mod = (await import('./appTitle')) as { APP_TITLE: string }
     expect(mod.APP_TITLE).toBe('Syntara')
   })
 
   it('resolveAppTitle returns Syntara with all defaults', async () => {
-    vi.stubEnv('VITE_EXTENDED', undefined as unknown as string)
-    vi.stubEnv('VITE_APP_TITLE', undefined as unknown as string)
+    vi.stubEnv('VITE_EXTENDED', undefined)
+    vi.stubEnv('VITE_APP_TITLE', undefined)
     vi.resetModules()
     const { resolveAppTitle } = (await import('./appTitle')) as {
       resolveAppTitle: (extended?: boolean, title?: string) => string

--- a/frontend/packages/syntara-ui/src/utils/deleteFile.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/deleteFile.test.ts
@@ -20,7 +20,7 @@ describe('deleteFileById', () => {
       data: undefined,
       error: undefined,
       response: new Response(null, { status: 204 }),
-    } as never)
+    })
 
     await deleteFileById('file-1')
 
@@ -54,7 +54,7 @@ describe('deleteFileById', () => {
       data: undefined,
       error: undefined,
       response: new Response(null, { status: 500 }),
-    } as never)
+    })
 
     await expect(deleteFileById('file-1')).rejects.toThrow('Failed to delete file. Please try again.')
   })

--- a/frontend/packages/syntara-ui/src/utils/docs/useDocLink.test.tsx
+++ b/frontend/packages/syntara-ui/src/utils/docs/useDocLink.test.tsx
@@ -36,7 +36,7 @@ describe('resolveDocUrl', () => {
         mode: 'community',
         version: '2.5',
         config: { communityBaseUrl: COMMUNITY_README, version: '2.5' },
-        urls: docsUrls as Record<DocKey, string>,
+        urls: docsUrls,
       })
     ).toBe(COMMUNITY_README)
   })
@@ -47,7 +47,7 @@ describe('resolveDocUrl', () => {
         mode: 'extended',
         version: '2.5',
         config: { communityBaseUrl: COMMUNITY_README, version: '2.5' },
-        urls: docsUrls as Record<DocKey, string>,
+        urls: docsUrls,
       })
     ).toBe(COMMUNITY_README)
   })

--- a/frontend/packages/syntara-ui/src/utils/graphTraversal.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/graphTraversal.test.ts
@@ -750,7 +750,7 @@ describe('getAncestorNodes', () => {
           },
           type: options.type || 'task',
           position: { x: 0, y: 0 },
-        } as Node
+        }
       }
 
       describe('Control Flow Node Type Detection', () => {

--- a/frontend/packages/syntara-ui/src/utils/jwtUtils.ts
+++ b/frontend/packages/syntara-ui/src/utils/jwtUtils.ts
@@ -13,7 +13,7 @@ export function getUserIdFromToken(token: string | null | undefined): string | n
     const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=')
     const payload: unknown = JSON.parse(atob(padded))
     if (typeof payload === 'object' && payload !== null && 'sub' in payload) {
-      const { sub } = payload as { sub: unknown }
+      const { sub } = payload
       return typeof sub === 'string' ? sub : null
     }
     return null

--- a/frontend/packages/syntara-ui/src/utils/xfailFromUrl.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/xfailFromUrl.test.ts
@@ -205,8 +205,7 @@ describe('formatListedXfailPasses', () => {
 describe('buildTestId', () => {
   // testInfo.titlePath already starts with the testDir-relative spec path
   // (verified against Playwright: e.g. ['sub/foo.spec.ts', 'describe', 'test']).
-  const asTestInfo = (titlePath: string[]): Pick<TestInfo, 'titlePath'> =>
-    ({ titlePath })
+  const asTestInfo = (titlePath: string[]): Pick<TestInfo, 'titlePath'> => ({ titlePath })
 
   it('joins the titlePath without duplicating the spec path', () => {
     // Regression: buildTestId used to prepend testInfo.file, yielding

--- a/frontend/packages/syntara-ui/src/utils/xfailFromUrl.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/xfailFromUrl.test.ts
@@ -206,7 +206,7 @@ describe('buildTestId', () => {
   // testInfo.titlePath already starts with the testDir-relative spec path
   // (verified against Playwright: e.g. ['sub/foo.spec.ts', 'describe', 'test']).
   const asTestInfo = (titlePath: string[]): Pick<TestInfo, 'titlePath'> =>
-    ({ titlePath }) as Pick<TestInfo, 'titlePath'>
+    ({ titlePath })
 
   it('joins the titlePath without duplicating the spec path', () => {
     // Regression: buildTestId used to prepend testInfo.file, yielding


### PR DESCRIPTION
## Description

Align `typescript-eslint` to `^8.61.0` across frontend packages (removing the old UI `~8.58.1` skew), then autofix newly reported `no-unnecessary-type-assertion` findings and clean secondary fallout.

Stacked on top of #474 (ESLint 10 upgrade).

## Changes Made

- [x] Set `typescript-eslint` to `^8.61.0` on UI, mock-api, and contracts
- [x] Autofix unnecessary type assertions; fix secondary unused-type / unsafe-assignment issues
- [x] Trim trailing whitespace left by autofix

## Out of Scope

- ESLint 10 core upgrade (see #474)
- Major `eslint-plugin-unicorn` bump

## How to Test

1. Checkout this branch (includes the ESLint 10 base)
2. `cd frontend && npm install`
3. `npm run lint` — expect 0 errors

## Additional Notes

- `Assisted-by: Grok <noreply@x.ai>`