### PR TITLE
refactor(ui): convert shared helpers to object params

### DIFF
--- a/frontend/packages/syntara-ui/src/hooks/projectSelectorUtils.ts
+++ b/frontend/packages/syntara-ui/src/hooks/projectSelectorUtils.ts
@@ -59,13 +59,19 @@ export function getProjectTogglePrefixLabelStyle(isDisabled: boolean | undefined
  * Extracted as a standalone function so the guard branches can be unit-tested
  * directly — PF's programmatic value swap cannot be replicated in happy-dom.
  */
-export function handleTypeaheadChange(
-  val: string,
-  suppressRef: RefObject<boolean>,
-  isOpen: boolean,
-  updateFilter: (v: string) => void,
+export function handleTypeaheadChange({
+  val,
+  suppressRef,
+  isOpen,
+  updateFilter,
+  setIsOpen,
+}: {
+  val: string
+  suppressRef: RefObject<boolean>
+  isOpen: boolean
+  updateFilter: (v: string) => void
   setIsOpen: (open: boolean) => void
-): void {
+}): void {
   if (suppressRef.current) {
     suppressRef.current = false
     if (!isOpen) return

--- a/frontend/packages/syntara-ui/src/hooks/useAAPBrowser.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useAAPBrowser.ts
@@ -82,13 +82,19 @@ function buildSearchParams(
   }
 }
 
-function useAAPQueries(
-  state: AAPSearchState,
-  isActive: boolean,
-  credentialId: string | undefined,
-  templateType: AAPBrowserTemplateType,
+function useAAPQueries({
+  state,
+  isActive,
+  credentialId,
+  templateType,
+  integrationId,
+}: {
+  state: AAPSearchState
+  isActive: boolean
+  credentialId: string | undefined
+  templateType: AAPBrowserTemplateType
   integrationId?: string
-) {
+}) {
   const orgsQuery = aapClient.useQuery(
     'get',
     '/proxies/aap/organizations',
@@ -348,7 +354,7 @@ export function useAAPBrowser(
   }))
   const isActive = credentialId !== undefined || integrationId !== undefined
 
-  const queries = useAAPQueries(state, isActive, credentialId, templateType, integrationId)
+  const queries = useAAPQueries({ state, isActive, credentialId, templateType, integrationId })
   const actions = useAAPActions(setState)
 
   const retryAll = useCallback(() => {

--- a/frontend/packages/syntara-ui/src/hooks/useCursorPagination.test.tsx
+++ b/frontend/packages/syntara-ui/src/hooks/useCursorPagination.test.tsx
@@ -160,25 +160,27 @@ describe('useCursorPagination', () => {
 
       renderHook(() => useCursorPagination({ transformFilters }))
 
-      expect(mockCreateFilterChangeHandler).toHaveBeenCalledWith(
-        null,
-        expect.any(Function),
-        mockClearAllFilters,
-        mockSetAllFilters,
-        transformFilters
-      )
+      const [args] = mockCreateFilterChangeHandler.mock.calls[0] ?? []
+      expect(args).toMatchObject({
+        cursor: null,
+        clearAllFilters: mockClearAllFilters,
+        setAllFilters: mockSetAllFilters,
+        transformFilters,
+      })
+      expect(typeof args?.resetCursor).toBe('function')
     })
 
     it('passes transformExecutionStatusFilter to createFilterChangeHandler', () => {
       renderHook(() => useCursorPagination({ transformFilters: transformExecutionStatusFilter }))
 
-      expect(mockCreateFilterChangeHandler).toHaveBeenCalledWith(
-        null,
-        expect.any(Function),
-        mockClearAllFilters,
-        mockSetAllFilters,
-        transformExecutionStatusFilter
-      )
+      const [args] = mockCreateFilterChangeHandler.mock.calls[0] ?? []
+      expect(args).toMatchObject({
+        cursor: null,
+        clearAllFilters: mockClearAllFilters,
+        setAllFilters: mockSetAllFilters,
+        transformFilters: transformExecutionStatusFilter,
+      })
+      expect(typeof args?.resetCursor).toBe('function')
     })
 
     it('includes approval_pending in queryParams when that filter is active', () => {
@@ -468,13 +470,14 @@ describe('useCursorPagination', () => {
     it('creates handler with correct arguments', () => {
       renderHook(() => useCursorPagination())
 
-      expect(mockCreateFilterChangeHandler).toHaveBeenCalledWith(
-        null, // initial cursor
-        expect.any(Function), // resetCursor
-        mockClearAllFilters,
-        mockSetAllFilters,
-        undefined // no transformFilters
-      )
+      const [args] = mockCreateFilterChangeHandler.mock.calls[0] ?? []
+      expect(args).toMatchObject({
+        cursor: null, // initial cursor
+        clearAllFilters: mockClearAllFilters,
+        setAllFilters: mockSetAllFilters,
+        transformFilters: undefined, // no transformFilters
+      })
+      expect(typeof args?.resetCursor).toBe('function')
     })
   })
 
@@ -645,7 +648,15 @@ describe('useCursorReset', () => {
   it('resets pagination when all conditions are met', () => {
     const resetPagination = vi.fn()
 
-    renderHook(() => useCursorReset(0, false, 'some-cursor', false, resetPagination))
+    renderHook(() =>
+      useCursorReset({
+        itemCount: 0,
+        hasActiveFilters: false,
+        cursor: 'some-cursor',
+        isFetching: false,
+        resetPagination,
+      })
+    )
 
     expect(resetPagination).toHaveBeenCalled()
   })
@@ -653,7 +664,15 @@ describe('useCursorReset', () => {
   it('does not reset when itemCount is greater than 0', () => {
     const resetPagination = vi.fn()
 
-    renderHook(() => useCursorReset(5, false, 'some-cursor', false, resetPagination))
+    renderHook(() =>
+      useCursorReset({
+        itemCount: 5,
+        hasActiveFilters: false,
+        cursor: 'some-cursor',
+        isFetching: false,
+        resetPagination,
+      })
+    )
 
     expect(resetPagination).not.toHaveBeenCalled()
   })
@@ -661,7 +680,15 @@ describe('useCursorReset', () => {
   it('does not reset when filters are active', () => {
     const resetPagination = vi.fn()
 
-    renderHook(() => useCursorReset(0, true, 'some-cursor', false, resetPagination))
+    renderHook(() =>
+      useCursorReset({
+        itemCount: 0,
+        hasActiveFilters: true,
+        cursor: 'some-cursor',
+        isFetching: false,
+        resetPagination,
+      })
+    )
 
     expect(resetPagination).not.toHaveBeenCalled()
   })
@@ -669,7 +696,9 @@ describe('useCursorReset', () => {
   it('does not reset when cursor is null', () => {
     const resetPagination = vi.fn()
 
-    renderHook(() => useCursorReset(0, false, null, false, resetPagination))
+    renderHook(() =>
+      useCursorReset({ itemCount: 0, hasActiveFilters: false, cursor: null, isFetching: false, resetPagination })
+    )
 
     expect(resetPagination).not.toHaveBeenCalled()
   })
@@ -677,7 +706,15 @@ describe('useCursorReset', () => {
   it('does not reset when query is fetching', () => {
     const resetPagination = vi.fn()
 
-    renderHook(() => useCursorReset(0, false, 'some-cursor', true, resetPagination))
+    renderHook(() =>
+      useCursorReset({
+        itemCount: 0,
+        hasActiveFilters: false,
+        cursor: 'some-cursor',
+        isFetching: true,
+        resetPagination,
+      })
+    )
 
     expect(resetPagination).not.toHaveBeenCalled()
   })
@@ -686,7 +723,8 @@ describe('useCursorReset', () => {
     const resetPagination = vi.fn()
 
     const { rerender } = renderHook(
-      ({ itemCount, isFetching }) => useCursorReset(itemCount, false, 'cursor-val', isFetching, resetPagination),
+      ({ itemCount, isFetching }) =>
+        useCursorReset({ itemCount, hasActiveFilters: false, cursor: 'cursor-val', isFetching, resetPagination }),
       {
         initialProps: { itemCount: 5, isFetching: false },
       }
@@ -703,7 +741,8 @@ describe('useCursorReset', () => {
     const resetPagination = vi.fn()
 
     const { rerender } = renderHook(
-      ({ isFetching }) => useCursorReset(0, false, 'cursor-val', isFetching, resetPagination),
+      ({ isFetching }) =>
+        useCursorReset({ itemCount: 0, hasActiveFilters: false, cursor: 'cursor-val', isFetching, resetPagination }),
       {
         initialProps: { isFetching: false },
       }

--- a/frontend/packages/syntara-ui/src/hooks/useCursorPagination.tsx
+++ b/frontend/packages/syntara-ui/src/hooks/useCursorPagination.tsx
@@ -152,7 +152,14 @@ export function useCursorPagination(options: UseCursorPaginationOptions = {}): U
   })
 
   const handleFilterChange = useMemo(
-    () => createFilterChangeHandler(cursor, resetPagination, clearAllFilters, setAllFilters, transformFilters),
+    () =>
+      createFilterChangeHandler({
+        cursor,
+        resetCursor: resetPagination,
+        clearAllFilters,
+        setAllFilters,
+        transformFilters,
+      }),
     [cursor, resetPagination, clearAllFilters, setAllFilters, transformFilters]
   )
 
@@ -269,13 +276,19 @@ export function useCursorPagination(options: UseCursorPaginationOptions = {}): U
  *
  * Use this in list views after getting query results.
  */
-export function useCursorReset(
-  itemCount: number,
-  hasActiveFilters: boolean,
-  cursor: string | null,
-  isFetching: boolean,
+export function useCursorReset({
+  itemCount,
+  hasActiveFilters,
+  cursor,
+  isFetching,
+  resetPagination,
+}: {
+  itemCount: number
+  hasActiveFilters: boolean
+  cursor: string | null
+  isFetching: boolean
   resetPagination: () => void
-): void {
+}): void {
   useEffect(() => {
     if (itemCount === 0 && !hasActiveFilters && cursor && !isFetching) {
       resetPagination()

--- a/frontend/packages/syntara-ui/src/hooks/useFilterChangeHandler.test.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useFilterChangeHandler.test.ts
@@ -10,7 +10,7 @@ describe('createFilterChangeHandler', () => {
     const clearAllFilters = vi.fn()
     const setAllFilters = vi.fn()
 
-    const handler = createFilterChangeHandler('page-2-cursor', resetCursor, clearAllFilters, setAllFilters)
+    const handler = createFilterChangeHandler({ cursor: 'page-2-cursor', resetCursor, clearAllFilters, setAllFilters })
 
     const newFilters: FilterConfig[] = [{ key: 'name', operator: 'contains', value: 'test' }]
     handler(newFilters)
@@ -25,7 +25,7 @@ describe('createFilterChangeHandler', () => {
     const clearAllFilters = vi.fn()
     const setAllFilters = vi.fn()
 
-    const handler = createFilterChangeHandler(null, resetCursor, clearAllFilters, setAllFilters)
+    const handler = createFilterChangeHandler({ cursor: null, resetCursor, clearAllFilters, setAllFilters })
 
     const newFilters: FilterConfig[] = [{ key: 'name', operator: 'contains', value: 'test' }]
     handler(newFilters)
@@ -39,7 +39,7 @@ describe('createFilterChangeHandler', () => {
     const clearAllFilters = vi.fn()
     const setAllFilters = vi.fn()
 
-    const handler = createFilterChangeHandler('page-2-cursor', resetCursor, clearAllFilters, setAllFilters)
+    const handler = createFilterChangeHandler({ cursor: 'page-2-cursor', resetCursor, clearAllFilters, setAllFilters })
 
     handler([])
 
@@ -53,7 +53,7 @@ describe('createFilterChangeHandler', () => {
     const clearAllFilters = vi.fn()
     const setAllFilters = vi.fn()
 
-    const handler = createFilterChangeHandler(null, resetCursor, clearAllFilters, setAllFilters)
+    const handler = createFilterChangeHandler({ cursor: null, resetCursor, clearAllFilters, setAllFilters })
 
     const newFilters: FilterConfig[] = [
       { key: 'name', operator: 'contains', value: 'test' },
@@ -78,7 +78,13 @@ describe('createFilterChangeHandler', () => {
       })
     )
 
-    const handler = createFilterChangeHandler(null, resetCursor, clearAllFilters, setAllFilters, transformFilters)
+    const handler = createFilterChangeHandler({
+      cursor: null,
+      resetCursor,
+      clearAllFilters,
+      setAllFilters,
+      transformFilters,
+    })
 
     const newFilters: FilterConfig[] = [{ key: 'is_enabled', operator: 'eq', value: 'true' }]
     handler(newFilters)
@@ -92,7 +98,7 @@ describe('createFilterChangeHandler', () => {
     const clearAllFilters = vi.fn()
     const setAllFilters = vi.fn()
 
-    const handler = createFilterChangeHandler(null, resetCursor, clearAllFilters, setAllFilters)
+    const handler = createFilterChangeHandler({ cursor: null, resetCursor, clearAllFilters, setAllFilters })
 
     const newFilters: FilterConfig[] = [{ key: 'is_enabled', operator: 'eq', value: 'true' }]
     handler(newFilters)
@@ -112,7 +118,13 @@ describe('createFilterChangeHandler', () => {
         return filter
       })
 
-    const handler = createFilterChangeHandler(null, resetCursor, clearAllFilters, setAllFilters, transformFilters)
+    const handler = createFilterChangeHandler({
+      cursor: null,
+      resetCursor,
+      clearAllFilters,
+      setAllFilters,
+      transformFilters,
+    })
 
     const newFilters: FilterConfig[] = [
       { key: 'name', operator: 'contains', value: 'test' },
@@ -131,7 +143,7 @@ describe('createFilterChangeHandler', () => {
     const clearAllFilters = vi.fn()
     const setAllFilters = vi.fn()
 
-    const handler = createFilterChangeHandler('cursor', resetCursor, clearAllFilters, setAllFilters)
+    const handler = createFilterChangeHandler({ cursor: 'cursor', resetCursor, clearAllFilters, setAllFilters })
 
     handler([])
 
@@ -146,7 +158,7 @@ describe('createFilterChangeHandler', () => {
     const clearAllFilters = vi.fn()
     const setAllFilters = vi.fn()
 
-    const handler = createFilterChangeHandler('cursor', resetCursor, clearAllFilters, setAllFilters)
+    const handler = createFilterChangeHandler({ cursor: 'cursor', resetCursor, clearAllFilters, setAllFilters })
 
     const newFilters: FilterConfig[] = [{ key: 'name', operator: 'contains', value: 'test' }]
     handler(newFilters)

--- a/frontend/packages/syntara-ui/src/hooks/useFilterChangeHandler.ts
+++ b/frontend/packages/syntara-ui/src/hooks/useFilterChangeHandler.ts
@@ -14,44 +14,50 @@ import type { FilterConfig } from '../types/filters'
  * - setAllFilters() preserves non-filter URL params, but cursor wouldn't be there anyway
  * - This keeps URLs clean and bookmarkable while maintaining pagination state
  *
- * @param cursor - Current pagination cursor value from component state
- * @param resetCursor - Function to reset the pagination cursor to null
- * @param clearAllFilters - Function to clear all active filters
- * @param setAllFilters - Function to set all filters atomically
- * @param transformFilters - Optional function to transform filters before applying (e.g., convert string to boolean)
+ * @param options.cursor - Current pagination cursor value from component state
+ * @param options.resetCursor - Function to reset the pagination cursor to null
+ * @param options.clearAllFilters - Function to clear all active filters
+ * @param options.setAllFilters - Function to set all filters atomically
+ * @param options.transformFilters - Optional function to transform filters before applying (e.g., convert string to boolean)
  * @returns Filter change handler function
  *
  * @example
  * // Basic usage (Integrations, Integration Tools)
- * const handleFilterChange = createFilterChangeHandler(
+ * const handleFilterChange = createFilterChangeHandler({
  *   cursor,
- *   () => setCursor(null),
+ *   resetCursor: () => setCursor(null),
  *   clearAllFilters,
- *   setAllFilters
- * )
+ *   setAllFilters,
+ * })
  *
  * @example
  * // With value transformation (Workflows - convert is_enabled string to boolean)
- * const handleFilterChange = createFilterChangeHandler(
+ * const handleFilterChange = createFilterChangeHandler({
  *   cursor,
- *   () => dispatch({ type: 'SET_CURSOR', payload: null }),
+ *   resetCursor: () => dispatch({ type: 'SET_CURSOR', payload: null }),
  *   clearAllFilters,
  *   setAllFilters,
- *   (filters) => filters.map((filter) => {
+ *   transformFilters: (filters) => filters.map((filter) => {
  *     if (filter.key === 'is_enabled' && typeof filter.value === 'string') {
  *       return { ...filter, value: filter.value === 'true' }
  *     }
  *     return filter
- *   })
- * )
+ *   }),
+ * })
  */
-export const createFilterChangeHandler = (
-  cursor: string | null,
-  resetCursor: () => void,
-  clearAllFilters: () => void,
-  setAllFilters: (filters: FilterConfig[]) => void,
+export const createFilterChangeHandler = ({
+  cursor,
+  resetCursor,
+  clearAllFilters,
+  setAllFilters,
+  transformFilters,
+}: {
+  cursor: string | null
+  resetCursor: () => void
+  clearAllFilters: () => void
+  setAllFilters: (filters: FilterConfig[]) => void
   transformFilters?: (filters: FilterConfig[]) => FilterConfig[]
-) => {
+}) => {
   return (newFilters: FilterConfig[]) => {
     // Reset to first page when filters change
     if (cursor) {

--- a/frontend/packages/syntara-ui/src/hooks/useProjectSelector.dropdown.tsx
+++ b/frontend/packages/syntara-ui/src/hooks/useProjectSelector.dropdown.tsx
@@ -268,7 +268,13 @@ export function ProjectSelectorDropdown(props: Readonly<ProjectSelectorDropdownP
                   aria-label="Project"
                   aria-invalid={menuToggleStatus === 'danger'}
                   onChange={(_e, val) =>
-                    handleTypeaheadChange(val, suppressFilterUpdateOnCloseRef, isOpen, updateFilter, setIsOpen)
+                    handleTypeaheadChange({
+                      val,
+                      suppressRef: suppressFilterUpdateOnCloseRef,
+                      isOpen,
+                      updateFilter,
+                      setIsOpen,
+                    })
                   }
                   onClick={() => {
                     if (!isOpen) {

--- a/frontend/packages/syntara-ui/src/hooks/useProjectSelector.test.tsx
+++ b/frontend/packages/syntara-ui/src/hooks/useProjectSelector.test.tsx
@@ -755,7 +755,7 @@ describe('useProjectSelector', () => {
       const updateFilter = vi.fn<(v: string) => void>()
       const setIsOpen = vi.fn<(open: boolean) => void>()
 
-      handleTypeaheadChange('Alpha', suppressRef, false, updateFilter, setIsOpen)
+      handleTypeaheadChange({ val: 'Alpha', suppressRef, isOpen: false, updateFilter, setIsOpen })
 
       // Guard should have consumed the ref and returned early
       expect(suppressRef.current).toBe(false)
@@ -770,7 +770,7 @@ describe('useProjectSelector', () => {
       const updateFilter = vi.fn<(v: string) => void>()
       const setIsOpen = vi.fn<(open: boolean) => void>()
 
-      handleTypeaheadChange('bet', suppressRef, true, updateFilter, setIsOpen)
+      handleTypeaheadChange({ val: 'bet', suppressRef, isOpen: true, updateFilter, setIsOpen })
 
       expect(suppressRef.current).toBe(false)
       expect(updateFilter).toHaveBeenCalledWith('bet')

--- a/frontend/packages/syntara-ui/src/routes/access-management/GroupsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/GroupsTab.tsx
@@ -99,7 +99,7 @@ export function GroupsTab() {
   const data = query.data
   const groups = data?.resources ?? []
 
-  useCursorReset(groups.length, hasActiveFilters, cursor, query.isFetching, resetPagination)
+  useCursorReset({ itemCount: groups.length, hasActiveFilters, cursor, isFetching: query.isFetching, resetPagination })
 
   const { mutate: deleteGroup } = usersClient.useMutation('delete', '/groups/{group_id}')
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/ProjectsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/ProjectsTab.tsx
@@ -190,7 +190,13 @@ export function ProjectsTab() {
   const projects = data?.resources ?? []
   const refetch = useCallback(() => detachPromise(query.refetch()), [query])
 
-  useCursorReset(projects.length, hasActiveFilters, cursor, query.isFetching, resetPagination)
+  useCursorReset({
+    itemCount: projects.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: query.isFetching,
+    resetPagination,
+  })
 
   const { mutate: deleteProject } = accessClient.useMutation('delete', '/projects/{project_id}')
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/UsersTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/UsersTab.tsx
@@ -93,13 +93,19 @@ const DELETE_USER_ACKNOWLEDGEMENT = {
   label: 'I understand this user will be permanently deleted.',
 }
 
-function getRowActions(
-  user: User,
-  onDelete: (user: User) => void,
-  onRevoke: (user: User) => void,
-  permissions: ReturnType<typeof useUserPermissions>,
+function getRowActions({
+  user,
+  onDelete,
+  onRevoke,
+  permissions,
+  onNavigate,
+}: {
+  user: User
+  onDelete: (user: User) => void
+  onRevoke: (user: User) => void
+  permissions: ReturnType<typeof useUserPermissions>
   onNavigate: (path: string) => void
-): KebabAction[] {
+}): KebabAction[] {
   return [
     {
       key: 'edit',
@@ -254,7 +260,7 @@ function UserTableRow({
       <Td isActionCell>
         {!user.is_builtin && (
           <SynKebabMenu
-            actions={getRowActions(user, onDelete, onRevoke, permissions, onNavigate)}
+            actions={getRowActions({ user, onDelete, onRevoke, permissions, onNavigate })}
             aria-label={`Actions for ${user.username}`}
           />
         )}
@@ -299,7 +305,13 @@ export function UsersTab() {
   const isAdminEnabled = builtinUser?.is_enabled ?? true
   const refetch = useCallback(() => query.refetch(), [query])
 
-  useCursorReset(serverUsers.length, hasActiveFilters, cursor, query.isFetching, resetPagination)
+  useCursorReset({
+    itemCount: serverUsers.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: query.isFetching,
+    resetPagination,
+  })
 
   const handleCreateUser = permissions.canCreate
     ? () => detachPromise(navigate({ to: AppRoute.AccessManagement.CreateUser }))

--- a/frontend/packages/syntara-ui/src/routes/access-management/groupFilters.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/groupFilters.test.ts
@@ -37,7 +37,7 @@ describe('groupFilters', () => {
       const clearAllFilters = vi.fn()
       const setAllFilters = vi.fn()
 
-      const handler = createFilterChangeHandler('some-cursor', resetCursor, clearAllFilters, setAllFilters)
+      const handler = createFilterChangeHandler({ cursor: 'some-cursor', resetCursor, clearAllFilters, setAllFilters })
 
       handler([{ key: 'name', operator: 'contains', value: 'test' }])
 
@@ -50,7 +50,7 @@ describe('groupFilters', () => {
       const clearAllFilters = vi.fn()
       const setAllFilters = vi.fn()
 
-      const handler = createFilterChangeHandler(null, resetCursor, clearAllFilters, setAllFilters)
+      const handler = createFilterChangeHandler({ cursor: null, resetCursor, clearAllFilters, setAllFilters })
 
       handler([])
 
@@ -63,7 +63,7 @@ describe('groupFilters', () => {
       const clearAllFilters = vi.fn()
       const setAllFilters = vi.fn()
 
-      const handler = createFilterChangeHandler(null, resetCursor, clearAllFilters, setAllFilters)
+      const handler = createFilterChangeHandler({ cursor: null, resetCursor, clearAllFilters, setAllFilters })
 
       handler([{ key: 'name', operator: 'contains', value: 'test' }])
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectRoleAssignmentsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/projects/ProjectRoleAssignmentsTab.tsx
@@ -33,6 +33,21 @@ import { AssignProjectRoleModal } from './AssignProjectRoleModal'
 
 const SORT_FIELDS = ['principal_name', 'role_name'] as const
 
+function buildAssignedRolesByPrincipal(assignments: RoleAssignmentRead[]): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>()
+  for (const a of assignments) {
+    const id = a.group_id ?? a.principal_id
+    if (!id) continue
+    const existing = map.get(id)
+    if (existing) {
+      existing.add(a.role_name)
+    } else {
+      map.set(id, new Set([a.role_name]))
+    }
+  }
+  return map
+}
+
 const filterFieldDefinitions: FilterFieldDefinition[] = [
   {
     key: 'principal_name',
@@ -176,7 +191,14 @@ export function ProjectRoleAssignmentsTab({ projectId }: Readonly<{ projectId: s
 
   const assignments = useMemo(() => query.data?.resources ?? [], [query.data])
 
-  useCursorReset(assignments.length, hasActiveFilters, cursor, query.isFetching, resetPagination)
+  const isAssignmentsFetching = query.isFetching
+  useCursorReset({
+    itemCount: assignments.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: isAssignmentsFetching,
+    resetPagination,
+  })
 
   const refetch = useCallback(() => detachPromise(query.refetch()), [query])
   const refetchAndInvalidateAuthz = useCallback(() => {
@@ -185,20 +207,7 @@ export function ProjectRoleAssignmentsTab({ projectId }: Readonly<{ projectId: s
     detachPromise(queryClient.invalidateQueries({ queryKey: ['role-assignments'] }))
   }, [queryClient, refetch])
 
-  const assignedRolesByPrincipal = useMemo(() => {
-    const map = new Map<string, Set<string>>()
-    for (const a of assignments) {
-      const id = a.group_id ?? a.principal_id
-      if (!id) continue
-      const existing = map.get(id)
-      if (existing) {
-        existing.add(a.role_name)
-      } else {
-        map.set(id, new Set([a.role_name]))
-      }
-    }
-    return map
-  }, [assignments])
+  const assignedRolesByPrincipal = useMemo(() => buildAssignedRolesByPrincipal(assignments), [assignments])
 
   const handleRoleCreated = useCallback(() => {
     detachPromise(queryClient.invalidateQueries({ queryKey: ['all-project-roles', projectId] }))

--- a/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/CredentialsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/CredentialsTab.tsx
@@ -359,7 +359,13 @@ export function CredentialsTab({
   const atLimit = totalCredentials >= maxCredentials
   const createDisabledTooltip = getCreateDisabledTooltip(permissions, serviceAccountName, maxCredentials)
 
-  useCursorReset(credentials.length, hasActiveFilters, cursor, query.isFetching, resetPagination)
+  useCursorReset({
+    itemCount: credentials.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: query.isFetching,
+    resetPagination,
+  })
 
   const actions = useCredentialActions(serviceAccountId, query.refetch, disableDialog.open)
 

--- a/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/service-accounts/ServiceAccountsTab.tsx
@@ -185,7 +185,13 @@ export function ServiceAccountsTab() {
   const serviceAccounts = query.data?.resources ?? []
   const refetch = useCallback(() => detachPromise(query.refetch()), [query])
 
-  useCursorReset(serviceAccounts.length, hasActiveFilters, cursor, query.isFetching, resetPagination)
+  useCursorReset({
+    itemCount: serviceAccounts.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: query.isFetching,
+    resetPagination,
+  })
 
   const createDialog = useDialogState()
   const deleteDialog = useDialogState<ServiceAccountRead>()

--- a/frontend/packages/syntara-ui/src/routes/access-management/userFilters.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/access-management/userFilters.test.ts
@@ -90,7 +90,7 @@ describe('userFilters', () => {
       const clearAllFilters = vi.fn()
       const setAllFilters = vi.fn()
 
-      const handler = createFilterChangeHandler('some-cursor', resetCursor, clearAllFilters, setAllFilters)
+      const handler = createFilterChangeHandler({ cursor: 'some-cursor', resetCursor, clearAllFilters, setAllFilters })
 
       handler([{ key: 'username', operator: 'contains', value: 'test' }])
 
@@ -103,7 +103,7 @@ describe('userFilters', () => {
       const clearAllFilters = vi.fn()
       const setAllFilters = vi.fn()
 
-      const handler = createFilterChangeHandler(null, resetCursor, clearAllFilters, setAllFilters)
+      const handler = createFilterChangeHandler({ cursor: null, resetCursor, clearAllFilters, setAllFilters })
 
       handler([])
 
@@ -116,7 +116,7 @@ describe('userFilters', () => {
       const clearAllFilters = vi.fn()
       const setAllFilters = vi.fn()
 
-      const handler = createFilterChangeHandler(null, resetCursor, clearAllFilters, setAllFilters)
+      const handler = createFilterChangeHandler({ cursor: null, resetCursor, clearAllFilters, setAllFilters })
 
       handler([{ key: 'username', operator: 'contains', value: 'test' }])
 

--- a/frontend/packages/syntara-ui/src/routes/access/AssignmentsTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/AssignmentsTab.tsx
@@ -262,7 +262,7 @@ export function AssignmentsTab() {
   const { expandedRows, allRowsExpanded, handleToggleRow, handleCollapseAll } = useExpandableRowIds(rowIds)
   const refetch = useCallback(() => detachPromise(assignmentsQuery.refetch()), [assignmentsQuery])
 
-  useCursorReset(rows.length, hasActiveFilters, cursor, isFetching, resetPagination)
+  useCursorReset({ itemCount: rows.length, hasActiveFilters, cursor, isFetching, resetPagination })
 
   const { mutate: deleteRoleAssignment } = accessClient.useMutation('delete', '/role_assignments/{assignment_id}')
   const { mutate: deleteProjectRoleAssignment } = accessClient.useMutation(

--- a/frontend/packages/syntara-ui/src/routes/access/PoliciesTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/PoliciesTab.tsx
@@ -166,7 +166,13 @@ export function PoliciesTab() {
   const policies = useMemo(() => (data?.resources ?? []).map(toPolicyRead), [data?.resources])
   const refetch = useCallback(() => detachPromise(policiesQuery.refetch()), [policiesQuery])
 
-  useCursorReset(policies.length, hasActiveFilters, cursor, policiesQuery.isFetching, resetPagination)
+  useCursorReset({
+    itemCount: policies.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: policiesQuery.isFetching,
+    resetPagination,
+  })
 
   const showToolbar = policies.length > 0 || hasActiveFilters
   const policyJsonItem = policyJsonDialog.item

--- a/frontend/packages/syntara-ui/src/routes/access/RolesTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/RolesTab.tsx
@@ -251,7 +251,13 @@ export function RolesTab() {
     refetch()
   }, [queryClient, refetch])
 
-  useCursorReset(roles.length, hasActiveFilters, cursor, rolesQuery.isFetching, resetPagination)
+  useCursorReset({
+    itemCount: roles.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: rolesQuery.isFetching,
+    resetPagination,
+  })
 
   const allRowsExpanded = roles.length > 0 && roles.every((r) => expandedRows.has(r.id))
 

--- a/frontend/packages/syntara-ui/src/routes/approvals/Approvals.tsx
+++ b/frontend/packages/syntara-ui/src/routes/approvals/Approvals.tsx
@@ -127,7 +127,13 @@ function ApprovalsPage({ approvalsDocLink }: { approvalsDocLink: string | null |
       return next
     })
 
-  useCursorReset(enrichedApprovals.length, hasActiveFilters, cursor, approvalsQuery.isFetching, resetPagination)
+  useCursorReset({
+    itemCount: enrichedApprovals.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: approvalsQuery.isFetching,
+    resetPagination,
+  })
 
   // Get per-project approval:decide permissions
   const {

--- a/frontend/packages/syntara-ui/src/routes/builder/Builder.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/Builder.test.tsx
@@ -56,7 +56,7 @@ describe('Builder Workflow Store Helpers', () => {
   describe('createEventTrigger', () => {
     it('creates event trigger without filter', async () => {
       const { createEventTrigger } = await import('../../stores/useWorkflowStore')
-      const trigger = createEventTrigger('test-trigger-6', 'github', 'push')
+      const trigger = createEventTrigger({ id: 'test-trigger-6', source: 'github', eventType: 'push' })
 
       expect(trigger.id).toBe('test-trigger-6')
       expect(trigger.type).toBe('event')
@@ -67,7 +67,12 @@ describe('Builder Workflow Store Helpers', () => {
 
     it('creates event trigger with filter', async () => {
       const { createEventTrigger } = await import('../../stores/useWorkflowStore')
-      const trigger = createEventTrigger('test-trigger-7', 'github', 'push', { branch: 'main' })
+      const trigger = createEventTrigger({
+        id: 'test-trigger-7',
+        source: 'github',
+        eventType: 'push',
+        filter: { branch: 'main' },
+      })
 
       expect(trigger.id).toBe('test-trigger-7')
       expect(trigger.type).toBe('event')

--- a/frontend/packages/syntara-ui/src/routes/builder/node-details/TaskNodeDetails.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-details/TaskNodeDetails.tsx
@@ -226,13 +226,14 @@ function getStringField(config: Record<string, unknown>, ...keys: string[]): str
   return undefined
 }
 
-function resolveUseInputVariables(
-  c: StoredAAPConfig,
-  organizationName: string,
-  jobTemplateName: string,
-  inventoryName: string,
+function resolveUseInputVariables(params: {
+  c: StoredAAPConfig
+  organizationName: string
+  jobTemplateName: string
+  inventoryName: string
   extraVars: string
-): boolean {
+}): boolean {
+  const { c, organizationName, jobTemplateName, inventoryName, extraVars } = params
   return (
     c.use_input_variables === true ||
     c.useInputVariables === true ||
@@ -282,7 +283,13 @@ function buildAAPInitialData(taskName: string, config: Record<string, unknown>):
     instance_group: getField(c.instance_group_name, c.instanceGroupName, '') as string | undefined,
     instance_group_id: c.instance_group_id ?? c.instanceGroupId,
     labels: c.labels ?? [],
-    use_input_variables: resolveUseInputVariables(c, organizationName, jobTemplateName, inventoryName, extraVars),
+    use_input_variables: resolveUseInputVariables({
+      c,
+      organizationName,
+      jobTemplateName,
+      inventoryName,
+      extraVars,
+    }),
   }
 }
 
@@ -365,13 +372,13 @@ function renderAAPTaskDetails({
           const workflowConfig = buildAAPWorkflowTemplateConfig(data)
           updateActivity(
             nodeId,
-            createAAPWorkflowTemplateActivity(
-              nodeId,
-              data.name,
-              workflow_job_template_id,
-              workflowConfig,
-              data.settings
-            )
+            createAAPWorkflowTemplateActivity({
+              id: nodeId,
+              name: data.name,
+              workflowTemplateId: workflow_job_template_id,
+              config: workflowConfig,
+              settings: data.settings,
+            })
           )
         }
 
@@ -407,7 +414,13 @@ function renderAAPTaskDetails({
         const aapNodeConfig = buildAAPConfig(data)
         updateActivity(
           nodeId,
-          createAAPJobTemplateActivity(nodeId, data.name, job_template_id, aapNodeConfig, data.settings)
+          createAAPJobTemplateActivity({
+            id: nodeId,
+            name: data.name,
+            jobTemplateId: job_template_id,
+            config: aapNodeConfig,
+            settings: data.settings,
+          })
         )
       }
 

--- a/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/QUICK_START.md
+++ b/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/QUICK_START.md
@@ -269,7 +269,7 @@ export default function registerWebhookNode() {
       },
       (data, onSuccess, onError) => {
         try {
-          const trigger = createEventTrigger('webhook', data.eventType)
+          const trigger = createEventTrigger({ id: 'webhook', source: 'webhook', eventType: data.eventType })
 
           if (trigger) {
             useWorkflowStore.getState().addTrigger(trigger)

--- a/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerAAPNode.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerAAPNode.ts
@@ -86,7 +86,7 @@ export default function registerAAPNode() {
                 label: 'AAP Job Template',
               })
               const { activityId, activity } = buildNamedActivity(baseName, jobData.name, (id, name) =>
-                createAAPJobTemplateActivity(id, name, jobData.job_template_id, config)
+                createAAPJobTemplateActivity({ id, name, jobTemplateId: jobData.job_template_id, config })
               )
               addActivity(activity)
               onSuccess(activityId)
@@ -114,7 +114,12 @@ export default function registerAAPNode() {
                 label: 'AAP Workflow Template',
               })
               const { activityId, activity } = buildNamedActivity(baseName, workflowData.name, (id, name) =>
-                createAAPWorkflowTemplateActivity(id, name, workflowData.workflow_job_template_id, config)
+                createAAPWorkflowTemplateActivity({
+                  id,
+                  name,
+                  workflowTemplateId: workflowData.workflow_job_template_id,
+                  config,
+                })
               )
               addActivity(activity)
               onSuccess(activityId)

--- a/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerLogicNodeSubmit.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerLogicNodeSubmit.ts
@@ -65,19 +65,19 @@ export function submitLoopLogic(options: {
     return false
   }
 
-  const activity = createLoopActivity(
-    activityId,
+  const activity = createLoopActivity({
+    id: activityId,
     name,
     loopType,
-    {
+    config: {
       items: data.items,
       condition: data.condition,
       maxIterations: data.maxIterations,
       indexVariable: data.indexVariable,
       itemVariable: data.itemVariable,
     },
-    data.settings
-  )
+    settings: data.settings,
+  })
 
   const genericNodeId = `task_${Date.now()}_${generateId()}`
   const genericName = getNodeDisplayName('Generic Step')

--- a/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerTriggerNode.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerTriggerNode.test.ts
@@ -27,11 +27,11 @@ vi.mock('../../../../stores/useWorkflowStore', () => ({
     id,
     type: TriggerTypeEnum.SCHEDULED,
   })),
-  createWebhookTrigger: vi.fn((id: string) => ({
+  createWebhookTrigger: vi.fn(({ id }: { id: string }) => ({
     id,
     type: TriggerTypeEnum.WEBHOOK_TRIGGER,
   })),
-  createEdaTrigger: vi.fn((id: string) => ({
+  createEdaTrigger: vi.fn(({ id }: { id: string }) => ({
     id,
     type: TriggerTypeEnum.EDA_TRIGGER,
   })),
@@ -203,13 +203,14 @@ describe('registerTriggerNode', () => {
       onError
     )
 
-    expect(vi.mocked(createWebhookTrigger)).toHaveBeenCalledWith(
-      expect.any(String),
-      '',
-      undefined,
-      expect.any(String),
-      undefined
-    )
+    const [webhookArgs] = vi.mocked(createWebhookTrigger).mock.calls[0] ?? []
+    expect(webhookArgs).toMatchObject({
+      webhookPath: '',
+      inputSchema: undefined,
+      authorizedServiceAccountIds: undefined,
+    })
+    expect(typeof webhookArgs?.id).toBe('string')
+    expect(typeof webhookArgs?.name).toBe('string')
     expect(onSuccess).toHaveBeenCalled()
   })
 
@@ -264,13 +265,14 @@ describe('registerTriggerNode', () => {
       onError
     )
 
-    expect(vi.mocked(createWebhookTrigger)).toHaveBeenCalledWith(
-      expect.any(String),
-      '/hooks/deploy',
-      undefined,
-      expect.any(String),
-      serviceAccountIds
-    )
+    const [webhookArgs] = vi.mocked(createWebhookTrigger).mock.calls[0] ?? []
+    expect(webhookArgs).toMatchObject({
+      webhookPath: '/hooks/deploy',
+      inputSchema: undefined,
+      authorizedServiceAccountIds: serviceAccountIds,
+    })
+    expect(typeof webhookArgs?.id).toBe('string')
+    expect(typeof webhookArgs?.name).toBe('string')
     expect(onSuccess).toHaveBeenCalled()
   })
 
@@ -298,13 +300,14 @@ describe('registerTriggerNode', () => {
       onError
     )
 
-    expect(vi.mocked(createEdaTrigger)).toHaveBeenCalledWith(
-      expect.any(String),
-      '/eda/events',
-      undefined,
-      expect.any(String),
-      serviceAccountIds
-    )
+    const [edaArgs] = vi.mocked(createEdaTrigger).mock.calls[0] ?? []
+    expect(edaArgs).toMatchObject({
+      webhookPath: '/eda/events',
+      inputSchema: undefined,
+      authorizedServiceAccountIds: serviceAccountIds,
+    })
+    expect(typeof edaArgs?.id).toBe('string')
+    expect(typeof edaArgs?.name).toBe('string')
     expect(onSuccess).toHaveBeenCalled()
   })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerTriggerNode.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/registry/nodes/registerTriggerNode.ts
@@ -95,13 +95,13 @@ export default function registerTriggerNode() {
               const inputSchema = parseJsonSchema(data.inputSchema)
               const factory =
                 data.triggerType === TriggerTypeEnum.WEBHOOK_TRIGGER ? createWebhookTrigger : createEdaTrigger
-              return factory(
-                triggerId,
-                normalizeWebhookPath(data.webhookPath ?? ''),
+              return factory({
+                id: triggerId,
+                webhookPath: normalizeWebhookPath(data.webhookPath ?? ''),
                 inputSchema,
                 name,
-                data.authorizedServiceAccountIds
-              )
+                authorizedServiceAccountIds: data.authorizedServiceAccountIds,
+              })
             }
             return createManualTrigger(triggerId, undefined, name)
           })

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/aapHelpers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/aapHelpers.ts
@@ -30,7 +30,7 @@ export function buildExpressionModeActivity(
   // job_template_id is set to 0 as a placeholder — expression-mode nodes resolve
   // the template by name at runtime, so the ID is removed from config below.
   const config = { ...buildAAPConfig(data), useInputVariables: true }
-  const activity = createAAPJobTemplateActivity(nodeId, name, 0, config)
+  const activity = createAAPJobTemplateActivity({ id: nodeId, name, jobTemplateId: 0, config })
   if (activity.parameters) {
     activity.parameters.job_template_name = data.job_template_name
     activity.parameters.organization_name = data.organization_name
@@ -227,7 +227,7 @@ export function buildWorkflowExpressionModeActivity(
   data: AAPWorkflowTemplateFormData
 ): ReturnType<typeof createAAPWorkflowTemplateActivity> {
   const config = buildAAPWorkflowTemplateConfig(data)
-  const activity = createAAPWorkflowTemplateActivity(nodeId, name, 0, config)
+  const activity = createAAPWorkflowTemplateActivity({ id: nodeId, name, workflowTemplateId: 0, config })
   if (activity.parameters) {
     activity.parameters.workflow_job_template_name = data.workflow_job_template_name
     activity.parameters.organization_name = data.organization_name

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/Credentials.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/Credentials.tsx
@@ -156,7 +156,13 @@ export default function Credentials() {
   const query = credentialsClient.useQuery('get', '/credentials', { params: { query: finalQueryParams } })
   const serverCredentials = useMemo(() => query.data?.resources ?? [], [query.data?.resources])
 
-  useCursorReset(serverCredentials.length, hasActiveFilters, cursor, query.isFetching, resetPagination)
+  useCursorReset({
+    itemCount: serverCredentials.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: query.isFetching,
+    resetPagination,
+  })
 
   // Fetch credential types for type name lookup
   const typesQuery = credentialsClient.useQuery('get', '/credential_types')

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/Integrations.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/Integrations.tsx
@@ -214,7 +214,7 @@ export default function Integrations() {
   // API order from queryParams.sort — no client-side re-sort
   const results = query.data?.resources ?? []
 
-  useCursorReset(results.length, hasActiveFilters, cursor, query.isFetching, resetPagination)
+  useCursorReset({ itemCount: results.length, hasActiveFilters, cursor, isFetching: query.isFetching, resetPagination })
 
   const isEmpty = results.length === 0
 

--- a/frontend/packages/syntara-ui/src/routes/executions/Executions.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/Executions.tsx
@@ -86,7 +86,13 @@ export default function Executions() {
 
   const executions = useMemo(() => (executionsQuery.data?.resources ?? []) as Execution[], [executionsQuery.data])
 
-  useCursorReset(executions.length, hasActiveFilters, cursor, executionsQuery.isFetching, resetPagination)
+  useCursorReset({
+    itemCount: executions.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: executionsQuery.isFetching,
+    resetPagination,
+  })
 
   const filterFieldDefinitions = useMemo(() => buildFilterFieldDefinitions(executions), [executions])
 

--- a/frontend/packages/syntara-ui/src/routes/executions/executionFilters.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/executionFilters.test.ts
@@ -236,7 +236,13 @@ describe('executionFilters', () => {
   describe('createFilterChangeHandler integration', () => {
     it('applies transformExecutionStatusFilter when filters change', () => {
       const setAllFilters = vi.fn()
-      const handler = createFilterChangeHandler(null, vi.fn(), vi.fn(), setAllFilters, transformExecutionStatusFilter)
+      const handler = createFilterChangeHandler({
+        cursor: null,
+        resetCursor: vi.fn(),
+        clearAllFilters: vi.fn(),
+        setAllFilters,
+        transformFilters: transformExecutionStatusFilter,
+      })
 
       handler([{ key: 'status', value: EXECUTION_STATUS_APPROVAL_PENDING }])
 

--- a/frontend/packages/syntara-ui/src/routes/workflows/Workflows.tsx
+++ b/frontend/packages/syntara-ui/src/routes/workflows/Workflows.tsx
@@ -78,6 +78,42 @@ function WorkflowsPageToolbar({
   )
 }
 
+type WorkflowRowActionContext = {
+  selectedProject: ReturnType<typeof useProjectSelector>['selectedProject']
+  projectsById: Map<string | undefined, { is_builtin?: boolean | undefined }>
+  permissions: ReturnType<typeof useWorkflowPermissions>
+  navigate: ReturnType<typeof useNavigate>
+  runDialog: ReturnType<typeof useDialogState<Workflow>>
+  publishDialog: ReturnType<typeof useDialogState<Workflow>>
+  unpublishDialog: ReturnType<typeof useDialogState<Workflow>>
+  deleteDialog: ReturnType<typeof useDialogState<Workflow>>
+  duplicateWorkflow: ReturnType<typeof useDuplicateWorkflow>['duplicateWorkflow']
+  isDuplicating: boolean
+  showError: ReturnType<typeof useAlerts>['showError']
+}
+
+function getWorkflowRowActions(workflow: Workflow, ctx: WorkflowRowActionContext) {
+  const isBuiltinProject = !!ctx.selectedProject?.is_builtin || !!ctx.projectsById.get(workflow.project_id)?.is_builtin
+  return buildWorkflowRowActions(workflow, ctx.permissions, isBuiltinProject, {
+    navigate: ctx.navigate,
+    onRun: (wf) => ctx.runDialog.open(wf),
+    onDuplicate: (wf) => detachPromise(ctx.duplicateWorkflow(wf)),
+    onExport: (wf) => {
+      if (wf.id) {
+        detachPromise(
+          downloadWorkflowExportById(wf.id).catch((err: unknown) => {
+            ctx.showError({ title: 'Export failed', description: getErrorMessage(err) })
+          })
+        )
+      }
+    },
+    onPublish: (wf) => ctx.publishDialog.open(wf),
+    onUnpublish: (wf) => ctx.unpublishDialog.open(wf),
+    onDelete: (wf) => ctx.deleteDialog.open(wf),
+    isDuplicating: ctx.isDuplicating,
+  })
+}
+
 export default function Workflows() {
   const workflowsDocLink = useDocLink('workflows')
   const { showAlert, showSuccess, showError } = useAlerts()
@@ -162,7 +198,13 @@ export default function Workflows() {
     isAllProjects
   )
 
-  useCursorReset(sortedWorkflows.length, hasActiveFilters, cursor, workflowsQuery.isFetching, resetPagination)
+  useCursorReset({
+    itemCount: sortedWorkflows.length,
+    hasActiveFilters,
+    cursor,
+    isFetching: workflowsQuery.isFetching,
+    resetPagination,
+  })
 
   const { handleDeleteProject: handleDeleteProjectBase, isDeletingProject } = useProjectActions({
     showSuccess,
@@ -192,27 +234,20 @@ export default function Workflows() {
     projectPermissions,
   })
 
-  const getRowActions = (workflow: Workflow) => {
-    const isBuiltinProject = !!selectedProject?.is_builtin || !!projectsById.get(workflow.project_id)?.is_builtin
-    return buildWorkflowRowActions(workflow, permissions, isBuiltinProject, {
+  const getRowActions = (workflow: Workflow) =>
+    getWorkflowRowActions(workflow, {
+      selectedProject,
+      projectsById,
+      permissions,
       navigate,
-      onRun: (wf) => runDialog.open(wf),
-      onDuplicate: (wf) => detachPromise(duplicateWorkflow(wf)),
-      onExport: (wf) => {
-        if (wf.id) {
-          detachPromise(
-            downloadWorkflowExportById(wf.id).catch((err: unknown) => {
-              showError({ title: 'Export failed', description: getErrorMessage(err) })
-            })
-          )
-        }
-      },
-      onPublish: (wf) => publishDialog.open(wf),
-      onUnpublish: (wf) => unpublishDialog.open(wf),
-      onDelete: (wf) => deleteDialog.open(wf),
+      runDialog,
+      publishDialog,
+      unpublishDialog,
+      deleteDialog,
+      duplicateWorkflow,
       isDuplicating,
+      showError,
     })
-  }
 
   const hasQueryState = workflowsQuery.isPending || !!workflowsQuery.error
   return (

--- a/frontend/packages/syntara-ui/src/stores/triggerFactories.test.ts
+++ b/frontend/packages/syntara-ui/src/stores/triggerFactories.test.ts
@@ -72,7 +72,7 @@ describe('triggerFactories', () => {
 
   describe('createEventTrigger', () => {
     it('creates an event trigger with required fields', () => {
-      const trigger = createEventTrigger('t1', 'github', 'push')
+      const trigger = createEventTrigger({ id: 't1', source: 'github', eventType: 'push' })
       expect(trigger).toEqual({
         id: 't1',
         type: TriggerTypeEnum.EVENT,
@@ -83,7 +83,13 @@ describe('triggerFactories', () => {
 
     it('includes filter when provided', () => {
       const filter = { branch: 'main' }
-      const trigger = createEventTrigger('t1', 'github', 'push', filter, 'Push Trigger')
+      const trigger = createEventTrigger({
+        id: 't1',
+        source: 'github',
+        eventType: 'push',
+        filter,
+        name: 'Push Trigger',
+      })
       expect(trigger.parameters).toEqual({ source: 'github', event_type: 'push', filter })
       expect(trigger.name).toBe('Push Trigger')
     })
@@ -91,7 +97,7 @@ describe('triggerFactories', () => {
 
   describe('createWebhookTrigger', () => {
     it('creates a webhook trigger with path only', () => {
-      const trigger = createWebhookTrigger('t1', 'my-hook')
+      const trigger = createWebhookTrigger({ id: 't1', webhookPath: 'my-hook' })
       expect(trigger).toEqual({
         id: 't1',
         type: TriggerTypeEnum.WEBHOOK_TRIGGER,
@@ -102,7 +108,13 @@ describe('triggerFactories', () => {
 
     it('includes input_schema and authorizedServiceAccountIds', () => {
       const schema = { type: 'object' }
-      const trigger = createWebhookTrigger('t1', 'hook', schema, 'Custom WH', ['sa-1', 'sa-2'])
+      const trigger = createWebhookTrigger({
+        id: 't1',
+        webhookPath: 'hook',
+        inputSchema: schema,
+        name: 'Custom WH',
+        authorizedServiceAccountIds: ['sa-1', 'sa-2'],
+      })
       expect(trigger.parameters).toEqual({
         webhook_path: 'hook',
         input_schema: schema,
@@ -112,14 +124,20 @@ describe('triggerFactories', () => {
     })
 
     it('omits authorized_service_account_ids when array is empty', () => {
-      const trigger = createWebhookTrigger('t1', 'hook', undefined, undefined, [])
+      const trigger = createWebhookTrigger({
+        id: 't1',
+        webhookPath: 'hook',
+        inputSchema: undefined,
+        name: undefined,
+        authorizedServiceAccountIds: [],
+      })
       expect(trigger.parameters).toEqual({ webhook_path: 'hook' })
     })
   })
 
   describe('createEdaTrigger', () => {
     it('creates an EDA trigger with path only', () => {
-      const trigger = createEdaTrigger('t1', 'eda-path')
+      const trigger = createEdaTrigger({ id: 't1', webhookPath: 'eda-path' })
       expect(trigger).toEqual({
         id: 't1',
         type: TriggerTypeEnum.EDA_TRIGGER,
@@ -130,7 +148,13 @@ describe('triggerFactories', () => {
 
     it('includes input_schema and authorizedServiceAccountIds', () => {
       const schema = { type: 'object' }
-      const trigger = createEdaTrigger('t1', 'eda', schema, 'My EDA', ['sa-3'])
+      const trigger = createEdaTrigger({
+        id: 't1',
+        webhookPath: 'eda',
+        inputSchema: schema,
+        name: 'My EDA',
+        authorizedServiceAccountIds: ['sa-3'],
+      })
       expect(trigger.parameters).toEqual({
         webhook_path: 'eda',
         input_schema: schema,
@@ -140,7 +164,13 @@ describe('triggerFactories', () => {
     })
 
     it('omits authorized_service_account_ids when array is empty', () => {
-      const trigger = createEdaTrigger('t1', 'eda', undefined, undefined, [])
+      const trigger = createEdaTrigger({
+        id: 't1',
+        webhookPath: 'eda',
+        inputSchema: undefined,
+        name: undefined,
+        authorizedServiceAccountIds: [],
+      })
       expect(trigger.parameters).toEqual({ webhook_path: 'eda' })
     })
   })

--- a/frontend/packages/syntara-ui/src/stores/triggerFactories.ts
+++ b/frontend/packages/syntara-ui/src/stores/triggerFactories.ts
@@ -50,17 +50,20 @@ export function createScheduledTrigger(
   }
 }
 
+export type CreateEventTriggerOptions = {
+  id: string
+  source: string
+  eventType: string
+  filter?: Record<string, unknown>
+  name?: string
+}
+
 /**
  * Create an event trigger (v2).
  * @note This trigger type is not yet in the v2 backend schema
  */
-export function createEventTrigger(
-  id: string,
-  source: string,
-  eventType: string,
-  filter?: Record<string, unknown>,
-  name?: string
-): Activity {
+export function createEventTrigger(options: CreateEventTriggerOptions): Activity {
+  const { id, source, eventType, filter, name } = options
   return {
     id,
     type: TriggerTypeEnum.EVENT,
@@ -73,52 +76,60 @@ export function createEventTrigger(
   }
 }
 
-type WebhookTriggerOptions = { inputSchema?: Record<string, unknown>; authorizedServiceAccountIds?: string[] }
+type CreateWebhookStyleTriggerOptions = {
+  id: string
+  webhookPath: string
+  type: typeof TriggerTypeEnum.WEBHOOK_TRIGGER | typeof TriggerTypeEnum.EDA_TRIGGER
+  name: string
+  inputSchema?: Record<string, unknown>
+  authorizedServiceAccountIds?: string[]
+}
 
-function createWebhookStyleTrigger(
-  id: string,
-  webhookPath: string,
-  type: typeof TriggerTypeEnum.WEBHOOK_TRIGGER | typeof TriggerTypeEnum.EDA_TRIGGER,
-  name: string,
-  options?: WebhookTriggerOptions
-): Activity {
+function createWebhookStyleTrigger(options: CreateWebhookStyleTriggerOptions): Activity {
+  const { id, webhookPath, type, name, inputSchema, authorizedServiceAccountIds } = options
   return {
     id,
     type,
     name,
     parameters: {
       webhook_path: webhookPath,
-      ...(options?.inputSchema && { input_schema: options.inputSchema }),
-      ...(options?.authorizedServiceAccountIds?.length && {
-        authorized_service_account_ids: options.authorizedServiceAccountIds,
+      ...(inputSchema && { input_schema: inputSchema }),
+      ...(authorizedServiceAccountIds?.length && {
+        authorized_service_account_ids: authorizedServiceAccountIds,
       }),
     },
   }
 }
 
-/** Create a webhook trigger (v2). */
-export function createWebhookTrigger(
-  id: string,
-  webhookPath: string,
-  inputSchema?: Record<string, unknown>,
-  name?: string,
+export type CreateWebhookTriggerOptions = {
+  id: string
+  webhookPath: string
+  inputSchema?: Record<string, unknown>
+  name?: string
   authorizedServiceAccountIds?: string[]
-): Activity {
-  return createWebhookStyleTrigger(id, webhookPath, TriggerTypeEnum.WEBHOOK_TRIGGER, name ?? 'Webhook Trigger', {
+}
+
+/** Create a webhook trigger (v2). */
+export function createWebhookTrigger(options: CreateWebhookTriggerOptions): Activity {
+  const { id, webhookPath, inputSchema, name, authorizedServiceAccountIds } = options
+  return createWebhookStyleTrigger({
+    id,
+    webhookPath,
+    type: TriggerTypeEnum.WEBHOOK_TRIGGER,
+    name: name ?? 'Webhook Trigger',
     inputSchema,
     authorizedServiceAccountIds,
   })
 }
 
 /** Create an EDA trigger (v2). */
-export function createEdaTrigger(
-  id: string,
-  webhookPath: string,
-  inputSchema?: Record<string, unknown>,
-  name?: string,
-  authorizedServiceAccountIds?: string[]
-): Activity {
-  return createWebhookStyleTrigger(id, webhookPath, TriggerTypeEnum.EDA_TRIGGER, name ?? 'EDA Trigger', {
+export function createEdaTrigger(options: CreateWebhookTriggerOptions): Activity {
+  const { id, webhookPath, inputSchema, name, authorizedServiceAccountIds } = options
+  return createWebhookStyleTrigger({
+    id,
+    webhookPath,
+    type: TriggerTypeEnum.EDA_TRIGGER,
+    name: name ?? 'EDA Trigger',
     inputSchema,
     authorizedServiceAccountIds,
   })

--- a/frontend/packages/syntara-ui/src/stores/workflowFactories.test.ts
+++ b/frontend/packages/syntara-ui/src/stores/workflowFactories.test.ts
@@ -117,7 +117,7 @@ describe('workflowFactories', () => {
 
     describe('createEventTrigger', () => {
       it('creates an event trigger', () => {
-        const trigger = createEventTrigger('trigger-12', 'github', 'push')
+        const trigger = createEventTrigger({ id: 'trigger-12', source: 'github', eventType: 'push' })
 
         expect(trigger.id).toBe('trigger-12')
         expect(trigger.type).toBe('event')
@@ -126,14 +126,25 @@ describe('workflowFactories', () => {
       })
 
       it('creates an event trigger with filter', () => {
-        const trigger = createEventTrigger('trigger-13', 'github', 'push', { branch: 'main' })
+        const trigger = createEventTrigger({
+          id: 'trigger-13',
+          source: 'github',
+          eventType: 'push',
+          filter: { branch: 'main' },
+        })
 
         expect(trigger.id).toBe('trigger-13')
         expect(trigger.parameters.filter).toEqual({ branch: 'main' })
       })
 
       it('creates an event trigger with name', () => {
-        const trigger = createEventTrigger('trigger-14', 'github', 'push', undefined, 'GitHub Push')
+        const trigger = createEventTrigger({
+          id: 'trigger-14',
+          source: 'github',
+          eventType: 'push',
+          filter: undefined,
+          name: 'GitHub Push',
+        })
 
         expect(trigger.id).toBe('trigger-14')
         expect(trigger.name).toBe('GitHub Push')
@@ -142,7 +153,7 @@ describe('workflowFactories', () => {
 
     describe('createWebhookTrigger', () => {
       it('creates a webhook trigger with path', () => {
-        const trigger = createWebhookTrigger('trigger-20', 'jira-updates')
+        const trigger = createWebhookTrigger({ id: 'trigger-20', webhookPath: 'jira-updates' })
 
         expect(trigger.id).toBe('trigger-20')
         expect(trigger.type).toBe(TriggerTypeEnum.WEBHOOK_TRIGGER)
@@ -153,7 +164,7 @@ describe('workflowFactories', () => {
 
       it('creates a webhook trigger with JSON schema', () => {
         const schema = { type: 'object', properties: { name: { type: 'string' } } }
-        const trigger = createWebhookTrigger('trigger-21', 'github-push', schema)
+        const trigger = createWebhookTrigger({ id: 'trigger-21', webhookPath: 'github-push', inputSchema: schema })
 
         expect(trigger.id).toBe('trigger-21')
         expect(trigger.parameters.webhook_path).toBe('github-push')
@@ -161,21 +172,26 @@ describe('workflowFactories', () => {
       })
 
       it('creates a webhook trigger with custom name', () => {
-        const trigger = createWebhookTrigger('trigger-22', 'slack-events', undefined, 'Slack Webhook')
+        const trigger = createWebhookTrigger({
+          id: 'trigger-22',
+          webhookPath: 'slack-events',
+          inputSchema: undefined,
+          name: 'Slack Webhook',
+        })
 
         expect(trigger.id).toBe('trigger-22')
         expect(trigger.name).toBe('Slack Webhook')
       })
 
       it('creates trigger with any path (format validation in schema layer)', () => {
-        const trigger = createWebhookTrigger('trigger-23', 'api/v2/events')
+        const trigger = createWebhookTrigger({ id: 'trigger-23', webhookPath: 'api/v2/events' })
         expect(trigger.parameters.webhook_path).toBe('api/v2/events')
       })
     })
 
     describe('createEdaTrigger', () => {
       it('creates an EDA trigger with path', () => {
-        const trigger = createEdaTrigger('trigger-30', 'eda-events')
+        const trigger = createEdaTrigger({ id: 'trigger-30', webhookPath: 'eda-events' })
 
         expect(trigger.id).toBe('trigger-30')
         expect(trigger.type).toBe(TriggerTypeEnum.EDA_TRIGGER)
@@ -186,7 +202,7 @@ describe('workflowFactories', () => {
 
       it('creates an EDA trigger with JSON schema', () => {
         const schema = { type: 'object', properties: { name: { type: 'string' } } }
-        const trigger = createEdaTrigger('trigger-31', 'eda-push', schema)
+        const trigger = createEdaTrigger({ id: 'trigger-31', webhookPath: 'eda-push', inputSchema: schema })
 
         expect(trigger.id).toBe('trigger-31')
         expect(trigger.parameters.webhook_path).toBe('eda-push')
@@ -194,14 +210,19 @@ describe('workflowFactories', () => {
       })
 
       it('creates an EDA trigger with custom name', () => {
-        const trigger = createEdaTrigger('trigger-32', 'eda-alerts', undefined, 'My EDA Trigger')
+        const trigger = createEdaTrigger({
+          id: 'trigger-32',
+          webhookPath: 'eda-alerts',
+          inputSchema: undefined,
+          name: 'My EDA Trigger',
+        })
 
         expect(trigger.id).toBe('trigger-32')
         expect(trigger.name).toBe('My EDA Trigger')
       })
 
       it('creates trigger with any path (format validation in schema layer)', () => {
-        const trigger = createEdaTrigger('trigger-33', 'api/v2/events')
+        const trigger = createEdaTrigger({ id: 'trigger-33', webhookPath: 'api/v2/events' })
         expect(trigger.parameters.webhook_path).toBe('api/v2/events')
       })
     })
@@ -569,10 +590,15 @@ describe('workflowFactories', () => {
 
     describe('createLoopActivity', () => {
       it('creates a forEach loop activity', () => {
-        const activity = createLoopActivity('loop-1', 'Process Items', 'forEach', {
-          items: '{{ items }}',
-          itemVariable: 'item',
-          indexVariable: 'idx',
+        const activity = createLoopActivity({
+          id: 'loop-1',
+          name: 'Process Items',
+          loopType: 'forEach',
+          config: {
+            items: '{{ items }}',
+            itemVariable: 'item',
+            indexVariable: 'idx',
+          },
         })
 
         expect(activity.type).toBe('loop')
@@ -582,9 +608,14 @@ describe('workflowFactories', () => {
       })
 
       it('creates a while loop activity', () => {
-        const activity = createLoopActivity('loop-1', 'While Loop', 'while', {
-          condition: 'count < 10',
-          maxIterations: 100,
+        const activity = createLoopActivity({
+          id: 'loop-1',
+          name: 'While Loop',
+          loopType: 'while',
+          config: {
+            condition: 'count < 10',
+            maxIterations: 100,
+          },
         })
 
         expect(activity.parameters.type).toBe('do_while')
@@ -593,36 +624,52 @@ describe('workflowFactories', () => {
       })
 
       it('does not include invalid maxIterations', () => {
-        const activity = createLoopActivity('loop-1', 'While Loop', 'while', {
-          condition: 'count < 10',
-          maxIterations: Number.NaN,
+        const activity = createLoopActivity({
+          id: 'loop-1',
+          name: 'While Loop',
+          loopType: 'while',
+          config: {
+            condition: 'count < 10',
+            maxIterations: Number.NaN,
+          },
         })
 
         expect(activity.parameters).not.toHaveProperty('max_iterations')
       })
 
       it('omits items when config is missing', () => {
-        const activity = createLoopActivity('loop-1', 'Loop', 'forEach', {})
+        const activity = createLoopActivity({ id: 'loop-1', name: 'Loop', loopType: 'forEach', config: {} })
 
         expect(activity.parameters.type).toBe('for_each')
         expect(activity.parameters).not.toHaveProperty('items')
       })
 
       it('omits condition when config is missing', () => {
-        const activity = createLoopActivity('loop-1', 'Loop', 'while', {})
+        const activity = createLoopActivity({ id: 'loop-1', name: 'Loop', loopType: 'while', config: {} })
 
         expect(activity.parameters.type).toBe('do_while')
         expect(activity.parameters).not.toHaveProperty('condition')
       })
 
       it('includes settings when provided', () => {
-        const activity = createLoopActivity('loop-1', 'Loop', 'forEach', { items: '{{ list }}' }, { timeout: 300 })
+        const activity = createLoopActivity({
+          id: 'loop-1',
+          name: 'Loop',
+          loopType: 'forEach',
+          config: { items: '{{ list }}' },
+          settings: { timeout: 300 },
+        })
 
         expect(activity.settings).toEqual({ timeout: 300 })
       })
 
       it('includes max_iterations for forEach', () => {
-        const activity = createLoopActivity('loop-1', 'Loop', 'forEach', { items: '{{ list }}', maxIterations: 50 })
+        const activity = createLoopActivity({
+          id: 'loop-1',
+          name: 'Loop',
+          loopType: 'forEach',
+          config: { items: '{{ list }}', maxIterations: 50 },
+        })
 
         expect(activity.parameters.max_iterations).toBe(50)
       })
@@ -683,7 +730,7 @@ describe('workflowFactories', () => {
 
     describe('createAAPJobTemplateActivity', () => {
       it('creates an AAP job template activity', () => {
-        const activity = createAAPJobTemplateActivity('aap-1', 'Run Playbook', 123)
+        const activity = createAAPJobTemplateActivity({ id: 'aap-1', name: 'Run Playbook', jobTemplateId: 123 })
 
         expect(activity.type).toBe('aap_job_template')
         expect(activity.id).toBe('aap-1')
@@ -691,17 +738,22 @@ describe('workflowFactories', () => {
       })
 
       it('creates an AAP activity with full config', () => {
-        const activity = createAAPJobTemplateActivity('aap-1', 'Run Playbook', 123, {
-          inventory: 456,
-          extraVars: { env: 'prod' },
-          limit: 'web-servers',
-          tags: 'deploy',
-          skipTags: 'test',
-          verbosity: 2,
-          jobType: 'run',
-          forks: 10,
-          jobSlicing: 2,
-          diffMode: true,
+        const activity = createAAPJobTemplateActivity({
+          id: 'aap-1',
+          name: 'Run Playbook',
+          jobTemplateId: 123,
+          config: {
+            inventory: 456,
+            extraVars: { env: 'prod' },
+            limit: 'web-servers',
+            tags: 'deploy',
+            skipTags: 'test',
+            verbosity: 2,
+            jobType: 'run',
+            forks: 10,
+            jobSlicing: 2,
+            diffMode: true,
+          },
         })
 
         expect(activity.parameters.inventory_id).toBe(456)
@@ -717,25 +769,40 @@ describe('workflowFactories', () => {
       })
 
       it('includes integration_id when integrationId is set in config', () => {
-        const activity = createAAPJobTemplateActivity('aap-1', 'Run Playbook', 123, {
-          integrationId: 'int-aap-1',
+        const activity = createAAPJobTemplateActivity({
+          id: 'aap-1',
+          name: 'Run Playbook',
+          jobTemplateId: 123,
+          config: {
+            integrationId: 'int-aap-1',
+          },
         })
 
         expect(activity.parameters.integration_id).toBe('int-aap-1')
       })
 
       it('omits integration_id when integrationId is empty string', () => {
-        const activity = createAAPJobTemplateActivity('aap-1', 'Run Playbook', 123, {
-          integrationId: '',
+        const activity = createAAPJobTemplateActivity({
+          id: 'aap-1',
+          name: 'Run Playbook',
+          jobTemplateId: 123,
+          config: {
+            integrationId: '',
+          },
         })
 
         expect(activity.parameters).not.toHaveProperty('integration_id')
       })
 
       it('includes both credential_id and integration_id when both set', () => {
-        const activity = createAAPJobTemplateActivity('aap-1', 'Run Playbook', 123, {
-          credentialId: 'cred-123',
-          integrationId: 'int-aap-1',
+        const activity = createAAPJobTemplateActivity({
+          id: 'aap-1',
+          name: 'Run Playbook',
+          jobTemplateId: 123,
+          config: {
+            credentialId: 'cred-123',
+            integrationId: 'int-aap-1',
+          },
         })
 
         expect(activity.parameters.credential_id).toBe('cred-123')
@@ -743,8 +810,13 @@ describe('workflowFactories', () => {
       })
 
       it('persists use_input_variables when useInputVariables is true', () => {
-        const activity = createAAPJobTemplateActivity('aap-1', 'Run Playbook', undefined, {
-          useInputVariables: true,
+        const activity = createAAPJobTemplateActivity({
+          id: 'aap-1',
+          name: 'Run Playbook',
+          jobTemplateId: undefined,
+          config: {
+            useInputVariables: true,
+          },
         })
 
         expect(activity.parameters.use_input_variables).toBe(true)
@@ -754,7 +826,11 @@ describe('workflowFactories', () => {
 
     describe('createAAPWorkflowTemplateActivity', () => {
       it('creates an AAP workflow template activity', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456)
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+        })
 
         expect(activity.type).toBe('aap_workflow_job_template')
         expect(activity.id).toBe('aap-wf-1')
@@ -762,14 +838,19 @@ describe('workflowFactories', () => {
       })
 
       it('creates an AAP workflow template activity with full config', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          inventory_id: 789,
-          extra_vars: { env: 'staging' },
-          limit: 'db-servers',
-          scm_branch: 'main',
-          tags: 'deploy',
-          skip_tags: 'debug',
-          labels: ['production', 'critical'],
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            inventory_id: 789,
+            extra_vars: { env: 'staging' },
+            limit: 'db-servers',
+            scm_branch: 'main',
+            tags: 'deploy',
+            skip_tags: 'debug',
+            labels: ['production', 'critical'],
+          },
         })
 
         expect(activity.parameters.workflow_job_template_id).toBe(456)
@@ -783,10 +864,15 @@ describe('workflowFactories', () => {
       })
 
       it('creates an AAP workflow template activity with credential and organization', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          credential_id: 'cred-123',
-          organization_id: 10,
-          organization_name: 'Engineering',
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            credential_id: 'cred-123',
+            organization_id: 10,
+            organization_name: 'Engineering',
+          },
         })
 
         expect(activity.parameters.credential_id).toBe('cred-123')
@@ -795,17 +881,27 @@ describe('workflowFactories', () => {
       })
 
       it('includes integration_id when set in workflow config', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          integration_id: 'int-aap-2',
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            integration_id: 'int-aap-2',
+          },
         })
 
         expect(activity.parameters.integration_id).toBe('int-aap-2')
       })
 
       it('includes both credential_id and integration_id in workflow config', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          credential_id: 'cred-xyz',
-          integration_id: 'int-aap-3',
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            credential_id: 'cred-xyz',
+            integration_id: 'int-aap-3',
+          },
         })
 
         expect(activity.parameters.credential_id).toBe('cred-xyz')
@@ -813,25 +909,40 @@ describe('workflowFactories', () => {
       })
 
       it('creates an AAP workflow template activity with inventory name', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          inventory_name: 'Production Inventory',
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            inventory_name: 'Production Inventory',
+          },
         })
 
         expect(activity.parameters.inventory_name).toBe('Production Inventory')
       })
 
       it('creates an AAP workflow template activity with workflow job template name', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          workflow_job_template_name: 'Deploy Application',
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            workflow_job_template_name: 'Deploy Application',
+          },
         })
 
         expect(activity.parameters.workflow_job_template_name).toBe('Deploy Application')
       })
 
       it('does not include job-specific fields (job_type, verbosity, forks, etc.)', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          inventory_id: 789,
-          extra_vars: { env: 'prod' },
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            inventory_id: 789,
+            extra_vars: { env: 'prod' },
+          },
         })
 
         // Workflow templates should NOT have job-specific fields
@@ -849,18 +960,28 @@ describe('workflowFactories', () => {
       })
 
       it('includes scm_branch field (workflow-specific)', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          scm_branch: 'feature/new-deployment',
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            scm_branch: 'feature/new-deployment',
+          },
         })
 
         expect(activity.parameters.scm_branch).toBe('feature/new-deployment')
       })
 
       it('filters undefined values correctly', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          inventory_id: undefined,
-          extra_vars: undefined,
-          limit: undefined,
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            inventory_id: undefined,
+            extra_vars: undefined,
+            limit: undefined,
+          },
         })
 
         expect(activity.parameters).not.toHaveProperty('inventory_id')
@@ -869,9 +990,14 @@ describe('workflowFactories', () => {
       })
 
       it('handles numeric zero values correctly (defined predicate)', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          inventory_id: 0,
-          organization_id: 0,
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            inventory_id: 0,
+            organization_id: 0,
+          },
         })
 
         // Zero is a valid value for numeric fields (defined predicate)
@@ -880,9 +1006,14 @@ describe('workflowFactories', () => {
       })
 
       it('filters invalid numeric values (NaN, Infinity)', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          inventory_id: Number.NaN,
-          organization_id: Number.POSITIVE_INFINITY,
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            inventory_id: Number.NaN,
+            organization_id: Number.POSITIVE_INFINITY,
+          },
         })
 
         expect(activity.parameters).not.toHaveProperty('inventory_id')
@@ -890,10 +1021,15 @@ describe('workflowFactories', () => {
       })
 
       it('filters empty strings for truthy predicate fields', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          organization_name: '',
-          workflow_job_template_name: '',
-          limit: '',
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            organization_name: '',
+            workflow_job_template_name: '',
+            limit: '',
+          },
         })
 
         expect(activity.parameters).not.toHaveProperty('organization_name')
@@ -902,8 +1038,13 @@ describe('workflowFactories', () => {
       })
 
       it('includes empty arrays for labels field', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          labels: [],
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            labels: [],
+          },
         })
 
         // Empty array is still truthy in JavaScript (all objects are truthy)
@@ -911,8 +1052,13 @@ describe('workflowFactories', () => {
       })
 
       it('includes non-empty arrays for labels field', () => {
-        const activity = createAAPWorkflowTemplateActivity('aap-wf-1', 'Run Workflow', 456, {
-          labels: ['production'],
+        const activity = createAAPWorkflowTemplateActivity({
+          id: 'aap-wf-1',
+          name: 'Run Workflow',
+          workflowTemplateId: 456,
+          config: {
+            labels: ['production'],
+          },
         })
 
         expect(activity.parameters.labels).toEqual(['production'])

--- a/frontend/packages/syntara-ui/src/stores/workflowFactories.ts
+++ b/frontend/packages/syntara-ui/src/stores/workflowFactories.ts
@@ -226,16 +226,19 @@ const aapConfigMapping: [keyof AAPJobTemplateConfig, string, 'truthy' | 'defined
   ['useInputVariables', 'use_input_variables', 'truthy'],
 ]
 
+export type CreateAAPJobTemplateActivityOptions = {
+  id: string
+  name: string
+  jobTemplateId?: number
+  config?: AAPJobTemplateConfig
+  settings?: NodeSettings
+}
+
 /**
  * Create an AAP Job Template node (v2).
  */
-export function createAAPJobTemplateActivity(
-  id: string,
-  name: string,
-  jobTemplateId?: number,
-  config?: AAPJobTemplateConfig,
-  settings?: NodeSettings
-): Activity {
+export function createAAPJobTemplateActivity(options: CreateAAPJobTemplateActivityOptions): Activity {
+  const { id, name, jobTemplateId, config, settings } = options
   const activityConfig: Record<string, unknown> = {
     ...(jobTemplateId !== undefined && { job_template_id: jobTemplateId }),
   }
@@ -283,16 +286,19 @@ export type AAPWorkflowTemplateConfig = {
   labels?: string[] // AAP Controller label names (prompt-on-launch override, supports creating new labels)
 }
 
+export type CreateAAPWorkflowTemplateActivityOptions = {
+  id: string
+  name: string
+  workflowTemplateId?: number
+  config?: AAPWorkflowTemplateConfig
+  settings?: NodeSettings
+}
+
 /**
  * Create an AAP Workflow Template node (v2).
  */
-export function createAAPWorkflowTemplateActivity(
-  id: string,
-  name: string,
-  workflowTemplateId?: number,
-  config?: AAPWorkflowTemplateConfig,
-  settings?: NodeSettings
-): Activity {
+export function createAAPWorkflowTemplateActivity(options: CreateAAPWorkflowTemplateActivityOptions): Activity {
+  const { id, name, workflowTemplateId, config, settings } = options
   const activityConfig: Record<string, unknown> = {
     ...(workflowTemplateId !== undefined && { workflow_job_template_id: workflowTemplateId }),
   }
@@ -363,22 +369,25 @@ export function createConditionActivity(id: string, name: string, condition?: st
   }
 }
 
-/**
- * Create a loop node (v2).
- */
-export function createLoopActivity(
-  id: string,
-  name: string,
-  loopType: 'forEach' | 'while',
+export type CreateLoopActivityOptions = {
+  id: string
+  name: string
+  loopType: 'forEach' | 'while'
   config: {
     items?: string
     condition?: string
     maxIterations?: number
     indexVariable?: string
     itemVariable?: string
-  },
+  }
   settings?: NodeSettings
-): Activity {
+}
+
+/**
+ * Create a loop node (v2).
+ */
+export function createLoopActivity(options: CreateLoopActivityOptions): Activity {
+  const { id, name, loopType, config, settings } = options
   const maxIterations =
     config.maxIterations !== undefined && !Number.isNaN(config.maxIterations) ? config.maxIterations : undefined
 

--- a/frontend/packages/syntara-ui/src/utils/expressions/serializer.ts
+++ b/frontend/packages/syntara-ui/src/utils/expressions/serializer.ts
@@ -240,13 +240,19 @@ function serializeCondition(condition: ExpressionCondition, forBackend: boolean)
  * }, true)
  * // Returns: "not ((trigger.age >= 18 && trigger.score > 50))" (backend mode)
  */
-function serializeSingleChild(
-  result: string,
-  negatePrefix: string,
-  isGroupNegated: boolean,
-  isChildNegated: boolean,
+function serializeSingleChild({
+  result,
+  negatePrefix,
+  isGroupNegated,
+  isChildNegated,
+  isNested,
+}: {
+  result: string
+  negatePrefix: string
+  isGroupNegated: boolean
+  isChildNegated: boolean
   isNested: boolean
-): string {
+}): string {
   if ((isGroupNegated && isChildNegated) || (isNested && isGroupNegated)) {
     return `${negatePrefix}((${result}))`
   }
@@ -275,7 +281,13 @@ function serializeGroup(group: ExpressionGroup, forBackend: boolean, isNested = 
   const negatePrefix = forBackend ? 'not ' : '!'
 
   if (childExpressions.length === 1) {
-    return serializeSingleChild(childExpressions[0], negatePrefix, !!group.negate, !!group.children[0].negate, isNested)
+    return serializeSingleChild({
+      result: childExpressions[0],
+      negatePrefix,
+      isGroupNegated: !!group.negate,
+      isChildNegated: !!group.children[0].negate,
+      isNested,
+    })
   }
 
   const separator = ` ${operatorSymbol} `


### PR DESCRIPTION
## Summary

Part 1 of 5 in the max-params stack (replaces #509).

Converts shared hooks, stores, and serializer helpers that take 5 positional arguments to one object parameter. Updates every call site so this layer stays green on `devel`.

Stack: #514 → #515 → #516 → #517 → #518

## Test plan

- [ ] CI lint / typecheck / test
- [ ] Spot-check `useCursorReset` and factory call sites