### PR TITLE
fix(e2e): retry apiRequest on TOKEN_STALE

### DIFF
--- a/frontend/packages/syntara-ui/e2e/utils/api-core.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api-core.ts
@@ -48,8 +48,19 @@ export async function getAuthToken(app: Page): Promise<string | null> {
   return null
 }
 
-function isStaleTokenResponse(response: APIResponse): boolean {
-  return response.status() === 401 && response.headers()['x-auth-failure-type'] === STALE_TOKEN_FAILURE_HEADER
+async function isStaleTokenResponse(response: APIResponse): Promise<boolean> {
+  if (response.status() !== 401) return false
+
+  const failureType = response.headers()['x-auth-failure-type']
+  if (failureType === STALE_TOKEN_FAILURE_HEADER) return true
+
+  // Metrics middleware strips X-Auth-Failure-Type before the response reaches clients.
+  try {
+    const body = (await response.json()) as { code?: string }
+    return body.code === 'TOKEN_STALE'
+  } catch {
+    return false
+  }
 }
 
 async function sendApiRequest(
@@ -84,7 +95,7 @@ export async function apiRequest(
   let token = options?.token ?? (await getAuthToken(app))
   let response = await sendApiRequest(app, method, path, token, options?.data)
 
-  if (isStaleTokenResponse(response)) {
+  if (await isStaleTokenResponse(response)) {
     token = await getAuthToken(app)
     if (!token) return response
     response = await sendApiRequest(app, method, path, token, options?.data)

--- a/frontend/packages/syntara-ui/e2e/utils/api-core.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api-core.ts
@@ -49,10 +49,7 @@ export async function getAuthToken(app: Page): Promise<string | null> {
 }
 
 function isStaleTokenResponse(response: APIResponse): boolean {
-  return (
-    response.status() === 401 &&
-    response.headers()['x-auth-failure-type'] === STALE_TOKEN_FAILURE_HEADER
-  )
+  return response.status() === 401 && response.headers()['x-auth-failure-type'] === STALE_TOKEN_FAILURE_HEADER
 }
 
 async function sendApiRequest(

--- a/frontend/packages/syntara-ui/e2e/utils/api-core.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api-core.ts
@@ -48,18 +48,11 @@ export async function getAuthToken(app: Page): Promise<string | null> {
   return null
 }
 
-async function isStaleTokenResponse(response: APIResponse): Promise<boolean> {
-  if (response.status() !== 401) return false
-
-  const failureType = response.headers()['x-auth-failure-type']
-  if (failureType === STALE_TOKEN_FAILURE_HEADER) return true
-
-  try {
-    const body = (await response.json()) as { code?: string }
-    return body.code === 'TOKEN_STALE'
-  } catch {
-    return false
-  }
+function isStaleTokenResponse(response: APIResponse): boolean {
+  return (
+    response.status() === 401 &&
+    response.headers()['x-auth-failure-type'] === STALE_TOKEN_FAILURE_HEADER
+  )
 }
 
 async function sendApiRequest(
@@ -94,7 +87,7 @@ export async function apiRequest(
   let token = options?.token ?? (await getAuthToken(app))
   let response = await sendApiRequest(app, method, path, token, options?.data)
 
-  if (await isStaleTokenResponse(response)) {
+  if (isStaleTokenResponse(response)) {
     token = await getAuthToken(app)
     if (!token) return response
     response = await sendApiRequest(app, method, path, token, options?.data)

--- a/frontend/packages/syntara-ui/e2e/utils/api-core.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api-core.ts
@@ -4,6 +4,8 @@
  * Provides authentication, request helpers, and project management
  * that all other domain-specific API modules depend on.
  */
+import type { APIResponse } from '@playwright/test'
+
 import { appBaseUrl, type Page } from '../fixtures'
 
 /** Get the API base URL (proxied through the UI server) */
@@ -13,6 +15,7 @@ export function apiUrl(path: string): string {
 
 const AUTH_ATTEMPTS = 3
 const AUTH_RETRY_DELAY = 500
+const STALE_TOKEN_FAILURE_HEADER = 'stale_token'
 
 /**
  * Authenticate via the API and return an access token.
@@ -45,27 +48,59 @@ export async function getAuthToken(app: Page): Promise<string | null> {
   return null
 }
 
-/** Make an authenticated API request */
+async function isStaleTokenResponse(response: APIResponse): Promise<boolean> {
+  if (response.status() !== 401) return false
+
+  const failureType = response.headers()['x-auth-failure-type']
+  if (failureType === STALE_TOKEN_FAILURE_HEADER) return true
+
+  try {
+    const body = (await response.json()) as { code?: string }
+    return body.code === 'TOKEN_STALE'
+  } catch {
+    return false
+  }
+}
+
+async function sendApiRequest(
+  app: Page,
+  method: 'get' | 'post' | 'patch' | 'delete',
+  path: string,
+  token: string | null,
+  data?: unknown
+): Promise<APIResponse> {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+
+  const url = apiUrl(path)
+  if (method === 'get') return app.request.get(url, { headers })
+  if (method === 'post') return app.request.post(url, { headers, data })
+  if (method === 'patch') return app.request.patch(url, { headers, data })
+  return app.request.delete(url, { headers })
+}
+
+/**
+ * Make an authenticated API request.
+ *
+ * Re-authenticates and retries once when the backend returns `401 TOKEN_STALE`
+ * (admin token_ver bumped while a worker still holds an older bearer token).
+ */
 export async function apiRequest(
   app: Page,
   method: 'get' | 'post' | 'patch' | 'delete',
   path: string,
   options?: { data?: unknown; token?: string }
 ) {
-  const token = options?.token ?? (await getAuthToken(app))
-  const headers: Record<string, string> = {}
-  if (token) headers['Authorization'] = `Bearer ${token}`
+  let token = options?.token ?? (await getAuthToken(app))
+  let response = await sendApiRequest(app, method, path, token, options?.data)
 
-  if (method === 'get') {
-    return app.request.get(apiUrl(path), { headers })
+  if (await isStaleTokenResponse(response)) {
+    token = await getAuthToken(app)
+    if (!token) return response
+    response = await sendApiRequest(app, method, path, token, options?.data)
   }
-  if (method === 'post') {
-    return app.request.post(apiUrl(path), { headers, data: options?.data })
-  }
-  if (method === 'patch') {
-    return app.request.patch(apiUrl(path), { headers, data: options?.data })
-  }
-  return app.request.delete(apiUrl(path), { headers })
+
+  return response
 }
 
 /**


### PR DESCRIPTION
## Description

compose E2E helpers cache a bearer token from `getAuthToken` and pass it through long `beforeAll` seed runs. when another worker bumps admin `token_ver`, the next API call gets `401 TOKEN_STALE` and the whole file fails (saw this on `pagination.spec.ts` during #489 CI).

`apiRequest` now detects stale-token 401s, re-logins, and retries once.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

- [x] `apiRequest` retries once on `401 TOKEN_STALE` (`X-Auth-Failure-Type: stale_token`, JSON `code` fallback)
- [x] fresh login via `getAuthToken` before the retry (ignores the cached bearer passed in `options.token`)

## Out of Scope

- other compose E2E flakes (builder timeouts, converge/switch node visibility, etc.). this only hardens API seed helpers.

## Related Issues

Related to compose E2E failures seen on #489 CI.

## How to Test

1. run compose E2E (or at least `pagination.spec.ts` on real backend)
2. confirm `beforeAll` seeding survives when admin token goes stale mid-run
3. mock API path unchanged (no `TOKEN_STALE` responses there)

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

matches the UI client's stale-token retry pattern. only `e2e/utils/api-core.ts` touched.