### PR TITLE
chore(ci): remove the @konflux-skip tag for Playwright tests

### DIFF
--- a/.claude/skills/frontend-playwright-e2e/SKILL.md
+++ b/.claude/skills/frontend-playwright-e2e/SKILL.md
@@ -49,24 +49,22 @@ The E2E suite uses Playwright tags to control which tests run in different envir
 test.describe('Integration filtering', { tag: '@pr-check' }, () => { ... })
 
 // Individual test tag — applies to one test
-test('my test', { tag: ['@konflux-skip'] }, async ({ app }) => { ... })
+test('my test', { tag: ['@local-only'] }, async ({ app }) => { ... })
 ```
 
 | Tag | What it marks | Runs in | Excluded from | Mechanism |
 |---|---|---|---|---|
 | `@pr-check` | Fast, reliable describe blocks covering the most critical user paths — intended as a quick PR gate subset | All CI environments (full suite always runs; `--grep @pr-check` selects this subset locally) | _(no current CI filter — tag exists for manual use and future CI optimization)_ | `--grep @pr-check` |
-| `@konflux-skip` | Tests confirmed flaky in Konflux's specific execution environment (not flaky in GitHub Actions) | GitHub Actions `test-compose-e2e` job (runs normally) | Konflux `ao-ui-tests` Tekton pipelines | `.tekton/automation-orchestrator-ui-tests-*.yaml` passes `playwright-grep-invert: '@konflux-skip'` → `--grep-invert` |
 | `@local-only` | Visual regression screenshot tests (`e2e/visual-regression/`) | Local development via `npm run e2e:visual-regression` | All CI | `playwright.config.ts` `testIgnore: **/visual-regression/**` + in-test `test.skip(!!process.env.CI)` |
 
 ### Tag rules
 
 - **`@pr-check`** — Tag a `test.describe` when the tests inside are fast (under ~30 s total), reliable (no flaky backend dependencies), and cover the most critical user paths. Do NOT tag slow, data-dependent, or flaky describe blocks.
-- **`@konflux-skip`** — Use only for a test confirmed flaky in Konflux's environment specifically. This is a last resort — fix the root cause first. Each tagged test must have a comment explaining the environment-specific cause. Discuss with the team before tagging additional tests.
 - **`@local-only`** — Reserved for visual regression tests. Do not apply to functional tests.
 
 ### Never commit `test.fixme` as a long-term state
 
-`test.fixme` marks a test as expected-to-fail, which shows up in CI reports as a "known failure" rather than a clean skip. It is appropriate only as a same-PR placeholder (a test whose fix is in the next commit). For environment-specific skipping use `@konflux-skip`; for data-dependent conditional skipping use `test.skip(!condition, 'reason')`.
+`test.fixme` marks a test as expected-to-fail, which shows up in CI reports as a "known failure" rather than a clean skip. It is appropriate only as a same-PR placeholder (a test whose fix is in the next commit). For data-dependent conditional skipping use `test.skip(!condition, 'reason')`.
 
 ---
 

--- a/.claude/skills/frontend-run-e2e/SKILL.md
+++ b/.claude/skills/frontend-run-e2e/SKILL.md
@@ -238,9 +238,6 @@ npx playwright test --grep "user creates a workflow"
 # @pr-check suite — fast, critical-path subset (intended quick gate; not yet used by CI automatically)
 npx playwright test --grep @pr-check
 
-# Simulate Konflux behavior — exclude @konflux-skip tests (mirrors Tekton playwright-grep-invert param)
-npx playwright test --grep-invert @konflux-skip
-
 # Exclude visual-regression (they require npm run e2e:visual-regression, not the default runner)
 npx playwright test --grep-invert @local-only
 
@@ -253,7 +250,6 @@ npx playwright show-trace test-results/*/trace.zip
 | Tag | Select with | Purpose |
 |---|---|---|
 | `@pr-check` | `--grep @pr-check` | Fast critical-path subset for quick local validation |
-| `@konflux-skip` | `--grep-invert @konflux-skip` | Tests skipped in Konflux pipelines (flaky in that env only) |
 | `@local-only` | `--grep-invert @local-only` | Visual regression tests; excluded from all CI automatically |
 
 See `.claude/skills/frontend-playwright-e2e/SKILL.md` → **Test Suite Tags** for the full rules on when to apply each tag.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,28 +130,6 @@ Konflux (the Red Hat CI pipeline) runs E2E tests in a restricted environment tha
 - The Temporal worker runs in a separate network namespace; it may not reach external URLs (e.g. httpbin.org) even when the test runner can.
 - Cluster load causes 30-second timeouts and transient 502 Bad Gateway responses.
 
-#### Playwright E2E skip pattern (`frontend/packages/syntara-ui/e2e/`)
-
-Add `{ tag: ['@konflux-skip'] }` to any test that reliably fails in Konflux but passes locally:
-
-```typescript
-test('my test', { tag: ['@konflux-skip'] }, async ({ app }) => { ... })
-
-// For long signatures, Prettier wraps to multi-line:
-test(
-  'my long test name',
-  { tag: ['@konflux-skip'] },
-  async ({ app }) => { ... }
-)
-```
-
-Konflux excludes these tests via `--grep-invert @konflux-skip`. They still run locally and in GitHub CI. After adding the tag, run `npx --prefix frontend prettier --write <file>` to keep formatting clean.
-
-**Common reasons to apply `@konflux-skip`:**
-- Test requires the Temporal worker to reach an external URL (httpbin, webhooks, LLM APIs)
-- Test creates real workflow executions and waits for Temporal to complete them (approval flows, multi-step runs) — Temporal under Konflux load frequently times out
-- Test has a >25s wall-clock time; Konflux runner load pushes it over the timeout
-
 #### Backend pytest skip patterns (`backend/tests/e2e/`)
 
 **`@requires_httpbin` class marker**: Applied at class level when all tests in a class call httpbin. Skip fires if httpbin is unreachable from the *test runner*. This does not handle the case where the backend Temporal worker can't reach httpbin.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -161,23 +161,9 @@ npm run e2e:visual-regression:update # Same, with --update-snapshots (see packag
 
 # E2E test suite tags — Playwright tags that control where each test runs:
 #   @pr-check      Fast critical-path tests; select with --grep @pr-check
-#   @konflux-skip  Tests excluded from Konflux pipelines via --grep-invert @konflux-skip (flaky in that env only)
 #   @local-only    Visual regression tests; excluded from all CI automatically
 # Full rules: .claude/skills/frontend-playwright-e2e/SKILL.md → "Test Suite Tags"
 #
-# When to apply @konflux-skip:
-#   - Test creates a real workflow execution and waits for Temporal to complete it
-#     (approval flows, multi-step runs, badge checks) — Temporal under Konflux cluster
-#     load frequently times out or returns unexpected states.
-#   - Test has a wall-clock budget >25s; Konflux runner load regularly pushes it over.
-#   - Test relies on the backend Temporal worker reaching an external URL (httpbin,
-#     webhooks, LLM APIs) — the worker's network is more restricted than the test runner.
-# How to apply:
-#   test('name', { tag: ['@konflux-skip'] }, async ({ app }) => { ... })
-#   After editing, run: npx --prefix .. prettier --write <file>
-#   (Prettier may reformat to multi-line — that is correct and expected.)
-# See also: root CLAUDE.md → "Konflux CI Environment" for backend skip patterns.
-
 # Run a specific test or coverage
 npx vitest run packages/syntara-ui/path/to/specific/test.test.ts
 npm run test:coverage

--- a/frontend/packages/syntara-ui/e2e/executions.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/executions.spec.ts
@@ -4,7 +4,7 @@ import { APP_TITLE } from './helpers/appTitle'
 test.describe('Execution list (requires running executions)', () => {
   test.skip(!!process.env.CI, 'CI deploys a fresh backend with no running executions to assert on')
 
-  test('user views executions and opens a running execution', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('user views executions and opens a running execution', async ({ app }) => {
     await app.goto(toAppUrl('/executions'))
     await expect(app.getByRole('heading', { name: 'Workflow Runs' })).toBeVisible()
     await expect(app).toHaveTitle(`Workflow Runs | ${APP_TITLE}`)

--- a/frontend/packages/syntara-ui/e2e/pagination.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/pagination.spec.ts
@@ -165,7 +165,7 @@ test.describe('Pagination Footer — Users Tab', () => {
 })
 
 test.describe('Pagination Footer — Groups Tab', () => {
-  test('pagination footer is visible on groups tab', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('pagination footer is visible on groups tab', async ({ app }) => {
     await app.goto(toAppUrl('/system-administration/access-management/groups'))
     await expect(app.getByRole('tab', { name: /Groups/i })).toHaveAttribute('aria-selected', 'true')
 

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -602,105 +602,97 @@ test.describe('Permission gating — Project actions', () => {
     }
   })
 
-  test(
-    'viewer: project kebab menu in page header (selected project) is not visible',
-    { tag: ['@konflux-skip'] },
-    async ({ app, viewerApp }) => {
-      const projectName = buildUniqueName('e2e-viewer-header-proj')
-      const workflowName = buildUniqueName('e2e-viewer-header-wf')
+  test('viewer: project kebab menu in page header (selected project) is not visible', async ({ app, viewerApp }) => {
+    const projectName = buildUniqueName('e2e-viewer-header-proj')
+    const workflowName = buildUniqueName('e2e-viewer-header-wf')
 
-      try {
-        // Create project as admin
-        const createProjectResp = await apiRequest(app, 'post', '/projects', {
-          data: { name: projectName },
-        })
-        if (!createProjectResp.ok()) throw new Error('Project creation failed')
-        const project = (await createProjectResp.json()) as { id: string }
+    try {
+      // Create project as admin
+      const createProjectResp = await apiRequest(app, 'post', '/projects', {
+        data: { name: projectName },
+      })
+      if (!createProjectResp.ok()) throw new Error('Project creation failed')
+      const project = (await createProjectResp.json()) as { id: string }
 
-        // Create workflow in the project
-        const createWorkflowResp = await apiRequest(app, 'post', '/workflows', {
-          data: {
+      // Create workflow in the project
+      const createWorkflowResp = await apiRequest(app, 'post', '/workflows', {
+        data: {
+          name: workflowName,
+          project_id: project.id,
+          workflow_definition: {
+            schema_version: '2.0.0',
             name: workflowName,
-            project_id: project.id,
-            workflow_definition: {
-              schema_version: '2.0.0',
-              name: workflowName,
-              triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-              nodes: [],
-              edges: [],
-            },
+            triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+            nodes: [],
+            edges: [],
           },
-        })
-        if (!createWorkflowResp.ok()) throw new Error('Workflow creation failed')
-        const workflow = (await createWorkflowResp.json()) as { id: string }
+        },
+      })
+      if (!createWorkflowResp.ok()) throw new Error('Workflow creation failed')
+      const workflow = (await createWorkflowResp.json()) as { id: string }
 
-        // Viewer cannot select individual projects — dropdown only shows "All projects"
-        await viewerApp.goto(toAppUrl('/workflows'))
-        const projectSelector = viewerApp.getByRole('textbox', { name: 'Project' })
-        await projectSelector.click()
-        await expect(viewerApp.getByRole('option', { name: 'All projects' })).toBeVisible()
-        await expect(viewerApp.getByRole('option', { name: projectName })).not.toBeVisible()
-        await expect(viewerApp.getByRole('option', { name: project.id })).not.toBeVisible()
-        await viewerApp.keyboard.press('Escape')
+      // Viewer cannot select individual projects — dropdown only shows "All projects"
+      await viewerApp.goto(toAppUrl('/workflows'))
+      const projectSelector = viewerApp.getByRole('textbox', { name: 'Project' })
+      await projectSelector.click()
+      await expect(viewerApp.getByRole('option', { name: 'All projects' })).toBeVisible()
+      await expect(viewerApp.getByRole('option', { name: projectName })).not.toBeVisible()
+      await expect(viewerApp.getByRole('option', { name: project.id })).not.toBeVisible()
+      await viewerApp.keyboard.press('Escape')
 
-        // Clean up
-        await apiRequest(app, 'delete', `/workflows/${workflow.id}`)
-        await apiRequest(app, 'delete', `/projects/${project.id}`)
-      } catch (error) {
-        // Best-effort cleanup on failure
-        try {
-          const listResp = await apiRequest(app, 'get', '/workflows')
-          if (listResp.ok()) {
-            const list = (await listResp.json()) as { resources: Array<{ id: string; name: string }> }
-            const wf = list.resources.find((w) => w.name === workflowName)
-            if (wf) await apiRequest(app, 'delete', `/workflows/${wf.id}`)
-          }
-          const projListResp = await apiRequest(app, 'get', '/projects')
-          if (projListResp.ok()) {
-            const projList = (await projListResp.json()) as { resources: Array<{ id: string; name: string }> }
-            const proj = projList.resources.find((p) => p.name === projectName)
-            if (proj) await apiRequest(app, 'delete', `/projects/${proj.id}`)
-          }
-        } catch {
-          // Ignore cleanup errors
+      // Clean up
+      await apiRequest(app, 'delete', `/workflows/${workflow.id}`)
+      await apiRequest(app, 'delete', `/projects/${project.id}`)
+    } catch (error) {
+      // Best-effort cleanup on failure
+      try {
+        const listResp = await apiRequest(app, 'get', '/workflows')
+        if (listResp.ok()) {
+          const list = (await listResp.json()) as { resources: Array<{ id: string; name: string }> }
+          const wf = list.resources.find((w) => w.name === workflowName)
+          if (wf) await apiRequest(app, 'delete', `/workflows/${wf.id}`)
         }
-        throw error
+        const projListResp = await apiRequest(app, 'get', '/projects')
+        if (projListResp.ok()) {
+          const projList = (await projListResp.json()) as { resources: Array<{ id: string; name: string }> }
+          const proj = projList.resources.find((p) => p.name === projectName)
+          if (proj) await apiRequest(app, 'delete', `/projects/${proj.id}`)
+        }
+      } catch {
+        // Ignore cleanup errors
       }
+      throw error
     }
-  )
+  })
 })
 
 // ── Action gating — Credentials ──────────────────────────────────────────
 
 test.describe('Permission gating — Credential actions', () => {
-  test(
-    'viewer: Create credential button is disabled with tooltip',
-    { tag: ['@konflux-skip'] },
-    async ({ app, viewerApp }) => {
-      const { id: credId, name: credName } = await createTestCredential(app)
+  test('viewer: Create credential button is disabled with tooltip', async ({ app, viewerApp }) => {
+    const { id: credId, name: credName } = await createTestCredential(app)
 
-      try {
-        await viewerApp.goto(toAppUrl('/configuration/credentials'))
-        await expect(viewerApp.getByRole('heading', { level: 1, name: 'Credentials' })).toBeVisible()
+    try {
+      await viewerApp.goto(toAppUrl('/configuration/credentials'))
+      await expect(viewerApp.getByRole('heading', { level: 1, name: 'Credentials' })).toBeVisible()
 
-        // Wait for credential data to load — the toolbar button only renders once credentials.length > 0
-        await expect(
-          viewerApp.getByRole('grid', { name: 'Credentials table' }).getByRole('row', { name: new RegExp(credName) })
-        ).toBeVisible({ timeout: 15_000 })
+      // Wait for credential data to load — the toolbar button only renders once credentials.length > 0
+      await expect(
+        viewerApp.getByRole('grid', { name: 'Credentials table' }).getByRole('row', { name: new RegExp(credName) })
+      ).toBeVisible({ timeout: 15_000 })
 
-        const createButton = viewerApp.getByRole('button', { name: /Create credential/i })
-        await expect(createButton).toBeVisible()
-        await expect(createButton).toHaveAttribute('aria-disabled', 'true')
+      const createButton = viewerApp.getByRole('button', { name: /Create credential/i })
+      await expect(createButton).toBeVisible()
+      await expect(createButton).toHaveAttribute('aria-disabled', 'true')
 
-        await createButton.hover()
-        await expect(viewerApp.getByRole('tooltip').filter({ hasText: 'credential:create' })).toBeVisible()
-      } finally {
-        await deleteCredentialViaApi(app, credId)
-      }
+      await createButton.hover()
+      await expect(viewerApp.getByRole('tooltip').filter({ hasText: 'credential:create' })).toBeVisible()
+    } finally {
+      await deleteCredentialViaApi(app, credId)
     }
-  )
+  })
 
-  test('auditor: Create credential button is disabled', { tag: ['@konflux-skip'] }, async ({ app, auditorApp }) => {
+  test('auditor: Create credential button is disabled', async ({ app, auditorApp }) => {
     const { id: credId } = await createTestCredential(app)
 
     try {
@@ -744,7 +736,7 @@ test.describe('Permission gating — Credential actions', () => {
 
   // Dual-browser auditor session + kebab aria-disabled is flaky under Konflux load.
   // Still runs in GitHub compose E2E. Currents quarantines are not applied in Konflux.
-  test('auditor: credential row actions are aria-disabled', { tag: ['@konflux-skip'] }, async ({ app, auditorApp }) => {
+  test('auditor: credential row actions are aria-disabled', async ({ app, auditorApp }) => {
     const credential = await createTestCredential(app)
 
     try {
@@ -1010,7 +1002,7 @@ test.describe('Permission gating — Identity Provider actions', () => {
     await expect(auditorApp.getByRole('tooltip').filter({ hasText: 'identity-provider:create' })).toBeVisible()
   })
 
-  test('auditor: IdP row actions are aria-disabled', { tag: ['@konflux-skip'] }, async ({ app, auditorApp }) => {
+  test('auditor: IdP row actions are aria-disabled', async ({ app, auditorApp }) => {
     const idpName = buildUniqueName('e2e-perm-idp')
     const idp = await createIdentityProviderViaApi(app, {
       name: idpName,

--- a/frontend/packages/syntara-ui/e2e/v2-workflow-migration.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/v2-workflow-migration.spec.ts
@@ -376,7 +376,7 @@ test.describe('V2 Workflow Schema Migration', () => {
   // 5. API response format verification
   // -------------------------------------------------------------------------
 
-  test('API response preserves v2 schema format on reload', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('API response preserves v2 schema format on reload', async ({ app }) => {
     const workflowName = buildUniqueName('v2-response-format')
     await app.goto(toAppUrl('/workflow-builder/new'))
 

--- a/frontend/packages/syntara-ui/e2e/workflow-verification.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflow-verification.spec.ts
@@ -331,7 +331,7 @@ test.describe('Save with warnings', () => {
 })
 
 test.describe('Variable reference validation', () => {
-  test('reference to nonexistent node shows validation error', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('reference to nonexistent node shows validation error', async ({ app }) => {
     test.setTimeout(90_000)
     const workflowName = buildUniqueName('e2e-varref-invalid')
 

--- a/frontend/packages/syntara-ui/e2e/workflows.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows.spec.ts
@@ -81,7 +81,7 @@ test('user searches, views, and deletes a workflow', async ({ app }) => {
   }
 })
 
-test('duplicates workflow from builder toolbar kebab menu', { tag: ['@konflux-skip'] }, async ({ app }) => {
+test('duplicates workflow from builder toolbar kebab menu', async ({ app }) => {
   const workflowName = buildUniqueName('duplicate-source')
   let duplicatedWorkflowName: string | undefined
 

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
@@ -10,94 +10,90 @@ import {
   publishWorkflowViaApi,
 } from '../utils/api'
 
-test(
-  'multi-approval navigation: Previous/Next buttons and deep-link counter',
-  { tag: ['@konflux-skip'] },
-  async ({ app }) => {
-    test.slow()
+test('multi-approval navigation: Previous/Next buttons and deep-link counter', async ({ app }) => {
+  test.slow()
 
-    const approvalNames = [buildUniqueName('nav-a'), buildUniqueName('nav-b')]
-    const workflowName = buildUniqueName('multi-approval')
-    const triggers = [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }]
-    const nodes = approvalNames.flatMap((name, i) => [
-      { id: `approval_${i + 1}`, type: 'approval', name, parameters: {} },
-      { id: `post_${i + 1}`, type: 'script', name: `Post ${name}`, parameters: { language: 'python', code: 'pass' } },
-    ])
-    const edges = approvalNames.flatMap((_, i) => [
-      { from: 'trigger_1', to: `approval_${i + 1}` },
-      { from: `approval_${i + 1}`, to: `post_${i + 1}`, from_port: 'approved' },
-    ])
+  const approvalNames = [buildUniqueName('nav-a'), buildUniqueName('nav-b')]
+  const workflowName = buildUniqueName('multi-approval')
+  const triggers = [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }]
+  const nodes = approvalNames.flatMap((name, i) => [
+    { id: `approval_${i + 1}`, type: 'approval', name, parameters: {} },
+    { id: `post_${i + 1}`, type: 'script', name: `Post ${name}`, parameters: { language: 'python', code: 'pass' } },
+  ])
+  const edges = approvalNames.flatMap((_, i) => [
+    { from: 'trigger_1', to: `approval_${i + 1}` },
+    { from: `approval_${i + 1}`, to: `post_${i + 1}`, from_port: 'approved' },
+  ])
 
-    const { id: workflowId, versionNumber } = await createWorkflowViaApi(app, workflowName, triggers, nodes, edges)
+  const { id: workflowId, versionNumber } = await createWorkflowViaApi(app, workflowName, triggers, nodes, edges)
 
-    try {
-      await publishWorkflowViaApi(app, workflowId, versionNumber)
+  try {
+    await publishWorkflowViaApi(app, workflowId, versionNumber)
 
-      const token = await getAuthToken(app)
-      if (!token) throw new Error('Could not obtain auth token')
+    const token = await getAuthToken(app)
+    if (!token) throw new Error('Could not obtain auth token')
 
-      const resp = await apiRequest(app, 'post', '/executions', {
-        token,
-        data: { workflow_id: workflowId, trigger_node_id: 'trigger_1' },
-      })
-      if (!resp.ok()) throw new Error(`POST /executions returned ${resp.status()}`)
-      const { id: executionId } = (await resp.json()) as { id: string }
+    const resp = await apiRequest(app, 'post', '/executions', {
+      token,
+      data: { workflow_id: workflowId, trigger_node_id: 'trigger_1' },
+    })
+    if (!resp.ok()) throw new Error(`POST /executions returned ${resp.status()}`)
+    const { id: executionId } = (await resp.json()) as { id: string }
 
-      await pollExecutionStatus(app, executionId, ['paused'], { token, timeout: 60_000 })
+    await pollExecutionStatus(app, executionId, ['paused'], { token, timeout: 60_000 })
 
-      // Wait for both approvals to be indexed — skip only if the API is unreachable
-      const probeResp = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`, { token })
-      test.skip(!probeResp.ok(), `Approvals API returned ${probeResp.status()} — service may be unavailable`)
+    // Wait for both approvals to be indexed — skip only if the API is unreachable
+    const probeResp = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`, { token })
+    test.skip(!probeResp.ok(), `Approvals API returned ${probeResp.status()} — service may be unavailable`)
 
-      let approvalIds: string[] = []
-      await expect(async () => {
-        const r = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`, { token })
-        const body = (await r.json()) as { resources?: Array<{ id: string }> }
-        approvalIds = (body.resources ?? []).map((a) => a.id)
-        expect(approvalIds).toHaveLength(2)
-      }).toPass({ timeout: 60_000, intervals: [2_000] })
+    let approvalIds: string[] = []
+    await expect(async () => {
+      const r = await apiRequest(app, 'get', `/approvals?execution_id=${executionId}&status=pending`, { token })
+      const body = (await r.json()) as { resources?: Array<{ id: string }> }
+      approvalIds = (body.resources ?? []).map((a) => a.id)
+      expect(approvalIds).toHaveLength(2)
+    }).toPass({ timeout: 60_000, intervals: [2_000] })
 
-      // --- Part 1: Deep-link to first approval, verify counter and navigation ---
-      // The component fetches pending approvals once on load. If it only gets 1 back
-      // (eventual consistency), the counter won't render. Reload forces a re-fetch.
-      const panelHeading = app.getByRole('heading', { name: /Review approval/i })
+    // --- Part 1: Deep-link to first approval, verify counter and navigation ---
+    // The component fetches pending approvals once on load. If it only gets 1 back
+    // (eventual consistency), the counter won't render. Reload forces a re-fetch.
+    const panelHeading = app.getByRole('heading', { name: /Review approval/i })
 
-      const deepLink1 = toAppUrl(`/executions/${executionId}?approval=${approvalIds[0]}&history=closed`)
+    const deepLink1 = toAppUrl(`/executions/${executionId}?approval=${approvalIds[0]}&history=closed`)
+    await app.goto(deepLink1)
+    await expect(async () => {
       await app.goto(deepLink1)
-      await expect(async () => {
-        await app.goto(deepLink1)
-        await waitForApprovalPanel(app)
-        await dismissConnectionBanner(app)
-        await expect(panelHeading.getByText('1 of 2')).toBeVisible({ timeout: 5_000 })
-      }).toPass({ timeout: 60_000, intervals: [5_000] })
+      await waitForApprovalPanel(app)
+      await dismissConnectionBanner(app)
+      await expect(panelHeading.getByText('1 of 2')).toBeVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 60_000, intervals: [5_000] })
 
-      const prevButton = app.getByRole('button', { name: 'Previous approval' })
-      const nextButton = app.getByRole('button', { name: 'Next approval' })
-      await expect(prevButton).toBeDisabled()
-      await expect(nextButton).toBeEnabled()
+    const prevButton = app.getByRole('button', { name: 'Previous approval' })
+    const nextButton = app.getByRole('button', { name: 'Next approval' })
+    await expect(prevButton).toBeDisabled()
+    await expect(nextButton).toBeEnabled()
 
-      // Navigate forward to second approval
-      await nextButton.click()
-      await expect(panelHeading.getByText('2 of 2')).toBeVisible({ timeout: 10_000 })
-      await expect(prevButton).toBeEnabled()
-      await expect(nextButton).toBeDisabled()
+    // Navigate forward to second approval
+    await nextButton.click()
+    await expect(panelHeading.getByText('2 of 2')).toBeVisible({ timeout: 10_000 })
+    await expect(prevButton).toBeEnabled()
+    await expect(nextButton).toBeDisabled()
 
-      // Navigate backward to first approval
-      await prevButton.click()
-      await expect(panelHeading.getByText('1 of 2')).toBeVisible({ timeout: 10_000 })
-      await expect(prevButton).toBeDisabled()
-      await expect(nextButton).toBeEnabled()
+    // Navigate backward to first approval
+    await prevButton.click()
+    await expect(panelHeading.getByText('1 of 2')).toBeVisible({ timeout: 10_000 })
+    await expect(prevButton).toBeDisabled()
+    await expect(nextButton).toBeEnabled()
 
-      // --- Part 2: Deep-link directly to second approval, verify counter ---
-      const deepLink2 = toAppUrl(`/executions/${executionId}?approval=${approvalIds[1]}&history=closed`)
-      await expect(async () => {
-        await app.goto(deepLink2)
-        await waitForApprovalPanel(app)
-        await dismissConnectionBanner(app)
-        await expect(panelHeading.getByText('2 of 2')).toBeVisible({ timeout: 5_000 })
-      }).toPass({ timeout: 60_000, intervals: [5_000] })
-    } finally {
-      await deleteWorkflowViaApi(app, workflowId)
-    }
+    // --- Part 2: Deep-link directly to second approval, verify counter ---
+    const deepLink2 = toAppUrl(`/executions/${executionId}?approval=${approvalIds[1]}&history=closed`)
+    await expect(async () => {
+      await app.goto(deepLink2)
+      await waitForApprovalPanel(app)
+      await dismissConnectionBanner(app)
+      await expect(panelHeading.getByText('2 of 2')).toBeVisible({ timeout: 5_000 })
+    }).toPass({ timeout: 60_000, intervals: [5_000] })
+  } finally {
+    await deleteWorkflowViaApi(app, workflowId)
   }
-)
+})

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-pending-badge.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-pending-badge.spec.ts
@@ -61,78 +61,74 @@ async function applyPendingApprovalStatusFilter(app: Page): Promise<void> {
 test.describe('Approval Pending Badge', () => {
   test.skip(!process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'], 'Temporal worker unavailable (globalSetup probe)')
 
-  test(
-    'shows "Pending approval" badge in all three locations when execution has pending approval',
-    { tag: ['@konflux-skip'] },
-    async ({ app }) => {
-      let workflowName: string | undefined
+  test('shows "Pending approval" badge in all three locations when execution has pending approval', async ({ app }) => {
+    let workflowName: string | undefined
 
-      try {
-        const result = await createPendingApproval(app)
-        workflowName = result.workflowName
-        const { workflowId, executionId } = result
+    try {
+      const result = await createPendingApproval(app)
+      workflowName = result.workflowName
+      const { workflowId, executionId } = result
 
-        // ===================================================================
-        // LOCATION 1: Execution Detail Page Header
-        // ===================================================================
-        // We're already on the execution detail page from createPendingApproval
-        const pageHeader = app.getByTestId('page-header')
-        const badgeInDetail = pageHeader.getByText('Pending approval')
-        await expect(badgeInDetail).toBeVisible({ timeout: 5_000 })
+      // ===================================================================
+      // LOCATION 1: Execution Detail Page Header
+      // ===================================================================
+      // We're already on the execution detail page from createPendingApproval
+      const pageHeader = app.getByTestId('page-header')
+      const badgeInDetail = pageHeader.getByText('Pending approval')
+      await expect(badgeInDetail).toBeVisible({ timeout: 5_000 })
 
-        // ===================================================================
-        // LOCATION 2: Workflow Run History Panel
-        // ===================================================================
-        // Navigate back to the workflow builder
-        await app.goto(`/workflow-builder/${workflowId}`)
-        await expect(app.getByPlaceholder('Workflow name')).toBeVisible({ timeout: 10_000 })
+      // ===================================================================
+      // LOCATION 2: Workflow Run History Panel
+      // ===================================================================
+      // Navigate back to the workflow builder
+      await app.goto(`/workflow-builder/${workflowId}`)
+      await expect(app.getByPlaceholder('Workflow name')).toBeVisible({ timeout: 10_000 })
 
-        // Open the run history panel via the kebab menu
-        const kebab = app.getByRole('button', { name: 'Workflow actions' })
-        await expect(kebab).toBeVisible({ timeout: 5_000 })
-        await kebab.click()
-        await app.getByRole('menuitem', { name: /Run history/i }).click()
+      // Open the run history panel via the kebab menu
+      const kebab = app.getByRole('button', { name: 'Workflow actions' })
+      await expect(kebab).toBeVisible({ timeout: 5_000 })
+      await kebab.click()
+      await app.getByRole('menuitem', { name: /Run history/i }).click()
 
-        // Verify badge appears in the history panel.
-        // PF6 SimpleList in grouped mode does not apply aria-label to any
-        // role="list" element, so confirm the panel via its heading instead.
-        await expect(app.getByRole('heading', { name: 'Run History' })).toBeVisible({ timeout: 5_000 })
-        const badgeInHistory = app.getByText('Pending approval')
-        await expect(badgeInHistory).toBeVisible({ timeout: 15_000 })
+      // Verify badge appears in the history panel.
+      // PF6 SimpleList in grouped mode does not apply aria-label to any
+      // role="list" element, so confirm the panel via its heading instead.
+      await expect(app.getByRole('heading', { name: 'Run History' })).toBeVisible({ timeout: 5_000 })
+      const badgeInHistory = app.getByText('Pending approval')
+      await expect(badgeInHistory).toBeVisible({ timeout: 15_000 })
 
-        // ===================================================================
-        // LOCATION 3: Executions List Table
-        // ===================================================================
-        // Navigate to executions list
-        await app.goto('/executions')
+      // ===================================================================
+      // LOCATION 3: Executions List Table
+      // ===================================================================
+      // Navigate to executions list
+      await app.goto('/executions')
 
-        // Wait for the table to load
-        await expect(app.getByRole('grid')).toBeVisible({ timeout: 10_000 })
+      // Wait for the table to load
+      await expect(app.getByRole('grid')).toBeVisible({ timeout: 10_000 })
 
-        // Find the row with our execution ID and verify badge is visible
-        const executionRow = app.locator('tr', { has: app.getByText(executionId.slice(0, 8)) })
-        const badgeInList = executionRow.getByText('Pending approval')
+      // Find the row with our execution ID and verify badge is visible
+      const executionRow = app.locator('tr', { has: app.getByText(executionId.slice(0, 8)) })
+      const badgeInList = executionRow.getByText('Pending approval')
 
-        await expect(badgeInList).toBeVisible({ timeout: 5_000 })
+      await expect(badgeInList).toBeVisible({ timeout: 5_000 })
 
-        // Verify the badge appears alongside the "Paused" status
-        const pausedStatus = executionRow.getByText('Paused')
-        await expect(pausedStatus).toBeVisible()
+      // Verify the badge appears alongside the "Paused" status
+      const pausedStatus = executionRow.getByText('Paused')
+      await expect(pausedStatus).toBeVisible()
 
-        // ===================================================================
-        // VERIFICATION: Filter by "Pending approval" via Status filter
-        // ===================================================================
-        await applyPendingApprovalStatusFilter(app)
-        await expect(app).toHaveURL(/approval_pending=true/)
-        await expect(badgeInList).toBeVisible()
-      } finally {
-        // Cleanup: Delete the workflow
-        if (workflowName) {
-          await deleteWorkflow(app, workflowName)
-        }
+      // ===================================================================
+      // VERIFICATION: Filter by "Pending approval" via Status filter
+      // ===================================================================
+      await applyPendingApprovalStatusFilter(app)
+      await expect(app).toHaveURL(/approval_pending=true/)
+      await expect(badgeInList).toBeVisible()
+    } finally {
+      // Cleanup: Delete the workflow
+      if (workflowName) {
+        await deleteWorkflow(app, workflowName)
       }
     }
-  )
+  })
 
   test('does NOT show "Pending approval" badge when execution has no pending approvals', async ({ app }) => {
     let workflowName: string | undefined

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-workflow-e2e.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-workflow-e2e.spec.ts
@@ -48,7 +48,7 @@ async function createPendingApproval(app: Page): Promise<{ workflowId: string; a
 test.describe('Approval Workflow E2E', () => {
   test.skip(!process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'], 'Temporal worker unavailable (globalSetup probe)')
 
-  test('view pending approval with previous step output', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('view pending approval with previous step output', async ({ app }) => {
     // Create a pending approval (workflow has a script node before the approval node)
     const approval = await createPendingApproval(app)
 

--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -125,7 +125,7 @@ test('user filters approvals by name and status', async ({ app }) => {
 test.describe('Approval Workflow Operations', () => {
   test.skip(!process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'], 'Temporal worker unavailable (globalSetup probe)')
 
-  test('user bulk-approves filtered approval rows', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('user bulk-approves filtered approval rows', async ({ app }) => {
     // Create 2 pending approvals with a shared prefix for filtering
     const batchId = `batch-${Date.now()}`
     const approval1 = await createPendingApproval(app, batchId)
@@ -188,7 +188,7 @@ test.describe('Approval Workflow Operations', () => {
     }
   })
 
-  test('user bulk-rejects filtered approval rows', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('user bulk-rejects filtered approval rows', async ({ app }) => {
     // Create 2 pending approvals with a shared prefix for filtering
     const batchId = `batch-${Date.now()}`
     const approval1 = await createPendingApproval(app, batchId)
@@ -250,8 +250,7 @@ test.describe('Approval Workflow Operations', () => {
   })
 
   // Temporal-backed pending approval + table filter/selection flakes under Konflux load.
-  // Sibling batch-approve tests already use @konflux-skip. Still runs in GitHub compose E2E.
-  test('user cancels batch approval without API call', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('user cancels batch approval without API call', async ({ app }) => {
     // Create a pending approval to test cancel behavior
     const approval = await createPendingApproval(app)
 
@@ -298,7 +297,7 @@ test.describe('Approval Workflow Operations', () => {
     }
   })
 
-  test('user changes decision from approve to reject (undo)', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('user changes decision from approve to reject (undo)', async ({ app }) => {
     // Create a pending approval to test undo behavior
     const approval = await createPendingApproval(app)
 
@@ -361,7 +360,7 @@ test.describe('Approval Workflow Operations', () => {
     }
   })
 
-  test('user clears decision with explicit undo button', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('user clears decision with explicit undo button', async ({ app }) => {
     // Create a pending approval to test undo/clear behavior
     const approval = await createPendingApproval(app)
 
@@ -470,7 +469,7 @@ test.describe('Approval Workflow Operations', () => {
     }
   })
 
-  test('UI-29: self-contained approve flow via approvals queue', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('UI-29: self-contained approve flow via approvals queue', async ({ app }) => {
     // Create a workflow with an approval node so we control the approval name
     const workflowName = buildUniqueName('e2e-approve')
     const approvalNodeName = buildUniqueName('gate')

--- a/frontend/packages/syntara-ui/e2e/workflows/incomplete-node-validation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/incomplete-node-validation.spec.ts
@@ -52,7 +52,7 @@ async function addIncompleteAapNode(page: Page, name: string) {
 }
 
 test.describe('UI-32: Workflow Verification — Missing Required Configuration', { tag: '@pr-check' }, () => {
-  test('unconfigured AAP node triggers verification error', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('unconfigured AAP node triggers verification error', async ({ app }) => {
     // Builds the workflow through the UI before verifying — the default budget is
     // too tight for that plus a verify retry on a loaded cluster.
     test.setTimeout(90_000)

--- a/frontend/packages/syntara-ui/e2e/workflows/manual-trigger.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/manual-trigger.spec.ts
@@ -24,84 +24,78 @@ import { buildUniqueName, deleteWorkflow, selectProjectIfRequired } from '../hel
 import { ensureProject } from '../utils/api'
 
 test.describe('Manual Trigger', () => {
-  test(
-    'creates workflow with manual trigger and verifies canvas display',
-    { tag: ['@konflux-skip'] },
-    async ({ app }) => {
-      const workflowName = buildUniqueName('e2e-manual')
+  test('creates workflow with manual trigger and verifies canvas display', async ({ app }) => {
+    const workflowName = buildUniqueName('e2e-manual')
 
-      await ensureProject(app)
-      await app.goto(toAppUrl('/workflow-builder/new'))
+    await ensureProject(app)
+    await app.goto(toAppUrl('/workflow-builder/new'))
 
-      try {
-        await addManualTrigger(app, 'Start workflow')
-        await addScriptNode(app, 'Process data', 'print("processing")')
+    try {
+      await addManualTrigger(app, 'Start workflow')
+      await addScriptNode(app, 'Process data', 'print("processing")')
 
-        await selectProjectIfRequired(app)
-        await app.getByPlaceholder('Workflow name').fill(workflowName)
-        await app.getByRole('button', { name: 'Save', exact: true }).click()
-        await expect(app).toHaveURL(/workflow-builder\/(?!new)[a-f0-9-]+/, { timeout: 15_000 })
+      await selectProjectIfRequired(app)
+      await app.getByPlaceholder('Workflow name').fill(workflowName)
+      await app.getByRole('button', { name: 'Save', exact: true }).click()
+      await expect(app).toHaveURL(/workflow-builder\/(?!new)[a-f0-9-]+/, { timeout: 15_000 })
 
-        await app.goto(toAppUrl('/workflows'))
-        await expect(app.getByRole('grid', { name: 'Workflows table' })).toBeVisible({ timeout: 15_000 })
-        await app.getByPlaceholder('Filter by name').fill(workflowName)
-        await app.getByRole('button', { name: 'Apply filter' }).click()
-        await expect(app.getByRole('link', { name: workflowName, exact: true })).toBeVisible({ timeout: 30_000 })
+      await app.goto(toAppUrl('/workflows'))
+      await expect(app.getByRole('grid', { name: 'Workflows table' })).toBeVisible({ timeout: 15_000 })
+      await app.getByPlaceholder('Filter by name').fill(workflowName)
+      await app.getByRole('button', { name: 'Apply filter' }).click()
+      await expect(app.getByRole('link', { name: workflowName, exact: true })).toBeVisible({ timeout: 30_000 })
 
-        await app.getByRole('link', { name: workflowName, exact: true }).click()
+      await app.getByRole('link', { name: workflowName, exact: true }).click()
 
-        // Wait for builder to load
-        await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15_000 })
+      // Wait for builder to load
+      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15_000 })
 
-        // Click Layout to position nodes within the viewport so both are visible
-        const layoutButton = app.getByRole('button', { name: 'Reset layout', exact: true })
-        await expect(layoutButton).toBeVisible({ timeout: 10_000 })
-        await layoutButton.click()
-        await app
-          .locator('[role="group"][aria-roledescription="node"]')
-          .filter({ hasText: 'Start workflow' })
-          .waitFor({ state: 'visible', timeout: 5_000 })
+      // Click Layout to position nodes within the viewport so both are visible
+      const layoutButton = app.getByRole('button', { name: 'Reset layout', exact: true })
+      await expect(layoutButton).toBeVisible({ timeout: 10_000 })
+      await layoutButton.click()
+      await app
+        .locator('[role="group"][aria-roledescription="node"]')
+        .filter({ hasText: 'Start workflow' })
+        .waitFor({ state: 'visible', timeout: 5_000 })
 
-        // Verify both nodes are visible on the canvas after reopening
-        const triggerNode = app
-          .locator('[role="group"][aria-roledescription="node"]')
-          .filter({ hasText: 'Start workflow' })
-        const scriptNode = app
-          .locator('[role="group"][aria-roledescription="node"]')
-          .filter({ hasText: 'Process data' })
+      // Verify both nodes are visible on the canvas after reopening
+      const triggerNode = app
+        .locator('[role="group"][aria-roledescription="node"]')
+        .filter({ hasText: 'Start workflow' })
+      const scriptNode = app.locator('[role="group"][aria-roledescription="node"]').filter({ hasText: 'Process data' })
 
-        await expect(triggerNode).toBeVisible({ timeout: 15_000 })
-        await expect(scriptNode).toBeVisible({ timeout: 15_000 })
+      await expect(triggerNode).toBeVisible({ timeout: 15_000 })
+      await expect(scriptNode).toBeVisible({ timeout: 15_000 })
 
-        // Verify the edge connection exists between the nodes
-        const edges = app.locator('[role="group"][aria-roledescription="edge"]')
-        const edgeCount = await edges.count()
-        expect(edgeCount).toBeGreaterThanOrEqual(1) // At least one edge: trigger -> script
+      // Verify the edge connection exists between the nodes
+      const edges = app.locator('[role="group"][aria-roledescription="edge"]')
+      const edgeCount = await edges.count()
+      expect(edgeCount).toBeGreaterThanOrEqual(1) // At least one edge: trigger -> script
 
-        // Test the full end-to-end journey: now run the workflow from the canvas
-        const runButton = app.getByRole('button', { name: 'Run' })
-        await expect(runButton).toBeVisible()
-        await expect(runButton).toBeEnabled()
+      // Test the full end-to-end journey: now run the workflow from the canvas
+      const runButton = app.getByRole('button', { name: 'Run' })
+      await expect(runButton).toBeVisible()
+      await expect(runButton).toBeEnabled()
 
-        await runButton.click()
-        const dialog = app.getByRole('dialog')
-        await expect(dialog).toBeVisible()
+      await runButton.click()
+      const dialog = app.getByRole('dialog')
+      await expect(dialog).toBeVisible()
 
-        // After reopening a saved workflow, the UI may detect state differences as unsaved changes
-        await dialog.getByRole('button', { name: /Run now|Save and run/ }).click()
-        await expect(dialog).not.toBeVisible()
+      // After reopening a saved workflow, the UI may detect state differences as unsaved changes
+      await dialog.getByRole('button', { name: /Run now|Save and run/ }).click()
+      await expect(dialog).not.toBeVisible()
 
-        // Verify the run details panel appears after execution starts
-        await expect(app.getByRole('heading', { name: 'Run details' })).toBeVisible({ timeout: 30_000 })
+      // Verify the run details panel appears after execution starts
+      await expect(app.getByRole('heading', { name: 'Run details' })).toBeVisible({ timeout: 30_000 })
 
-        // Trigger completed successfully. do not require the script node's badge;
-        // see file header note.
-        await expect(triggerNode.getByRole('img', { name: 'Success' })).toBeVisible({ timeout: 60_000 })
-      } finally {
-        await deleteWorkflow(app, workflowName)
-      }
+      // Trigger completed successfully. do not require the script node's badge;
+      // see file header note.
+      await expect(triggerNode.getByRole('img', { name: 'Success' })).toBeVisible({ timeout: 60_000 })
+    } finally {
+      await deleteWorkflow(app, workflowName)
     }
-  )
+  })
 
   test('trigger form shows name field with default value', async ({ app }) => {
     await ensureProject(app)

--- a/frontend/packages/syntara-ui/e2e/workflows/node-editor-panels.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/node-editor-panels.spec.ts
@@ -1050,7 +1050,7 @@ test.describe('Node editor panels', () => {
     await expect(app.getByText('Mock data pinned (1)')).not.toBeVisible()
   })
 
-  test('mock data cancel flow', { tag: ['@konflux-skip'] }, async ({ app }) => {
+  test('mock data cancel flow', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-mock-cancel')
     await app.goto(toAppUrl('/workflow-builder/new'))
     await selectProjectIfRequired(app)


### PR DESCRIPTION
All these tests are now marked a xfailed through the syntara-ci filter.

See: https://github.com/syntara-orchestration/syntara-ci/pull/16
