### PR TITLE
test: verify CI workflows run on feat/* branches

### DIFF
--- a/.github/workflows/check-contract-drift.yml
+++ b/.github/workflows/check-contract-drift.yml
@@ -4,7 +4,7 @@ name: Check Contract Drift
 on:
   pull_request:
   push:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -3,11 +3,11 @@ name: CI Backend
 
 on:
   pull_request:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
   merge_group:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
   push:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
 
 concurrency:
   group: ci-backend-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -5,11 +5,11 @@ name: CI Frontend
 
 on:
   pull_request:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
   merge_group:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
   push:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
   schedule:
     # Daily E2E run with Currents reporting at 2 AM UTC
     - cron: '0 2 * * *'

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -4,9 +4,9 @@ name: CI Pre-commit
 on:
   pull_request:
   merge_group:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
   push:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
 
 permissions:
   contents: read

--- a/.github/workflows/konflux-requirements-sync.yml
+++ b/.github/workflows/konflux-requirements-sync.yml
@@ -9,7 +9,7 @@ name: Konflux Requirements
 
 on:
   pull_request_target:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
     paths:
       - backend/uv.lock
       - backend/requirements.txt

--- a/.github/workflows/openapi-breaking-changes.yml
+++ b/.github/workflows/openapi-breaking-changes.yml
@@ -8,7 +8,7 @@ name: OpenAPI Breaking Changes
 
 on:
   pull_request:
-    branches: [devel, early-access]
+    branches: [devel, early-access, 'feat/*']
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - 'backend/**'

--- a/.github/workflows/sast-snyk.yml
+++ b/.github/workflows/sast-snyk.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - 'devel'
       - 'early-access'
+      - 'feat/*'
     paths:
       - '.github/workflows/sast-snyk.yml'
   workflow_dispatch:

--- a/.github/workflows/sca-snyk.yml
+++ b/.github/workflows/sca-snyk.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - 'devel'
       - 'early-access'
+      - 'feat/*'
     paths:
       - 'backend/pyproject.toml'
       - 'backend/requirements*.txt'

--- a/backend/src/syntara/__init__.py
+++ b/backend/src/syntara/__init__.py
@@ -1,4 +1,7 @@
-"""Top-level Syntara package exposing subpackages for agents, API, and tool manager."""
+"""Top-level Syntara package exposing subpackages for agents, API, and tool manager.
+
+Test comment for CI workflow verification on feat/* branches.
+"""
 
 # regopy (rego-cpp) must be imported before any module that loads greenlet or
 # temporalio's native bridge: librego_shared.so statically links snmalloc and


### PR DESCRIPTION
## Summary
Test PR to verify that CI workflows now run on `feat/*` branches.

## Changes
- Updated 8 GitHub workflow files to include `feat/*` in branch triggers
- Added test comment to verify workflows execute

## Testing
This PR itself is the test - we should see CI workflows trigger and run.

Expected workflows to run:
- CI Pre-commit
- Check Contract Drift
- CI Backend
- CI Frontend
- OpenAPI Breaking Changes
- Konflux Requirements Sync (if applicable)
- SAST Snyk
- SCA Snyk