### PR TITLE
fix(AAP-78981): keep dock nav expanded on medium viewports in builder

### DIFF
--- a/frontend/packages/syntara-ui/src/app/AppDockedNav.test.tsx
+++ b/frontend/packages/syntara-ui/src/app/AppDockedNav.test.tsx
@@ -395,6 +395,17 @@ describe('AppDockedNav', () => {
       })
     })
 
+    it('shows label text for docked actions when mobile overlay is expanded', () => {
+      renderDockedNav()
+      expect(screen.getByText('Light mode')).toBeInTheDocument()
+      expect(screen.getByText('Documentation')).toBeInTheDocument()
+    })
+
+    it('does not apply icon-only nav styles when mobile overlay is expanded', () => {
+      renderDockedNav()
+      expect(screen.getByRole('navigation', { name: 'Main navigation' })).not.toHaveClass(styles.iconDockNav)
+    })
+
     it('renders expandable nav groups when dock is expanded on mobile', () => {
       renderDockedNav()
       expect(screen.getByText('Integrations')).toBeInTheDocument()

--- a/frontend/packages/syntara-ui/src/app/AppDockedNav.tsx
+++ b/frontend/packages/syntara-ui/src/app/AppDockedNav.tsx
@@ -270,8 +270,8 @@ export function AppDockedNav() {
   const navItemRefs = useMemo(() => createNavItemRefs(visibleItems), [visibleItems])
 
   const colorSchemeToggleLabel = colorScheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
-  const isExpanded = isDockTextExpanded || isDockExpanded
-  const showTooltips = !isExpanded
+  const isDockShowingLabels = isDockTextExpanded || isDockExpanded
+  const showTooltips = !isDockShowingLabels
 
   /* v8 ignore start -- phantom branches from compiled JSX props, ternaries, and map callbacks */
   return (
@@ -285,11 +285,11 @@ export function AppDockedNav() {
               isHamburger
               onClick={onToggleDock}
               aria-label="Global navigation"
-              isExpanded={isDockTextExpanded}
+              isExpanded={isDockShowingLabels}
             />
           </MastheadToggle>
-          <MastheadBrand className={!isExpanded ? styles.collapsedBrand : undefined}>
-            {isExpanded ? (
+          <MastheadBrand className={!isDockShowingLabels ? styles.collapsedBrand : undefined}>
+            {isDockShowingLabels ? (
               <MastheadLogo component={(props) => <Link {...props} to="/" />} aria-label="Home">
                 <img
                   src={colorScheme === 'dark' ? brand.logoExpandedDark : brand.logoExpandedLight}
@@ -325,7 +325,7 @@ export function AppDockedNav() {
                   }
                   variant="docked"
                   aria-label="Main navigation"
-                  className={!isDockTextExpanded ? styles.iconDockNav : undefined}
+                  className={!isDockShowingLabels ? styles.iconDockNav : undefined}
                 >
                   <NavList>
                     {visibleItems.flatMap((item) => {
@@ -337,7 +337,7 @@ export function AppDockedNav() {
                       if (hasDropdownChildren(item)) {
                         return [
                           separator,
-                          isExpanded ? (
+                          isDockShowingLabels ? (
                             <NavExpandableItem
                               key={item.path}
                               item={item}

--- a/frontend/packages/syntara-ui/src/app/AppShell.module.css
+++ b/frontend/packages/syntara-ui/src/app/AppShell.module.css
@@ -1,3 +1,8 @@
+.compass :global(.pf-v6-c-compass__main) {
+  min-width: 0;
+}
+
 .mainContent {
   outline: none;
+  min-width: 0;
 }

--- a/frontend/packages/syntara-ui/src/app/AppShell.tsx
+++ b/frontend/packages/syntara-ui/src/app/AppShell.tsx
@@ -29,7 +29,7 @@ export function AppShell({ children }: Readonly<{ children: React.ReactNode }>) 
         <SessionTimeoutWarning />
         <DockStateContext.Provider value={dockState}>
           <Compass
-            className="pf-m-no-screen-warning"
+            className={`pf-m-no-screen-warning ${styles.compass}`}
             isDockExpanded={dockState.isDockExpanded}
             isDockTextExpanded={dockState.isDockTextExpanded}
             masthead={<AppMobileMasthead />}

--- a/frontend/packages/syntara-ui/src/app/useDockState.test.ts
+++ b/frontend/packages/syntara-ui/src/app/useDockState.test.ts
@@ -203,6 +203,26 @@ describe('useDockStateProvider', () => {
     expect(result.current.isDockTextExpanded).toBe(true)
   })
 
+  it('falls back to collapsed dock state when sessionStorage JSON is invalid', () => {
+    sessionStorage.setItem('syntara-nav-dock-state', 'not-json')
+
+    const { result } = renderHook(() => useDockStateProvider())
+    expect(result.current.isDockExpanded).toBe(false)
+    expect(result.current.isDockTextExpanded).toBe(false)
+  })
+
+  it('normalizes stale mobile overlay state on desktop mount', () => {
+    sessionStorage.setItem(
+      'syntara-nav-dock-state',
+      JSON.stringify({ isDockExpanded: true, isDockTextExpanded: false })
+    )
+
+    const { result } = renderHook(() => useDockStateProvider())
+    expect(result.current.isMobile).toBe(false)
+    expect(result.current.isDockTextExpanded).toBe(true)
+    expect(result.current.isDockExpanded).toBe(false)
+  })
+
   it('opens mobile overlay when crossing into mobile with text expanded', () => {
     const { result } = renderHook(() => useDockStateProvider())
 

--- a/frontend/packages/syntara-ui/src/app/useDockState.test.ts
+++ b/frontend/packages/syntara-ui/src/app/useDockState.test.ts
@@ -33,6 +33,7 @@ describe('useDockStateProvider', () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
+    sessionStorage.clear()
     mockMql = createMockMatchMedia(false)
     vi.stubGlobal(
       'matchMedia',
@@ -181,6 +182,55 @@ describe('useDockStateProvider', () => {
 
     await act(() => vi.advanceTimersByTime(200))
     expect(mockFocus).not.toHaveBeenCalled()
+  })
+
+  it('persists dock expansion to sessionStorage', () => {
+    const { result } = renderHook(() => useDockStateProvider())
+
+    act(() => result.current.onToggleDock())
+    expect(sessionStorage.getItem('syntara-nav-dock-state')).toBe(
+      JSON.stringify({ isDockExpanded: false, isDockTextExpanded: true })
+    )
+  })
+
+  it('restores dock expansion from sessionStorage on mount', () => {
+    sessionStorage.setItem(
+      'syntara-nav-dock-state',
+      JSON.stringify({ isDockExpanded: false, isDockTextExpanded: true })
+    )
+
+    const { result } = renderHook(() => useDockStateProvider())
+    expect(result.current.isDockTextExpanded).toBe(true)
+  })
+
+  it('opens mobile overlay when crossing into mobile with text expanded', () => {
+    const { result } = renderHook(() => useDockStateProvider())
+
+    act(() => result.current.onToggleDock())
+    expect(result.current.isDockTextExpanded).toBe(true)
+
+    act(() => mockMql.trigger(true))
+    expect(result.current.isMobile).toBe(true)
+    expect(result.current.isDockExpanded).toBe(true)
+    expect(result.current.isDockTextExpanded).toBe(true)
+  })
+
+  it('migrates mobile overlay expansion to text expansion when crossing to desktop', () => {
+    mockMql = createMockMatchMedia(true)
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => mockMql.mql)
+    )
+
+    const { result } = renderHook(() => useDockStateProvider())
+
+    act(() => result.current.onToggleDock())
+    expect(result.current.isDockExpanded).toBe(true)
+
+    act(() => mockMql.trigger(false))
+    expect(result.current.isMobile).toBe(false)
+    expect(result.current.isDockTextExpanded).toBe(true)
+    expect(result.current.isDockExpanded).toBe(false)
   })
 })
 

--- a/frontend/packages/syntara-ui/src/app/useDockState.ts
+++ b/frontend/packages/syntara-ui/src/app/useDockState.ts
@@ -73,9 +73,15 @@ export function useDockStateProvider(): DockState {
   const dockedToggleRef = useRef<HTMLButtonElement>(null)
   const mobileToggleRef = useRef<HTMLButtonElement>(null)
   const focusTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
-  const prevIsMobileRef = useRef(isMobile)
+  const isDockExpandedRef = useRef(isDockExpanded)
+  const isDockTextExpandedRef = useRef(isDockTextExpanded)
 
   useEffect(() => () => clearTimeout(focusTimerRef.current), [])
+
+  useEffect(() => {
+    isDockExpandedRef.current = isDockExpanded
+    isDockTextExpandedRef.current = isDockTextExpanded
+  }, [isDockExpanded, isDockTextExpanded])
 
   useEffect(() => {
     writePersistedDockState({ isDockExpanded, isDockTextExpanded })
@@ -84,28 +90,31 @@ export function useDockStateProvider(): DockState {
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') return
     const mq = window.matchMedia(`(max-width: ${DOCK_DESKTOP_BREAKPOINT_PX}px)`)
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    let wasMobile = mq.matches
+
+    const handler = (e: MediaQueryListEvent) => {
+      const nowMobile = e.matches
+      if (wasMobile === nowMobile) {
+        setIsMobile(nowMobile)
+        return
+      }
+
+      if (nowMobile) {
+        if (isDockTextExpandedRef.current && !isDockExpandedRef.current) {
+          setIsDockExpanded(true)
+        }
+      } else if (isDockExpandedRef.current) {
+        setIsDockTextExpanded(true)
+        setIsDockExpanded(false)
+      }
+
+      wasMobile = nowMobile
+      setIsMobile(nowMobile)
+    }
+
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [])
-
-  useEffect(() => {
-    const wasMobile = prevIsMobileRef.current
-    prevIsMobileRef.current = isMobile
-    if (wasMobile === isMobile) return
-
-    if (isMobile) {
-      if (isDockTextExpanded && !isDockExpanded) {
-        setIsDockExpanded(true)
-      }
-      return
-    }
-
-    if (isDockExpanded) {
-      setIsDockTextExpanded(true)
-      setIsDockExpanded(false)
-    }
-  }, [isMobile, isDockExpanded, isDockTextExpanded])
 
   const onMobileToggle = useCallback(() => {
     setIsDockExpanded((prev) => !prev)

--- a/frontend/packages/syntara-ui/src/app/useDockState.ts
+++ b/frontend/packages/syntara-ui/src/app/useDockState.ts
@@ -27,14 +27,44 @@ export function useDockState(): DockState {
  * on open/close to maintain keyboard flow.
  */
 const DOCK_DESKTOP_BREAKPOINT_PX = Number.parseInt(globalBreakpointLg.value) * 16
+const DOCK_STATE_STORAGE_KEY = 'syntara-nav-dock-state'
 
 /** Delay before transferring focus between mobile and docked toggle buttons,
  *  allowing PF's CSS transition to complete so the target element is visible. */
 const FOCUS_TRANSFER_DELAY_MS = 200
 
+type PersistedDockState = {
+  isDockExpanded: boolean
+  isDockTextExpanded: boolean
+}
+
+function readPersistedDockState(): PersistedDockState {
+  try {
+    const raw = sessionStorage.getItem(DOCK_STATE_STORAGE_KEY)
+    if (!raw) {
+      return { isDockExpanded: false, isDockTextExpanded: false }
+    }
+    const parsed = JSON.parse(raw) as Partial<PersistedDockState>
+    return {
+      isDockExpanded: parsed.isDockExpanded === true,
+      isDockTextExpanded: parsed.isDockTextExpanded === true,
+    }
+  } catch {
+    return { isDockExpanded: false, isDockTextExpanded: false }
+  }
+}
+
+function writePersistedDockState(state: PersistedDockState) {
+  try {
+    sessionStorage.setItem(DOCK_STATE_STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // sessionStorage may be unavailable in private browsing or restricted embeds.
+  }
+}
+
 export function useDockStateProvider(): DockState {
-  const [isDockExpanded, setIsDockExpanded] = useState(false)
-  const [isDockTextExpanded, setIsDockTextExpanded] = useState(false)
+  const [isDockExpanded, setIsDockExpanded] = useState(() => readPersistedDockState().isDockExpanded)
+  const [isDockTextExpanded, setIsDockTextExpanded] = useState(() => readPersistedDockState().isDockTextExpanded)
   const [isMobile, setIsMobile] = useState(() =>
     typeof window.matchMedia === 'function'
       ? window.matchMedia(`(max-width: ${DOCK_DESKTOP_BREAKPOINT_PX}px)`).matches
@@ -43,8 +73,13 @@ export function useDockStateProvider(): DockState {
   const dockedToggleRef = useRef<HTMLButtonElement>(null)
   const mobileToggleRef = useRef<HTMLButtonElement>(null)
   const focusTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const prevIsMobileRef = useRef(isMobile)
 
   useEffect(() => () => clearTimeout(focusTimerRef.current), [])
+
+  useEffect(() => {
+    writePersistedDockState({ isDockExpanded, isDockTextExpanded })
+  }, [isDockExpanded, isDockTextExpanded])
 
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') return
@@ -53,6 +88,24 @@ export function useDockStateProvider(): DockState {
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [])
+
+  useEffect(() => {
+    const wasMobile = prevIsMobileRef.current
+    prevIsMobileRef.current = isMobile
+    if (wasMobile === isMobile) return
+
+    if (isMobile) {
+      if (isDockTextExpanded && !isDockExpanded) {
+        setIsDockExpanded(true)
+      }
+      return
+    }
+
+    if (isDockExpanded) {
+      setIsDockTextExpanded(true)
+      setIsDockExpanded(false)
+    }
+  }, [isMobile, isDockExpanded, isDockTextExpanded])
 
   const onMobileToggle = useCallback(() => {
     setIsDockExpanded((prev) => !prev)

--- a/frontend/packages/syntara-ui/src/app/useDockState.ts
+++ b/frontend/packages/syntara-ui/src/app/useDockState.ts
@@ -54,6 +54,23 @@ function readPersistedDockState(): PersistedDockState {
   }
 }
 
+function readIsMobileViewport(): boolean {
+  return typeof window.matchMedia === 'function'
+    ? window.matchMedia(`(max-width: ${DOCK_DESKTOP_BREAKPOINT_PX}px)`).matches
+    : false
+}
+
+function readInitialDockState(): PersistedDockState & { isMobile: boolean } {
+  const { isDockExpanded, isDockTextExpanded } = readPersistedDockState()
+  const isMobile = readIsMobileViewport()
+
+  if (!isMobile && isDockExpanded && !isDockTextExpanded) {
+    return { isDockExpanded: false, isDockTextExpanded: true, isMobile }
+  }
+
+  return { isDockExpanded, isDockTextExpanded, isMobile }
+}
+
 function writePersistedDockState(state: PersistedDockState) {
   try {
     sessionStorage.setItem(DOCK_STATE_STORAGE_KEY, JSON.stringify(state))
@@ -63,13 +80,10 @@ function writePersistedDockState(state: PersistedDockState) {
 }
 
 export function useDockStateProvider(): DockState {
-  const [isDockExpanded, setIsDockExpanded] = useState(() => readPersistedDockState().isDockExpanded)
-  const [isDockTextExpanded, setIsDockTextExpanded] = useState(() => readPersistedDockState().isDockTextExpanded)
-  const [isMobile, setIsMobile] = useState(() =>
-    typeof window.matchMedia === 'function'
-      ? window.matchMedia(`(max-width: ${DOCK_DESKTOP_BREAKPOINT_PX}px)`).matches
-      : false
-  )
+  const [initialDockState] = useState(readInitialDockState)
+  const [isDockExpanded, setIsDockExpanded] = useState(initialDockState.isDockExpanded)
+  const [isDockTextExpanded, setIsDockTextExpanded] = useState(initialDockState.isDockTextExpanded)
+  const [isMobile, setIsMobile] = useState(initialDockState.isMobile)
   const dockedToggleRef = useRef<HTMLButtonElement>(null)
   const mobileToggleRef = useRef<HTMLButtonElement>(null)
   const focusTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
@@ -94,10 +108,7 @@ export function useDockStateProvider(): DockState {
 
     const handler = (e: MediaQueryListEvent) => {
       const nowMobile = e.matches
-      if (wasMobile === nowMobile) {
-        setIsMobile(nowMobile)
-        return
-      }
+      if (wasMobile === nowMobile) return
 
       if (nowMobile) {
         if (isDockTextExpandedRef.current && !isDockExpandedRef.current) {

--- a/frontend/packages/syntara-ui/src/components/layout/SynPageHeader.module.css
+++ b/frontend/packages/syntara-ui/src/components/layout/SynPageHeader.module.css
@@ -7,3 +7,7 @@
 .header :global(.pf-v6-c-compass__main-header-title) {
   min-width: 0;
 }
+
+.header :global(.pf-v6-c-compass__main-header-toolbar) {
+  min-width: 0;
+}


### PR DESCRIPTION
## Description

on medium viewports, the left dock nav could collapse when entering the workflow builder even after the user expanded it. this aligns dock label state with the patternfly compass mobile overlay flag, persists expansion across navigation, and lets the compass main column shrink so the builder header does not push the dock off-screen.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- treat `isDockTextExpanded || isDockExpanded` as the dock label state in `AppDockedNav` (hamburger, nav text, icon-only styles)
- persist dock expansion in `sessionStorage` and sync text vs overlay flags when crossing the mobile breakpoint
- add `min-width: 0` on compass main / page header toolbar so builder chrome can shrink beside the dock
- unit tests for breakpoint sync, persistence, and mobile expanded nav styling

## Out of Scope

- changing the react flow viewport guard threshold
- redesigning builder toolbar layout beyond shrink fixes

## Related Issues

Fixes AAP-78981

## How to Test

1. set the browser to about 1280px wide
2. on workflows, expand the left nav with the hamburger
3. open a workflow in the builder
4. confirm the nav stays in the expanded state you set (labels visible, not forced back to icon-only)
5. repeat on another non-builder page at the same width to confirm behavior matches

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [x] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

https://github.com/user-attachments/assets/c5ce893f-681f-4f69-a918-2c542568eec9



## Additional Notes