### PR TITLE
test(workflow-engine): cover quoted operator literals in unified eval

### DIFF
--- a/backend/tests/unit/workflows/workflow_engine/test_unified_eval.py
+++ b/backend/tests/unit/workflows/workflow_engine/test_unified_eval.py
@@ -919,3 +919,99 @@ class TestVisualBuilderOperators:
     def test_contains_word_form_on_list(self) -> None:
         assert safe_eval_with_namespace("${items} contains 2", {"items": [1, 2, 3]}) is True
         assert safe_eval_with_namespace("${items} contains 9", {"items": [1, 2, 3]}) is False
+
+
+# (keyword, literal containing that keyword in non-operator position).
+#
+# Python keywords the frontend normalizer rewrites, listed in its module header
+# (frontend/packages/syntara-ui/src/utils/expressions/normalizer.ts:1-13) and
+# covered by normalizer.test.ts "preserves strings with ... inside".
+PYTHON_KEYWORD_LITERALS = [
+    ("and", "bread and butter"),
+    ("or", "yes or no"),
+    ("not", "not sure"),
+    ("in", "log in"),
+]
+
+# The nine visual-builder word operators, in the order they are declared in
+# frontend/packages/syntara-ui/src/utils/expressions/operators.ts WORD_OPERATORS.
+# These are the operators offered in the node's operator dropdown (OPERATOR_GROUPS
+# String / Existence / Length groups) and the ones _translate_custom_operators
+# rewrites. The Comparison group is symbolic (==, >, <, >=, <=) and has no
+# rewrite rule, so it is not represented here.
+WORD_OPERATOR_LITERALS = [
+    ("startsWith", "name startsWith 5"),
+    ("endsWith", "name endsWith 7"),
+    ("matches", "value matches 3"),
+    ("contains", "list contains 5"),
+    ("exists", "Resource already exists in target"),
+    ("isEmpty", "field isEmpty here"),
+    ("lengthEqualTo", "items lengthEqualTo 2"),
+    ("lengthGreaterThan", "count lengthGreaterThan 1"),
+    ("lengthLessThan", "count lengthLessThan 9"),
+]
+
+
+class TestKeywordInsideStringLiteral:
+    """An operator keyword inside a quoted string literal must stay literal text.
+
+    In the visual builder the operator is chosen from a dropdown (OPERATOR_GROUPS
+    in operators.ts) and only the comparison value is free text, so a keyword
+    appearing inside quotes in a stored condition is always user data, never an
+    operator.
+
+    The frontend upholds this by tokenizing before rewriting (normalizer.ts
+    imports tokenize/detokenize, so a STRING token cannot be modified) and pins it
+    with tests. The backend's `_translate_custom_operators` instead runs `re.sub`
+    over the raw expression string with no notion of quoting, before `ast.parse`.
+
+    Both quoting styles are exercised because they fail differently. The visual
+    builder emits double quotes (`quoteValueIfNeeded` in serializer.ts), where the
+    injected rewrite still parses and the comparison silently returns the wrong
+    branch. Raw-mode and imported definitions can carry single quotes, where the
+    `__exists__('...')` rewrite unbalances the literal and raises instead.
+    """
+
+    @pytest.mark.parametrize(
+        ("keyword", "literal"),
+        PYTHON_KEYWORD_LITERALS,
+        ids=[keyword for keyword, _ in PYTHON_KEYWORD_LITERALS],
+    )
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    def test_python_keyword_inside_literal_is_preserved(self, keyword: str, literal: str, quote: str) -> None:
+        """Control: keywords the backend never rewrites are unaffected by quoting."""
+        expression = f"${{text}} == {quote}{literal}{quote}"
+        assert safe_eval_with_namespace(expression, {"text": literal}) is True, keyword
+
+    @pytest.mark.parametrize(
+        ("operator", "literal"),
+        WORD_OPERATOR_LITERALS,
+        ids=[operator for operator, _ in WORD_OPERATOR_LITERALS],
+    )
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    def test_word_operator_inside_literal_is_preserved(self, operator: str, literal: str, quote: str) -> None:
+        """Reproducer: same invariant, one case per WORD_OPERATORS entry."""
+        expression = f"${{text}} == {quote}{literal}{quote}"
+        assert safe_eval_with_namespace(expression, {"text": literal}) is True, operator
+
+    def test_builder_emitted_condition_matches_its_own_value(self) -> None:
+        """The exact stored condition the visual builder writes for a typed value.
+
+        `quoteValueIfNeeded` (serializer.ts) wraps a free-text value in double
+        quotes, escaping only backslash and double-quote, so this is what a user
+        who typed the value into the Value field gets. It evaluates to the wrong
+        branch with no error raised.
+        """
+        value = "Resource already exists in target"
+        expression = f'${{step_1.output}} == "{value}"'
+        assert safe_eval_with_namespace(expression, {"step_1": {"output": value}}) is True
+
+    def test_single_quoted_exists_literal_does_not_raise(self) -> None:
+        """Same literal single-quoted, as raw mode or an imported definition stores it.
+
+        `_exists_repl` injects single quotes around the extracted path, which
+        unbalances a single-quoted literal and fails the parse.
+        """
+        value = "Resource already exists in target"
+        expression = f"${{step_1.output}} == '{value}'"
+        assert safe_eval_with_namespace(expression, {"step_1": {"output": value}}) is True


### PR DESCRIPTION
Generated By: Claude Code (Claude Opus 5)

---

# Word operators inside string literals — test rationale

Adds `TestKeywordInsideStringLiteral` to
`backend/tests/unit/workflows/workflow_engine/test_unified_eval.py:955`.

28 cases: 8 pass (control), 20 fail (reproducers). No production code changed.

## 1. The invariant being tested

In the visual expression builder the operator is not typed. It is chosen from a
dropdown built from `OPERATOR_GROUPS`
(`frontend/packages/syntara-ui/src/utils/expressions/operators.ts:77-94`),
rendered by `ExpressionCondition.tsx:264-285`. Only the comparison value is free
text — a `TextInput` with no `pattern`, no `maxLength`, and no validation beyond
non-empty (`ExpressionCondition.tsx:289-299`). The adjacent Field input *is*
restricted (`ExpressionCondition.tsx:35-42`), which makes the absence of any
constraint on the value deliberate rather than an oversight.

It follows that an operator keyword appearing inside quotes in a stored
condition is always user data. There is no authoring path that produces an
operator in that position — the serializer places operators outside the quoted
value (`serializer.ts:189`).

So: **a keyword inside a string literal must survive evaluation as literal
text.** That is what these tests assert.

## 2. Where the test data came from

The nine reproducer cases are one per entry in `WORD_OPERATORS`
(`operators.ts:22-32`), in declaration order. Labels are from `OPERATOR_LABELS`
(`operators.ts:51-71`), which is what the product documentation renders.

| # | UI label | Operator token | Test id | Literal under test |
|---|---|---|---|---|
| 1 | starts with | `startsWith` | `startsWith` | `name startsWith 5` |
| 2 | ends with | `endsWith` | `endsWith` | `name endsWith 7` |
| 3 | matches regex | `matches` | `matches` | `value matches 3` |
| 4 | contains | `contains` | `contains` | `list contains 5` |
| 5 | exists | `exists` | `exists` | `Resource already exists in target` |
| 6 | is empty | `isEmpty` | `isEmpty` | `field isEmpty here` |
| 7 | length is equal to | `lengthEqualTo` | `lengthEqualTo` | `items lengthEqualTo 2` |
| 8 | length is greater than | `lengthGreaterThan` | `lengthGreaterThan` | `count lengthGreaterThan 1` |
| 9 | length is less than | `lengthLessThan` | `lengthLessThan` | `count lengthLessThan 9` |

The Comparison group (`==`, `>`, `<`, `>=`, `<=`, from `OPERATOR_GROUPS`,
`operators.ts:80`) is deliberately excluded. `_translate_custom_operators`
(`unified_eval.py:104-125`) has no rewrite rule for symbols, so there is nothing
to corrupt.

The four control cases use the Python keywords `normalizer.ts` rewrites, listed
in its own module header (`normalizer.ts:1-13`) and implemented at
`transformBooleanOperator:20`, `transformNotOperator:33`, `transformInOperator:43`.
The four literals are taken verbatim from `normalizer.test.ts:101-120`
("preserves strings with `and` / `or` / `not` / `in` inside").

## 3. Why the frontend does not have this problem

`normalizer.ts` rewrites tokens, not text. `tokenizeString`
(`tokenizer.ts:71-81`) emits an entire quoted span as a single `STRING` token,
and `transformTokens` (`normalizer.ts:108-149`) dispatches only on
`TokenType.BOOL_OP`, `TokenType.NOT_OP`, and `TokenType.IN_OP` — every other
token reaches `// All other tokens pass through unchanged` (`normalizer.ts:144`).
A keyword inside quotes is therefore unreachable by any transform, by
construction rather than by test. Its literal-preservation tests
(`normalizer.test.ts:101-120`) pin the behavior.

(Read, not executed — the frontend test suite was not run for this document.)

`_translate_custom_operators` (`unified_eval.py:104-125`) instead applies eight
`re.sub` passes plus one `_exists_repl` pass (`unified_eval.py:125`) to the raw
expression string, before `ast.parse` (`unified_eval.py:287`). The operand
pattern `_OPERAND_PATTERN` (`unified_eval.py:61`) matches any bare word, and the
substitutions have no notion of quoting, so they fire inside string literals.

The `exists` and `isEmpty` rules (`unified_eval.py:121,125`) have no trailing
value pattern, so a bare word followed by the keyword is enough to trigger them.
Those two are also the operators the UI marks unary (`operators.ts:45`), for
which no value input is rendered at all (`ExpressionCondition.tsx:289`).

## 4. Why the tests are shaped this way

1. **Unit-level, against `safe_eval_with_namespace`.** That function is the
   single chokepoint every affected node reaches: Condition
   (`activities/condition.py:62`), Switch, once per case
   (`activities/switch.py:115`), and do-while Loop
   (`dynamic_workflow.py:1230`). A grep for the symbol across `src/` returns 11
   lines: those three call sites, their imports, the definition
   (`unified_eval.py:215`), three doctest examples (`:239`, `:243`, `:247`), and
   one docstring mention (`expression_resolver.py:4`). No fourth call site.
   Testing at the evaluator covers all three without triplicating fixtures.

2. **Both quote styles, per operator.** They fail differently and both are
   reachable. `quoteValueIfNeeded` (`serializer.ts:79-98`) wraps free-text values
   in double quotes, escaping only backslash and double-quote
   (`serializer.ts:94-95`) — so the visual builder's own output is the
   double-quoted form. Values that arrive already quoted are passed through
   untouched (`serializer.ts:84,97`), so single-quoted literals reach the backend
   from the raw editor (`ExpressionBuilderCore.tsx:263-266`,
   `ExpressionRawEditor.tsx:29-43`) and from imported or API-posted definitions.

3. **The namespace echoes the literal.** Each case evaluates
   `${text} == "<literal>"` with `{"text": "<literal>"}`, so the correct result
   is unambiguously `True`. Any failure is attributable to the rewrite, not to
   comparison semantics, type coercion, or namespace resolution.

4. **A control group with an identical assertion shape.** The four Python-keyword
   cases use the same expression template and the same assertion. They pass. That
   rules out the test harness itself as the cause of the 20 failures.

5. **One case per operator, ids named after the operator.** A failure reports as
   `test_word_operator_inside_literal_is_preserved["-exists]`, so the operator
   and quote style are readable from the summary line without opening a
   traceback.

6. **Nothing is asserted about save-time behavior.** The condition string is not
   parsed when a workflow is saved — the Pydantic fields carry only
   `min_length=1` (`models/workflow_definition.py:791`, `:799`, `:829`). Runtime
   is the first and only place the expression is interpreted, so runtime is where
   the test belongs.

## 5. Results

```
$ pytest tests/unit/workflows/workflow_engine/test_unified_eval.py::TestKeywordInsideStringLiteral -q
........FFFFFFFFFFFFFFFFFFFF                                             [100%]
```

- 8 control cases pass.
- All 18 operator cases fail (9 operators × 2 quote styles).
- 2 named end-to-end cases fail.

Two distinct failure modes, both represented:

- **Double-quoted** — the rewrite parses cleanly and the comparison returns the
  wrong branch. No exception, no log entry. This is the form the visual builder
  emits.
- **Single-quoted, `exists` only** — `_exists_repl` (`unified_eval.py:97-101`)
  injects single quotes around the extracted path, unbalancing the literal.
  `ast.parse` raises `SyntaxError`, converted to
  `ValueError("Invalid expression syntax: ...")` at `unified_eval.py:288-290`.

Whole file: 163 tests, 143 pass, 20 fail — every failure is one of the new cases.
`ruff check`, `ruff format --check`, and `mypy --strict src/ tests/` are clean.

## 6. These are regressions, not pre-existing gaps

`_translate_custom_operators` does not exist at the merge base. `git show
5b964018:backend/src/syntara/workflows/workflow_engine/unified_eval.py` shows
`safe_eval_with_namespace` going directly from length validation to `${}`
stripping, with no translation step. Every one of the 20 failing expressions
evaluates correctly at `5b964018`.

## 7. No existing test already covers this

Checked three ways before writing the new cases.

1. **Full read of `TestVisualBuilderOperators`**
   (`test_unified_eval.py:708-919`, all 47 test methods), plus the activity tests this PR adds
   (`activities/test_condition.py`, `activities/test_switch.py`). Every case
   places the operator in operator position, outside quotes. None places a
   keyword inside a string literal.

2. **Unfiltered AST scan of the backend test tree.** Every string constant in
   all 1220 `.py` files under `tests/` — 112,131 constants, no pre-filter —
   searched for a quoted span containing any of the nine word operators or
   `and` / `or` / `not` / `in`. Sixty-two spans match. Exactly two contain a word
   operator, neither a condition under test: the PR's own reproduction docstring
   (`activities/test_switch.py:640`, `'${node.status} exists'`) and an unrelated
   API query-filter field name (`core/utils/test_api_client_filters.py:152`,
   `'contains'`, in a test named `test_field_name_that_looks_like_operator`). The
   other sixty contain `and` / `or` / `not` / `in` as ordinary English in
   assertion messages and docstrings — "User not found.", "should not run".

3. **Definitive check**: extracted all 172 literal expressions passed to
   `safe_eval_with_namespace` anywhere under `tests/`, excluding the new class,
   and ran the real `_translate_custom_operators` over each. 59 are rewritten —
   and in all 59 the operator is in operator position, which is the intended
   rewrite. Zero cases of a rewrite firing inside a string literal.

The closest existing coverage is `TestStringQuotingEdgeCases`
(`test_unified_eval.py:307-340`), which tests quotes, backslashes, and newlines
inside literals but no operator keywords. The `__exists__` / `__is_empty__` /
`__re_search__` arity and type cases (`test_unified_eval.py:862-917`, inside
`TestVisualBuilderOperators`) mix two shapes: direct calls to the gated
functions (`__is_empty__()`, `len(*items)`), which never reach the translation
step, and word-operator expressions (`${items} isEmpty`, `${code} matches 123`),
which are translated like any other. Some methods use both. Neither shape places
a keyword inside a quoted value.

## 8. Why the case has no prior coverage

Nothing in the repository excludes it, accepts it as a limitation, or documents
it as a known behavior. Four places where it could have been recorded:

1. **The evaluator itself.** `unified_eval.py` contains no occurrence of
   `quote`, `literal`, `string boundar`, or `tokeniz` anywhere in the file. No
   comment notes that the substitution is quote-blind.
2. **`backend/decision-records.md`** — 24 lines, 18 entries (orchestration
   engine, Django vs FastAPI, delete semantics, UUIDs, PATCH, packaging,
   podman-compose, SSE, SQLModel, Redis, logging, audit database, background
   execution, worker autoscaling, PgBouncer, `NUM_HISTORY_SHARDS`, and two
   more). Nothing about expression evaluation.
3. **`expression-system.md` Security** (`:95`) — enumerates
   `MAX_EXPRESSION_LENGTH`, `MAX_VARIABLE_NAME_LENGTH`, `MAX_AST_DEPTH`,
   `MAX_AST_NODES`, and the disallowed constructs. It places no constraint on
   what a string literal may contain.
4. **This PR's "Out of Scope"** — frontend serializer changes, arbitrary
   method/function calls, and changes to comparison / `in` / `and` / `or`
   semantics. Interaction with string literals is not listed.

Two things explain the gap.

**The tests were written along the operator axis.**
`TestSwitchVisualBuilderOperators` is docstringed "Word operators from the visual
builder must evaluate (AAP-91413)", and its first case is "Ticket reproduction:
`'${node.status} exists'` used to raise Invalid expression syntax"
(`activities/test_switch.py:635-640`). All 47 methods of
`TestVisualBuilderOperators` are named for a per-operator behavior or a
per-operator rejection. The question under test was whether each operator
evaluates and whether unsafe calls are refused. The comparison *value* was never
an axis.

**No fixture in the repository would have surfaced it.** Every condition in the
shipped example workflows — 27 distinct values across
`backend/tests/integration/workflows/examples/` and
`frontend/packages/syntara-mock-api/src/examples/` — uses a single-token string
literal, a number, or a boolean (`${trigger.status} == 'approved'`,
`${trigger.age} >= 18`, `'test' != 'other'`, `${trigger.use_python} == true`).
There is no multi-word string value anywhere in the corpus.

So the input shape is ordinary — a free-text Value field is the default
authoring path — but it is unrepresented in every example the codebase ships.

## 9. Two documentation statements this PR leaves stale

Both are in `expression-system.md`, the file this PR edits. The doc diff adds the
operator table and three behavior bullets; neither sentence below is touched.

1. **Evaluation order** (`expression-system.md:48`): "`${...}` templates are
   resolved first, then the resulting expression is parsed and only allowlisted
   AST node types are evaluated." The order is now translate
   (`unified_eval.py:260`), then resolve templates (`:262-277`), then parse
   (`:287`). This PR inserts a stage ahead of the documented first step.

2. **Function calls** (`expression-system.md:95`): "It also disallows function
   calls, imports/module access, and attribute access beyond namespace lookup."
   This PR deliberately allows gated `ast.Call` for `len`, `__exists__`,
   `__is_empty__`, and `__re_search__` (`_ALLOWED_CALL_NAMES`), plus the
   `startswith` and `endswith` methods (`_ALLOWED_METHODS`). The sentence is now false, and
   it sits in the Security section.

The architectural point behind both: the documented safety model is *parse, then
allowlist AST node types*. A textual rewrite before the parse is the one stage
where the AST allowlist offers no protection, and it is now the first thing that
touches user-authored text. That stage is undocumented, and item 2 above means
the section a reader would consult to learn otherwise currently describes the
pre-PR evaluator.

These two are independent of the test failures. They are worth correcting
whether or not the literal-corruption behavior is changed.

## 10. Scope notes

1. These tests assert only that a keyword inside a quoted literal is preserved.
   They make no claim about the correctness of the operators themselves — the
   operator behavior is covered by `TestVisualBuilderOperators`.
2. The four control cases pass without any backend code doing work for them:
   `and`, `or`, `not`, and `in` are native Python and have no rewrite rule. They
   are a baseline for the assertion shape, not evidence of existing backend
   coverage.
3. The frontend has no equivalent word-operator tests, and does not need any —
   `normalizer.ts` never rewrites those tokens.
4. No fix is included. Making the substitution quote-aware — masking quoted
   spans before the eight replacements, or tokenizing as `normalizer.ts` does —
   is a change to `_translate_custom_operators` only, and would turn these 20
   failures green without touching the tests.
5. The PR description names Switch and Condition nodes. Do-while Loop conditions
   call the same evaluator (`dynamic_workflow.py:1230`) and are affected
   identically.

## 11. Reproducing

```bash
cd backend
uv run --no-sync pytest \
  tests/unit/workflows/workflow_engine/test_unified_eval.py::TestKeywordInsideStringLiteral -q
```
