### PR TITLE
feat(builder): move loop body nodes together when dragging loop [AAP-76892]

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/loop-nodes.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/loop-nodes.spec.ts
@@ -24,8 +24,10 @@ import {
   closeNodeEditorPanel,
   deleteWorkflow,
   openNodeForEditing,
+  openWorkflowInBuilder,
   saveWorkflow,
   startWorkflowWithTrigger,
+  triggerLayout,
   verifyNodeVisible,
   waitForUIReady,
 } from '../helpers/workflows'
@@ -250,6 +252,45 @@ test.describe('Loop Node Configuration [UI-16]', () => {
       }
     })
   }
+
+  test('loop-back edge renders after save and reopen', async ({ app }) => {
+    const workflowName = buildUniqueName('e2e-loop-back-reopen')
+
+    try {
+      await startWorkflowWithTrigger(app)
+
+      await addWhileLoopNode(app, {
+        name: 'Loop header',
+        condition: 'true',
+      })
+      await addChildScriptToLoop(app, 'Loop body', 'print("body")')
+      await waitForUIReady(app)
+      await triggerLayout(app)
+
+      const edgePathCountBeforeSave = await app.locator('svg g.react-flow__edge path').count()
+      expect(edgePathCountBeforeSave).toBeGreaterThanOrEqual(2)
+
+      await saveWorkflow(app, workflowName)
+      const workflowId = app.url().match(/workflow-builder\/([^/?]+)/)?.[1]
+      expect(workflowId).toBeTruthy()
+
+      await openWorkflowInBuilder(app, workflowName, workflowId)
+      await verifyNodeVisible(app, 'Loop header')
+      await verifyNodeVisible(app, 'Loop body')
+      await triggerLayout(app)
+
+      const edgePaths = await app.evaluate(() =>
+        [...document.querySelectorAll('svg g.react-flow__edge path')]
+          .map((path) => path.getAttribute('d'))
+          .filter((path): path is string => Boolean(path))
+      )
+
+      expect(edgePaths.length).toBeGreaterThanOrEqual(2)
+      edgePaths.forEach((path) => expect(path.trim()).toMatch(/^M/))
+    } finally {
+      await deleteWorkflow(app, workflowName)
+    }
+  })
 
   test('verifies configuration persists after multiple edits', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-loop-multi-edit')

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.execution-view.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.execution-view.test.tsx
@@ -41,6 +41,7 @@ vi.mock('@xyflow/react', async (importOriginal) => {
       getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
       getNode: vi.fn(),
     }),
+    useUpdateNodeInternals: () => vi.fn(),
   }
 })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.test.tsx
@@ -59,6 +59,7 @@ vi.mock('@xyflow/react', () => ({
     getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
     getNode: vi.fn(),
   }),
+  useUpdateNodeInternals: () => vi.fn(),
 }))
 
 vi.mock('../workflows/canvas/CanvasControls', () => ({
@@ -165,6 +166,35 @@ const sampleWorkflow = {
 
 const sampleEdges = [
   { id: 'e1', source: 'trigger-0', target: 'task-1', sourceHandle: 'source', targetHandle: 'target' },
+]
+
+const loopWorkflow = {
+  id: 'wf-1',
+  name: 'Loop Workflow',
+  inputs: {},
+  triggers: [{ type: 'manual_trigger', name: 'Manual Trigger' }],
+  workflow: {
+    activities: [
+      {
+        id: 'loop-1',
+        type: 'loop',
+        name: 'While loop',
+        parameters: { type: 'while', condition: 'true', max_iterations: 100 },
+      },
+      {
+        id: 'task-1',
+        type: 'script',
+        name: 'Loop body',
+        parameters: { type: 'script', language: 'python', code: 'print("body")' },
+      },
+    ],
+  },
+}
+
+const loopEdges = [
+  { id: 'e-trigger', source: 'trigger-0', target: 'loop-1', sourceHandle: 'source', targetHandle: 'target' },
+  { id: 'e-loop', source: 'loop-1', target: 'task-1', sourceHandle: 'loop', targetHandle: 'target' },
+  { id: 'e-back', source: 'task-1', target: 'loop-1', sourceHandle: 'source', targetHandle: 'end', type: 'loopBack' },
 ]
 
 const defaultProps = {
@@ -275,6 +305,40 @@ describe('BuilderFlow (builder mode)', () => {
     onNodeDragStop({}, {}, [{ id: 'task-1', position: { x: 100, y: 200 } }])
 
     expect(mockUpdateNodePositions).toHaveBeenCalledWith({ 'task-1': { x: 100, y: 200 } })
+  })
+
+  it('persists loop group body positions via onNodeDragStop handlers', () => {
+    seedWorkflow({
+      currentWorkflow: loopWorkflow,
+      edges: loopEdges,
+      nodePositions: {
+        'loop-1': { x: 0, y: 0 },
+        'task-1': { x: 200, y: 100 },
+      },
+    })
+    render(<BuilderFlow {...defaultProps} />)
+
+    const onNodeDragStart = latestReactFlowProps?.onNodeDragStart as (
+      event: unknown,
+      node: { id: string; type: string; position: { x: number; y: number } },
+      draggedNodes: Array<{ id: string; type: string; position: { x: number; y: number } }>
+    ) => void
+    const onNodeDragStop = latestReactFlowProps?.onNodeDragStop as (
+      event: unknown,
+      node: { id: string; type: string; position: { x: number; y: number } },
+      draggedNodes: Array<{ id: string; type: string; position: { x: number; y: number } }>
+    ) => void
+
+    const loopNode = { id: 'loop-1', type: 'loop', position: { x: 0, y: 0 } }
+    onNodeDragStart({}, loopNode, [loopNode])
+
+    const movedLoopNode = { id: 'loop-1', type: 'loop', position: { x: 50, y: 30 } }
+    onNodeDragStop({}, movedLoopNode, [movedLoopNode])
+
+    expect(mockUpdateNodePositions).toHaveBeenCalledWith({
+      'loop-1': { x: 50, y: 30 },
+      'task-1': { x: 250, y: 130 },
+    })
   })
 
   it('skips updateNodePositions when no nodes were dragged', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 // TODO: Refactor into smaller hooks to reduce file size
 // Suggested hooks: useWorkflowGraphInit, useExecutionStateEnrichment, useCanvasInteractions
 
@@ -289,7 +290,12 @@ export function BuilderFlow(props: BuilderFlowProps) {
 
   useExternalNodeSelection(selectedActivityId, setNodes)
 
-  const { onNodeDragStop, onLayout } = usePositionEventHandlers(nodes, edges, setNodes, setEdges)
+  const { onNodeDragStart, onNodeDrag, onNodeDragStop, onLayout } = usePositionEventHandlers(
+    nodes,
+    edges,
+    setNodes,
+    setEdges
+  )
 
   const onEdgesChange = useCallback(
     (changes: EdgeChange<EdgeType>[]) => {
@@ -597,6 +603,8 @@ export function BuilderFlow(props: BuilderFlowProps) {
           nodeTypes={builderNodeTypes}
           edgeTypes={builderEdgeTypes}
           onNodesChange={onNodesChange}
+          onNodeDragStart={isReadOnly ? undefined : onNodeDragStart}
+          onNodeDrag={isReadOnly ? undefined : onNodeDrag}
           onNodeDragStop={isReadOnly ? undefined : onNodeDragStop}
           onEdgesChange={onEdgesChange}
           onNodesDelete={isReadOnly ? undefined : onNodesDelete}

--- a/frontend/packages/syntara-ui/src/routes/builder/edges/LoopBackEdge.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/edges/LoopBackEdge.test.tsx
@@ -7,18 +7,23 @@ import { LoopBackEdge } from './LoopBackEdge'
 
 const mockNodesConnectable = vi.hoisted(() => ({ value: true }))
 const mockIsHovered = vi.hoisted(() => ({ value: false }))
+const mockNodes = vi.hoisted(() => ({
+  value: [
+    { id: 'loop-node', position: { x: 50, y: 25 }, measured: { height: 50 } },
+    { id: 'body-node', position: { x: 250, y: 125 }, measured: { height: 50 } },
+  ] as Array<{ id: string; position: { x: number; y: number }; measured?: { height: number } }>,
+}))
 
 // Mock @xyflow/react
-const mockGetNodes = vi.fn()
 vi.mock('@xyflow/react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@xyflow/react')>()
   return {
     ...actual,
     useReactFlow: () => ({
-      getNodes: mockGetNodes,
+      getNodes: () => mockNodes.value,
     }),
-    useStore: (selector: (s: { nodesConnectable: boolean }) => boolean) =>
-      selector({ nodesConnectable: mockNodesConnectable.value }),
+    useStore: <T,>(selector: (s: { nodes: typeof mockNodes.value; nodesConnectable: boolean }) => T) =>
+      selector({ nodes: mockNodes.value, nodesConnectable: mockNodesConnectable.value }),
   }
 })
 
@@ -67,10 +72,10 @@ describe('LoopBackEdge', () => {
   }
 
   beforeEach(() => {
-    mockGetNodes.mockReturnValue([
+    mockNodes.value = [
       { id: 'loop-node', position: { x: 50, y: 25 }, measured: { height: 50 } },
       { id: 'body-node', position: { x: 250, y: 125 }, measured: { height: 50 } },
-    ])
+    ]
   })
 
   it('renders EdgePath', () => {
@@ -94,22 +99,36 @@ describe('LoopBackEdge', () => {
   })
 
   it('calculates path around loop body nodes', () => {
-    // Add an intermediate node
-    mockGetNodes.mockReturnValue([
+    mockNodes.value = [
       { id: 'loop-node', position: { x: 50, y: 25 }, measured: { height: 50 } },
       { id: 'body-node', position: { x: 250, y: 125 }, measured: { height: 50 } },
       { id: 'middle-node', position: { x: 150, y: 25 }, measured: { height: 100 } },
-    ])
+    ]
 
     render(<LoopBackEdge {...defaultProps} />)
     expect(screen.getByTestId('edge-path')).toBeInTheDocument()
   })
 
+  it('updates path when node measured height changes', () => {
+    const { rerender } = render(<LoopBackEdge {...defaultProps} />)
+    const initialPath = screen.getByTestId('edge-path').getAttribute('d')
+
+    mockNodes.value = [
+      { id: 'loop-node', position: { x: 50, y: 25 }, measured: { height: 50 } },
+      { id: 'body-node', position: { x: 250, y: 125 }, measured: { height: 120 } },
+    ]
+    rerender(<LoopBackEdge {...defaultProps} />)
+
+    const updatedPath = screen.getByTestId('edge-path').getAttribute('d')
+    expect(updatedPath).toBeTruthy()
+    expect(updatedPath).not.toBe(initialPath)
+  })
+
   it('handles nodes without measured dimensions', () => {
-    mockGetNodes.mockReturnValue([
+    mockNodes.value = [
       { id: 'loop-node', position: { x: 50, y: 25 } },
       { id: 'body-node', position: { x: 250, y: 125 } },
-    ])
+    ]
 
     render(<LoopBackEdge {...defaultProps} />)
     expect(screen.getByTestId('edge-path')).toBeInTheDocument()

--- a/frontend/packages/syntara-ui/src/routes/builder/edges/LoopBackEdge.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/edges/LoopBackEdge.tsx
@@ -1,15 +1,13 @@
-import { useReactFlow, Position, useStore } from '@xyflow/react'
+import { Position, useStore } from '@xyflow/react'
+import { useCallback } from 'react'
 
 import { EdgeActions } from './EdgeActions'
 import { EdgeLabel } from './EdgeLabel'
 import { EdgePath } from './EdgePath'
 import { adjustSourceCoordinates } from './edgeUtils'
+import { loopBackEdgeGeometryEqual, selectLoopBackEdgeGeometry } from './loopBackEdgeGeometry'
 import type { BaseEdgeProps } from './types'
 import { useEdgeHandlers } from './useEdgeHandlers'
-
-function getNodeBottom(node: { position: { y: number }; measured?: { height?: number } }): number {
-  return node.position.y + (node.measured?.height ?? 0)
-}
 
 /**
  * Loop-back edge component with custom path routing
@@ -18,8 +16,12 @@ function getNodeBottom(node: { position: { y: number }; measured?: { height?: nu
  */
 export function LoopBackEdge(props: BaseEdgeProps) {
   const { sourceX, sourceY, targetX, targetY, label, style, id, source, target, data, markerEnd, selected } = props
-  const reactFlowInstance = useReactFlow()
-  const { getNodes } = reactFlowInstance
+  const geometrySelector = useCallback(
+    (state: { nodes: Parameters<typeof selectLoopBackEdgeGeometry>[0] }) =>
+      selectLoopBackEdgeGeometry(state.nodes, { source, target, sourceX, sourceY, targetX, targetY }),
+    [source, target, sourceX, sourceY, targetX, targetY]
+  )
+  const geometry = useStore(geometrySelector, loopBackEdgeGeometryEqual)
   const nodesConnectable = useStore((s) => s.nodesConnectable)
 
   const {
@@ -41,41 +43,7 @@ export function LoopBackEdge(props: BaseEdgeProps) {
     data,
   })
 
-  // Calculate vertical offset dynamically based on nodes in the loop body
-  // Find the loop node (target of this edge)
-  const targetNode = getNodes().find((n) => n.id === target)
-  const sourceNode = getNodes().find((n) => n.id === source)
-
-  // Calculate the maximum bottom position so the edge's horizontal segment goes below the loop node and all loop body nodes
-  let maxBottomY = sourceY
-
-  if (targetNode && sourceNode) {
-    // Include the loop node (target) so the edge passes below it and isn't hidden underneath
-    maxBottomY = Math.max(maxBottomY, getNodeBottom(targetNode))
-
-    // Include the source node (last node in the loop body)
-    maxBottomY = Math.max(maxBottomY, getNodeBottom(sourceNode))
-
-    // Also include any other nodes between target and source
-    const allNodes = getNodes()
-    const loopBodyNodes = allNodes.filter((node) => {
-      if (!node.position || node.measured?.height == null) return false // Skip nodes without position or height (include height === 0)
-      if (node.id === source || node.id === target) return false // Already handled by target/source nodes
-      const nodeY = node.position.y + node.measured.height / 2
-      const nodeX = node.position.x
-      // Nodes at similar Y level to target/source and between them horizontally
-      return (
-        Math.abs(nodeY - targetY) < 100 && // Similar Y level (within 100px)
-        nodeX > targetX && // To the right of target (loop node)
-        nodeX < sourceX // To the left of source (last node in loop)
-      )
-    })
-
-    // Find the maximum bottom edge of these nodes
-    loopBodyNodes.forEach((node) => {
-      maxBottomY = Math.max(maxBottomY, getNodeBottom(node))
-    })
-  }
+  const maxBottomY = geometry.loopBodyMaxBottom
 
   const { x: adjustedSourceX, y: adjustedSourceY } = adjustSourceCoordinates(sourceX, sourceY, Position.Right)
 

--- a/frontend/packages/syntara-ui/src/routes/builder/edges/loopBackEdgeGeometry.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/edges/loopBackEdgeGeometry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { loopBackEdgeGeometryEqual, selectLoopBackEdgeGeometry } from './loopBackEdgeGeometry'
+
+describe('selectLoopBackEdgeGeometry', () => {
+  const nodes = [
+    { id: 'loop-node', position: { x: 50, y: 25 }, measured: { height: 50 } },
+    { id: 'body-node', position: { x: 250, y: 125 }, measured: { height: 50 } },
+    { id: 'middle-node', position: { x: 150, y: 25 }, measured: { height: 100 } },
+  ]
+
+  it('includes loop, source, and intermediate body nodes in max bottom', () => {
+    const geometry = selectLoopBackEdgeGeometry(nodes, {
+      source: 'body-node',
+      target: 'loop-node',
+      sourceX: 300,
+      sourceY: 150,
+      targetX: 100,
+      targetY: 50,
+    })
+
+    expect(geometry.loopBodyMaxBottom).toBe(175)
+    expect(geometry.source).toEqual({ x: 250, y: 125, height: 50 })
+    expect(geometry.target).toEqual({ x: 50, y: 25, height: 50 })
+  })
+
+  it('returns sourceY when nodes are missing geometry', () => {
+    const geometry = selectLoopBackEdgeGeometry([{ id: 'loop-node', position: { x: 50, y: 25 } }], {
+      source: 'body-node',
+      target: 'loop-node',
+      sourceX: 300,
+      sourceY: 150,
+      targetX: 100,
+      targetY: 50,
+    })
+
+    expect(geometry.loopBodyMaxBottom).toBe(150)
+    expect(geometry.source).toBeUndefined()
+  })
+})
+
+describe('loopBackEdgeGeometryEqual', () => {
+  it('detects changes in loop body max bottom', () => {
+    const a = { loopBodyMaxBottom: 100, source: { x: 1, y: 2, height: 50 }, target: { x: 3, y: 4, height: 50 } }
+    const b = { ...a, loopBodyMaxBottom: 120 }
+
+    expect(loopBackEdgeGeometryEqual(a, a)).toBe(true)
+    expect(loopBackEdgeGeometryEqual(a, b)).toBe(false)
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/builder/edges/loopBackEdgeGeometry.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/edges/loopBackEdgeGeometry.ts
@@ -1,0 +1,85 @@
+type FlowNodeSnapshot = {
+  id: string
+  position?: { x: number; y: number }
+  measured?: { height?: number }
+}
+
+export type LoopBackEdgeGeometry = {
+  source?: { x: number; y: number; height: number }
+  target?: { x: number; y: number; height: number }
+  loopBodyMaxBottom: number
+}
+
+export type LoopBackEdgeGeometryContext = {
+  source: string
+  target: string
+  sourceX: number
+  sourceY: number
+  targetX: number
+  targetY: number
+}
+
+function hasPosition(node: FlowNodeSnapshot): node is FlowNodeSnapshot & { position: { x: number; y: number } } {
+  return node.position != null
+}
+
+function getNodeBottom(node: { position: { y: number }; measured?: { height?: number } }): number {
+  return node.position.y + (node.measured?.height ?? 0)
+}
+
+/**
+ * Selects only the node geometry LoopBackEdge needs for path routing.
+ * Keeps subscriptions narrow so unrelated node updates do not re-render the edge.
+ */
+export function selectLoopBackEdgeGeometry(
+  nodes: FlowNodeSnapshot[],
+  { source, target, sourceX, sourceY, targetX, targetY }: LoopBackEdgeGeometryContext
+): LoopBackEdgeGeometry {
+  const targetNode = nodes.find((n) => n.id === target)
+  const sourceNode = nodes.find((n) => n.id === source)
+
+  let loopBodyMaxBottom = sourceY
+
+  if (targetNode && hasPosition(targetNode)) {
+    loopBodyMaxBottom = Math.max(loopBodyMaxBottom, getNodeBottom(targetNode))
+  }
+  if (sourceNode && hasPosition(sourceNode)) {
+    loopBodyMaxBottom = Math.max(loopBodyMaxBottom, getNodeBottom(sourceNode))
+  }
+
+  if (targetNode && sourceNode) {
+    nodes.forEach((node) => {
+      if (!hasPosition(node) || node.measured?.height == null) return
+      if (node.id === source || node.id === target) return
+      const nodeY = node.position.y + node.measured.height / 2
+      const nodeX = node.position.x
+      if (Math.abs(nodeY - targetY) < 100 && nodeX > targetX && nodeX < sourceX) {
+        loopBodyMaxBottom = Math.max(loopBodyMaxBottom, getNodeBottom(node))
+      }
+    })
+  }
+
+  return {
+    source:
+      sourceNode && hasPosition(sourceNode)
+        ? { x: sourceNode.position.x, y: sourceNode.position.y, height: sourceNode.measured?.height ?? 0 }
+        : undefined,
+    target:
+      targetNode && hasPosition(targetNode)
+        ? { x: targetNode.position.x, y: targetNode.position.y, height: targetNode.measured?.height ?? 0 }
+        : undefined,
+    loopBodyMaxBottom,
+  }
+}
+
+export function loopBackEdgeGeometryEqual(a: LoopBackEdgeGeometry, b: LoopBackEdgeGeometry): boolean {
+  if (a.loopBodyMaxBottom !== b.loopBodyMaxBottom) return false
+  if (!!a.source !== !!b.source || !!a.target !== !!b.target) return false
+  if (a.source && b.source) {
+    if (a.source.x !== b.source.x || a.source.y !== b.source.y || a.source.height !== b.source.height) return false
+  }
+  if (a.target && b.target) {
+    if (a.target.x !== b.target.x || a.target.y !== b.target.y || a.target.height !== b.target.height) return false
+  }
+  return true
+}

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useLoopGroupPositionSync.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useLoopGroupPositionSync.test.ts
@@ -1,0 +1,106 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
+import type { EdgeType } from '../utils/workflowToGraph'
+
+import { useLoopGroupPositionSync } from './useLoopGroupPositionSync'
+
+const mockUpdateNodeInternals = vi.fn()
+const mockUpdateNodePositions = vi.fn()
+
+let storeState: Record<string, unknown> = {}
+
+vi.mock('@xyflow/react', () => ({
+  useUpdateNodeInternals: () => mockUpdateNodeInternals,
+}))
+
+vi.mock('../../../stores/useWorkflowStore', () => ({
+  useWorkflowStore: (selector: (state: Record<string, unknown>) => unknown) => selector(storeState),
+  selectWorkflowVersion: (state: Record<string, unknown>) => state.workflowVersion,
+  selectTriggers: (state: Record<string, unknown>) =>
+    (state.currentWorkflow as { triggers?: Array<{ id: string }> } | undefined)?.triggers,
+}))
+
+function makeNode(id: string, type = 'task', position = { x: 0, y: 0 }): NodeType {
+  return { id, type, position, data: {} } as unknown as NodeType
+}
+
+function makeEdge(id: string, source: string, target: string, sourceHandle: string): EdgeType {
+  return { id, source, target, sourceHandle } as unknown as EdgeType
+}
+
+describe('useLoopGroupPositionSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storeState = { workflowVersion: 1, currentWorkflow: { triggers: [] } }
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  it('does nothing before initialization', () => {
+    renderHook(() =>
+      useLoopGroupPositionSync({
+        nodes: [makeNode('loop-1', 'loop')],
+        edges: [],
+        isInitialized: false,
+        updateNodePositions: mockUpdateNodePositions,
+      })
+    )
+
+    expect(mockUpdateNodePositions).not.toHaveBeenCalled()
+    expect(mockUpdateNodeInternals).not.toHaveBeenCalled()
+  })
+
+  it('syncs loop group positions and refreshes node internals after init', () => {
+    const nodes = [makeNode('loop-1', 'loop', { x: 10, y: 20 }), makeNode('task-1', 'task', { x: 110, y: 70 })]
+    const edges = [makeEdge('e-loop', 'loop-1', 'task-1', 'loop')]
+
+    renderHook(() =>
+      useLoopGroupPositionSync({
+        nodes,
+        edges,
+        isInitialized: true,
+        updateNodePositions: mockUpdateNodePositions,
+      })
+    )
+
+    expect(mockUpdateNodePositions).toHaveBeenCalledWith(
+      {
+        'loop-1': { x: 10, y: 20 },
+        'task-1': { x: 110, y: 70 },
+      },
+      { skipTracking: true, markDirty: false }
+    )
+    expect(mockUpdateNodeInternals).toHaveBeenCalledWith('loop-1')
+    expect(mockUpdateNodeInternals).toHaveBeenCalledWith('task-1')
+  })
+
+  it('runs only once per workflow version', () => {
+    const nodes = [makeNode('loop-1', 'loop', { x: 10, y: 20 }), makeNode('task-1', 'task', { x: 110, y: 70 })]
+    const edges = [makeEdge('e-loop', 'loop-1', 'task-1', 'loop')]
+
+    const { rerender } = renderHook(
+      ({ nodes: hookNodes }) =>
+        useLoopGroupPositionSync({
+          nodes: hookNodes,
+          edges,
+          isInitialized: true,
+          updateNodePositions: mockUpdateNodePositions,
+        }),
+      { initialProps: { nodes } }
+    )
+
+    expect(mockUpdateNodePositions).toHaveBeenCalledTimes(1)
+
+    rerender({ nodes })
+    expect(mockUpdateNodePositions).toHaveBeenCalledTimes(1)
+
+    storeState = { ...storeState, workflowVersion: 2 }
+    rerender({ nodes })
+    expect(mockUpdateNodePositions).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useLoopGroupPositionSync.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useLoopGroupPositionSync.ts
@@ -1,0 +1,57 @@
+import { useUpdateNodeInternals } from '@xyflow/react'
+import { useEffect, useRef } from 'react'
+
+import { selectTriggers, selectWorkflowVersion, useWorkflowStore } from '../../../stores/useWorkflowStore'
+import { toPositionKey } from '../../../utils/triggerNodeIds'
+import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
+import { collectLoopGroupPositions, getLoopGroupNodeIds } from '../utils/loopUtils'
+import type { EdgeType } from '../utils/workflowToGraph'
+
+/** Stable empty array so `?? EMPTY_TRIGGERS` does not recreate deps every render. */
+const EMPTY_TRIGGERS: Array<{ id: string }> = []
+
+type UseLoopGroupPositionSyncParams = {
+  nodes: NodeType[]
+  edges: EdgeType[]
+  isInitialized: boolean
+  updateNodePositions: (
+    positions: Record<string, { x: number; y: number }>,
+    options?: { markDirty?: boolean; skipTracking?: boolean }
+  ) => void
+}
+
+/**
+ * After workflow init, syncs loop-group node positions into the store and refreshes
+ * React Flow handle geometry so loop-back edges route correctly on load/reopen.
+ */
+export function useLoopGroupPositionSync({
+  nodes,
+  edges,
+  isInitialized,
+  updateNodePositions,
+}: UseLoopGroupPositionSyncParams) {
+  const workflowVersion = useWorkflowStore(selectWorkflowVersion)
+  const triggers = useWorkflowStore(selectTriggers) ?? EMPTY_TRIGGERS
+  const updateNodeInternals = useUpdateNodeInternals()
+  const syncedVersionRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!isInitialized) return
+    if (syncedVersionRef.current === workflowVersion) return
+    syncedVersionRef.current = workflowVersion
+
+    const groupPositions = collectLoopGroupPositions(nodes, edges, (id) => toPositionKey(id, triggers))
+    if (Object.keys(groupPositions).length > 0) {
+      updateNodePositions(groupPositions, { skipTracking: true, markDirty: false })
+    }
+
+    const groupNodeIds = getLoopGroupNodeIds(nodes, edges)
+    if (groupNodeIds.size === 0) return
+
+    // Defer until after React Flow finishes applying restored dimensions.
+    const frameId = requestAnimationFrame(() => {
+      groupNodeIds.forEach((nodeId) => updateNodeInternals(nodeId))
+    })
+    return () => cancelAnimationFrame(frameId)
+  }, [nodes, edges, isInitialized, workflowVersion, triggers, updateNodePositions, updateNodeInternals])
+}

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodePositioning.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodePositioning.test.tsx
@@ -5,6 +5,10 @@ import type { FlowPosition } from '../types'
 
 import { useNodePositioning } from './useNodePositioning'
 
+vi.mock('./useLoopGroupPositionSync', () => ({
+  useLoopGroupPositionSync: vi.fn(),
+}))
+
 describe('useNodePositioning', () => {
   const mockSetNodes = vi.fn()
   const mockGetViewport = vi.fn(() => ({ x: 0, y: 0, zoom: 1 }))

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodePositioning.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodePositioning.ts
@@ -8,6 +8,8 @@ import type { FlowPosition } from '../types'
 import { LOOP_BODY_SPACING } from '../utils/layoutConstants'
 import type { EdgeType } from '../utils/workflowToGraph'
 
+import { useLoopGroupPositionSync } from './useLoopGroupPositionSync'
+
 type UseNodePositioningParams = {
   nodes: NodeType[]
   edges: EdgeType[]
@@ -281,6 +283,7 @@ export function useNodePositioning({
   desiredPosition,
   onClearDesiredPosition,
 }: UseNodePositioningParams) {
+  useLoopGroupPositionSync({ nodes, edges, isInitialized, updateNodePositions })
   const loopPositionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/usePositionEventHandlers.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/usePositionEventHandlers.test.ts
@@ -2,16 +2,18 @@ import { renderHook } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
+import type { EdgeType } from '../utils/workflowToGraph'
 
 import { usePositionEventHandlers } from './usePositionEventHandlers'
 
 const mockUpdateNodePositions = vi.fn()
 const mockFitView = vi.fn().mockResolvedValue(undefined)
+const mockGetNodes = vi.fn()
 
 let storeState: Record<string, unknown> = {}
 
 vi.mock('@xyflow/react', () => ({
-  useReactFlow: () => ({ fitView: mockFitView }),
+  useReactFlow: () => ({ fitView: mockFitView, getNodes: mockGetNodes }),
 }))
 
 vi.mock('../../../stores/useWorkflowStore', () => {
@@ -35,8 +37,12 @@ vi.mock('../utils/layoutEngine', () => ({
   }),
 }))
 
-function makeNode(id: string, position = { x: 0, y: 0 }): NodeType {
-  return { id, type: 'task', position, data: {} } as unknown as NodeType
+function makeNode(id: string, position = { x: 0, y: 0 }, type = 'task'): NodeType {
+  return { id, type, position, data: {} } as unknown as NodeType
+}
+
+function makeEdge(id: string, source: string, target: string, sourceHandle: string): EdgeType {
+  return { id, source, target, sourceHandle } as unknown as EdgeType
 }
 
 describe('usePositionEventHandlers', () => {
@@ -128,6 +134,127 @@ describe('usePositionEventHandlers', () => {
       result.current.onLayout()
 
       expect(mockFitView).toHaveBeenCalledWith({ maxZoom: 1 })
+    })
+  })
+
+  describe('loop group drag', () => {
+    it('moves body nodes alongside the loop node during drag', () => {
+      const loopNode = makeNode('loop-1', { x: 0, y: 0 }, 'loop')
+      const bodyNode = makeNode('task-1', { x: 100, y: 50 }, 'task')
+      const edges = [makeEdge('e-loop', 'loop-1', 'task-1', 'loop')]
+      const { result } = renderSyncHook([loopNode, bodyNode], edges)
+
+      result.current.onNodeDragStart({} as never, loopNode, [loopNode])
+      const movedLoopNode = makeNode('loop-1', { x: 40, y: 20 }, 'loop')
+      result.current.onNodeDrag({} as never, movedLoopNode)
+
+      expect(mockSetNodes).toHaveBeenCalled()
+      const updater = mockSetNodes.mock.calls[0][0] as (prev: NodeType[]) => NodeType[]
+      const updated = updater([loopNode, bodyNode])
+      const updatedBody = updated.find((n) => n.id === 'task-1')
+
+      // Body should be at new loop position + original offset (100, 50)
+      expect(updatedBody?.position).toEqual({ x: 140, y: 70 })
+    })
+
+    it('does not call setNodes when dragging a non-loop node', () => {
+      const taskNode = makeNode('task-1', { x: 0, y: 0 }, 'task')
+      const { result } = renderSyncHook([taskNode])
+
+      result.current.onNodeDragStart({} as never, taskNode, [taskNode])
+      result.current.onNodeDrag({} as never, makeNode('task-1', { x: 50, y: 30 }, 'task'))
+
+      expect(mockSetNodes).not.toHaveBeenCalled()
+    })
+
+    it('does not start group drag when loop has no body nodes', () => {
+      const loopNode = makeNode('loop-1', { x: 0, y: 0 }, 'loop')
+      const { result } = renderSyncHook([loopNode], []) // no edges connecting body
+
+      result.current.onNodeDragStart({} as never, loopNode, [loopNode])
+      result.current.onNodeDrag({} as never, makeNode('loop-1', { x: 50, y: 30 }, 'loop'))
+
+      expect(mockSetNodes).not.toHaveBeenCalled()
+    })
+
+    it('persists loop and body positions together in one updateNodePositions call', () => {
+      const loopNode = makeNode('loop-1', { x: 0, y: 0 }, 'loop')
+      const bodyNode = makeNode('task-1', { x: 100, y: 50 }, 'task')
+      const edges = [makeEdge('e-loop', 'loop-1', 'task-1', 'loop')]
+      const { result } = renderSyncHook([loopNode, bodyNode], edges)
+
+      result.current.onNodeDragStart({} as never, loopNode, [loopNode])
+      const movedLoopNode = makeNode('loop-1', { x: 40, y: 20 }, 'loop')
+      result.current.onNodeDragStop({} as never, movedLoopNode, [movedLoopNode])
+
+      expect(mockUpdateNodePositions).toHaveBeenCalledWith({
+        'loop-1': { x: 40, y: 20 },
+        'task-1': { x: 140, y: 70 },
+      })
+    })
+
+    it('persists body positions from drag offsets when getNodes would be stale', () => {
+      const loopNode = makeNode('loop-1', { x: 0, y: 0 }, 'loop')
+      const bodyNode = makeNode('task-1', { x: 100, y: 50 }, 'task')
+      const edges = [makeEdge('e-loop', 'loop-1', 'task-1', 'loop')]
+      const { result } = renderSyncHook([loopNode, bodyNode], edges)
+
+      result.current.onNodeDragStart({} as never, loopNode, [loopNode])
+      const movedLoopNode = makeNode('loop-1', { x: 40, y: 20 }, 'loop')
+      mockGetNodes.mockReturnValue([movedLoopNode, bodyNode])
+      result.current.onNodeDragStop({} as never, movedLoopNode, [movedLoopNode])
+
+      expect(mockUpdateNodePositions).toHaveBeenCalledWith({
+        'loop-1': { x: 40, y: 20 },
+        'task-1': { x: 140, y: 70 },
+      })
+    })
+
+    it('does not include body nodes when loop has no drag state on stop', () => {
+      const loopNode = makeNode('loop-1', { x: 0, y: 0 }, 'loop')
+      const { result } = renderSyncHook([loopNode])
+
+      // Stop without a prior start (simulates edge case / programmatic drag)
+      const movedLoopNode = makeNode('loop-1', { x: 40, y: 20 }, 'loop')
+      result.current.onNodeDragStop({} as never, movedLoopNode, [movedLoopNode])
+
+      expect(mockUpdateNodePositions).toHaveBeenCalledWith({ 'loop-1': { x: 40, y: 20 } })
+    })
+
+    it('skips already-selected body nodes to avoid double-movement', () => {
+      const loopNode = makeNode('loop-1', { x: 0, y: 0 }, 'loop')
+      const bodyNode = makeNode('task-1', { x: 100, y: 50 }, 'task')
+      const edges = [makeEdge('e-loop', 'loop-1', 'task-1', 'loop')]
+      const { result } = renderSyncHook([loopNode, bodyNode], edges)
+
+      // Both loop and body node are in draggedNodes (multi-select)
+      result.current.onNodeDragStart({} as never, loopNode, [loopNode, bodyNode])
+      result.current.onNodeDrag({} as never, makeNode('loop-1', { x: 40, y: 20 }, 'loop'))
+
+      // setNodes should NOT be called since body is already being dragged by React Flow
+      expect(mockSetNodes).not.toHaveBeenCalled()
+    })
+
+    it('moves done-branch nodes alongside the loop node during drag', () => {
+      const loopNode = makeNode('loop-1', { x: 0, y: 0 }, 'loop')
+      const loopBodyNode = makeNode('task-loop', { x: 100, y: 50 }, 'task')
+      const doneNode = makeNode('task-done', { x: 100, y: -80 }, 'task')
+      const edges = [
+        makeEdge('e-loop', 'loop-1', 'task-loop', 'loop'),
+        makeEdge('e-done', 'loop-1', 'task-done', 'done'),
+      ]
+      const { result } = renderSyncHook([loopNode, loopBodyNode, doneNode], edges)
+
+      result.current.onNodeDragStart({} as never, loopNode, [loopNode])
+      const movedLoopNode = makeNode('loop-1', { x: 40, y: 20 }, 'loop')
+      result.current.onNodeDrag({} as never, movedLoopNode)
+
+      expect(mockSetNodes).toHaveBeenCalled()
+      const updater = mockSetNodes.mock.calls[0][0] as (prev: NodeType[]) => NodeType[]
+      const updated = updater([loopNode, loopBodyNode, doneNode])
+      const updatedDone = updated.find((n) => n.id === 'task-done')
+
+      expect(updatedDone?.position).toEqual({ x: 140, y: -60 })
     })
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/usePositionEventHandlers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/usePositionEventHandlers.ts
@@ -1,6 +1,7 @@
 import { useReactFlow, type OnNodeDrag } from '@xyflow/react'
 import { useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react'
 
+import { FlowNodeType } from '../../../constants'
 import {
   useWorkflowStore,
   useWorkflowStoreActions,
@@ -10,8 +11,16 @@ import {
 import { detachPromise } from '../../../utils/detachPromise'
 import { toPositionKey } from '../../../utils/triggerNodeIds'
 import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
+import { filterRealEdges, filterRealNodes } from '../utils/filterHelpers'
 import { getLayoutedElements } from '../utils/layoutEngine'
+import { getLoopBodyMap } from '../utils/loopUtils'
 import type { EdgeType } from '../utils/workflowToGraph'
+
+type LoopDragState = {
+  loopNodeId: string
+  /** Offsets of non-selected body nodes relative to the loop node at drag start */
+  offsets: Map<string, { dx: number; dy: number }>
+}
 
 export function usePositionEventHandlers(
   nodes: NodeType[],
@@ -39,11 +48,78 @@ export function usePositionEventHandlers(
     )
   }, [positionUndoVersion, currentWorkflow?.triggers, setNodes])
 
+  const loopDragRef = useRef<LoopDragState | null>(null)
+
+  const onNodeDragStart = useCallback(
+    (_event: Parameters<OnNodeDrag<NodeType>>[0], node: NodeType, draggedNodes: NodeType[]) => {
+      if (node.type !== FlowNodeType.LOOP) {
+        loopDragRef.current = null
+        return
+      }
+      const bodyMap = getLoopBodyMap(filterRealNodes(nodes), filterRealEdges(edges), { includeDoneBranch: true })
+      const bodyNodeIds = bodyMap.get(node.id)
+      if (!bodyNodeIds || bodyNodeIds.length === 0) {
+        loopDragRef.current = null
+        return
+      }
+      // Only track body nodes that aren't already being dragged by React Flow (multi-select case)
+      const draggedNodeIds = new Set(draggedNodes.map((n) => n.id))
+      const offsets = new Map<string, { dx: number; dy: number }>()
+      for (const bodyId of bodyNodeIds) {
+        if (draggedNodeIds.has(bodyId)) continue
+        const bodyNode = nodes.find((n) => n.id === bodyId)
+        if (bodyNode) {
+          offsets.set(bodyId, {
+            dx: bodyNode.position.x - node.position.x,
+            dy: bodyNode.position.y - node.position.y,
+          })
+        }
+      }
+      if (offsets.size === 0) {
+        loopDragRef.current = null
+        return
+      }
+      loopDragRef.current = { loopNodeId: node.id, offsets }
+    },
+    [nodes, edges]
+  )
+
+  const onNodeDrag = useCallback(
+    (_event: Parameters<OnNodeDrag<NodeType>>[0], node: NodeType) => {
+      if (loopDragRef.current?.loopNodeId !== node.id) return
+      const { offsets } = loopDragRef.current
+      setNodes((prev) =>
+        prev.map((n) => {
+          const offset = offsets.get(n.id)
+          if (!offset) return n
+          return { ...n, position: { x: node.position.x + offset.dx, y: node.position.y + offset.dy } }
+        })
+      )
+    },
+    [setNodes]
+  )
+
   const onNodeDragStop = useCallback(
-    (_event: Parameters<OnNodeDrag<NodeType>>[0], _node: NodeType, draggedNodes: NodeType[]) => {
+    (_event: Parameters<OnNodeDrag<NodeType>>[0], node: NodeType, draggedNodes: NodeType[]) => {
       if (draggedNodes.length === 0) return
       const trigs = currentWorkflow?.triggers ?? []
-      updateNodePositions(Object.fromEntries(draggedNodes.map((n) => [toPositionKey(n.id, trigs), n.position])))
+      const positions: Record<string, { x: number; y: number }> = Object.fromEntries(
+        draggedNodes.map((n) => [toPositionKey(n.id, trigs), n.position])
+      )
+      // Include body nodes moved during loop group drag using offsets captured at drag start.
+      // This avoids relying on React Flow's getNodes() being flushed before drag stop.
+      // Require node.id so `undefined === undefined` cannot match when loopDrag is null.
+      const loopDrag = loopDragRef.current
+      if (node.id && loopDrag?.loopNodeId === node.id) {
+        for (const [bodyId, offset] of loopDrag.offsets) {
+          positions[toPositionKey(bodyId, trigs)] = {
+            x: node.position.x + offset.dx,
+            y: node.position.y + offset.dy,
+          }
+        }
+        loopDragRef.current = null
+      }
+      updateNodePositions(positions)
     },
     [updateNodePositions, currentWorkflow?.triggers]
   )
@@ -62,5 +138,5 @@ export function usePositionEventHandlers(
     [nodes, edges, setNodes, setEdges, fitView, updateNodePositions, currentWorkflow?.triggers]
   )
 
-  return { onNodeDragStop, onLayout }
+  return { onNodeDragStart, onNodeDrag, onNodeDragStop, onLayout }
 }

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/layoutEngine.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/layoutEngine.ts
@@ -5,6 +5,7 @@ import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
 
 import { filterRealEdges, filterRealNodes } from './filterHelpers'
 import { LOOP_BODY_SPACING } from './layoutConstants'
+import { getLoopBodyMap } from './loopUtils'
 import type { EdgeType } from './workflowToGraph'
 
 type DagreNodeLabel = {
@@ -101,62 +102,19 @@ function calculateLoopBodyPositions(
 }
 
 /**
- * Identify loop structures and their body nodes
+ * Identify loop structures and their body nodes.
+ * Delegates BFS traversal to getLoopBodyMap and derives auxiliary maps from the result.
  */
 function identifyLoopStructures(realNodes: NodeType[], realEdges: EdgeType[]) {
+  const loopBodies = getLoopBodyMap(realNodes, realEdges)
   const loopBodyNodes = new Set<string>()
   const loopParents = new Map<string, string>() // Map: nodeId -> loopNodeId
-  const loopBodies = new Map<string, string[]>() // Map: loopNodeId -> array of body node IDs
 
-  realNodes.forEach((node) => {
-    if (node.type === 'loop') {
-      // Find all edges from this loop's 'loop' handle
-      const loopEdges = realEdges.filter((e) => e.source === node.id && e.sourceHandle === EdgeHandleEnum.LOOP)
-      const bodyNodeIds: string[] = []
-
-      loopEdges.forEach((loopEdge) => {
-        // Traverse from loop edge to find all nodes that connect back to loop's end handle
-        const visited = new Set<string>()
-        const queue: string[] = [loopEdge.target]
-
-        // SECURITY: Secondary iteration limit as defense-in-depth (visited set is primary defense)
-        const MAX_ITERATIONS = 10_000
-        let iterations = 0
-
-        while (queue.length > 0 && iterations < MAX_ITERATIONS) {
-          iterations++
-          const nodeId = queue[0]
-          queue.shift()
-          if (visited.has(nodeId)) continue
-          visited.add(nodeId)
-
-          loopBodyNodes.add(nodeId)
-          loopParents.set(nodeId, node.id)
-          bodyNodeIds.push(nodeId)
-
-          // SECURITY: Domain-invariant check — loop body can't exceed total node count
-          if (loopBodyNodes.size > realNodes.length) {
-            break
-          }
-
-          // Find outgoing edges (but don't follow edges back to the loop node)
-          // We exclude ANY edge that points back to the loop node to prevent circular traversal
-          const outgoing = realEdges.filter(
-            (e) => e.source === nodeId && e.sourceHandle === EdgeHandleEnum.SOURCE && e.target !== node.id // Don't follow edges back to the loop node itself
-          )
-
-          outgoing.forEach((e) => {
-            if (!visited.has(e.target)) {
-              queue.push(e.target)
-            }
-          })
-        }
-      })
-
-      if (bodyNodeIds.length > 0) {
-        loopBodies.set(node.id, bodyNodeIds)
-      }
-    }
+  loopBodies.forEach((bodyNodeIds, loopNodeId) => {
+    bodyNodeIds.forEach((nodeId) => {
+      loopBodyNodes.add(nodeId)
+      loopParents.set(nodeId, loopNodeId)
+    })
   })
 
   return { loopBodyNodes, loopParents, loopBodies }

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/loopUtils.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/loopUtils.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+
+import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
+
+import { collectLoopGroupPositions, getLoopBodyMap } from './loopUtils'
+import type { EdgeType } from './workflowToGraph'
+
+function makeNode(id: string, type = 'task'): NodeType {
+  return { id, type, position: { x: 0, y: 0 }, data: {} } as unknown as NodeType
+}
+
+function makeEdge(id: string, source: string, target: string, sourceHandle: string): EdgeType {
+  return { id, source, target, sourceHandle } as unknown as EdgeType
+}
+
+describe('getLoopBodyMap', () => {
+  it('returns empty map when there are no loop nodes', () => {
+    const nodes = [makeNode('task-1'), makeNode('task-2')]
+    const edges = [makeEdge('e1', 'task-1', 'task-2', 'source')]
+
+    expect(getLoopBodyMap(nodes, edges)).toEqual(new Map())
+  })
+
+  it('returns empty map when the loop node has no loop-handle edge', () => {
+    const nodes = [makeNode('loop-1', 'loop'), makeNode('task-1')]
+    const edges: EdgeType[] = []
+
+    expect(getLoopBodyMap(nodes, edges)).toEqual(new Map())
+  })
+
+  it('identifies a single body node', () => {
+    const nodes = [makeNode('loop-1', 'loop'), makeNode('task-1')]
+    const edges = [makeEdge('e-loop', 'loop-1', 'task-1', 'loop')]
+
+    const result = getLoopBodyMap(nodes, edges)
+
+    expect(result.get('loop-1')).toEqual(['task-1'])
+  })
+
+  it('identifies multiple body nodes connected in a chain', () => {
+    const nodes = [makeNode('loop-1', 'loop'), makeNode('task-1'), makeNode('task-2')]
+    const edges = [makeEdge('e-loop', 'loop-1', 'task-1', 'loop'), makeEdge('e-chain', 'task-1', 'task-2', 'source')]
+
+    const result = getLoopBodyMap(nodes, edges)
+
+    expect(result.get('loop-1')).toContain('task-1')
+    expect(result.get('loop-1')).toContain('task-2')
+    expect(result.get('loop-1')).toHaveLength(2)
+  })
+
+  it('does not follow edges back to the loop node itself', () => {
+    const nodes = [makeNode('loop-1', 'loop'), makeNode('task-1')]
+    const edges = [
+      makeEdge('e-loop', 'loop-1', 'task-1', 'loop'),
+      // loop-back edge (source handle on task, target is the loop node)
+      makeEdge('e-back', 'task-1', 'loop-1', 'source'),
+    ]
+
+    const result = getLoopBodyMap(nodes, edges)
+
+    expect(result.get('loop-1')).toEqual(['task-1'])
+  })
+
+  it('excludes placeholder nodes from traversal', () => {
+    const nodes = [
+      makeNode('loop-1', 'loop'),
+      makeNode('task-1'),
+      makeNode('placeholder-abc'), // filtered out by filterRealNodes
+    ]
+    const edges = [
+      makeEdge('e-loop', 'loop-1', 'task-1', 'loop'),
+      makeEdge('e-ph', 'task-1', 'placeholder-abc', 'source'),
+    ]
+
+    const result = getLoopBodyMap(nodes, edges)
+
+    // The loop body contains task-1 but since placeholder-abc is filtered,
+    // BFS won't reach it as a loop node; however it can still appear as a
+    // body node if reachable (filterRealNodes only filters loop/edge source nodes).
+    // The key assertion: loop-1's body does NOT include placeholder-abc as a loop header
+    expect(result.has('placeholder-abc')).toBe(false)
+  })
+
+  it('handles two independent loop nodes', () => {
+    const nodes = [makeNode('loop-1', 'loop'), makeNode('task-1'), makeNode('loop-2', 'loop'), makeNode('task-2')]
+    const edges = [makeEdge('e1', 'loop-1', 'task-1', 'loop'), makeEdge('e2', 'loop-2', 'task-2', 'loop')]
+
+    const result = getLoopBodyMap(nodes, edges)
+
+    expect(result.get('loop-1')).toEqual(['task-1'])
+    expect(result.get('loop-2')).toEqual(['task-2'])
+  })
+
+  it('handles nested loops — inner body is included in outer body traversal', () => {
+    // Outer loop -> inner loop -> task (via source handle chain)
+    const nodes = [makeNode('outer-loop', 'loop'), makeNode('inner-loop', 'loop'), makeNode('task-1')]
+    const edges = [
+      makeEdge('e-outer', 'outer-loop', 'inner-loop', 'loop'),
+      makeEdge('e-inner', 'inner-loop', 'task-1', 'loop'),
+      // inner-loop is chained via outer's loop handle, so it's an outer body node
+    ]
+
+    const result = getLoopBodyMap(nodes, edges)
+
+    // inner-loop is a direct body of outer-loop
+    expect(result.get('outer-loop')).toContain('inner-loop')
+    // task-1 is a body of inner-loop and should also be included in outer-loop's body
+    expect(result.get('inner-loop')).toContain('task-1')
+    expect(result.get('outer-loop')).toContain('task-1')
+    expect(result.get('outer-loop')).toHaveLength(2)
+  })
+
+  it('includes nested loop done-branch nodes in outer body when includeDoneBranch is true', () => {
+    const nodes = [
+      makeNode('outer-loop', 'loop'),
+      makeNode('inner-loop', 'loop'),
+      makeNode('inner-body', 'task'),
+      makeNode('after-inner', 'task'),
+    ]
+    const edges = [
+      makeEdge('e-outer-loop', 'outer-loop', 'inner-loop', 'loop'),
+      makeEdge('e-inner-loop', 'inner-loop', 'inner-body', 'loop'),
+      makeEdge('e-inner-done', 'inner-loop', 'after-inner', 'done'),
+    ]
+
+    const result = getLoopBodyMap(nodes, edges, { includeDoneBranch: true })
+
+    expect(result.get('outer-loop')).toEqual(['inner-loop', 'inner-body', 'after-inner'])
+    expect(result.get('inner-loop')).toEqual(['inner-body', 'after-inner'])
+  })
+
+  it('does not include done-branch nodes by default', () => {
+    const nodes = [makeNode('loop-1', 'loop'), makeNode('task-loop', 'task'), makeNode('task-done', 'task')]
+    const edges = [makeEdge('e-loop', 'loop-1', 'task-loop', 'loop'), makeEdge('e-done', 'loop-1', 'task-done', 'done')]
+
+    const result = getLoopBodyMap(nodes, edges)
+
+    expect(result.get('loop-1')).toEqual(['task-loop'])
+  })
+
+  it('includes done-branch nodes when includeDoneBranch is true', () => {
+    const nodes = [makeNode('loop-1', 'loop'), makeNode('task-loop', 'task'), makeNode('task-done', 'task')]
+    const edges = [makeEdge('e-loop', 'loop-1', 'task-loop', 'loop'), makeEdge('e-done', 'loop-1', 'task-done', 'done')]
+
+    const result = getLoopBodyMap(nodes, edges, { includeDoneBranch: true })
+
+    expect(result.get('loop-1')).toContain('task-loop')
+    expect(result.get('loop-1')).toContain('task-done')
+    expect(result.get('loop-1')).toHaveLength(2)
+  })
+
+  it('excludes done edges that loop back to a parent loop end handle', () => {
+    const nodes = [makeNode('outer-loop', 'loop'), makeNode('inner-loop', 'loop'), makeNode('inner-body', 'task')]
+    const edges = [
+      makeEdge('e-outer-loop', 'outer-loop', 'inner-loop', 'loop'),
+      makeEdge('e-inner-loop', 'inner-loop', 'inner-body', 'loop'),
+      makeEdge('e-inner-done', 'inner-loop', 'outer-loop', 'done'),
+    ]
+    // Simulate loop-back: done target uses the end handle on the parent loop
+    edges[2] = { ...edges[2], targetHandle: 'end' } as EdgeType
+
+    const result = getLoopBodyMap(nodes, edges, { includeDoneBranch: true })
+
+    expect(result.get('inner-loop')).toEqual(['inner-body'])
+  })
+})
+
+describe('collectLoopGroupPositions', () => {
+  it('collects positions for loop header and all group members', () => {
+    const nodes = [makeNode('loop-1', 'loop'), makeNode('task-loop', 'task'), makeNode('task-done', 'task')]
+    nodes[0].position = { x: 10, y: 20 }
+    nodes[1].position = { x: 110, y: 70 }
+    nodes[2].position = { x: 10, y: -50 }
+    const edges = [makeEdge('e-loop', 'loop-1', 'task-loop', 'loop'), makeEdge('e-done', 'loop-1', 'task-done', 'done')]
+
+    const positions = collectLoopGroupPositions(nodes, edges, (id) => id)
+
+    expect(positions).toEqual({
+      'loop-1': { x: 10, y: 20 },
+      'task-loop': { x: 110, y: 70 },
+      'task-done': { x: 10, y: -50 },
+    })
+  })
+})

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/loopUtils.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/loopUtils.ts
@@ -1,0 +1,141 @@
+import { EdgeHandleEnum } from '@syntara/contracts'
+
+import { FlowNodeType } from '../../../constants'
+import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
+
+import { filterRealEdges, filterRealNodes } from './filterHelpers'
+import type { EdgeType } from './workflowToGraph'
+
+type GetLoopBodyMapOptions = {
+  /** When true, also includes direct targets of the loop's done handle (for group drag). */
+  includeDoneBranch?: boolean
+}
+
+/**
+ * Traverses edges from each Loop node's loop handle to identify all body nodes via BFS.
+ * Expects pre-filtered real nodes and edges (no placeholder nodes, no button edges).
+ * Returns a map from loop node ID to the ordered array of its body node IDs.
+ */
+export function getLoopBodyMap(
+  realNodes: NodeType[],
+  realEdges: EdgeType[],
+  { includeDoneBranch = false }: GetLoopBodyMapOptions = {}
+): Map<string, string[]> {
+  const loopBodies = new Map<string, string[]>()
+  const nodeById = new Map(realNodes.map((n) => [n.id, n]))
+
+  realNodes.forEach((node) => {
+    if (node.type !== FlowNodeType.LOOP) return
+
+    const bodyNodeIds: string[] = []
+    const seen = new Set<string>()
+
+    const addBodyNode = (nodeId: string) => {
+      if (seen.has(nodeId)) return
+      seen.add(nodeId)
+      bodyNodeIds.push(nodeId)
+    }
+
+    const loopEdges = realEdges.filter((e) => e.source === node.id && e.sourceHandle === EdgeHandleEnum.LOOP)
+
+    loopEdges.forEach((loopEdge) => {
+      const visited = new Set<string>()
+      const queue: string[] = [loopEdge.target]
+      // SECURITY: Secondary iteration limit as defense-in-depth (visited set is primary defense)
+      const MAX_ITERATIONS = 10_000
+      let iterations = 0
+
+      while (queue.length > 0 && iterations < MAX_ITERATIONS) {
+        iterations++
+        const nodeId = queue.shift()
+        if (nodeId === undefined) break
+        if (visited.has(nodeId)) continue
+        visited.add(nodeId)
+
+        addBodyNode(nodeId)
+
+        // SECURITY: Domain-invariant check — loop body can't exceed total node count
+        if (bodyNodeIds.length > realNodes.length) break
+
+        // Follow source edges, but not edges back to the loop node (prevents circular traversal)
+        const outgoing = realEdges.filter(
+          (e) => e.source === nodeId && e.sourceHandle === EdgeHandleEnum.SOURCE && e.target !== node.id
+        )
+        outgoing.forEach((e) => {
+          if (!visited.has(e.target)) queue.push(e.target)
+        })
+
+        // Nested loops: also traverse into the inner loop body (and done branch when requested)
+        const visitedNode = nodeById.get(nodeId)
+        if (visitedNode?.type === FlowNodeType.LOOP && nodeId !== node.id) {
+          realEdges
+            .filter((e) => e.source === nodeId && e.sourceHandle === EdgeHandleEnum.LOOP)
+            .forEach((e) => {
+              if (!visited.has(e.target)) queue.push(e.target)
+            })
+
+          if (includeDoneBranch) {
+            realEdges
+              .filter(
+                (e) =>
+                  e.source === nodeId && e.sourceHandle === EdgeHandleEnum.DONE && e.targetHandle !== EdgeHandleEnum.END
+              )
+              .forEach((e) => {
+                if (!visited.has(e.target)) queue.push(e.target)
+              })
+          }
+        }
+      }
+    })
+
+    if (includeDoneBranch) {
+      const doneEdges = realEdges.filter(
+        (e) => e.source === node.id && e.sourceHandle === EdgeHandleEnum.DONE && e.targetHandle !== EdgeHandleEnum.END
+      )
+      doneEdges.forEach((e) => addBodyNode(e.target))
+    }
+
+    if (bodyNodeIds.length > 0) {
+      loopBodies.set(node.id, bodyNodeIds)
+    }
+  })
+
+  return loopBodies
+}
+
+/**
+ * Returns every node ID that belongs to a loop group (loop header + body + done branch).
+ */
+export function getLoopGroupNodeIds(nodes: NodeType[], edges: EdgeType[]): Set<string> {
+  const bodyMap = getLoopBodyMap(filterRealNodes(nodes), filterRealEdges(edges), { includeDoneBranch: true })
+  const ids = new Set<string>()
+  bodyMap.forEach((bodyIds, loopId) => {
+    ids.add(loopId)
+    bodyIds.forEach((id) => ids.add(id))
+  })
+  return ids
+}
+
+/**
+ * Collects canvas positions for every node in each loop group so they persist together on save.
+ */
+export function collectLoopGroupPositions(
+  nodes: NodeType[],
+  edges: EdgeType[],
+  toKey: (nodeId: string) => string
+): Record<string, { x: number; y: number }> {
+  const bodyMap = getLoopBodyMap(filterRealNodes(nodes), filterRealEdges(edges), { includeDoneBranch: true })
+  const nodeById = new Map(nodes.map((n) => [n.id, n]))
+  const positions: Record<string, { x: number; y: number }> = {}
+
+  bodyMap.forEach((bodyIds, loopId) => {
+    const loopNode = nodeById.get(loopId)
+    if (loopNode) positions[toKey(loopId)] = loopNode.position
+    for (const bodyId of bodyIds) {
+      const bodyNode = nodeById.get(bodyId)
+      if (bodyNode) positions[toKey(bodyId)] = bodyNode.position
+    }
+  })
+
+  return positions
+}


### PR DESCRIPTION
## Description

When dragging a Loop node on the workflow builder canvas, loop body and done-branch nodes now move as a group while preserving relative positions. Individual body nodes can still be dragged independently. Loop-back edges also route correctly after save/reopen.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Changes Made

- [x] Extract shared `loopUtils` (`getLoopBodyMap`, `collectLoopGroupPositions`) used by layout and drag handlers
- [x] Add loop group drag handlers (`onNodeDragStart`, `onNodeDrag`, updated `onNodeDragStop`) in `usePositionEventHandlers`
- [x] Persist group positions from drag offsets (avoids stale `getNodes()` at drag stop)
- [x] Add `useLoopGroupPositionSync` to sync group positions and refresh node internals on workflow load
- [x] Narrow `LoopBackEdge` subscriptions via `useStore` geometry selector
- [x] Add unit tests for loop utils, drag handlers, sync hook, edge geometry, and BuilderFlow wiring
- [x] Add E2E test for loop-back edge rendering after save/reopen

## Out of Scope

- Playwright coverage for drag interactions (headless drag is unreliable; covered by unit/integration tests)
- Migrating legacy workflows with inconsistent stored positions (fixed on next loop drag + save)

## Related Issues

Fixes [AAP-76892](https://issues.redhat.com/browse/AAP-76892)

## How to Test

1. Open the workflow builder and create a Loop (While) with a body script node
2. Drag the Loop node — verify body (and done-branch nodes, if present) move together
3. Drag a single body node — verify only that node moves
4. Save the workflow, reopen it — verify loop-back edge routes correctly without nudging the loop
5. Undo after a loop group drag — verify all positions restore in one step

```bash
cd frontend/packages/syntara-ui && npx vitest run \
  src/routes/builder/utils/loopUtils.test.ts \
  src/routes/builder/hooks/usePositionEventHandlers.test.ts \
  src/routes/builder/hooks/useLoopGroupPositionSync.test.ts \
  src/routes/builder/edges/loopBackEdgeGeometry.test.ts \
  src/routes/builder/edges/LoopBackEdge.test.tsx \
  src/routes/builder/BuilderFlow.test.tsx

cd frontend && npm run e2e -- --grep "loop-back edge renders after save and reopen"
```

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [x] Screenshots or screen recordings are attached for UI changes

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

https://github.com/user-attachments/assets/6497a2f2-d428-4fe6-b406-ee5d0eef58b0

## Additional Notes

Legacy workflows saved before this change may have mismatched loop/body coordinates until the user drags the loop once and re-saves.

Made with [Cursor](https://cursor.com)