### PR TITLE
fix(ui): persist job template input-variables toggle

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/builder/node-details/TaskNodeDetails.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-details/TaskNodeDetails.test.tsx
@@ -132,6 +132,19 @@ vi.mock('../node-forms/AAPJobTemplateForm', () => ({
       >
         {submitButtonText ?? 'Add step'}
       </button>
+      <button
+        onClick={() =>
+          onSubmit({
+            name: 'Updated AAP Task',
+            use_input_variables: true,
+            organization_name: '',
+            job_template_name: '',
+          })
+        }
+        data-testid="aap-submit-input-vars-button"
+      >
+        Update with input variables
+      </button>
       <button onClick={onCancel} data-testid="aap-cancel-button">
         Cancel
       </button>
@@ -386,6 +399,25 @@ describe('TaskNodeDetails Component', () => {
     await user.click(screen.getByTestId('submit-button'))
 
     expect(mockUpdateActivity).toHaveBeenCalledWith('task-1', expect.objectContaining({ name: 'Updated Task' }))
+  })
+
+  it('updates an AAP job template with use_input_variables and no job template id', async () => {
+    const user = userEvent.setup()
+    const taskData = {
+      type: 'aap_job_template' as const,
+      id: 'task-aap',
+      name: 'AAP Task',
+      parameters: {
+        use_input_variables: true,
+      },
+    }
+
+    renderTaskNodeDetails(taskData, 'task-aap')
+
+    await user.click(screen.getByTestId('aap-submit-input-vars-button'))
+
+    expect(mockShowError).not.toHaveBeenCalled()
+    expect(mockUpdateActivity).toHaveBeenCalledWith('task-aap', expect.objectContaining({ name: 'Updated AAP Task' }))
   })
 
   it('calls updateActivity on successful AAP form submission', async () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/node-details/TaskNodeDetails.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-details/TaskNodeDetails.tsx
@@ -33,6 +33,7 @@ import {
   buildExpressionModeActivity,
   buildWorkflowExpressionModeActivity,
   hasExpressionValue,
+  isJobTemplateInputVariablesMode,
   validateJobTemplateId,
   validateWorkflowTemplateId,
 } from '../utils/aapHelpers'
@@ -97,7 +98,11 @@ function hasJobTemplateConfig(config: Record<string, unknown>): config is Stored
     'job_template_id' in config ||
     'jobTemplateId' in config ||
     'job_template_name' in config ||
-    'jobTemplateName' in config
+    'jobTemplateName' in config ||
+    'use_input_variables' in config ||
+    'useInputVariables' in config ||
+    'extra_vars' in config ||
+    'extraVars' in config
   )
 }
 
@@ -221,23 +226,49 @@ function getStringField(config: Record<string, unknown>, ...keys: string[]): str
   return undefined
 }
 
+function resolveUseInputVariables(
+  c: StoredAAPConfig,
+  organizationName: string,
+  jobTemplateName: string,
+  inventoryName: string,
+  extraVars: string
+): boolean {
+  return (
+    c.use_input_variables === true ||
+    c.useInputVariables === true ||
+    hasExpressionValue(
+      organizationName,
+      jobTemplateName,
+      inventoryName,
+      c.limit ?? '',
+      c.tags ?? '',
+      c.skip_tags ?? c.skipTags ?? '',
+      extraVars
+    )
+  )
+}
+
 function buildAAPInitialData(taskName: string, config: Record<string, unknown>): Partial<AAPJobTemplateFormData> {
   if (!hasJobTemplateConfig(config)) {
     return { name: taskName }
   }
   const c = config
+  const organizationName = getField(c.organization_name, c.organization, '')
+  const jobTemplateName = getField(c.job_template_name, c.jobTemplateName, '')
+  const inventoryName = getField(c.inventory_name, c.inventoryName, '')
+  const extraVars = serializeExtraVars(c.extra_vars ?? c.extraVars)
 
   return {
     name: taskName,
     credential_id: getStringField(c, 'credential_id', 'credentialId'),
     integration_id: getStringField(c, 'integration_id', 'integrationId'),
     organization_id: c.organization_id ?? c.organizationId,
-    organization_name: getField(c.organization_name, c.organization, ''),
-    job_template_name: getField(c.job_template_name, c.jobTemplateName, ''),
+    organization_name: organizationName,
+    job_template_name: jobTemplateName,
     job_template_id: (c.job_template_id ?? c.jobTemplateId) as number | undefined,
-    inventory_name: getField(c.inventory_name, c.inventoryName, ''),
+    inventory_name: inventoryName,
     inventory_id: c.inventory_id ?? c.inventory,
-    extra_vars: serializeExtraVars(c.extra_vars ?? c.extraVars),
+    extra_vars: extraVars,
     limit: c.limit ?? '',
     tags: c.tags ?? '',
     skip_tags: c.skip_tags ?? c.skipTags ?? '',
@@ -251,6 +282,7 @@ function buildAAPInitialData(taskName: string, config: Record<string, unknown>):
     instance_group: getField(c.instance_group_name, c.instanceGroupName, '') as string | undefined,
     instance_group_id: c.instance_group_id ?? c.instanceGroupId,
     labels: c.labels ?? [],
+    use_input_variables: resolveUseInputVariables(c, organizationName, jobTemplateName, inventoryName, extraVars),
   }
 }
 
@@ -368,7 +400,7 @@ function renderAAPTaskDetails({
 
   const handleAAPSubmit = (data: AAPJobTemplateFormData) => {
     try {
-      if (hasExpressionValue(data.job_template_name, data.organization_name)) {
+      if (isJobTemplateInputVariablesMode(data)) {
         updateActivity(nodeId, buildExpressionModeActivity(nodeId, data.name, data))
       } else {
         const job_template_id = validateJobTemplateId(data.job_template_id)

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPJobTemplateForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPJobTemplateForm.tsx
@@ -52,18 +52,7 @@ function AAPFormFields({
   const isVersionView = useIsVersionView()
   const { register, setValue, getValues } = useFormContext<AAPJobTemplateFormData>()
 
-  // Auto-detect expression mode from saved input-variable values, including extra_vars
-  const hasExpressionInInitialData = hasExpressionValue(
-    initialData?.organization_name,
-    initialData?.job_template_name,
-    initialData?.inventory_name,
-    initialData?.limit,
-    initialData?.tags,
-    initialData?.skip_tags,
-    initialData?.extra_vars
-  )
-
-  const [expressionMode, setExpressionMode] = useState(hasExpressionInInitialData)
+  const expressionMode = Boolean(useWatch({ name: 'use_input_variables' }))
 
   const browser = useAAPBrowser(
     selectedCredentialId,
@@ -115,7 +104,9 @@ function AAPFormFields({
             id="aap-expression-mode"
             aria-label="Use input variables"
             isChecked={expressionMode}
-            onChange={(_e, checked) => setExpressionMode(checked)}
+            onChange={(_e, checked) =>
+              setValue('use_input_variables', checked, { shouldDirty: true, shouldValidate: true })
+            }
             isDisabled={isVersionView}
           />
         </FormGroup>
@@ -274,6 +265,17 @@ export function AAPJobTemplateForm(props: Readonly<AAPNodeFormProps>) {
     diff_mode: false,
     settings: {},
     ...sanitizedInitialData,
+    use_input_variables:
+      sanitizedInitialData?.use_input_variables === true ||
+      hasExpressionValue(
+        sanitizedInitialData?.organization_name,
+        sanitizedInitialData?.job_template_name,
+        sanitizedInitialData?.inventory_name,
+        sanitizedInitialData?.limit,
+        sanitizedInitialData?.tags,
+        sanitizedInitialData?.skip_tags,
+        sanitizedInitialData?.extra_vars
+      ),
   }
 
   const methods = useForm<AAPJobTemplateFormData>({

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPJobTemplateForm.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPJobTemplateForm.tsx
@@ -8,9 +8,10 @@ import { detachPromise } from '../../../utils/detachPromise'
 import { AAPIntegrationSection } from '../components/AAPIntegrationSection'
 import type { ExpandableCodeEditorHandle } from '../components/ExpandableCodeEditor'
 import { NodeEditorAutoSubmitContext, useRegisterAutoSubmit } from '../hooks/useNodeEditorAutoSubmit'
+import { hasExpressionValue } from '../utils/aapHelpers'
 import { useIsVersionView } from '../VersionViewContext'
 
-import { applyDefaultValues, isExpression, sanitizeArrayField } from './aapFormHelpers'
+import { applyDefaultValues, sanitizeArrayField } from './aapFormHelpers'
 import { aapJobTemplateSchema, type AAPJobTemplateFormData } from './aapJobTemplateSchema'
 import { PromptOnLaunchFields } from './AAPPromptOnLaunchFields'
 import { AAPResourcePickers } from './AAPResourcePickers'
@@ -51,12 +52,16 @@ function AAPFormFields({
   const isVersionView = useIsVersionView()
   const { register, setValue, getValues } = useFormContext<AAPJobTemplateFormData>()
 
-  // Auto-detect expression mode from initial data
-  const hasExpressionInInitialData =
-    isExpression(initialData?.organization_name) ||
-    isExpression(initialData?.job_template_name) ||
-    isExpression(initialData?.inventory_name) ||
-    isExpression(initialData?.limit)
+  // Auto-detect expression mode from saved input-variable values, including extra_vars
+  const hasExpressionInInitialData = hasExpressionValue(
+    initialData?.organization_name,
+    initialData?.job_template_name,
+    initialData?.inventory_name,
+    initialData?.limit,
+    initialData?.tags,
+    initialData?.skip_tags,
+    initialData?.extra_vars
+  )
 
   const [expressionMode, setExpressionMode] = useState(hasExpressionInInitialData)
 

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPNodeForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPNodeForm.test.tsx
@@ -628,6 +628,27 @@ describe('AAPNodeForm', () => {
       expect(screen.getByPlaceholderText('skip tags or drag expression')).toHaveValue('${inputs.skip_tags}')
     })
 
+    it('persists use_input_variables when the toggle is on without expressions', async () => {
+      const user = userEvent.setup()
+      renderWithHeader(<AAPNodeForm onSubmit={mockOnSubmit} onCancel={vi.fn()} />)
+
+      await user.click(screen.getByRole('switch', { name: 'Use input variables' }))
+      await submitForm()
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({ use_input_variables: true }))
+      })
+    })
+
+    it('enables the toggle from persisted use_input_variables without expressions', () => {
+      renderWithHeader(
+        <AAPNodeForm onSubmit={mockOnSubmit} onCancel={vi.fn()} initialData={{ use_input_variables: true }} />
+      )
+
+      expect(screen.getByRole('switch', { name: 'Use input variables' })).toBeChecked()
+      expect(screen.getByPlaceholderText('{"key": "value"} or drag expression')).toBeVisible()
+    })
+
     it('does not enable the toggle for extra_vars without expressions', () => {
       renderWithHeader(
         <AAPNodeForm

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPNodeForm.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/AAPNodeForm.test.tsx
@@ -540,4 +540,110 @@ describe('AAPNodeForm', () => {
       })
     })
   })
+
+  describe('Use input variables', () => {
+    it('toggles use input variables switch', async () => {
+      const user = userEvent.setup()
+      renderWithHeader(<AAPNodeForm onSubmit={mockOnSubmit} onCancel={vi.fn()} />)
+
+      const inputVarsSwitch = screen.getByRole('switch', { name: 'Use input variables' })
+      expect(inputVarsSwitch).not.toBeChecked()
+
+      await user.click(inputVarsSwitch)
+
+      expect(inputVarsSwitch).toBeChecked()
+    })
+
+    it('shows extra_vars expression field when use input variables is enabled', async () => {
+      const user = userEvent.setup()
+      renderWithHeader(<AAPNodeForm onSubmit={mockOnSubmit} onCancel={vi.fn()} />)
+
+      await user.click(screen.getByRole('switch', { name: 'Use input variables' }))
+
+      expect(screen.getByPlaceholderText('{"key": "value"} or drag expression')).toBeInTheDocument()
+    })
+
+    it('enables the toggle and shows extra_vars when loading saved extra_vars expressions', () => {
+      const savedExtraVars = '{"app_version": "${inputs.version}"}'
+      renderWithHeader(
+        <AAPNodeForm
+          onSubmit={mockOnSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            name: 'Deploy with vars',
+            organization_name: 'Default',
+            job_template_name: 'Deploy App',
+            extra_vars: savedExtraVars,
+          }}
+        />
+      )
+
+      expect(screen.getByRole('switch', { name: 'Use input variables' })).toBeChecked()
+      expect(screen.getByPlaceholderText('{"key": "value"} or drag expression')).toHaveValue(savedExtraVars)
+    })
+
+    it('enables the toggle when loading saved extra_vars with pretty-printed expressions', () => {
+      const savedExtraVars = JSON.stringify({ app_version: '${inputs.version}' }, null, 2)
+      renderWithHeader(
+        <AAPNodeForm
+          onSubmit={mockOnSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            extra_vars: savedExtraVars,
+          }}
+        />
+      )
+
+      expect(screen.getByRole('switch', { name: 'Use input variables' })).toBeChecked()
+      expect(screen.getByPlaceholderText('{"key": "value"} or drag expression')).toBeVisible()
+    })
+
+    it('enables the toggle from tags expressions', () => {
+      renderWithHeader(
+        <AAPNodeForm
+          onSubmit={mockOnSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            tags: '${inputs.tags}',
+          }}
+        />
+      )
+
+      expect(screen.getByRole('switch', { name: 'Use input variables' })).toBeChecked()
+      expect(screen.getByPlaceholderText('tags or drag expression')).toHaveValue('${inputs.tags}')
+    })
+
+    it('enables the toggle from skip_tags expressions', () => {
+      renderWithHeader(
+        <AAPNodeForm
+          onSubmit={mockOnSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            skip_tags: '${inputs.skip_tags}',
+          }}
+        />
+      )
+
+      expect(screen.getByRole('switch', { name: 'Use input variables' })).toBeChecked()
+      expect(screen.getByPlaceholderText('skip tags or drag expression')).toHaveValue('${inputs.skip_tags}')
+    })
+
+    it('does not enable the toggle for extra_vars without expressions', () => {
+      renderWithHeader(
+        <AAPNodeForm
+          onSubmit={mockOnSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            organization_name: 'Default',
+            job_template_name: 'Deploy App',
+            job_template_id: 10,
+            extra_vars: '{"key": "value"}',
+          }}
+        />
+      )
+
+      expect(screen.getByRole('switch', { name: 'Use input variables' })).not.toBeChecked()
+      expect(screen.queryByPlaceholderText('{"key": "value"} or drag expression')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/aapJobTemplateSchema.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/aapJobTemplateSchema.test.ts
@@ -111,4 +111,9 @@ describe('aapJobTemplateSchema', () => {
     const result = aapJobTemplateSchema.safeParse({ name: 'Incomplete Node' })
     expect(result.success).toBe(true)
   })
+
+  it('accepts use_input_variables without a job template id', () => {
+    const result = aapJobTemplateSchema.safeParse({ name: 'Incomplete Node', use_input_variables: true })
+    expect(result.success).toBe(true)
+  })
 })

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/aapJobTemplateSchema.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/aapJobTemplateSchema.ts
@@ -44,6 +44,8 @@ export const aapJobTemplateSchema = z
     instance_group_id: optionalNumber.optional(),
     labels: z.array(z.string()).optional(),
     settings: nodeSettingsSchema.optional(),
+    // Local UI mode: persisted in node parameters so reopen restores the toggle
+    use_input_variables: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
     validateExtraVars(data.extra_vars, ctx)

--- a/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerAAPNode.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerAAPNode.test.ts
@@ -136,6 +136,37 @@ describe('registerAAPNode', () => {
     expect(mockAddActivity).toHaveBeenCalled()
   })
 
+  it('creates expression-mode activity when use_input_variables is true without a job template', () => {
+    const mockAddActivity = vi.fn()
+    vi.mocked(useWorkflowStore.getState).mockReturnValue({
+      addActivity: mockAddActivity,
+    } as never)
+
+    registerAAPNode()
+    const registration = NodeRegistry.get(RegistryNodeId.AAP_EXECUTION)
+    const onSuccess = vi.fn()
+    const onError = vi.fn()
+
+    registration?.onSubmit(
+      {
+        name: 'Test AAP Job',
+        use_input_variables: true,
+        organization_name: '',
+        job_template_name: '',
+        job_template_id: undefined,
+      },
+      onSuccess,
+      onError,
+      RegistryNodeId.AAP_JOB_TEMPLATE
+    )
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onSuccess).toHaveBeenCalledWith(expect.any(String))
+    expect(mockAddActivity).toHaveBeenCalled()
+    const activity = mockAddActivity.mock.calls[0]?.[0] as { parameters?: Record<string, unknown> }
+    expect(activity.parameters).not.toHaveProperty('job_template_id')
+  })
+
   it('creates activity even when job_template_id is undefined', () => {
     const mockAddActivity = vi.fn()
     vi.mocked(useWorkflowStore.getState).mockReturnValue({

--- a/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerAAPNode.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerAAPNode.ts
@@ -13,6 +13,7 @@ import {
   buildExpressionModeActivity,
   buildWorkflowExpressionModeActivity,
   hasExpressionValue,
+  isJobTemplateInputVariablesMode,
 } from '../../utils/aapHelpers'
 import { buildNamedActivity } from '../../utils/nodeCreationHelpers'
 import { getDefaultNodeBaseName } from '../../utils/nodeNaming'
@@ -68,7 +69,7 @@ export default function registerAAPNode() {
           // Job Template subtype
           if (subtypeId === RegistryNodeId.AAP_JOB_TEMPLATE) {
             const jobData = data as AAPJobTemplateFormData
-            if (hasExpressionValue(jobData.job_template_name, jobData.organization_name)) {
+            if (isJobTemplateInputVariablesMode(jobData)) {
               const baseName = getDefaultNodeBaseName({
                 nodeTypeId: RegistryNodeId.AAP_JOB_TEMPLATE,
                 label: 'AAP Job Template',

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/aapHelpers.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/aapHelpers.test.ts
@@ -240,6 +240,11 @@ describe('hasExpressionValue', () => {
     expect(hasExpressionValue(undefined, '${expr}', 'test')).toBe(true)
   })
 
+  it('returns true for extra_vars JSON that embeds ${ expressions', () => {
+    expect(hasExpressionValue(undefined, undefined, '{"app_version": "${inputs.version}"}')).toBe(true)
+    expect(hasExpressionValue(JSON.stringify({ app_version: '${inputs.version}' }, null, 2))).toBe(true)
+  })
+
   it('returns false when no values contain ${', () => {
     expect(hasExpressionValue('normal', 'text')).toBe(false)
     expect(hasExpressionValue(undefined, undefined)).toBe(false)

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/aapHelpers.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/aapHelpers.test.ts
@@ -9,6 +9,7 @@ import {
   buildExpressionModeActivity,
   buildWorkflowExpressionModeActivity,
   hasExpressionValue,
+  isJobTemplateInputVariablesMode,
   validateJobTemplateId,
   validateWorkflowTemplateId,
 } from './aapHelpers'
@@ -169,6 +170,11 @@ describe('buildAAPConfig', () => {
     expect(result?.tags).toBeUndefined()
   })
 
+  it('includes useInputVariables when the toggle is on', () => {
+    const result = buildAAPConfig(makeFormData({ use_input_variables: true }))
+    expect(result?.useInputVariables).toBe(true)
+  })
+
   it('includes credentialId when set', () => {
     const result = buildAAPConfig(makeFormData({ credential_id: 'cred-123' }))
     expect(result?.credentialId).toBe('cred-123')
@@ -230,6 +236,27 @@ describe('buildExpressionModeActivity', () => {
     expect(activity.parameters.job_template_name).toBe('${trigger.template}')
     expect(activity.parameters.organization_name).toBe('${trigger.org}')
     expect(activity.parameters).not.toHaveProperty('job_template_id')
+  })
+
+  it('persists use_input_variables without a job template id', () => {
+    const activity = buildExpressionModeActivity('node-1', 'AAP Job', makeFormData({ use_input_variables: true }))
+
+    expect(activity.parameters.use_input_variables).toBe(true)
+    expect(activity.parameters).not.toHaveProperty('job_template_id')
+  })
+})
+
+describe('isJobTemplateInputVariablesMode', () => {
+  it('returns true when use_input_variables is set without expressions', () => {
+    expect(isJobTemplateInputVariablesMode(makeFormData({ use_input_variables: true }))).toBe(true)
+  })
+
+  it('returns true when organization or template contains an expression', () => {
+    expect(isJobTemplateInputVariablesMode(makeFormData({ job_template_name: '${inputs.jt}' }))).toBe(true)
+  })
+
+  it('returns false when toggle is off and names have no expressions', () => {
+    expect(isJobTemplateInputVariablesMode(makeFormData({ job_template_name: 'Deploy' }))).toBe(false)
   })
 })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/aapHelpers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/aapHelpers.ts
@@ -11,6 +11,13 @@ export function hasExpressionValue(...values: (string | undefined)[]): boolean {
   return values.some((v) => v?.includes('${'))
 }
 
+/** True when the job template form is in input-variables (expression) mode. */
+export function isJobTemplateInputVariablesMode(
+  data: Pick<AAPJobTemplateFormData, 'use_input_variables' | 'organization_name' | 'job_template_name'>
+): boolean {
+  return Boolean(data.use_input_variables) || hasExpressionValue(data.organization_name, data.job_template_name)
+}
+
 /**
  * Build an AAP activity in expression mode (template name/org provided as expressions
  * that resolve at runtime rather than a concrete job_template_id).
@@ -22,7 +29,7 @@ export function buildExpressionModeActivity(
 ): ReturnType<typeof createAAPJobTemplateActivity> {
   // job_template_id is set to 0 as a placeholder — expression-mode nodes resolve
   // the template by name at runtime, so the ID is removed from config below.
-  const config = buildAAPConfig(data)
+  const config = { ...buildAAPConfig(data), useInputVariables: true }
   const activity = createAAPJobTemplateActivity(nodeId, name, 0, config)
   if (activity.parameters) {
     activity.parameters.job_template_name = data.job_template_name
@@ -158,6 +165,10 @@ function setDiffModeField(config: AAPJobTemplateConfig, data: AAPJobTemplateForm
   if (data.diff_mode !== undefined) config.diffMode = data.diff_mode
 }
 
+function setUseInputVariablesField(config: AAPJobTemplateConfig, data: AAPJobTemplateFormData): void {
+  if (data.use_input_variables) config.useInputVariables = true
+}
+
 function setInstanceGroupFields(config: AAPJobTemplateConfig, data: AAPJobTemplateFormData): void {
   // Instance group ID (takes precedence over name)
   if (data.instance_group_id !== undefined && data.instance_group_id !== null) {
@@ -185,6 +196,7 @@ export function buildAAPConfig(data: AAPJobTemplateFormData): AAPJobTemplateConf
   setLabelsField(config, data)
   setDiffModeField(config, data)
   setInstanceGroupFields(config, data)
+  setUseInputVariablesField(config, data)
   collectStringFields(config, data)
   collectNumberFields(config, data)
 

--- a/frontend/packages/syntara-ui/src/stores/workflowFactories.test.ts
+++ b/frontend/packages/syntara-ui/src/stores/workflowFactories.test.ts
@@ -741,6 +741,15 @@ describe('workflowFactories', () => {
         expect(activity.parameters.credential_id).toBe('cred-123')
         expect(activity.parameters.integration_id).toBe('int-aap-1')
       })
+
+      it('persists use_input_variables when useInputVariables is true', () => {
+        const activity = createAAPJobTemplateActivity('aap-1', 'Run Playbook', undefined, {
+          useInputVariables: true,
+        })
+
+        expect(activity.parameters.use_input_variables).toBe(true)
+        expect(activity.parameters).not.toHaveProperty('job_template_id')
+      })
     })
 
     describe('createAAPWorkflowTemplateActivity', () => {

--- a/frontend/packages/syntara-ui/src/stores/workflowFactories.ts
+++ b/frontend/packages/syntara-ui/src/stores/workflowFactories.ts
@@ -196,6 +196,7 @@ export type AAPJobTemplateConfig = {
   instanceGroupId?: number
   instanceGroupName?: string
   labels?: string[] // AAP Controller label names (prompt-on-launch override, supports creating new labels)
+  useInputVariables?: boolean
 }
 
 /** Mapping from AAPJobTemplateConfig key → API config key, with a predicate type. */
@@ -222,6 +223,7 @@ const aapConfigMapping: [keyof AAPJobTemplateConfig, string, 'truthy' | 'defined
   ['instanceGroupId', 'instance_group_id', 'defined'],
   ['instanceGroupName', 'instance_group_name', 'truthy'],
   ['labels', 'labels', 'truthy'],
+  ['useInputVariables', 'use_input_variables', 'truthy'],
 ]
 
 /**


### PR DESCRIPTION
## Description

job template "use input variables" was local ui state; reopen dropped the toggle and hid extra_vars. the toggle is now a `use_input_variables` form field on node parameters.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] persist "use input variables" as `use_input_variables` on node parameters
- [x] restore the toggle from that flag
- [x] unit tests for persist / restore / picker extra_vars without expressions

## Out of Scope

job template picker ux beyond the extra_vars toggle. backend extra_vars schema. other aap node types.

## Related Issues

Fixes AAP-88185

## How to Test

1. builder, add launch aap job template
2. enable use input variables, create (no template needed)
3. reopen: toggle stays on


https://github.com/user-attachments/assets/96977816-12e6-4a5e-a6ee-85b1415ddc60


