### PR TITLE
feat(ui): add field help to workflow template prompt fields

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPWorkflowTemplatePromptFields.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPWorkflowTemplatePromptFields.test.tsx
@@ -160,6 +160,27 @@ describe('AAPWorkflowTemplatePromptFields', () => {
     expect(screen.getByText('Skip tags')).toBeInTheDocument()
   })
 
+  it('attaches field help popovers to prompt-on-launch labels', () => {
+    render(
+      <TestWrapper>
+        <AAPWorkflowTemplatePromptFields
+          templateDetail={mockTemplateDetail}
+          isLoadingDetail={false}
+          inventories={mockInventories}
+          loadingInventories={false}
+          labels={mockLabels}
+          loadingLabels={false}
+          onSearchInventories={vi.fn()}
+          onSearchLabels={vi.fn()}
+        />
+      </TestWrapper>
+    )
+
+    for (const label of ['Inventory', 'Labels', 'Limit', 'Source control branch', 'Job tags', 'Skip tags']) {
+      expect(screen.getByRole('button', { name: `More info for ${label}` })).toBeInTheDocument()
+    }
+  })
+
   it('shows default inventory name in placeholder', () => {
     render(
       <TestWrapper>

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPWorkflowTemplatePromptFields.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPWorkflowTemplatePromptFields.tsx
@@ -1,4 +1,5 @@
 import { FormGroup, FormSection, StackItem, TextInput } from '@patternfly/react-core'
+import type { ReactElement } from 'react'
 import { useFormContext } from 'react-hook-form'
 
 import type { AAPWorkflowTemplateDetail } from '../../../hooks/useAAPBrowser'
@@ -8,6 +9,7 @@ import { AAPLabelsField } from './AAPLabelsField'
 import { ExtraVariablesField, TagInputField } from './AAPPromptFields'
 import { AAPResourceSelectField } from './AAPResourceSelectField'
 import type { AAPWorkflowTemplateFormData } from './aapWorkflowTemplateSchema'
+import { nodeHelp } from './shared/nodeFieldHelp'
 
 type AAPWorkflowTemplatePromptFieldsProps = Readonly<{
   templateDetail: AAPWorkflowTemplateDetail | undefined
@@ -26,15 +28,17 @@ function TextInputField({
   label,
   fieldId,
   name,
+  labelHelp,
 }: Readonly<{
   label: string
   fieldId: string
   name: keyof AAPWorkflowTemplateFormData
+  labelHelp?: ReactElement
 }>) {
   const { register } = useFormContext<AAPWorkflowTemplateFormData>()
   return (
     <StackItem>
-      <FormGroup label={label} fieldId={fieldId}>
+      <FormGroup label={label} labelHelp={labelHelp} fieldId={fieldId}>
         <TextInput {...register(name)} id={fieldId} type="text" />
       </FormGroup>
     </StackItem>
@@ -92,6 +96,7 @@ export function AAPWorkflowTemplatePromptFields(props: AAPWorkflowTemplatePrompt
             }
             placeholderText={inventoryDefaultName ? `${inventoryDefaultName} (default)` : 'No default inventory'}
             onSearchChange={onSearchInventories}
+            labelHelp={nodeHelp.aapInventory}
           />
         )}
 
@@ -104,13 +109,21 @@ export function AAPWorkflowTemplatePromptFields(props: AAPWorkflowTemplatePrompt
             helperText="Select or create labels for the workflow"
             placeholderText="Select or create labels"
             onSearchChange={onSearchLabels}
+            labelHelp={nodeHelp.aapLabels}
           />
         )}
 
-        {templateDetail.ask_limit_on_launch && <TextInputField label="Limit" fieldId="aap-wf-limit" name="limit" />}
+        {templateDetail.ask_limit_on_launch && (
+          <TextInputField label="Limit" fieldId="aap-wf-limit" name="limit" labelHelp={nodeHelp.aapLimit} />
+        )}
 
         {templateDetail.ask_scm_branch_on_launch && (
-          <TextInputField label="Source control branch" fieldId="aap-wf-scmBranch" name="scm_branch" />
+          <TextInputField
+            label="Source control branch"
+            fieldId="aap-wf-scmBranch"
+            name="scm_branch"
+            labelHelp={nodeHelp.aapScmBranch}
+          />
         )}
 
         {templateDetail.ask_tags_on_launch && (
@@ -120,6 +133,7 @@ export function AAPWorkflowTemplatePromptFields(props: AAPWorkflowTemplatePrompt
             name="tags"
             placeholder="tag1"
             helperText="Type a tag and press Enter or comma to add"
+            labelHelp={nodeHelp.aapWfTags}
           />
         )}
 
@@ -130,6 +144,7 @@ export function AAPWorkflowTemplatePromptFields(props: AAPWorkflowTemplatePrompt
             name="skip_tags"
             placeholder="tag1"
             helperText="Type a tag and press Enter or comma to add"
+            labelHelp={nodeHelp.aapWfSkipTags}
           />
         )}
 


### PR DESCRIPTION
## Description

AAP workflow template prompt-on-launch fields were missing the `labelHelp` popovers that job template prompt fields already have. this wires the existing `nodeHelp` copy through so inventory, labels, limit, source control branch, job tags, and skip tags match.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] pass `nodeHelp` into workflow template prompt-on-launch fields
- [x] unit test for the six `More info` popover triggers

## Out of Scope

create-service-account modal fields. extra variables already had help via `ExtraVariablesField`.

## Related Issues

Fixes AAP-68793

## How to Test

1. log in (demo / coffee on local mock)
2. add an AAP workflow template node and pick a template with prompt-on-launch fields enabled
3. confirm each prompt-on-launch label has the same help popover as the job template node

## Additional Notes

the rest of node parameter field help was already on devel. this is the leftover gap on the workflow template node.

