### PR TITLE
fix(ui): drop tab names from breadcrumbs

### DIFF
--- a/frontend/packages/syntara-ui/src/app/breadcrumbBuilders.test.ts
+++ b/frontend/packages/syntara-ui/src/app/breadcrumbBuilders.test.ts
@@ -19,93 +19,65 @@ import {
   breadcrumbsCredentialDetail,
   breadcrumbsGroupDetail,
   breadcrumbsProjectDetail,
-  breadcrumbsSettingsCategory,
   breadcrumbsSettingsPage,
   breadcrumbsUserDetail,
   breadcrumbsUserDetailEarlyShell,
   breadcrumbsUserFormLoading,
-  type CredentialDetailBreadcrumbTab,
+  breadcrumbsIntegrationDetail,
+  breadcrumbsServiceAccountDetail,
 } from './breadcrumbBuilders'
 
 describe('breadcrumbBuilders', () => {
-  it('omits the default details tab segment for project detail', () => {
-    const items = breadcrumbsProjectDetail(
-      'My project',
-      '/system-administration/access-management/projects/uuid-1',
-      'details'
-    )
-    expect(items).toHaveLength(3)
-    expect(items[2]).toEqual({ label: 'My project' })
-    expect(items[2]).not.toHaveProperty('href')
+  it('uses page hierarchy only for project detail, without a tab segment', () => {
+    const items = breadcrumbsProjectDetail('My project')
+    expect(items).toEqual([
+      { label: 'Access management', href: AppRoute.AccessManagement.Root },
+      { label: 'Projects', href: AppRoute.AccessManagement.Projects },
+      { label: 'My project' },
+    ])
   })
 
-  it('includes a tab segment when not on the default details tab', () => {
-    const base = '/system-administration/access-management/projects/uuid-1'
-    const items = breadcrumbsProjectDetail('My project', base, 'role-assignments')
-    expect(items).toHaveLength(4)
-    expect(items[2]).toEqual({ label: 'My project', href: base })
-    expect(items[3]).toEqual({ label: 'Assignments' })
-  })
-
-  it('omits default details tab for user, group, and identity provider detail', () => {
-    expect(breadcrumbsUserDetail('alice', '/system-administration/access-management/users/u1', 'details')).toEqual([
+  it('uses page hierarchy only for user, group, and identity provider detail', () => {
+    expect(breadcrumbsUserDetail('alice')).toEqual([
       { label: 'Access management', href: AppRoute.AccessManagement.Root },
       { label: 'Users', href: AppRoute.AccessManagement.Users },
       { label: 'alice' },
     ])
-    expect(breadcrumbsGroupDetail('g1', '/system-administration/access-management/groups/g1', 'details')).toEqual([
+    expect(breadcrumbsGroupDetail('g1')).toEqual([
       { label: 'Access management', href: AppRoute.AccessManagement.Root },
       { label: 'Groups', href: AppRoute.AccessManagement.Groups },
       { label: 'g1' },
     ])
-    expect(
-      breadcrumbsIdentityProviderDetail(
-        'Okta',
-        '/system-administration/authentication/identity-providers/p1',
-        'details'
-      )
-    ).toEqual([
+    expect(breadcrumbsIdentityProviderDetail('Okta')).toEqual([
       { label: 'Identity providers', href: AppRoute.SystemAdministration.Authentication.Root },
       { label: 'Okta' },
     ])
   })
 
-  it('omits Details segment for credential detail on the default tab', () => {
-    const items = breadcrumbsCredentialDetail('cred-1', 'Prod key', 'details')
-    expect(items).toHaveLength(3)
-    expect(items[2]).toEqual({ label: 'Prod key' })
+  it('uses page hierarchy only for credential and integration detail', () => {
+    expect(breadcrumbsCredentialDetail('Prod key')).toEqual([
+      { label: 'Configuration', href: AppRoute.Configuration.Overview },
+      { label: 'Credentials', href: AppRoute.Configuration.Credentials.Root },
+      { label: 'Prod key' },
+    ])
+    expect(breadcrumbsIntegrationDetail('GitHub')).toEqual([
+      { label: 'Configuration', href: AppRoute.Configuration.Overview },
+      { label: 'Integrations', href: AppRoute.Configuration.Integrations.Root },
+      { label: 'GitHub' },
+    ])
   })
 
-  it('adds Workflows segment when on the workflows tab', () => {
-    const items = breadcrumbsCredentialDetail('cred-1', 'Prod key', 'workflows')
-    expect(items).toHaveLength(4)
-    expect(items[2]).toMatchObject({
-      label: 'Prod key',
-      href: AppRoute.Configuration.Credentials.Detail.replace(':credentialId', 'cred-1'),
-    })
-    expect(items[3]).toEqual({ label: 'Workflows' })
-  })
-
-  it('adds Integrations segment when on the integrations tab', () => {
-    const items = breadcrumbsCredentialDetail('cred-1', 'Prod key', 'integrations')
-    expect(items).toHaveLength(4)
-    expect(items[2]).toMatchObject({
-      label: 'Prod key',
-      href: AppRoute.Configuration.Credentials.Detail.replace(':credentialId', 'cred-1'),
-    })
-    expect(items[3]).toEqual({ label: 'Integrations' })
-  })
-
-  it('uses raw tab name as fallback for unknown tab', () => {
-    const items = breadcrumbsCredentialDetail('cred-1', 'Prod key', 'unknown-tab' as CredentialDetailBreadcrumbTab)
-    expect(items).toHaveLength(4)
-    expect(items[3]).toEqual({ label: 'unknown-tab' })
+  it('uses page hierarchy only for service account detail', () => {
+    expect(breadcrumbsServiceAccountDetail('ci-bot')).toEqual([
+      { label: 'Access management', href: AppRoute.AccessManagement.Root },
+      { label: 'Service Accounts', href: AppRoute.AccessManagement.ServiceAccounts },
+      { label: 'ci-bot' },
+    ])
   })
 
   it('covers hub, forms, settings, integrations, approvals, and loading shells', () => {
-    expect(breadcrumbsAccessManagementHub('Policies')).toEqual([
+    expect(breadcrumbsAccessManagementHub()).toEqual([
       { label: 'Access management', href: AppRoute.AccessManagement.Root },
-      { label: 'Policies' },
     ])
     expect(breadcrumbsIdentityProvidersPage()).toEqual([{ label: 'Identity providers' }])
     expect(breadcrumbsCreateUser()).toHaveLength(3)
@@ -114,8 +86,7 @@ describe('breadcrumbBuilders', () => {
     expect(breadcrumbsIdentityProviderAdd()).toHaveLength(2)
     expect(breadcrumbsIdentityProviderEdit('Auth0', '/path')).toHaveLength(3)
 
-    expect(breadcrumbsSettingsPage()).toEqual([{ label: 'Settings' }])
-    expect(breadcrumbsSettingsCategory('AI / LLM')).toHaveLength(2)
+    expect(breadcrumbsSettingsPage()).toEqual([{ label: 'Settings', href: AppRoute.SystemAdministration.Settings }])
 
     expect(breadcrumbsApprovalsPage('Loading')).toHaveLength(2)
 
@@ -129,26 +100,5 @@ describe('breadcrumbBuilders', () => {
     expect(breadcrumbsProjectDetailEarlyShell()).toHaveLength(3)
     expect(breadcrumbsIdentityProviderFormLoading('…')).toHaveLength(2)
     expect(breadcrumbsIdentityProviderDetailEarlyShell()).toHaveLength(2)
-  })
-
-  it('includes non-default tab segments for entity detail builders', () => {
-    expect(breadcrumbsUserDetail('u', '/system-administration/access-management/users/u1', 'groups').at(-1)).toEqual({
-      label: 'Groups',
-    })
-    expect(breadcrumbsGroupDetail('g', '/system-administration/access-management/groups/g1', 'members').at(-1)).toEqual(
-      { label: 'Members' }
-    )
-    expect(
-      breadcrumbsProjectDetail('p', '/system-administration/access-management/projects/p1', 'role-assignments').at(-1)
-    ).toEqual({
-      label: 'Assignments',
-    })
-    expect(
-      breadcrumbsIdentityProviderDetail(
-        'Idp',
-        '/system-administration/authentication/identity-providers/p1',
-        'group-mapping'
-      ).at(-1)
-    ).toEqual({ label: 'Group mapping' })
   })
 })

--- a/frontend/packages/syntara-ui/src/app/breadcrumbBuilders.ts
+++ b/frontend/packages/syntara-ui/src/app/breadcrumbBuilders.ts
@@ -46,34 +46,8 @@ function crumbApprovals(): AppBreadcrumbItem {
   return { label: LABEL_APPROVALS, href: AppRoute.Approvals.Root }
 }
 
-function userDetailTabLabel(tab: string): string {
-  if (tab === 'details') return 'Details'
-  if (tab === 'groups') return 'Groups'
-  if (tab === 'identities') return 'Identities'
-  if (tab === 'roles') return 'Assignments'
-  return tab
-}
-
-function groupDetailTabLabel(tab: string): string {
-  if (tab === 'details') return 'Details'
-  if (tab === 'members') return 'Members'
-  if (tab === 'roles') return 'Assignments'
-  return tab
-}
-
-function projectDetailTabLabel(tab: string): string {
-  if (tab === 'details') return 'Details'
-  if (tab === 'role-assignments') return 'Assignments'
-  return tab
-}
-
-function identityProviderDetailTabLabel(tab: string): string {
-  if (tab === 'group-mapping') return 'Group mapping'
-  return 'Details'
-}
-
-export function breadcrumbsAccessManagementHub(activeTabLabel: string): AppBreadcrumbItem[] {
-  return [crumbAccessManagement(), { label: activeTabLabel }]
+export function breadcrumbsAccessManagementHub(): AppBreadcrumbItem[] {
+  return [crumbAccessManagement()]
 }
 
 export function breadcrumbsIdentityProvidersPage(): AppBreadcrumbItem[] {
@@ -88,35 +62,16 @@ export function breadcrumbsEditUser(displayName: string, userBasePath: string): 
   return [crumbAccessManagement(), crumbUsersList(), { label: displayName, href: userBasePath }, { label: 'Edit user' }]
 }
 
-/** `useUrlTab` default; URL with no trailing segment is the same as this tab — omit a redundant last crumb. */
-const DEFAULT_ENTITY_TAB = 'details'
-
-export function breadcrumbsUserDetail(displayName: string, userBasePath: string, tab: string): AppBreadcrumbItem[] {
-  const prefix = [crumbAccessManagement(), crumbUsersList()]
-  if (tab === DEFAULT_ENTITY_TAB) {
-    return [...prefix, { label: displayName }]
-  }
-  return [...prefix, { label: displayName, href: userBasePath }, { label: userDetailTabLabel(tab) }]
+export function breadcrumbsUserDetail(displayName: string): AppBreadcrumbItem[] {
+  return [crumbAccessManagement(), crumbUsersList(), { label: displayName }]
 }
 
-export function breadcrumbsGroupDetail(groupName: string, groupBasePath: string, tab: string): AppBreadcrumbItem[] {
-  const prefix = [crumbAccessManagement(), crumbGroupsList()]
-  if (tab === DEFAULT_ENTITY_TAB) {
-    return [...prefix, { label: groupName }]
-  }
-  return [...prefix, { label: groupName, href: groupBasePath }, { label: groupDetailTabLabel(tab) }]
+export function breadcrumbsGroupDetail(groupName: string): AppBreadcrumbItem[] {
+  return [crumbAccessManagement(), crumbGroupsList(), { label: groupName }]
 }
 
-export function breadcrumbsProjectDetail(
-  projectName: string,
-  projectBasePath: string,
-  tab: string
-): AppBreadcrumbItem[] {
-  const prefix = [crumbAccessManagement(), crumbProjectsList()]
-  if (tab === DEFAULT_ENTITY_TAB) {
-    return [...prefix, { label: projectName }]
-  }
-  return [...prefix, { label: projectName, href: projectBasePath }, { label: projectDetailTabLabel(tab) }]
+export function breadcrumbsProjectDetail(projectName: string): AppBreadcrumbItem[] {
+  return [crumbAccessManagement(), crumbProjectsList(), { label: projectName }]
 }
 
 export function breadcrumbsIdentityProviderAdd(): AppBreadcrumbItem[] {
@@ -141,54 +96,25 @@ export function breadcrumbsIdentityProviderGroupMappingForm(
   ]
 }
 
-export function breadcrumbsIdentityProviderDetail(
-  providerName: string,
-  detailBasePath: string,
-  tab: string
-): AppBreadcrumbItem[] {
-  const prefix = [crumbIdentityProvidersList()]
-  if (tab === DEFAULT_ENTITY_TAB) {
-    return [...prefix, { label: providerName }]
-  }
-  return [...prefix, { label: providerName, href: detailBasePath }, { label: identityProviderDetailTabLabel(tab) }]
-}
-
-export function breadcrumbsSettingsCategory(categoryName: string): AppBreadcrumbItem[] {
-  return [crumbSettings(), { label: categoryName }]
+export function breadcrumbsIdentityProviderDetail(providerName: string): AppBreadcrumbItem[] {
+  return [crumbIdentityProvidersList(), { label: providerName }]
 }
 
 /** Settings page before a category is selected or when only the page title applies. */
 export function breadcrumbsSettingsPage(): AppBreadcrumbItem[] {
-  return [{ label: 'Settings' }]
+  return [crumbSettings()]
 }
 
 export function breadcrumbsIntegrationConfigure(): AppBreadcrumbItem[] {
   return [crumbConfiguration(), crumbIntegrations(), { label: 'Configure integration' }]
 }
 
-export type IntegrationDetailBreadcrumbTab = 'details' | 'resources'
-
-export function breadcrumbsIntegrationDetail(
-  integrationId: string,
-  integrationName: string,
-  tab: IntegrationDetailBreadcrumbTab
-): AppBreadcrumbItem[] {
-  const prefix = [crumbConfiguration(), crumbIntegrations()]
-  if (tab === DEFAULT_ENTITY_TAB) {
-    return [...prefix, { label: integrationName }]
-  }
-  const detailHref = AppRoute.Configuration.Integrations.Detail.replace(':integrationId', integrationId)
-  return [...prefix, { label: integrationName, href: detailHref }, { label: integrationDetailTabLabel(tab) }]
+export function breadcrumbsIntegrationDetail(integrationName: string): AppBreadcrumbItem[] {
+  return [crumbConfiguration(), crumbIntegrations(), { label: integrationName }]
 }
 
 export function breadcrumbsIntegrationDetailEarlyShell(): AppBreadcrumbItem[] {
   return [crumbConfiguration(), crumbIntegrations(), { label: 'Integration details' }]
-}
-
-function integrationDetailTabLabel(tab: string): string {
-  if (tab === 'details') return 'Details'
-  if (tab === 'resources') return 'Enabled resources'
-  return tab
 }
 
 export function breadcrumbsIntegrationEdit(integrationName: string, detailBasePath: string): AppBreadcrumbItem[] {
@@ -200,26 +126,8 @@ export function breadcrumbsIntegrationEdit(integrationName: string, detailBasePa
   ]
 }
 
-export type CredentialDetailBreadcrumbTab = 'details' | 'workflows' | 'integrations'
-
-function credentialDetailTabLabel(tab: string): string {
-  if (tab === 'details') return 'Details'
-  if (tab === 'workflows') return 'Workflows'
-  if (tab === 'integrations') return 'Integrations'
-  return tab
-}
-
-export function breadcrumbsCredentialDetail(
-  credentialId: string,
-  credentialName: string,
-  tab: CredentialDetailBreadcrumbTab
-): AppBreadcrumbItem[] {
-  const prefix = [crumbConfiguration(), crumbCredentials()]
-  if (tab === DEFAULT_ENTITY_TAB) {
-    return [...prefix, { label: credentialName }]
-  }
-  const detailHref = AppRoute.Configuration.Credentials.Detail.replace(':credentialId', credentialId)
-  return [...prefix, { label: credentialName, href: detailHref }, { label: credentialDetailTabLabel(tab) }]
+export function breadcrumbsCredentialDetail(credentialName: string): AppBreadcrumbItem[] {
+  return [crumbConfiguration(), crumbCredentials(), { label: credentialName }]
 }
 
 export function breadcrumbsCredentialEarlyShell(currentLabel: string): AppBreadcrumbItem[] {
@@ -243,19 +151,8 @@ function crumbServiceAccountsList(): AppBreadcrumbItem {
   return { label: 'Service Accounts', href: AppRoute.AccessManagement.ServiceAccounts }
 }
 
-function serviceAccountDetailTabLabel(tab: string): string {
-  if (tab === 'details') return 'Details'
-  if (tab === 'credentials') return 'Credentials'
-  if (tab === 'assignments') return 'Assignments'
-  return tab
-}
-
-export function breadcrumbsServiceAccountDetail(name: string, basePath: string, tab: string): AppBreadcrumbItem[] {
-  const prefix = [crumbAccessManagement(), crumbServiceAccountsList()]
-  if (tab === DEFAULT_ENTITY_TAB) {
-    return [...prefix, { label: name }]
-  }
-  return [...prefix, { label: name, href: basePath }, { label: serviceAccountDetailTabLabel(tab) }]
+export function breadcrumbsServiceAccountDetail(name: string): AppBreadcrumbItem[] {
+  return [crumbAccessManagement(), crumbServiceAccountsList(), { label: name }]
 }
 
 export function breadcrumbsServiceAccountDetailEarlyShell(): AppBreadcrumbItem[] {

--- a/frontend/packages/syntara-ui/src/routes/access-management/AccessManagement.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/AccessManagement.test.tsx
@@ -154,18 +154,17 @@ describe('AccessManagement', () => {
     })
   })
 
-  it('renders breadcrumbs on all tabs including Users', async () => {
+  it('does not render breadcrumbs on the Users hub tab', async () => {
     await renderAndSettle(<AccessManagement />)
 
-    expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument()
+    expect(screen.queryByRole('navigation', { name: 'Breadcrumb' })).not.toBeInTheDocument()
   })
 
-  it('renders breadcrumbs on non-default hub tabs', async () => {
+  it('does not include the tab name in breadcrumbs on non-default hub tabs', async () => {
     routerTestState.pathname = AppRoute.AccessManagement.Groups
     await renderAndSettle(<AccessManagement />)
 
-    expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Access management' })).toBeInTheDocument()
+    expect(screen.queryByRole('navigation', { name: 'Breadcrumb' })).not.toBeInTheDocument()
   })
 
   it('defaults to first tab when location does not match any tab path', async () => {

--- a/frontend/packages/syntara-ui/src/routes/access-management/AccessManagement.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/AccessManagement.tsx
@@ -127,8 +127,7 @@ export function AccessManagement() {
     )
   }
 
-  const activeTabDef = validTabDefs.find((t) => t.key === activeTab) ?? validTabDefs[0]
-  const hubBreadcrumbs = breadcrumbsAccessManagementHub(activeTabDef?.label ?? 'Access Management')
+  const hubBreadcrumbs = breadcrumbsAccessManagementHub()
 
   return (
     <SynPage>

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/IdentityProviderDetail.tsx
@@ -183,10 +183,6 @@ function TabContent({
 const GROUP_MAPPING_TAB = 'group-mapping' as const
 type TabKey = 'details' | typeof GROUP_MAPPING_TAB
 
-function identityProviderDetailBreadcrumbTrail(provider: ProviderData, idpDetailBasePath: string, activeTab: TabKey) {
-  return breadcrumbsIdentityProviderDetail(provider.name ?? 'Identity provider', idpDetailBasePath, activeTab)
-}
-
 function IdentityProviderDetailEarlyLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <SynPage>
@@ -420,7 +416,7 @@ export function IdentityProviderDetail() {
 
   if (!providerData) return null
 
-  const idpDetailCrumbs = identityProviderDetailBreadcrumbTrail(providerData, idpDetailBasePath, activeTab)
+  const idpDetailCrumbs = breadcrumbsIdentityProviderDetail(providerData.name ?? 'Identity provider')
 
   const config = providerData.configuration
   const idpType = config?.idp_type

--- a/frontend/packages/syntara-ui/src/routes/access-management/groups/GroupDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/groups/GroupDetail.tsx
@@ -281,7 +281,7 @@ export function GroupDetail() {
 
   if (!groupData) return null
 
-  const groupCrumbs = breadcrumbsGroupDetail(groupData.name, basePath, activeTab)
+  const groupCrumbs = breadcrumbsGroupDetail(groupData.name)
 
   return (
     <SynPage>

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectDetail.tsx
@@ -207,7 +207,7 @@ export function ProjectDetail() {
 
   if (!projectData) return null
 
-  const projectCrumbs = breadcrumbsProjectDetail(projectData.name, basePath, activeTab)
+  const projectCrumbs = breadcrumbsProjectDetail(projectData.name)
 
   return (
     <SynPage>

--- a/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountDetail.tsx
@@ -255,7 +255,7 @@ export function ServiceAccountDetail() {
 
   if (!serviceAccount) return null
 
-  const crumbs = breadcrumbsServiceAccountDetail(serviceAccount.name, basePath, activeTab)
+  const crumbs = breadcrumbsServiceAccountDetail(serviceAccount.name)
   const isEnabled = serviceAccount.status === 'active'
 
   return (

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserDetail.tsx
@@ -400,7 +400,7 @@ export function UserDetail({ isMyProfile }: Readonly<UserDetailProps> = {}) {
 
   const displayName = userDisplayName(userData)
   const pageTitle = isMyProfile ? 'My Profile' : displayName
-  const userBreadcrumbs = isMyProfile ? [] : breadcrumbsUserDetail(displayName, basePath, activeTab)
+  const userBreadcrumbs = isMyProfile ? [] : breadcrumbsUserDetail(displayName)
 
   return (
     <SynPage>

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/CredentialDetail.tsx
@@ -27,7 +27,6 @@ import { SynPageTitle } from '../../../components/SynPageTitle'
 import { UserTimestamp } from '../../../components/table/UserTimestamp'
 import { SynUrlTabs } from '../../../components/tabs/SynUrlTabs'
 import { useDeleteAction } from '../../../hooks/useDeleteAction'
-import { useUrlTab } from '../../../hooks/useUrlTab'
 import { useAlerts } from '../../../providers/alerts'
 import { getErrorMessage } from '../../../utils/apiErrors'
 import { detachPromise } from '../../../utils/detachPromise'
@@ -107,7 +106,6 @@ export default function CredentialDetail() {
   const { credentialId }: { credentialId: string } = useParams({ strict: false })
   const navigate = useNavigate()
   const credentialBasePath = AppRoute.Configuration.Credentials.Detail.replace(':credentialId', credentialId ?? '')
-  const [activeTab] = useUrlTab<CredentialTab>(credentialBasePath)
   const { canReadWorkflows, canReadIntegrations, isLoading: permissionsLoading } = useCredentialDetailPermissions()
 
   const validTabs = useMemo(
@@ -286,7 +284,7 @@ export default function CredentialDetail() {
   const credentialTypeDisplayText = getTypeDisplayText(credType?.name, typeLoadError)
   const hasDescription = Boolean(credential.description?.trim())
 
-  const credentialCrumbs = breadcrumbsCredentialDetail(credential.id, credential.name, activeTab)
+  const credentialCrumbs = breadcrumbsCredentialDetail(credential.name)
 
   return (
     <SynPage>

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationDetail.tsx
@@ -19,11 +19,7 @@ import { IntegrationTypeEnum } from '@syntara/contracts'
 import { useNavigate, useParams } from '@tanstack/react-router'
 
 import { AppRoute } from '../../../app/AppRoute'
-import {
-  breadcrumbsIntegrationDetail,
-  breadcrumbsIntegrationDetailEarlyShell,
-  type IntegrationDetailBreadcrumbTab,
-} from '../../../app/breadcrumbBuilders'
+import { breadcrumbsIntegrationDetail, breadcrumbsIntegrationDetailEarlyShell } from '../../../app/breadcrumbBuilders'
 import { credentialsClient, integrationsClient } from '../../../client'
 import { SynDetail } from '../../../components/details/SynDetail'
 import { DisabledWithTooltip } from '../../../components/DisabledWithTooltip'
@@ -280,12 +276,14 @@ function hasResourcesTab(integration: IntegrationsAPI.components['schemas']['Int
   return isLLMProvider(integration) || integration.integration_type === IntegrationTypeEnum.MCP_SERVER
 }
 
+type IntegrationDetailTab = 'details' | 'resources' | 'edit'
+
 export function IntegrationDetail() {
   const { integrationId }: { integrationId: string } = useParams({ strict: false })
   const navigate = useNavigate()
   const integrationBasePath = AppRoute.Configuration.Integrations.Detail.replace(':integrationId', integrationId)
   const editPath = AppRoute.Configuration.Integrations.Edit.replace(':integrationId', integrationId)
-  const [activeTab] = useUrlTab<IntegrationDetailBreadcrumbTab | 'edit'>(integrationBasePath)
+  const [activeTab] = useUrlTab<IntegrationDetailTab>(integrationBasePath)
   const docLink = useDocLink('integrations')
   const permissions = useIntegrationPermissions()
 
@@ -379,7 +377,7 @@ export function IntegrationDetail() {
 
   if (!integration?.id) return null
 
-  const integrationCrumbs = breadcrumbsIntegrationDetail(integration.id, integration.name, activeTab)
+  const integrationCrumbs = breadcrumbsIntegrationDetail(integration.name)
   const footer = activeTab === 'resources' ? <ResourcesFooter {...footerState} /> : undefined
 
   return (

--- a/frontend/packages/syntara-ui/src/routes/configuration/settings/Settings.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/settings/Settings.test.tsx
@@ -220,6 +220,14 @@ describe('Settings', () => {
     expect(screen.queryByRole('link', { name: 'Configuration' })).not.toBeInTheDocument()
   })
 
+  it('does not render breadcrumbs when a category tab is selected', () => {
+    mockLocation.value = '/system-administration/settings/application'
+    mockQueries()
+    render(<Settings />)
+
+    expect(screen.queryByRole('navigation', { name: 'Breadcrumb' })).not.toBeInTheDocument()
+  })
+
   it('navigates to the correct URL when a tab is clicked', async () => {
     const user = userEvent.setup()
     mockQueries()

--- a/frontend/packages/syntara-ui/src/routes/configuration/settings/Settings.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/settings/Settings.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useRouterState } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { AppRoute } from '../../../app/AppRoute'
-import { breadcrumbsSettingsCategory, breadcrumbsSettingsPage } from '../../../app/breadcrumbBuilders'
+import { breadcrumbsSettingsPage } from '../../../app/breadcrumbBuilders'
 import { settingsClient } from '../../../client'
 import { EmptyStateAccessDenied } from '../../../components/EmptyStateAccessDenied'
 import { SynPage, SynPageBody } from '../../../components/layout/SynPage'
@@ -107,14 +107,6 @@ export default function Settings() {
     const idx = categories.findIndex((c) => c.slug === activeSlug)
     return Math.max(idx, 0)
   }, [activeSlug, categories])
-
-  const settingsBreadcrumbs = useMemo(() => {
-    const category = categories[activeIndex]
-    if (category && activeIndex > 0) {
-      return breadcrumbsSettingsCategory(category.name)
-    }
-    return breadcrumbsSettingsPage()
-  }, [categories, activeIndex])
 
   const settingsByCategory = useMemo(() => {
     const grouped = new Map<string, (typeof allSettings)[number][]>()
@@ -223,7 +215,7 @@ export default function Settings() {
   return (
     <SynPage>
       <SynPageTitle segments={['Settings']} />
-      <SynPageHeader title="Settings" docLink={settingsDocLink} breadcrumbs={settingsBreadcrumbs} />
+      <SynPageHeader title="Settings" docLink={settingsDocLink} breadcrumbs={breadcrumbsSettingsPage()} />
       <SynPageBody>
         <FileStorageAlert />
         <SynPanel


### PR DESCRIPTION
## Description

ao breadcrumbs were including the active tab / list-table name as the last segment, so the trail changed when you stayed on the same page. this keeps breadcrumbs to page hierarchy only.

hub pages (access management, settings) are a single segment, so SynPageBreadcrumbs hides the trail. detail pages keep prefix + entity name and drop the tab segment.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] stop appending tab / list-table labels from hub, settings, and detail breadcrumb builders
- [x] drop unused activeTab args and DetailTabLabel helpers
- [x] unit tests for the new trails

## Out of Scope

tab UI, page titles, and url tab routing. form/action pages (create/edit user, configure integration, etc). my profile already had no breadcrumbs.

## Related Issues

Fixes AAP-88952

## How to Test

1. log in (demo / coffee on local mock)
2. access management hub: switch users / groups / policies. no breadcrumb, tab name is not in a trail
3. settings: switch category tabs. same
4. open a user, group, or credential detail and switch sub-tabs. trail stays prefix plus entity name

<img width="1508" height="648" alt="image" src="https://github.com/user-attachments/assets/76defcb4-dbad-4689-b8d4-e4e36e5d7afa" />

<img width="1740" height="604" alt="image" src="https://github.com/user-attachments/assets/e725e4bf-f44f-48da-ab60-ef75248a7a4c" />
<img width="1484" height="726" alt="image" src="https://github.com/user-attachments/assets/1850775e-05e9-4202-a011-bd75846eda84" />
<img width="1390" height="808" alt="image" src="https://github.com/user-attachments/assets/313ae47f-5bf9-4f53-b586-4816edbe8573" />
