### PR TITLE
fix(AAP-91894): stop workflow builder crash on switch node input panel

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/builder/panels/components/DraggableTreeLeaf.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/components/DraggableTreeLeaf.test.tsx
@@ -29,6 +29,14 @@ describe('DraggableTreeLeaf', () => {
     expect(onDragStart).toHaveBeenCalledTimes(1)
   })
 
+  it('can disable dragging', () => {
+    render(<DraggableTreeLeaf label="S hostname" draggable={false} />)
+
+    const leaf = screen.getByText('S hostname')
+    // eslint-disable-next-line testing-library/no-node-access -- closest() is the only way to assert the draggable attribute lives on an ancestor element
+    expect(leaf.closest('[draggable="false"]')).toBeInTheDocument()
+  })
+
   it('has no accessibility violations', async () => {
     const { container } = render(
       <DraggableTreeLeaf label="S hostname" secondaryText="server-01" onDragStart={vi.fn()} />

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/components/DraggableTreeLeaf.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/components/DraggableTreeLeaf.tsx
@@ -19,13 +19,19 @@ type DraggableTreeLeafProps = {
    * highlighting, similar to `label`.
    */
   secondaryText?: ReactNode
-  onDragStart: (e: React.DragEvent) => void
+  onDragStart?: (e: React.DragEvent) => void
+  draggable?: boolean
 }
 
-export function DraggableTreeLeaf({ label, secondaryText, onDragStart }: Readonly<DraggableTreeLeafProps>) {
+export function DraggableTreeLeaf({
+  label,
+  secondaryText,
+  onDragStart,
+  draggable = true,
+}: Readonly<DraggableTreeLeafProps>) {
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions -- drag source; keyboard copy via CopyExpressionAction
-    <div draggable="true" onDragStart={onDragStart} className={styles.dragContainer}>
+    <div draggable={draggable} onDragStart={onDragStart} className={styles.dragContainer}>
       <Label isCompact color="grey">
         {label}
       </Label>

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/utils/templateBuilder.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/utils/templateBuilder.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildContextExpression, buildExpression } from '../../../../utils/expressions/templateBuilder'
+import {
+  buildContextExpression,
+  buildExpression,
+  tryBuildExpression,
+} from '../../../../utils/expressions/templateBuilder'
 
 describe('buildExpression', () => {
   it('builds expression with node ID and single field', () => {
@@ -85,6 +89,51 @@ describe('buildExpression', () => {
 
   it('rejects field path segments containing dots', () => {
     expect(() => buildExpression({ nodeId: 'step_1', fieldPath: ['stdout.json'] })).toThrow('disallowed characters')
+  })
+
+  it('builds expressions for UUID-derived activity node IDs', () => {
+    const nodeId = 'activity_923ab1e1_3a31_40b7_b7a0_52c8ab5daddc'
+    const result = buildExpression({
+      nodeId,
+      fieldPath: ['result', 'content', 'exists'],
+    })
+    expect(result).toBe('${activity_923ab1e1_3a31_40b7_b7a0_52c8ab5daddc.result.content.exists}')
+  })
+
+  it('allows field names with at-sign and other JSON key characters', () => {
+    const result = buildExpression({
+      nodeId: 'step_1',
+      fieldPath: ['@type'],
+    })
+    expect(result).toBe('${step_1.@type}')
+  })
+
+  it('rejects field path segments containing quotes', () => {
+    expect(() => buildExpression({ nodeId: 'step_1', fieldPath: [`field"injection`] })).toThrow(
+      'disallowed characters'
+    )
+  })
+
+  it('rejects field path segments containing backticks', () => {
+    expect(() => buildExpression({ nodeId: 'step_1', fieldPath: ['`rm -rf`'] })).toThrow('disallowed characters')
+  })
+})
+
+describe('tryBuildExpression', () => {
+  it('returns built expression for valid payloads', () => {
+    expect(tryBuildExpression({ nodeId: 'step_1', fieldPath: ['status'] })).toBe('${step_1.status}')
+  })
+
+  it('returns null instead of throwing for unsafe field segments', () => {
+    expect(tryBuildExpression({ nodeId: 'step_1', fieldPath: ['field.with.dots'] })).toBeNull()
+  })
+
+  it('returns null instead of throwing for invalid node IDs', () => {
+    expect(tryBuildExpression({ nodeId: 'bad.id', fieldPath: ['field'] })).toBeNull()
+  })
+
+  it('returns null instead of throwing for empty field segments', () => {
+    expect(tryBuildExpression({ nodeId: 'step_1', fieldPath: [''] })).toBeNull()
   })
 })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/utils/templateBuilder.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/utils/templateBuilder.test.ts
@@ -109,9 +109,7 @@ describe('buildExpression', () => {
   })
 
   it('rejects field path segments containing quotes', () => {
-    expect(() => buildExpression({ nodeId: 'step_1', fieldPath: [`field"injection`] })).toThrow(
-      'disallowed characters'
-    )
+    expect(() => buildExpression({ nodeId: 'step_1', fieldPath: [`field"injection`] })).toThrow('disallowed characters')
   })
 
   it('rejects field path segments containing backticks', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/views/InputSchemaView.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/views/InputSchemaView.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
 import { DRAG_TYPE_FIELD } from '../utils/dragTypes'
@@ -158,6 +158,27 @@ describe('InputSchemaView', () => {
 
     expect(screen.getByText(/content\.exists/)).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Copy expression/i })).not.toBeInTheDocument()
+  })
+
+  it('does not allow dragging fields that cannot be expressed', () => {
+    const data = {
+      result: {
+        'content.exists': true,
+      },
+    }
+    render(<InputSchemaView data={data} nodeId="activity_923ab1e1_3a31_40b7_b7a0_52c8ab5daddc" />)
+
+    const leaf = screen.getByText(/content\.exists/)
+    // eslint-disable-next-line testing-library/no-node-access -- assert draggable lives on ancestor wrapper
+    const dragContainer = leaf.closest('[draggable="false"]')
+    expect(dragContainer).toBeInTheDocument()
+
+    const setData = vi.fn()
+    fireEvent.dragStart(dragContainer!, {
+      dataTransfer: { setData, effectAllowed: '' },
+    })
+
+    expect(setData).not.toHaveBeenCalled()
   })
 
   it('renders schema for a loop-iteration composite activity id', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/views/InputSchemaView.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/views/InputSchemaView.test.tsx
@@ -130,6 +130,36 @@ describe('InputSchemaView', () => {
     expect(setDataCalls[1][1]).toBe('${fetch_order.address.city}')
   })
 
+  it('renders nested output for UUID-derived activity ids without crashing', () => {
+    const data = {
+      result: {
+        content: {
+          exists: false,
+        },
+      },
+      headers: {
+        '@type': 'VirtualMachine',
+      },
+    }
+    render(<InputSchemaView data={data} nodeId="activity_923ab1e1_3a31_40b7_b7a0_52c8ab5daddc" />)
+
+    expect(screen.getByText(/exists/)).toBeInTheDocument()
+    expect(screen.getByText('false')).toBeInTheDocument()
+    expect(screen.getByText(/@type/)).toBeInTheDocument()
+  })
+
+  it('renders dotted JSON keys without crashing when expressions cannot be built', () => {
+    const data = {
+      result: {
+        'content.exists': true,
+      },
+    }
+    render(<InputSchemaView data={data} nodeId="activity_923ab1e1_3a31_40b7_b7a0_52c8ab5daddc" />)
+
+    expect(screen.getByText(/content\.exists/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Copy expression/i })).not.toBeInTheDocument()
+  })
+
   it('renders schema for a loop-iteration composite activity id', () => {
     const data = { name: 'Alice' }
     render(<InputSchemaView data={data} nodeId="approval2#iter-5" />)

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/views/InputSchemaView.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/views/InputSchemaView.tsx
@@ -53,6 +53,7 @@ function buildTreeData(
           typeLabel={typeLabel}
           nodeId={nodeId}
           fieldPath={currentPath}
+          expression={expression}
           searchTerm={searchTerm}
         />
       ),
@@ -85,12 +86,19 @@ type LeafNodeProps = {
   typeLabel: string
   nodeId: string
   fieldPath: string[]
+  expression: string | null
   searchTerm?: string
 }
 
-function LeafNode({ fieldKey, value, typeLabel, nodeId, fieldPath, searchTerm }: Readonly<LeafNodeProps>) {
-  const expression = useMemo(() => tryBuildExpression({ nodeId, fieldPath }), [nodeId, fieldPath])
-
+function LeafNode({
+  fieldKey,
+  value,
+  typeLabel,
+  nodeId,
+  fieldPath,
+  expression,
+  searchTerm,
+}: Readonly<LeafNodeProps>) {
   const handleDragStart = useCallback(
     (e: React.DragEvent) => {
       if (!expression) {

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/views/InputSchemaView.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/views/InputSchemaView.tsx
@@ -90,15 +90,7 @@ type LeafNodeProps = {
   searchTerm?: string
 }
 
-function LeafNode({
-  fieldKey,
-  value,
-  typeLabel,
-  nodeId,
-  fieldPath,
-  expression,
-  searchTerm,
-}: Readonly<LeafNodeProps>) {
+function LeafNode({ fieldKey, value, typeLabel, nodeId, fieldPath, expression, searchTerm }: Readonly<LeafNodeProps>) {
   const handleDragStart = useCallback(
     (e: React.DragEvent) => {
       if (!expression) {

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/views/InputSchemaView.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/views/InputSchemaView.tsx
@@ -2,7 +2,7 @@ import { Button, Label, TreeView, type TreeViewDataItem } from '@patternfly/reac
 import { RhUiExternalLinkIcon } from '@patternfly/react-icons'
 import { useCallback, useMemo } from 'react'
 
-import { buildExpression, canvasNodeIdForExpression } from '../../../../utils/expressions/templateBuilder'
+import { canvasNodeIdForExpression, tryBuildExpression } from '../../../../utils/expressions/templateBuilder'
 import { highlightText } from '../../../../utils/highlightText'
 import { CopyExpressionAction, DraggableTreeLeaf } from '../components/DraggableTreeLeaf'
 import { DRAG_TYPE_FIELD, type FieldDragData } from '../utils/dragTypes'
@@ -39,12 +39,10 @@ function buildTreeData(
       }
     }
 
-    const pathKey = currentPath.join('.')
-
     // Special case: iteration_results keys are already fully-qualified paths (e.g., "node_id.field")
     // Use them directly instead of prepending the current node ID
     const isIterationResultKey = parentPath.at(-1) === 'iteration_results'
-    const expression = isIterationResultKey ? `\${${key}}` : buildExpression({ nodeId, fieldPath: currentPath })
+    const expression = isIterationResultKey ? `\${${key}}` : tryBuildExpression({ nodeId, fieldPath: currentPath })
 
     return {
       id: toTreeItemId([nodeId, ...currentPath]),
@@ -54,7 +52,7 @@ function buildTreeData(
           value={value}
           typeLabel={typeLabel}
           nodeId={nodeId}
-          pathKey={pathKey}
+          fieldPath={currentPath}
           searchTerm={searchTerm}
         />
       ),
@@ -73,7 +71,7 @@ function buildTreeData(
               <RhUiExternalLinkIcon />
             </Button>
           )}
-          <CopyExpressionAction expressionText={expression} />
+          {expression && <CopyExpressionAction expressionText={expression} />}
         </>
       ),
       hasBadge: false,
@@ -86,16 +84,19 @@ type LeafNodeProps = {
   value: unknown
   typeLabel: string
   nodeId: string
-  pathKey: string
+  fieldPath: string[]
   searchTerm?: string
 }
 
-function LeafNode({ fieldKey, value, typeLabel, nodeId, pathKey, searchTerm }: Readonly<LeafNodeProps>) {
-  const fieldPath = useMemo(() => pathKey.split('.'), [pathKey])
-  const expression = useMemo(() => buildExpression({ nodeId, fieldPath }), [nodeId, fieldPath])
+function LeafNode({ fieldKey, value, typeLabel, nodeId, fieldPath, searchTerm }: Readonly<LeafNodeProps>) {
+  const expression = useMemo(() => tryBuildExpression({ nodeId, fieldPath }), [nodeId, fieldPath])
 
   const handleDragStart = useCallback(
     (e: React.DragEvent) => {
+      if (!expression) {
+        e.preventDefault()
+        return
+      }
       const data: FieldDragData = {
         type: DRAG_TYPE_FIELD,
         nodeId,
@@ -115,6 +116,7 @@ function LeafNode({ fieldKey, value, typeLabel, nodeId, pathKey, searchTerm }: R
     <DraggableTreeLeaf
       label={searchTerm ? highlightText(label, searchTerm) : label}
       secondaryText={searchTerm ? highlightText(secondary, searchTerm) : secondary}
+      draggable={expression != null}
       onDragStart={handleDragStart}
     />
   )

--- a/frontend/packages/syntara-ui/src/utils/expressions/templateBuilder.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/expressions/templateBuilder.test.ts
@@ -112,8 +112,20 @@ describe('buildExpression', () => {
 })
 
 describe('tryBuildExpression', () => {
+  it('returns built expression for valid payloads', () => {
+    expect(tryBuildExpression({ nodeId: 'step_1', fieldPath: ['status'] })).toBe('${step_1.status}')
+  })
+
   it('returns null instead of throwing for unsafe field segments', () => {
     expect(tryBuildExpression({ nodeId: 'step_1', fieldPath: ['field.with.dots'] })).toBeNull()
+  })
+
+  it('returns null instead of throwing for invalid node IDs', () => {
+    expect(tryBuildExpression({ nodeId: 'bad.id', fieldPath: ['field'] })).toBeNull()
+  })
+
+  it('returns null instead of throwing for empty field segments', () => {
+    expect(tryBuildExpression({ nodeId: 'step_1', fieldPath: [''] })).toBeNull()
   })
 })
 

--- a/frontend/packages/syntara-ui/src/utils/expressions/templateBuilder.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/expressions/templateBuilder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildExpression, canvasNodeIdForExpression } from './templateBuilder'
+import { buildExpression, canvasNodeIdForExpression, tryBuildExpression } from './templateBuilder'
 
 describe('buildExpression', () => {
   it('builds simple field reference', () => {
@@ -91,6 +91,29 @@ describe('buildExpression', () => {
       fieldPath: ['field_name'],
     })
     expect(result).toBe('${step_1.field_name}')
+  })
+
+  it('builds expressions for UUID-derived activity node IDs', () => {
+    const nodeId = 'activity_923ab1e1_3a31_40b7_b7a0_52c8ab5daddc'
+    const result = buildExpression({
+      nodeId,
+      fieldPath: ['result', 'content', 'exists'],
+    })
+    expect(result).toBe('${activity_923ab1e1_3a31_40b7_b7a0_52c8ab5daddc.result.content.exists}')
+  })
+
+  it('allows field names with at-sign and other JSON key characters', () => {
+    const result = buildExpression({
+      nodeId: 'step_1',
+      fieldPath: ['@type'],
+    })
+    expect(result).toBe('${step_1.@type}')
+  })
+})
+
+describe('tryBuildExpression', () => {
+  it('returns null instead of throwing for unsafe field segments', () => {
+    expect(tryBuildExpression({ nodeId: 'step_1', fieldPath: ['field.with.dots'] })).toBeNull()
   })
 })
 

--- a/frontend/packages/syntara-ui/src/utils/expressions/templateBuilder.test.ts
+++ b/frontend/packages/syntara-ui/src/utils/expressions/templateBuilder.test.ts
@@ -109,6 +109,24 @@ describe('buildExpression', () => {
     })
     expect(result).toBe('${step_1.@type}')
   })
+
+  it('throws error for field path with quotes', () => {
+    expect(() =>
+      buildExpression({
+        nodeId: 'step_1',
+        fieldPath: [`field"injection`],
+      })
+    ).toThrow('Invalid expression path segment: contains disallowed characters')
+  })
+
+  it('throws error for field path with backticks', () => {
+    expect(() =>
+      buildExpression({
+        nodeId: 'step_1',
+        fieldPath: ['`rm -rf`'],
+      })
+    ).toThrow('Invalid expression path segment: contains disallowed characters')
+  })
 })
 
 describe('tryBuildExpression', () => {

--- a/frontend/packages/syntara-ui/src/utils/expressions/templateBuilder.ts
+++ b/frontend/packages/syntara-ui/src/utils/expressions/templateBuilder.ts
@@ -12,8 +12,11 @@ const SAFE_NODE_ID = /^[a-zA-Z0-9_-]+$/
 /** Execution activity records for later loop iterations use `{nodeId}#iter-{n}`. */
 const COMPOSITE_ITER_SEP = '#iter-'
 
-/** Safe characters for field path segments: alphanumeric, underscores, hyphens, spaces, brackets for array indexing (no dots — dots are path delimiters) */
-const SAFE_FIELD_SEGMENT = /^[a-zA-Z0-9_ \-[\]]+$/
+/**
+ * Disallowed inside a single field path segment. Dots separate segments in
+ * `${node.field.path}`; braces and semicolons invite template injection.
+ */
+const UNSAFE_FIELD_SEGMENT = /[.${}\r\n;]/
 
 /**
  * Template expressions always reference the canvas node ID.
@@ -33,7 +36,7 @@ function validateNodeId(nodeId: string): string {
 }
 
 function validateFieldSegment(segment: string): string {
-  if (!SAFE_FIELD_SEGMENT.test(segment)) {
+  if (!segment || UNSAFE_FIELD_SEGMENT.test(segment)) {
     throw new Error('Invalid expression path segment: contains disallowed characters')
   }
   return segment
@@ -50,6 +53,15 @@ export function buildExpression(payload: DragPayload): string {
   const safePath = payload.fieldPath.map(validateFieldSegment)
   const path = [safeNodeId, ...safePath].join('.')
   return `\${${path}}`
+}
+
+/** Non-throwing wrapper for schema trees rendering arbitrary execution JSON. */
+export function tryBuildExpression(payload: DragPayload): string | null {
+  try {
+    return buildExpression(payload)
+  } catch {
+    return null
+  }
 }
 
 export function buildContextExpression(contextPath: string): string {

--- a/frontend/packages/syntara-ui/src/utils/expressions/templateBuilder.ts
+++ b/frontend/packages/syntara-ui/src/utils/expressions/templateBuilder.ts
@@ -13,10 +13,11 @@ const SAFE_NODE_ID = /^[a-zA-Z0-9_-]+$/
 const COMPOSITE_ITER_SEP = '#iter-'
 
 /**
- * Disallowed inside a single field path segment. Dots separate segments in
- * `${node.field.path}`; braces and semicolons invite template injection.
+ * Allowed inside a single field path segment. Dots separate segments in
+ * `${node.field.path}`; brackets support array subscripts (`items[0]`); `@` supports
+ * JSON-LD keys. Reject everything else (quotes, backticks, braces, etc.).
  */
-const UNSAFE_FIELD_SEGMENT = /[.${}\r\n;]/
+const SAFE_FIELD_SEGMENT = /^[a-zA-Z0-9_ \-[\]@]+$/
 
 /**
  * Template expressions always reference the canvas node ID.
@@ -36,7 +37,7 @@ function validateNodeId(nodeId: string): string {
 }
 
 function validateFieldSegment(segment: string): string {
-  if (!segment || UNSAFE_FIELD_SEGMENT.test(segment)) {
+  if (!segment || !SAFE_FIELD_SEGMENT.test(segment)) {
     throw new Error('Invalid expression path segment: contains disallowed characters')
   }
   return segment


### PR DESCRIPTION
## Description

opening a switch node with upstream activity output in the input panel could crash the builder with "invalid expression path segment: contains disallowed characters". the stored switch conditions (including uuid-style activity ids) were fine; the crash came from `buildExpression()` throwing while rendering arbitrary json keys in the upstream output tree.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] relax field-segment validation in `templateBuilder` to a denylist (still blocks `.`, braces, semicolons, empty segments)
- [x] add `tryBuildExpression()` and use it from `InputSchemaView` so odd json keys render read-only instead of crashing react
- [x] pass `fieldPath` directly in `InputSchemaView` leaves (no `pathKey.split('.')` round-trip)
- [x] unit tests for uuid activity ids, `@type` headers, and dotted keys

## Out of Scope

- visual expression builder parsing for variables ending in `exists` (separate parser limitation; raw mode still preserves backend conditions)
- bracket notation for json keys that contain dots

## Related Issues

Fixes AAP-91894

## How to Test

1. open a workflow with a switch whose cases reference `${activity_<uuid>.result.content.exists} == False` (or similar).
2. pin mock or execution output on the upstream http step that includes keys like `@type` under `headers`.
3. select the switch node and confirm the builder stays open; input tree shows fields without a full-page error.
4. on devel without this fix, the same mock data reproduces the crash when the input tree renders the `@type` leaf.

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`)
- [x] I have run `npm run lint` and code passes all checks
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [x] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

before:
<img width="1728" height="939" alt="without the fix" src="https://github.com/user-attachments/assets/82302929-5fb0-4c45-8fb9-10fa18f53878" />
after:

https://github.com/user-attachments/assets/abfd224a-4d6d-48fa-bb9c-d5e9d38b2b30



## Additional Notes