### PR TITLE
refactor(ui): convert builder helpers to object params

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.roundTrip.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.roundTrip.test.tsx
@@ -22,14 +22,21 @@ function makeEdge(source: string, target: string, sourceHandle?: string, targetH
   }
 }
 
-function roundTrip(
-  activities: Activity[],
-  triggers: Activity[],
-  edges: EdgeConnection[],
-  name = 'round-trip-test',
-  description = ''
-) {
-  const v2Def = buildWorkflowDefinition(name, description, activities, triggers, { edges })
+function roundTrip(params: {
+  activities: Activity[]
+  triggers: Activity[]
+  edges: EdgeConnection[]
+  name?: string
+  description?: string
+}) {
+  const { activities, triggers, edges, name = 'round-trip-test', description = '' } = params
+  const v2Def = buildWorkflowDefinition({
+    workflowName: name,
+    workflowDescription: description,
+    activities,
+    triggers,
+    edges,
+  })
 
   const {
     flattenedActivities,
@@ -41,7 +48,11 @@ function roundTrip(
     v2Def.triggers as Array<Record<string, unknown>>
   )
 
-  const rebuilt = buildWorkflowDefinition(name, description, flattenedActivities, loadedTriggers, {
+  const rebuilt = buildWorkflowDefinition({
+    workflowName: name,
+    workflowDescription: description,
+    activities: flattenedActivities,
+    triggers: loadedTriggers,
     edges: loadedEdges,
   })
 
@@ -66,7 +77,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
       ]
       const edges = [makeEdge('trigger-0', 'script_1'), makeEdge('script_1', 'script_2')]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       expect(rebuilt.schema_version).toBe('2.0.0')
       expect(rebuilt.nodes).toHaveLength(original.nodes.length)
@@ -87,7 +98,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
         makeEdge('http_node', 'condition_node'),
       ]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       const originalTypes = original.nodes.map((n) => n.type).sort()
       const rebuiltTypes = rebuilt.nodes.map((n) => n.type).sort()
@@ -109,7 +120,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
         makeEdge('cond', 'false_branch', EdgeHandleEnum.FALSE),
       ]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       const originalCondEdges = original.edges.filter((e) => e.from === 'cond')
       const rebuiltCondEdges = rebuilt.edges.filter((e) => e.from === 'cond')
@@ -141,7 +152,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
         makeEdge('loop_node', 'after_loop', EdgeHandleEnum.DONE),
       ]
 
-      const { rebuilt } = roundTrip(activities, triggers, edges)
+      const { rebuilt } = roundTrip({ activities, triggers, edges })
 
       const rebuiltLoopEdges = rebuilt.edges.filter((e) => e.from === 'loop_node')
       expect(rebuiltLoopEdges).toHaveLength(2)
@@ -167,7 +178,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
         makeEdge('approval_node', 'rejected_action', EdgeHandleEnum.REJECTED),
       ]
 
-      const { rebuilt } = roundTrip(activities, triggers, edges)
+      const { rebuilt } = roundTrip({ activities, triggers, edges })
 
       const rebuiltApprovalEdges = rebuilt.edges.filter((e) => e.from === 'approval_node')
       expect(rebuiltApprovalEdges).toHaveLength(2)
@@ -200,7 +211,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
         makeEdge('switch_node', 'default_action', EdgeHandleEnum.DEFAULT),
       ]
 
-      const { rebuilt } = roundTrip(activities, triggers, edges)
+      const { rebuilt } = roundTrip({ activities, triggers, edges })
 
       const rebuiltSwitchEdges = rebuilt.edges.filter((e) => e.from === 'switch_node')
       expect(rebuiltSwitchEdges).toHaveLength(3)
@@ -216,7 +227,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
       const activities = [makeActivity({ id: 'script_1', type: ActivityTypeEnum.SCRIPT })]
       const edges = [makeEdge('trigger-0', 'script_1')]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       expect(rebuilt.triggers[0].id).toBe(original.triggers[0].id)
       expect(rebuilt.triggers[0].type).toBe('manual_trigger')
@@ -230,7 +241,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
       const activities = [makeActivity({ id: 'script_1', type: ActivityTypeEnum.SCRIPT })]
       const edges = [makeEdge('trigger-0', 'script_1'), makeEdge('trigger-1', 'script_1')]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       expect(rebuilt.triggers).toHaveLength(2)
       for (let i = 0; i < original.triggers.length; i++) {
@@ -252,7 +263,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
       ]
       const edges = [makeEdge('trigger-0', 'script_1')]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       const originalNode = original.nodes.find((n) => n.id === 'script_1')!
       const rebuiltNode = rebuilt.nodes.find((n) => n.id === 'script_1')!
@@ -274,7 +285,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
       ]
       const edges = [makeEdge('trigger-0', 'http_1')]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       expect(rebuilt.nodes[0].parameters).toEqual(original.nodes[0].parameters)
     })
@@ -291,7 +302,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
       ]
       const edges = [makeEdge('trigger-0', 'script_1')]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       expect(rebuilt.nodes[0].outputs).toEqual(original.nodes[0].outputs)
     })
@@ -312,7 +323,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
       ]
       const edges = [makeEdge('trigger-0', 'http_1')]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       expect(rebuilt.nodes[0].settings).toEqual(original.nodes[0].settings)
     })
@@ -328,7 +339,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
       const activities = [makeActivity({ id: 'script_1', type: ActivityTypeEnum.SCRIPT })]
       const edges = [makeEdge('trigger-0', 'script_1')]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       expect(rebuilt.triggers[0].parameters).toEqual(original.triggers[0].parameters)
     })
@@ -351,7 +362,7 @@ describe('V2 Workflow Definition Round-Trip', () => {
         makeEdge('branch_b', 'converge_node'),
       ]
 
-      const { original, rebuilt } = roundTrip(activities, triggers, edges)
+      const { original, rebuilt } = roundTrip({ activities, triggers, edges })
 
       const originalConverge = original.nodes.find((n) => n.id === 'converge_node')!
       const rebuiltConverge = rebuilt.nodes.find((n) => n.id === 'converge_node')!

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderContent.tsx
@@ -257,21 +257,23 @@ export function BuilderContent(props: BuilderContentProps) {
     createWorkflow: createWorkflow as UseBuilderSaveWorkflowParams['createWorkflow'],
     updateWorkflow,
   })
-  const guardedSaveWorkflow = useGuardedSaveWorkflow(
+  const guardedSaveWorkflow = useGuardedSaveWorkflow({
     handleSaveWorkflow,
     isNodeEditorOpen,
     nodeEditorMode,
     autoSubmitRef,
-    dispatch
-  )
+    dispatch,
+  })
 
-  const { publish: onPublish, isPublishing } = usePublishWorkflow(
+  const { publish: onPublish, isPublishing } = usePublishWorkflow({
     workflowId,
     currentVersion,
     workflowName,
     workflowDescription,
-    { expectedVersion: loadedVersion, onConflict: handleConflict('publish'), onVersionUpdated }
-  )
+    expectedVersion: loadedVersion,
+    onConflict: handleConflict('publish'),
+    onVersionUpdated,
+  })
 
   const mostRecentExecution = mostRecentExecutionQuery.data
   const {
@@ -456,7 +458,11 @@ export function BuilderContent(props: BuilderContentProps) {
     const { edges, nodePositions } = useWorkflowStore.getState()
     const activities = currentWorkflow.workflow.activities ?? []
     const triggers = currentWorkflow.triggers ?? []
-    const definition = buildWorkflowDefinition(workflowName, workflowDescription, activities, triggers, {
+    const definition = buildWorkflowDefinition({
+      workflowName: workflowName,
+      workflowDescription: workflowDescription,
+      activities: activities,
+      triggers: triggers,
       edges,
       nodePositions,
     })

--- a/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/BuilderFlow.tsx
@@ -523,13 +523,13 @@ export function BuilderFlow(props: BuilderFlowProps) {
         }
         const activity = activitiesById.get(node.id)
         if (!activity) return node
-        const enriched = executionStateEnricher.enrichActivity(
-          activity,
-          effectiveExecutionStatus,
-          activityStates,
-          edgeSnapshot,
-          { preResolvedNodes, skipInferenceActivityIds: copiedRunActivityIds ?? undefined }
-        )
+        const enriched = executionStateEnricher.enrichActivity({
+          activity: activity,
+          executionStatus: effectiveExecutionStatus,
+          activityStates: activityStates,
+          edges: edgeSnapshot,
+          options: { preResolvedNodes, skipInferenceActivityIds: copiedRunActivityIds ?? undefined },
+        })
         return applyEnrichedData(node, enriched, anyChangedRef)
       })
 

--- a/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/NodeDetailsPanel.tsx
@@ -176,13 +176,14 @@ function findActivityInCurrentWorkflow(activityId: string): Activity | undefined
 }
 
 /** Renders the appropriate details component for a given node in edit mode. */
-function renderEditModeContent(
-  node: Node<NodeType['data']>,
-  currentWorkflow: ReturnType<typeof selectCurrentWorkflow>,
-  onClose: () => void,
-  onHeaderContentChange: (content: ReactNode | null) => void,
+function renderEditModeContent(params: {
+  node: Node<NodeType['data']>
+  currentWorkflow: ReturnType<typeof selectCurrentWorkflow>
+  onClose: () => void
+  onHeaderContentChange: (content: ReactNode | null) => void
   projectId?: string
-): ReactNode {
+}): ReactNode {
+  const { node, currentWorkflow, onClose, onHeaderContentChange, projectId } = params
   if (node.type === FlowNodeType.TRIGGER) {
     const triggerIdx = parseTriggerIndex(node.id) ?? 0
     const trigger = currentWorkflow?.triggers?.[triggerIdx]
@@ -473,7 +474,13 @@ export function NodeDetailsPanel(props: NodeDetailsPanelProps) {
     if (!node) return null
     return (
       <Flex key={node.id} direction={{ default: 'column' }} style={{ height: '100%', minHeight: 0 }}>
-        {renderEditModeContent(node, currentWorkflow, onClose, setHeaderContent, projectId)}
+        {renderEditModeContent({
+          node,
+          currentWorkflow,
+          onClose,
+          onHeaderContentChange: setHeaderContent,
+          projectId,
+        })}
       </Flex>
     )
   }

--- a/frontend/packages/syntara-ui/src/routes/builder/edges/types.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/edges/types.ts
@@ -1,12 +1,12 @@
 import type { EdgeProps } from '@xyflow/react'
 
-import type { FlowPosition } from '../types'
+import type { FlowPosition, OnAddNodeFromEdge } from '../types'
 
 /**
  * Shared edge data interface used by all edge types
  */
 export type EdgeData = {
-  onAddNode?: (sourceNodeId: string, targetNodeId: string, edgeId: string, sourceHandle?: string) => void
+  onAddNode?: OnAddNodeFromEdge
   isActive?: boolean
   isPending?: boolean
   executionStatus?: 'passed' | 'pending'

--- a/frontend/packages/syntara-ui/src/routes/builder/edges/useEdgeHandlers.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/edges/useEdgeHandlers.test.tsx
@@ -106,7 +106,12 @@ describe('useEdgeHandlers', () => {
     })
 
     expect(mockStopPropagation).toHaveBeenCalled()
-    expect(mockOnAddNode).toHaveBeenCalledWith('node-1', 'node-2', 'edge-1', 'source-handle')
+    expect(mockOnAddNode).toHaveBeenCalledWith({
+      sourceNodeId: 'node-1',
+      targetNodeId: 'node-2',
+      edgeId: 'edge-1',
+      sourceHandle: 'source-handle',
+    })
   })
 
   it('handleAddNode does nothing when data.onAddNode is not defined', () => {

--- a/frontend/packages/syntara-ui/src/routes/builder/edges/useEdgeHandlers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/edges/useEdgeHandlers.ts
@@ -53,7 +53,12 @@ export function useEdgeHandlers(props: UseEdgeHandlersProps) {
   const handleAddNode = useCallback(
     (event: React.MouseEvent) => {
       event.stopPropagation()
-      data?.onAddNode?.(source, target, edgeId, actualSourceHandle ?? undefined)
+      data?.onAddNode?.({
+        sourceNodeId: source,
+        targetNodeId: target,
+        edgeId,
+        sourceHandle: actualSourceHandle ?? undefined,
+      })
     },
     [data, source, target, edgeId, actualSourceHandle]
   )

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/computeButtonEdgesUpdate.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/computeButtonEdgesUpdate.ts
@@ -2,7 +2,7 @@ import { EdgeHandleEnum } from '@syntara/contracts'
 
 import { FlowNodeType } from '../../../constants'
 import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
-import type { FlowPosition } from '../types'
+import type { FlowPosition, OnAddNodeFromEdge } from '../types'
 import { isSwitchCasePort } from '../utils/switchCaseHelpers'
 import type { EdgeType } from '../utils/workflowToGraph'
 
@@ -17,13 +17,7 @@ export type ComputeButtonEdgesParams = {
   nodesNeedingButtonEdges: string[]
   activeEdgeButtonNodeId: string | null
   activeEdgeButtonHandle: string | null
-  onAddNodeFromEdge?: (
-    sourceNodeId: string,
-    targetNodeId?: string,
-    edgeId?: string,
-    sourceHandle?: string,
-    desiredPosition?: FlowPosition
-  ) => void
+  onAddNodeFromEdge?: OnAddNodeFromEdge
 }
 
 function createOnButtonClick(
@@ -32,7 +26,7 @@ function createOnButtonClick(
   handleId: string
 ): (pos: FlowPosition | undefined) => void {
   return (pos: FlowPosition | undefined) => {
-    onAddNodeFromEdge?.(nodeId, undefined, undefined, handleId, pos)
+    onAddNodeFromEdge?.({ sourceNodeId: nodeId, sourceHandle: handleId, desiredPosition: pos })
   }
 }
 
@@ -134,12 +128,20 @@ function collectKeptButtonEdges(
   return kept
 }
 
-function buildRegularNodeButtonEdge(
-  nodeId: string,
-  onAddNodeFromEdge: ComputeButtonEdgesParams['onAddNodeFromEdge'],
-  activeNodeId: string | null,
+type BuildButtonEdgeOptions = {
+  nodeId: string
+  handleId?: string
+  onAddNodeFromEdge: ComputeButtonEdgesParams['onAddNodeFromEdge']
+  activeNodeId: string | null
   activeHandle: string | null
-): EdgeType {
+}
+
+function buildRegularNodeButtonEdge({
+  nodeId,
+  onAddNodeFromEdge,
+  activeNodeId,
+  activeHandle,
+}: BuildButtonEdgeOptions): EdgeType {
   const buttonEdgeId = `button-${nodeId}`
   const placeholderId = `placeholder-${nodeId}`
   return {
@@ -159,13 +161,13 @@ function buildRegularNodeButtonEdge(
   } as unknown as EdgeType
 }
 
-function buildMultiHandleButtonEdge(
-  nodeId: string,
-  handleId: string,
-  onAddNodeFromEdge: ComputeButtonEdgesParams['onAddNodeFromEdge'],
-  activeNodeId: string | null,
-  activeHandle: string | null
-): EdgeType {
+function buildMultiHandleButtonEdge({
+  nodeId,
+  handleId,
+  onAddNodeFromEdge,
+  activeNodeId,
+  activeHandle,
+}: BuildButtonEdgeOptions & { handleId: string }): EdgeType {
   const buttonEdgeId = `button-${nodeId}-${handleId}`
   const placeholderId = `placeholder-${nodeId}-${handleId}`
   return {
@@ -200,7 +202,7 @@ function appendMissingRegularButtonEdges(options: AppendMissingRegularButtonEdge
     if (nodesWithButtonEdge.has(nodeId)) {
       continue
     }
-    buttonEdgesToAdd.push(buildRegularNodeButtonEdge(nodeId, onAddNodeFromEdge, activeNodeId, activeHandle))
+    buttonEdgesToAdd.push(buildRegularNodeButtonEdge({ nodeId, onAddNodeFromEdge, activeNodeId, activeHandle }))
   }
 }
 
@@ -220,7 +222,9 @@ function appendMissingMultiHandleButtonEdges(options: AppendMissingMultiHandleBu
     if (existingKeys.has(key)) {
       continue
     }
-    buttonEdgesToAdd.push(buildMultiHandleButtonEdge(nodeId, handleId, onAddNodeFromEdge, activeNodeId, activeHandle))
+    buttonEdgesToAdd.push(
+      buildMultiHandleButtonEdge({ nodeId, handleId, onAddNodeFromEdge, activeNodeId, activeHandle })
+    )
   }
 }
 
@@ -237,13 +241,21 @@ function anyKeptButtonEdgeChanged(existingButtonEdges: EdgeType[], buttonEdgesTo
   })
 }
 
-function shouldReturnNewEdgeList(
-  currentEdges: EdgeType[],
-  result: EdgeType[],
-  buttonEdgesToAdd: EdgeType[],
-  existingButtonEdges: EdgeType[],
+type ShouldReturnNewEdgeListOptions = {
+  currentEdges: EdgeType[]
+  result: EdgeType[]
+  buttonEdgesToAdd: EdgeType[]
+  existingButtonEdges: EdgeType[]
   buttonEdgesToKeep: EdgeType[]
-): boolean {
+}
+
+function shouldReturnNewEdgeList({
+  currentEdges,
+  result,
+  buttonEdgesToAdd,
+  existingButtonEdges,
+  buttonEdgesToKeep,
+}: ShouldReturnNewEdgeListOptions): boolean {
   if (result.length !== currentEdges.length || buttonEdgesToAdd.length > 0) {
     return true
   }
@@ -322,7 +334,15 @@ export function computeNextButtonEdges(params: ComputeButtonEdgesParams): EdgeTy
 
   const result = [...nonButtonEdges, ...buttonEdgesToKeep, ...buttonEdgesToAdd]
 
-  if (!shouldReturnNewEdgeList(currentEdges, result, buttonEdgesToAdd, existingButtonEdges, buttonEdgesToKeep)) {
+  if (
+    !shouldReturnNewEdgeList({
+      currentEdges,
+      result,
+      buttonEdgesToAdd,
+      existingButtonEdges,
+      buttonEdgesToKeep,
+    })
+  ) {
     return currentEdges
   }
 

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderConflict.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderConflict.ts
@@ -134,13 +134,14 @@ export function useBuilderConflict(params: UseBuilderConflictParams) {
       setIsConflictLoading(true)
       try {
         const { edges, nodePositions } = useWorkflowStore.getState()
-        const definition = buildWorkflowDefinition(
-          workflowName,
-          workflowDescription,
-          currentWorkflow.workflow.activities ?? [],
-          currentWorkflow.triggers ?? [],
-          { edges, nodePositions }
-        )
+        const definition = buildWorkflowDefinition({
+          workflowName: workflowName,
+          workflowDescription: workflowDescription,
+          activities: currentWorkflow.workflow.activities ?? [],
+          triggers: currentWorkflow.triggers ?? [],
+          edges,
+          nodePositions,
+        })
         const projectId = workflowProjectId ?? selectedProjectId
 
         const { data: created, error: createError } = await workflowFetchClient.POST('/workflows', {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderFlowGraph.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderFlowGraph.ts
@@ -5,6 +5,7 @@ import { FlowNodeType } from '../../../constants'
 import { buildTriggerNodeId } from '../../../utils/triggerNodeIds'
 import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
 import type { ActivityState } from '../../workflows/execution/types'
+import type { OnAddNodeFromEdge } from '../types'
 import type { EdgeConnection } from '../types/edge'
 import { detectLoopBackNodes } from '../utils/detectLoopBackNodes'
 import { ExecutionStateEnricher, type ActivityWithMetadata } from '../utils/executionState'
@@ -31,7 +32,7 @@ type UseBuilderFlowGraphParams = {
   storedEdges: EdgeConnection[]
   executionStatus: string | null | undefined
   activityStates: Map<string, ActivityState>
-  onAddNodeFromEdge: ((sourceNodeId: string, sourceHandle: string) => void) | undefined
+  onAddNodeFromEdge: OnAddNodeFromEdge | undefined
   workflowVersion: number
   preResolvedNodes?: Set<string>
   skipInferenceActivityIds?: ReadonlySet<string> | null
@@ -105,16 +106,16 @@ export function useBuilderFlowGraph({
         return
       }
 
-      const activityData = executionStateEnricher.enrichActivity(
-        activity,
-        executionStatus,
-        activityStates,
-        storedEdges,
-        {
+      const activityData = executionStateEnricher.enrichActivity({
+        activity: activity,
+        executionStatus: executionStatus,
+        activityStates: activityStates,
+        edges: storedEdges,
+        options: {
           preResolvedNodes,
           skipInferenceActivityIds: inferenceAllowlist,
-        }
-      )
+        },
+      })
       nodes.push({
         id: activity.id,
         type: activity.type,
@@ -140,13 +141,13 @@ export function useBuilderFlowGraph({
 
         let edgeExecutionStatus: 'passed' | 'pending' | undefined
         if (executionStatus) {
-          edgeExecutionStatus = executionStateEnricher.determineEdgeStatus(
-            edge,
-            activityStates,
-            activities,
-            undefined,
-            storedEdges
-          )
+          edgeExecutionStatus = executionStateEnricher.determineEdgeStatus({
+            edge: edge,
+            activityStates: activityStates,
+            activities: activities,
+            triggerDisplayToRealId: undefined,
+            edges: storedEdges,
+          })
         }
 
         // Transform trigger real IDs to display IDs for React Flow
@@ -187,16 +188,16 @@ export function useBuilderFlowGraph({
         nodeType = FlowNodeType.APPROVAL
       }
 
-      const activityData = executionStateEnricher.enrichActivity(
-        activity,
-        executionStatus,
-        activityStates,
-        storedEdges,
-        {
+      const activityData = executionStateEnricher.enrichActivity({
+        activity: activity,
+        executionStatus: executionStatus,
+        activityStates: activityStates,
+        edges: storedEdges,
+        options: {
           preResolvedNodes,
           skipInferenceActivityIds: inferenceAllowlist,
-        }
-      )
+        },
+      })
 
       const node = {
         id: activity.id,

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderFlowInteractionHandlers.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderFlowInteractionHandlers.test.tsx
@@ -17,8 +17,8 @@ vi.mock('../../../stores/useWorkflowStore', () => ({
 
 const calculateEdgeConnection = vi.hoisted(() => vi.fn(() => ({ activityReorderTarget: null as string | null })))
 const applyEdgeConnection = vi.hoisted(() =>
-  vi.fn((_r: unknown, _p: unknown, _t: unknown, _rf: unknown, onComplete?: () => void) => {
-    onComplete?.()
+  vi.fn((options?: { onComplete?: () => void }) => {
+    options?.onComplete?.()
   })
 )
 
@@ -102,7 +102,7 @@ describe('useBuilderFlowInteractionHandlers', () => {
       targetHandle: 'custom',
     })
     act(() => {
-      result.current.handleAddNodeFromEdge('s', 't', 'edge-1')
+      result.current.handleAddNodeFromEdge({ sourceNodeId: 's', targetNodeId: 't', edgeId: 'edge-1' })
     })
     expect(dispatch).toHaveBeenCalledWith({
       type: 'OPEN_ADD_NODE_FROM_EDGE',
@@ -120,7 +120,7 @@ describe('useBuilderFlowInteractionHandlers', () => {
   it('handleAddNodeFromEdge leaves targetHandle undefined when edgeId is omitted', () => {
     const { result, dispatch } = renderWith()
     act(() => {
-      result.current.handleAddNodeFromEdge('s', 't')
+      result.current.handleAddNodeFromEdge({ sourceNodeId: 's', targetNodeId: 't' })
     })
     expect(dispatch).toHaveBeenCalledWith({
       type: 'OPEN_ADD_NODE_FROM_EDGE',
@@ -139,7 +139,7 @@ describe('useBuilderFlowInteractionHandlers', () => {
     const { result, dispatch, reactFlowInstance } = renderWith()
     vi.mocked(reactFlowInstance.getEdge).mockReturnValue(undefined)
     act(() => {
-      result.current.handleAddNodeFromEdge('s', 't', 'edge-missing')
+      result.current.handleAddNodeFromEdge({ sourceNodeId: 's', targetNodeId: 't', edgeId: 'edge-missing' })
     })
     expect(dispatch).toHaveBeenCalledWith({
       type: 'OPEN_ADD_NODE_FROM_EDGE',

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderFlowInteractionHandlers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderFlowInteractionHandlers.ts
@@ -6,7 +6,7 @@ import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
 import type { BuilderAction } from '../builderReducer'
 import { findDuplicatePosition } from '../duplicateNodePosition'
 import type { NodeActionsContextValue } from '../NodeActionsContext'
-import type { FlowPosition } from '../types'
+import type { AddNodeFromEdgeOptions } from '../types'
 import { applyEdgeConnection, calculateEdgeConnection } from '../utils/edgeConnectionHelpers'
 
 export type UseBuilderFlowInteractionHandlersOptions = {
@@ -47,7 +47,13 @@ export function useBuilderFlowInteractionHandlers({
   )
 
   const handleAddNodeFromEdge = useCallback(
-    (sourceId: string, targetId?: string, edgeId?: string, handle?: string, desiredPosition?: FlowPosition) => {
+    ({
+      sourceNodeId: sourceId,
+      targetNodeId: targetId,
+      edgeId,
+      sourceHandle: handle,
+      desiredPosition,
+    }: AddNodeFromEdgeOptions) => {
       let edgeTargetHandle: string | undefined = undefined
       if (edgeId) {
         const edge = reactFlowInstance.getEdge(edgeId)
@@ -75,10 +81,16 @@ export function useBuilderFlowInteractionHandlers({
 
       const result = calculateEdgeConnection(params, reactFlowInstance)
 
-      applyEdgeConnection(result, params, targetId, reactFlowInstance, () => {
-        if (result.activityReorderTarget) {
-          useWorkflowStore.getState().moveActivityBefore(targetId, result.activityReorderTarget)
-        }
+      applyEdgeConnection({
+        result,
+        params,
+        targetId,
+        reactFlowInstance,
+        onComplete: () => {
+          if (result.activityReorderTarget) {
+            useWorkflowStore.getState().moveActivityBefore(targetId, result.activityReorderTarget)
+          }
+        },
       })
     },
     [edgeIdToReplace, targetNodeId, sourceHandle, targetHandle, reactFlowInstance, handleAddNodeFromEdge]

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderImportHandlers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderImportHandlers.ts
@@ -57,7 +57,11 @@ export function useBuilderImportHandlers(
     const importDescription = pendingImport.description || importName
     const activities = pendingImport.workflowDef.workflow.activities ?? []
     const triggers = pendingImport.workflowDef.triggers ?? []
-    const fullDefinition = buildWorkflowDefinition(importName, importDescription, activities, triggers, {
+    const fullDefinition = buildWorkflowDefinition({
+      workflowName: importName,
+      workflowDescription: importDescription,
+      activities: activities,
+      triggers: triggers,
       edges: pendingImport.edges,
       nodePositions: pendingImport.nodePositions,
     })

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderSaveWorkflow.ts
@@ -309,7 +309,11 @@ export function useBuilderSaveWorkflow(
     const activities = freshWorkflow?.workflow.activities ?? []
     const triggers = freshWorkflow?.triggers ?? []
 
-    return buildWorkflowDefinition(workflowName, workflowDescription, activities, triggers, {
+    return buildWorkflowDefinition({
+      workflowName: workflowName,
+      workflowDescription: workflowDescription,
+      activities: activities,
+      triggers: triggers,
       edges,
       nodePositions,
     })

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderToolbarHandlers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useBuilderToolbarHandlers.ts
@@ -17,13 +17,21 @@ import type { ConflictInfo } from '../VersionConflictDialog'
 
 type ShowAlert = (options: AlertMessage) => void
 
-async function checkVersionConflictBeforeRun(
-  workflowId: string,
-  loadedVersion: number,
-  onRunConflict: (info: ConflictInfo) => void,
-  loadedVersionName?: string | null,
+type CheckVersionConflictBeforeRunOptions = {
+  workflowId: string
+  loadedVersion: number
+  onRunConflict: (info: ConflictInfo) => void
+  loadedVersionName?: string | null
   loadedVersionCreatedAt?: string | null
-): Promise<boolean> {
+}
+
+async function checkVersionConflictBeforeRun({
+  workflowId,
+  loadedVersion,
+  onRunConflict,
+  loadedVersionName,
+  loadedVersionCreatedAt,
+}: CheckVersionConflictBeforeRunOptions): Promise<boolean> {
   const { data: latest } = await workflowFetchClient.GET('/workflows/{workflow_id}', {
     params: { path: { workflow_id: workflowId } },
   })
@@ -112,13 +120,13 @@ export function useBuilderToolbarHandlers({
       if (!workflow?.id) return
 
       if (loadedVersion != null && !runOptions?.skipPreflightCheck && onRunConflict) {
-        const hasConflict = await checkVersionConflictBeforeRun(
-          workflow.id,
+        const hasConflict = await checkVersionConflictBeforeRun({
+          workflowId: workflow.id,
           loadedVersion,
           onRunConflict,
           loadedVersionName,
-          loadedVersionCreatedAt
-        )
+          loadedVersionCreatedAt,
+        })
         if (hasConflict) {
           dispatch({ type: 'SET_CONFIRM_DIALOG', payload: false })
           return

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useButtonEdgeMaintenance.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useButtonEdgeMaintenance.test.tsx
@@ -27,13 +27,13 @@ vi.mock('../utils/filterHelpers', () => ({
 
 type SetNodesFn = React.Dispatch<React.SetStateAction<NodeType[]>>
 type SetEdgesFn = React.Dispatch<React.SetStateAction<EdgeType[]>>
-type OnAddNodeFn = (
-  sourceNodeId: string,
-  targetNodeId?: string,
-  edgeId?: string,
-  sourceHandle?: string,
+type OnAddNodeFn = (options: {
+  sourceNodeId: string
+  targetNodeId?: string
+  edgeId?: string
+  sourceHandle?: string
   desiredPosition?: { x: number; y: number }
-) => void
+}) => void
 
 describe('useButtonEdgeMaintenance', () => {
   const mockSetNodes = vi.fn<SetNodesFn>()

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useButtonEdgeMaintenance.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useButtonEdgeMaintenance.ts
@@ -4,7 +4,7 @@ import { flushSync } from 'react-dom'
 
 import { FlowNodeType } from '../../../constants'
 import type { ButtonEdgePlaceholderNode, NodeType } from '../../workflows/canvas/nodes/NodeType'
-import type { FlowPosition } from '../types'
+import type { OnAddNodeFromEdge } from '../types'
 import { filterButtonEdges, filterRealNodes, isPlaceholderNode, isRealEdge } from '../utils/filterHelpers'
 import type { EdgeType } from '../utils/workflowToGraph'
 
@@ -21,13 +21,7 @@ type UseButtonEdgeMaintenanceOptions = {
   isInitialized: boolean
   activeEdgeButtonNodeId: string | null
   activeEdgeButtonHandle: string | null
-  onAddNodeFromEdge?: (
-    sourceNodeId: string,
-    targetNodeId?: string,
-    edgeId?: string,
-    sourceHandle?: string,
-    desiredPosition?: FlowPosition
-  ) => void
+  onAddNodeFromEdge?: OnAddNodeFromEdge
   pendingEdge: { sourceNodeId: string; sourceHandle?: string; x: number; y: number } | null
   setNodes: React.Dispatch<React.SetStateAction<NodeType[]>>
   setEdges: React.Dispatch<React.SetStateAction<EdgeType[]>>

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useConnectionHandlers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useConnectionHandlers.ts
@@ -4,7 +4,7 @@ import { useCallback, useRef, type Dispatch, type SetStateAction } from 'react'
 
 import { FlowNodeType } from '../../../constants'
 import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
-import type { ConnectionState, FlowPosition, PendingEdge } from '../types'
+import type { ConnectionState, OnAddNodeFromEdge, PendingEdge } from '../types'
 import { EdgeFactory } from '../utils/EdgeFactory'
 import { getPlaceholderNodeId } from '../utils/edgeHelpers'
 import { consumePendingDragHandle } from '../utils/pendingDragHandle'
@@ -13,13 +13,7 @@ import type { EdgeType } from '../utils/workflowToGraph'
 type UseConnectionHandlersParams = {
   nodes: NodeType[]
   edges: EdgeType[]
-  onAddNodeFromEdge?: (
-    sourceNodeId: string,
-    nodeType?: string,
-    activityId?: string,
-    sourceHandle?: string,
-    desiredPosition?: FlowPosition
-  ) => void
+  onAddNodeFromEdge?: OnAddNodeFromEdge
   setNodes: Dispatch<SetStateAction<NodeType[]>>
   setEdges: Dispatch<SetStateAction<EdgeType[]>>
   setPendingEdge: Dispatch<SetStateAction<PendingEdge | null>>
@@ -199,7 +193,11 @@ export function useConnectionHandlers({
           y: flowPosition.y,
         })
 
-        onAddNodeFromEdge?.(sourceNodeId, undefined, undefined, sourceHandleId ?? undefined, flowPosition)
+        onAddNodeFromEdge?.({
+          sourceNodeId,
+          sourceHandle: sourceHandleId ?? undefined,
+          desiredPosition: flowPosition,
+        })
       }
     },
     [onAddNodeFromEdge, screenToFlowPosition, setPendingEdge]

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useEdgeActiveState.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useEdgeActiveState.ts
@@ -1,6 +1,7 @@
 import { EdgeHandleEnum } from '@syntara/contracts'
 import { useEffect } from 'react'
 
+import type { OnAddNodeFromEdge } from '../types'
 import { markerEnd, type EdgeType } from '../utils/workflowToGraph'
 
 type UseEdgeActiveStateOptions = {
@@ -8,7 +9,7 @@ type UseEdgeActiveStateOptions = {
   activeEdgeId: string | null
   activeEdgeButtonNodeId: string | null
   activeEdgeButtonHandle: string | null
-  onAddNodeFromEdge?: (sourceNodeId: string, targetNodeId?: string, edgeId?: string, sourceHandle?: string) => void
+  onAddNodeFromEdge?: OnAddNodeFromEdge
   setEdges: React.Dispatch<React.SetStateAction<EdgeType[]>>
 }
 

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useEdgeExecutionStatus.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useEdgeExecutionStatus.ts
@@ -60,13 +60,13 @@ export function useEdgeExecutionStatus({
 
     setEdges((currentEdges) =>
       currentEdges.map((edge) => {
-        const edgeExecutionStatus = executionStateEnricher.determineEdgeStatus(
-          edge,
-          activityStates,
-          activities,
-          triggerDisplayToRealId,
-          storedEdges
-        )
+        const edgeExecutionStatus = executionStateEnricher.determineEdgeStatus({
+          edge: edge,
+          activityStates: activityStates,
+          activities: activities,
+          triggerDisplayToRealId: triggerDisplayToRealId,
+          edges: storedEdges,
+        })
 
         if (edge.data?.executionStatus !== edgeExecutionStatus) {
           return {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useGuardedSaveWorkflow.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useGuardedSaveWorkflow.test.ts
@@ -21,13 +21,13 @@ function renderGuard(
 
   const utils = renderHook(() => {
     const autoSubmitRef = useRef<AutoSubmitFn | null>(overrides.autoSubmitFn ?? null)
-    return useGuardedSaveWorkflow(
+    return useGuardedSaveWorkflow({
       handleSaveWorkflow,
-      overrides.isNodeEditorOpen ?? false,
-      overrides.nodeEditorMode ?? null,
+      isNodeEditorOpen: overrides.isNodeEditorOpen ?? false,
+      nodeEditorMode: overrides.nodeEditorMode ?? null,
       autoSubmitRef,
-      dispatch
-    )
+      dispatch,
+    })
   })
 
   return { ...utils, dispatch, handleSaveWorkflow }

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useGuardedSaveWorkflow.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useGuardedSaveWorkflow.ts
@@ -4,13 +4,21 @@ import type { BuilderAction } from '../builderReducer'
 
 type AutoSubmitFn = () => Promise<boolean>
 
-export function useGuardedSaveWorkflow(
-  handleSaveWorkflow: (options?: { expectedVersionOverride?: number }) => Promise<boolean>,
-  isNodeEditorOpen: boolean,
-  nodeEditorMode: 'add' | 'edit' | null,
-  autoSubmitRef: MutableRefObject<AutoSubmitFn | null>,
+type UseGuardedSaveWorkflowOptions = {
+  handleSaveWorkflow: (options?: { expectedVersionOverride?: number }) => Promise<boolean>
+  isNodeEditorOpen: boolean
+  nodeEditorMode: 'add' | 'edit' | null
+  autoSubmitRef: MutableRefObject<AutoSubmitFn | null>
   dispatch: Dispatch<BuilderAction>
-) {
+}
+
+export function useGuardedSaveWorkflow({
+  handleSaveWorkflow,
+  isNodeEditorOpen,
+  nodeEditorMode,
+  autoSubmitRef,
+  dispatch,
+}: UseGuardedSaveWorkflowOptions) {
   return useCallback(
     async (options?: { expectedVersionOverride?: number }): Promise<boolean> => {
       if (isNodeEditorOpen) {

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodeDeletion.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodeDeletion.ts
@@ -6,6 +6,7 @@ import { FlowNodeType } from '../../../constants'
 import { useWorkflowStore, useWorkflowStoreActions } from '../../../stores/useWorkflowStore'
 import { parseTriggerIndex } from '../../../utils/triggerNodeIds'
 import type { NodeType } from '../../workflows/canvas/nodes/NodeType'
+import type { OnAddNodeFromEdge } from '../types'
 import type { EdgeConnection } from '../types/edge'
 import { EdgeFactory } from '../utils/EdgeFactory'
 import { buildTriggerIndexRemappping, remapTriggerIdsInEdges } from '../utils/triggerIndexRemapping'
@@ -147,7 +148,7 @@ type UseNodeDeletionParams = {
   setNodes: Dispatch<SetStateAction<NodeType[]>>
   setEdges: Dispatch<SetStateAction<EdgeType[]>>
   isDeletingRef: MutableRefObject<boolean>
-  onAddNodeFromEdge?: (sourceNodeId: string, nodeType?: string, activityId?: string, sourceHandle?: string) => void
+  onAddNodeFromEdge?: OnAddNodeFromEdge
   onNodesDeleted?: (nodeIds: string[]) => void
   onError?: (message: string) => void
 }

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodePositioning.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/useNodePositioning.ts
@@ -75,17 +75,25 @@ function positionLoopNode(options: PositionLoopNodeOptions): NodeType {
   return node
 }
 
-function positionLoopBodyNode(
-  node: NodeType,
-  newlyAddedNodeIdsRef: RefObject<Set<string>>,
-  loopBodyNodeMap: Map<string, string>,
-  loopPositions: Map<string, { x: number; y: number; width: number; height: number }>,
+type PositionLoopBodyNodeOptions = {
+  node: NodeType
+  newlyAddedNodeIdsRef: RefObject<Set<string>>
+  loopBodyNodeMap: Map<string, string>
+  loopPositions: Map<string, { x: number; y: number; width: number; height: number }>
   positionedNodes: Map<string, NodeType>
-): NodeType {
+}
+
+function positionLoopBodyNode({
+  node,
+  newlyAddedNodeIdsRef,
+  loopBodyNodeMap,
+  loopPositions,
+  positionedNodes,
+}: PositionLoopBodyNodeOptions): NodeType {
   if (!newlyAddedNodeIdsRef.current.has(node.id) || !node.measured || !loopBodyNodeMap.has(node.id)) {
     return node
   }
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe: loopBodyNodeMap.has(node.id) is checked in the early-return guard above (line 85)
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe: loopBodyNodeMap.has(node.id) is checked in the early-return guard above
   const loopNodeId = loopBodyNodeMap.get(node.id)!
   const loopPos = loopPositions.get(loopNodeId)
   if (!loopPos) return node
@@ -156,7 +164,13 @@ function positionLoopBranch(ctx: LoopPositioningContext) {
         overridePosition,
       })
       if (loopPositioned !== node) return loopPositioned
-      return positionLoopBodyNode(node, newlyAddedNodeIdsRef, loopBodyNodeMap, loopPositions, positionedNodes)
+      return positionLoopBodyNode({
+        node,
+        newlyAddedNodeIdsRef,
+        loopBodyNodeMap,
+        loopPositions,
+        positionedNodes,
+      })
     })
 
     const nodesChanged = updatedNodes.some((node, index) => node !== currentNodes[index])

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/usePublishWorkflow.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/usePublishWorkflow.test.ts
@@ -75,7 +75,7 @@ describe('usePublishWorkflow', () => {
   })
 
   it('calls publish mutation with correct params', () => {
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -96,7 +96,7 @@ describe('usePublishWorkflow', () => {
   })
 
   it('sends null name when no name provided', () => {
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 2), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 2 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -113,7 +113,7 @@ describe('usePublishWorkflow', () => {
   })
 
   it('does not call mutation when workflowId is null', () => {
-    const { result } = renderHook(() => usePublishWorkflow(null, 1), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: null, currentVersion: 1 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -125,7 +125,7 @@ describe('usePublishWorkflow', () => {
   })
 
   it('does not call mutation when currentVersion is undefined', () => {
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', undefined), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: undefined }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -146,7 +146,7 @@ describe('usePublishWorkflow', () => {
     // Pre-populate the query cache with a workflows query so invalidation has something to match
     queryClient.setQueryData(['get', '/workflows'], { resources: [] })
 
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -167,7 +167,7 @@ describe('usePublishWorkflow', () => {
       }
     )
 
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -189,7 +189,7 @@ describe('usePublishWorkflow', () => {
       }
     )
 
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -207,7 +207,7 @@ describe('usePublishWorkflow', () => {
       callbacks?.onError?.(mockError)
     })
 
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -233,7 +233,7 @@ describe('usePublishWorkflow', () => {
       }
     )
 
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -245,7 +245,7 @@ describe('usePublishWorkflow', () => {
   })
 
   it('sends description when provided', () => {
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 2), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 2 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -275,9 +275,18 @@ describe('usePublishWorkflow', () => {
       markClean: mockMarkClean,
     } as unknown as ReturnType<typeof useWorkflowStore.getState>)
 
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3, 'My WF', 'My Desc'), {
-      wrapper: makeWrapper(queryClient),
-    })
+    const { result } = renderHook(
+      () =>
+        usePublishWorkflow({
+          workflowId: 'wf-123',
+          currentVersion: 3,
+          workflowName: 'My WF',
+          workflowDescription: 'My Desc',
+        }),
+      {
+        wrapper: makeWrapper(queryClient),
+      }
+    )
 
     act(() => {
       result.current.publish('v1.0')
@@ -312,7 +321,7 @@ describe('usePublishWorkflow', () => {
       }
     )
 
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -336,7 +345,7 @@ describe('usePublishWorkflow', () => {
       markClean: mockMarkClean,
     } as unknown as ReturnType<typeof useWorkflowStore.getState>)
 
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -372,7 +381,7 @@ describe('usePublishWorkflow — version conflict detection', () => {
     })
 
     const { result } = renderHook(
-      () => usePublishWorkflow('wf-123', 3, undefined, undefined, { expectedVersion: 3, onConflict }),
+      () => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3, expectedVersion: 3, onConflict }),
       { wrapper: makeWrapper(queryClient) }
     )
 
@@ -394,7 +403,7 @@ describe('usePublishWorkflow — version conflict detection', () => {
     })
 
     const { result } = renderHook(
-      () => usePublishWorkflow('wf-123', 3, undefined, undefined, { expectedVersion: 3, onConflict }),
+      () => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3, expectedVersion: 3, onConflict }),
       { wrapper: makeWrapper(queryClient) }
     )
 
@@ -410,9 +419,12 @@ describe('usePublishWorkflow — version conflict detection', () => {
   })
 
   it('sends expected_version in publish body when provided', () => {
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3, undefined, undefined, { expectedVersion: 7 }), {
-      wrapper: makeWrapper(queryClient),
-    })
+    const { result } = renderHook(
+      () => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3, expectedVersion: 7 }),
+      {
+        wrapper: makeWrapper(queryClient),
+      }
+    )
 
     act(() => {
       result.current.publish('v1.0')
@@ -424,7 +436,7 @@ describe('usePublishWorkflow — version conflict detection', () => {
   })
 
   it('does not send expected_version when not provided', () => {
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3), {
+    const { result } = renderHook(() => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3 }), {
       wrapper: makeWrapper(queryClient),
     })
 
@@ -438,9 +450,12 @@ describe('usePublishWorkflow — version conflict detection', () => {
   })
 
   it('uses expectedVersionOverride from callOptions over hook-level expectedVersion', () => {
-    const { result } = renderHook(() => usePublishWorkflow('wf-123', 3, undefined, undefined, { expectedVersion: 7 }), {
-      wrapper: makeWrapper(queryClient),
-    })
+    const { result } = renderHook(
+      () => usePublishWorkflow({ workflowId: 'wf-123', currentVersion: 3, expectedVersion: 7 }),
+      {
+        wrapper: makeWrapper(queryClient),
+      }
+    )
 
     act(() => {
       result.current.publish('v1.0', undefined, undefined, { expectedVersionOverride: 10 })

--- a/frontend/packages/syntara-ui/src/routes/builder/hooks/usePublishWorkflow.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/hooks/usePublishWorkflow.ts
@@ -23,28 +23,35 @@ function getDirtyWorkflowDefinition(
   const { currentWorkflow, isDirty, edges, nodePositions } = useWorkflowStore.getState()
   if (!isDirty || !currentWorkflow) return undefined
   const wf = currentWorkflow.workflow as { name?: string; description?: string } | undefined
-  return buildWorkflowDefinition(
-    workflowName || String(wf?.name ?? ''),
-    workflowDescription || String(wf?.description ?? ''),
-    currentWorkflow.workflow.activities ?? [],
-    currentWorkflow.triggers ?? [],
-    { edges, nodePositions }
-  ) as unknown as Record<string, unknown>
+  return buildWorkflowDefinition({
+    workflowName: workflowName || String(wf?.name ?? ''),
+    workflowDescription: workflowDescription || String(wf?.description ?? ''),
+    activities: currentWorkflow.workflow.activities ?? [],
+    triggers: currentWorkflow.triggers ?? [],
+    edges,
+    nodePositions,
+  }) as unknown as Record<string, unknown>
 }
 
 type UsePublishWorkflowOptions = {
+  workflowId: string | null
+  currentVersion: number | undefined
+  workflowName?: string
+  workflowDescription?: string
   expectedVersion?: number | null
   onConflict?: (info: ConflictInfo) => void
   onVersionUpdated?: (version: number) => void
 }
 
-export function usePublishWorkflow(
-  workflowId: string | null,
-  currentVersion: number | undefined,
-  workflowName?: string,
-  workflowDescription?: string,
-  options?: UsePublishWorkflowOptions
-) {
+export function usePublishWorkflow({
+  workflowId,
+  currentVersion,
+  workflowName,
+  workflowDescription,
+  expectedVersion: optionsExpectedVersion,
+  onConflict,
+  onVersionUpdated,
+}: UsePublishWorkflowOptions) {
   const queryClient = useQueryClient()
   const { showSuccess, showError, showWarning } = useAlerts()
 
@@ -64,7 +71,7 @@ export function usePublishWorkflow(
       if (!workflowId || versionToPublish == null) return
 
       const workflowDefinition = getDirtyWorkflowDefinition(workflowName, workflowDescription)
-      const expectedVersion = callOptions?.expectedVersionOverride ?? options?.expectedVersion
+      const expectedVersion = callOptions?.expectedVersionOverride ?? optionsExpectedVersion
       publishMutation(
         {
           params: { path: { workflow_id: workflowId, version: versionToPublish } },
@@ -87,13 +94,13 @@ export function usePublishWorkflow(
             }
             if (workflowDefinition) useWorkflowStore.getState().markClean()
             if (data?.current_version != null) {
-              options?.onVersionUpdated?.(data.current_version)
+              onVersionUpdated?.(data.current_version)
             }
             detachPromise(queryClient.invalidateQueries({ predicate: isWorkflowQuery }))
           },
           onError: (error: unknown) => {
-            if (isWorkflowVersionConflictError(error) && options?.onConflict) {
-              options.onConflict(extractVersionConflictInfo(error))
+            if (isWorkflowVersionConflictError(error) && onConflict) {
+              onConflict(extractVersionConflictInfo(error))
               return
             }
             showError({ title: 'Failed to publish workflow', description: getErrorMessage(error) })
@@ -107,7 +114,9 @@ export function usePublishWorkflow(
       currentVersion,
       workflowName,
       workflowDescription,
-      options,
+      optionsExpectedVersion,
+      onConflict,
+      onVersionUpdated,
       publishMutation,
       queryClient,
       showSuccess,

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/ToolsMultiSelect.test.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/ToolsMultiSelect.test.tsx
@@ -30,13 +30,19 @@ const NONE: ToolSelection = { strategy: 'NONE' }
 const ALL: ToolSelection = { strategy: 'ALL' }
 const selected = (...ids: string[]): ToolSelection => ({ strategy: 'SELECTED', toolIds: ids })
 
-function renderComponent(
-  value: ToolSelection = NONE,
+function renderComponent({
+  value = NONE,
   onChange = vi.fn(),
-  integrations: IntegrationWithTools[] = mockIntegrations,
+  integrations = mockIntegrations,
   isLoading = false,
-  hasNoIntegrations = false
-) {
+  hasNoIntegrations = false,
+}: {
+  value?: ToolSelection
+  onChange?: (selection: ToolSelection) => void
+  integrations?: IntegrationWithTools[]
+  isLoading?: boolean
+  hasNoIntegrations?: boolean
+} = {}) {
   return render(
     <ToolsMultiSelect
       value={value}
@@ -50,17 +56,17 @@ function renderComponent(
 
 describe('ToolsMultiSelect', () => {
   it('renders "No tools selected" when strategy is NONE', () => {
-    renderComponent(NONE)
+    renderComponent({ value: NONE })
     expect(screen.getByDisplayValue('No tools selected')).toBeInTheDocument()
   })
 
   it('renders "All tools selected" when strategy is ALL', () => {
-    renderComponent(ALL)
+    renderComponent({ value: ALL })
     expect(screen.getByDisplayValue('All tools selected')).toBeInTheDocument()
   })
 
   it('shows N of M tools selected when strategy is SELECTED', () => {
-    renderComponent(selected('tool-1', 'tool-4'))
+    renderComponent({ value: selected('tool-1', 'tool-4') })
     expect(screen.getByDisplayValue('2 of 5 tools selected')).toBeInTheDocument()
   })
 
@@ -82,11 +88,10 @@ describe('ToolsMultiSelect', () => {
 
     expect(screen.getByText('list_resources')).toBeInTheDocument()
     expect(screen.getByText('get_resource')).toBeInTheDocument()
-    expect(screen.getByText('dev_tool_1')).toBeInTheDocument()
     expect(screen.queryByText('Primary MCP Server::list_resources')).not.toBeInTheDocument()
   })
 
-  it('renders an "All tools" option at the top of the dropdown', async () => {
+  it('renders "All tools" option at the top of the dropdown', async () => {
     const user = userEvent.setup()
     renderComponent()
 
@@ -97,7 +102,7 @@ describe('ToolsMultiSelect', () => {
 
   it('renders "All tools" even when no tools are discovered yet', async () => {
     const user = userEvent.setup()
-    renderComponent(NONE, vi.fn(), [])
+    renderComponent({ value: NONE, integrations: [] })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
 
@@ -106,7 +111,7 @@ describe('ToolsMultiSelect', () => {
 
   it('"All tools" checkbox is checked when strategy is ALL', async () => {
     const user = userEvent.setup()
-    renderComponent(ALL)
+    renderComponent({ value: ALL })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
 
@@ -115,7 +120,7 @@ describe('ToolsMultiSelect', () => {
 
   it('"All tools" checkbox is unchecked when strategy is NONE', async () => {
     const user = userEvent.setup()
-    renderComponent(NONE)
+    renderComponent({ value: NONE })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
 
@@ -125,7 +130,7 @@ describe('ToolsMultiSelect', () => {
   it('clicking "All tools" when NONE emits ALL strategy', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    renderComponent(NONE, onChange)
+    renderComponent({ value: NONE, onChange })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
     await user.click(screen.getByRole('checkbox', { name: 'All tools' }))
@@ -136,7 +141,7 @@ describe('ToolsMultiSelect', () => {
   it('clicking "All tools" when ALL emits NONE strategy', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    renderComponent(ALL, onChange)
+    renderComponent({ value: ALL, onChange })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
     await user.click(screen.getByRole('checkbox', { name: 'All tools' }))
@@ -147,7 +152,7 @@ describe('ToolsMultiSelect', () => {
   it('selects all tools in an integration when the integration row is clicked (from NONE)', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    renderComponent(NONE, onChange)
+    renderComponent({ value: NONE, onChange })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
     await user.click(screen.getByRole('checkbox', { name: 'Primary MCP Server (3)' }))
@@ -158,7 +163,7 @@ describe('ToolsMultiSelect', () => {
   it('deselects all tools in an integration when integration row is clicked while all selected', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    renderComponent(selected('tool-1', 'tool-2', 'tool-3'), onChange)
+    renderComponent({ value: selected('tool-1', 'tool-2', 'tool-3'), onChange })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
     await user.click(screen.getByRole('checkbox', { name: 'Primary MCP Server (3)' }))
@@ -169,7 +174,7 @@ describe('ToolsMultiSelect', () => {
   it('adds a tool to a SELECTED set when a specific tool is clicked', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    renderComponent(NONE, onChange)
+    renderComponent({ value: NONE, onChange })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
     await user.click(screen.getByText('list_resources'))
@@ -180,7 +185,7 @@ describe('ToolsMultiSelect', () => {
   it('removes a tool from SELECTED when a selected tool is clicked', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    renderComponent(selected('tool-1', 'tool-4'), onChange)
+    renderComponent({ value: selected('tool-1', 'tool-4'), onChange })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
     await user.click(screen.getByText('list_resources'))
@@ -191,7 +196,7 @@ describe('ToolsMultiSelect', () => {
   it('clicking a tool when ALL transitions to SELECTED with that tool excluded', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    renderComponent(ALL, onChange)
+    renderComponent({ value: ALL, onChange })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
     await user.click(screen.getByText('list_resources'))
@@ -205,7 +210,7 @@ describe('ToolsMultiSelect', () => {
   it('adds tools from a second integration to an existing SELECTED set', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    renderComponent(selected('tool-4'), onChange)
+    renderComponent({ value: selected('tool-4'), onChange })
 
     await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
     await user.click(screen.getByRole('checkbox', { name: 'Primary MCP Server (3)' }))
@@ -221,13 +226,13 @@ describe('ToolsMultiSelect', () => {
   })
 
   it('shows loading placeholder when isLoading is true', () => {
-    renderComponent(NONE, vi.fn(), mockIntegrations, true)
+    renderComponent({ value: NONE, integrations: mockIntegrations, isLoading: true })
 
     expect(screen.getByPlaceholderText('Loading tools...')).toBeInTheDocument()
   })
 
   it('disables the inner text input when isLoading is true', () => {
-    renderComponent(NONE, vi.fn(), mockIntegrations, true)
+    renderComponent({ value: NONE, integrations: mockIntegrations, isLoading: true })
 
     expect(screen.getByRole('textbox', { name: 'Select tools' })).toBeDisabled()
   })
@@ -262,7 +267,7 @@ describe('ToolsMultiSelect', () => {
   })
 
   it('has no accessibility violations with ALL strategy', async () => {
-    const { container } = renderComponent(ALL)
+    const { container } = renderComponent({ value: ALL })
 
     const results = await axe(container)
     expect(results).toHaveNoViolations()
@@ -270,14 +275,14 @@ describe('ToolsMultiSelect', () => {
 
   describe('empty integrations state', () => {
     it('shows placeholder text instead of "No tools selected" when hasNoIntegrations is true', () => {
-      renderComponent(NONE, vi.fn(), [], false, true)
+      renderComponent({ value: NONE, integrations: [], hasNoIntegrations: true })
       expect(screen.getByPlaceholderText('Select tools')).toBeInTheDocument()
       expect(screen.queryByDisplayValue('No tools selected')).not.toBeInTheDocument()
     })
 
     it('shows "No MCP server integrations configured" in dropdown when hasNoIntegrations is true', async () => {
       const user = userEvent.setup()
-      renderComponent(NONE, vi.fn(), [], false, true)
+      renderComponent({ value: NONE, integrations: [], hasNoIntegrations: true })
 
       await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
 
@@ -286,7 +291,7 @@ describe('ToolsMultiSelect', () => {
 
     it('does not show "All tools" option when hasNoIntegrations is true', async () => {
       const user = userEvent.setup()
-      renderComponent(NONE, vi.fn(), [], false, true)
+      renderComponent({ value: NONE, integrations: [], hasNoIntegrations: true })
 
       await user.click(screen.getByRole('textbox', { name: 'Select tools' }))
 
@@ -294,7 +299,7 @@ describe('ToolsMultiSelect', () => {
     })
 
     it('has no accessibility violations when hasNoIntegrations is true', async () => {
-      const { container } = renderComponent(NONE, vi.fn(), [], false, true)
+      const { container } = renderComponent({ value: NONE, integrations: [], hasNoIntegrations: true })
 
       const results = await axe(container)
       expect(results).toHaveNoViolations()

--- a/frontend/packages/syntara-ui/src/routes/builder/node-forms/useFileUploadState.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/node-forms/useFileUploadState.ts
@@ -38,13 +38,14 @@ type DeleteFailureContext = {
   showError: (opts: { title: string }) => void
 }
 
-function handleBatchDeleteFailure(
-  failedIndex: number,
-  replacements: UploadedFile[],
-  deleted: UploadedFile[],
-  err: unknown,
+function handleBatchDeleteFailure(params: {
+  failedIndex: number
+  replacements: UploadedFile[]
+  deleted: UploadedFile[]
+  err: unknown
   ctx: DeleteFailureContext
-): void {
+}): void {
+  const { failedIndex, replacements, deleted, err, ctx } = params
   const { clearDeletingState, showError } = ctx
   const file = replacements[failedIndex]
   const msg = err instanceof Error ? err.message : `Unable to delete ${file.file.name}. Please try again.`
@@ -76,7 +77,13 @@ async function deleteSessionReplacements(
       await deleteFileById(replacements[i].id)
       deleted.push(replacements[i])
     } catch (err: unknown) {
-      handleBatchDeleteFailure(i, replacements, deleted, err, { clearDeletingState, showError })
+      handleBatchDeleteFailure({
+        failedIndex: i,
+        replacements,
+        deleted,
+        err,
+        ctx: { clearDeletingState, showError },
+      })
       return { success: false, deleted }
     }
   }

--- a/frontend/packages/syntara-ui/src/routes/builder/panels/InputPanel.tsx
+++ b/frontend/packages/syntara-ui/src/routes/builder/panels/InputPanel.tsx
@@ -45,13 +45,14 @@ type InputPanelProps = {
 }
 
 /** Compute the effective upstream nodes, falling back to source ancestors when direct upstream is empty. */
-function computeEffectiveUpstream(
-  upstreamNodes: UpstreamNodeInfo[],
-  sourceNodeId: string | null | undefined,
-  sourceAncestors: UpstreamNodeInfo[],
-  activities: { id: string; name?: string; type: string }[] | undefined,
+function computeEffectiveUpstream(params: {
+  upstreamNodes: UpstreamNodeInfo[]
+  sourceNodeId: string | null | undefined
+  sourceAncestors: UpstreamNodeInfo[]
+  activities: { id: string; name?: string; type: string }[] | undefined
   triggers: { id: string; name?: string; type: string }[] | undefined
-): UpstreamNodeInfo[] {
+}): UpstreamNodeInfo[] {
+  const { upstreamNodes, sourceNodeId, sourceAncestors, activities, triggers } = params
   if (upstreamNodes.length > 0) return upstreamNodes
   if (!sourceNodeId) return []
 
@@ -268,7 +269,7 @@ export function InputPanel({
   const triggers = useWorkflowStore(selectTriggers)
 
   const effectiveUpstream = useMemo(
-    () => computeEffectiveUpstream(upstreamNodes, sourceNodeId, sourceAncestors, activities, triggers),
+    () => computeEffectiveUpstream({ upstreamNodes, sourceNodeId, sourceAncestors, activities, triggers }),
     [upstreamNodes, sourceNodeId, sourceAncestors, activities, triggers]
   )
 

--- a/frontend/packages/syntara-ui/src/routes/builder/types.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/types.ts
@@ -7,6 +7,18 @@ import type { ValidationError } from './builderReducer'
 /** Flow coordinate (e.g. for node placement or edge end position) */
 export type FlowPosition = { x: number; y: number }
 
+/** Arguments for opening the add-node flow from an edge, button edge, or canvas drop. */
+export type AddNodeFromEdgeOptions = {
+  sourceNodeId: string
+  targetNodeId?: string
+  edgeId?: string
+  sourceHandle?: string
+  /** Places the new node's left edge at this flow coordinate when set */
+  desiredPosition?: FlowPosition
+}
+
+export type OnAddNodeFromEdge = (options: AddNodeFromEdgeOptions) => void
+
 /**
  * Props for the BuilderFlow component
  */
@@ -33,13 +45,7 @@ export type BuilderFlowProps = {
   /** Handler for node click events */
   onNodeClick?: NodeMouseHandler<NodeType>
   /** Handler for adding a node from an edge; desiredPosition places the new node's left edge at that flow coordinate */
-  onAddNodeFromEdge?: (
-    sourceNodeId: string,
-    targetNodeId?: string,
-    edgeId?: string,
-    sourceHandle?: string,
-    desiredPosition?: FlowPosition
-  ) => void
+  onAddNodeFromEdge?: OnAddNodeFromEdge
   /** Desired position for the new node (e.g. from [+] click or pending edge drop); consumed by useNodePositioning */
   newNodeDesiredPosition?: FlowPosition | null
   /** Called when desired position has been applied so it can be cleared */

--- a/frontend/packages/syntara-ui/src/routes/builder/useWorkflowImportExport.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/useWorkflowImportExport.ts
@@ -114,7 +114,11 @@ export function useWorkflowImportExport({
       const triggers = currentWorkflow.triggers ?? []
       const name = workflowName || 'workflow'
       const description = workflowDescription
-      const definition = buildWorkflowDefinition(name, description, activities, triggers, {
+      const definition = buildWorkflowDefinition({
+        workflowName: name,
+        workflowDescription: description,
+        activities: activities,
+        triggers: triggers,
         edges,
         nodePositions,
       })

--- a/frontend/packages/syntara-ui/src/routes/builder/useWorkflowVerification.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/useWorkflowVerification.ts
@@ -165,7 +165,11 @@ export function useWorkflowVerification({ dispatch }: UseWorkflowVerificationOpt
 
       let definition: ReturnType<typeof buildWorkflowDefinition>
       try {
-        definition = buildWorkflowDefinition(name, description, activities, triggers, {
+        definition = buildWorkflowDefinition({
+          workflowName: name,
+          workflowDescription: description,
+          activities: activities,
+          triggers: triggers,
           edges,
           nodePositions,
         })

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/EdgeFactory.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/EdgeFactory.ts
@@ -1,6 +1,7 @@
 import { EdgeHandleEnum } from '@syntara/contracts'
 import { addEdge } from '@xyflow/react'
 
+import type { OnAddNodeFromEdge } from '../types'
 import type { EdgeConnection } from '../types/edge'
 
 import { getButtonEdgeId, isBranchHandle } from './edgeHelpers'
@@ -11,7 +12,7 @@ export type CreateEdgeOptions = {
   target: string
   sourceHandle?: string
   targetHandle?: string
-  onAddNode?: (sourceId: string, targetId?: string, edgeId?: string, handle?: string) => void
+  onAddNode?: OnAddNodeFromEdge
 }
 
 /**

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/builderPanelConnectFlow.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/builderPanelConnectFlow.ts
@@ -3,7 +3,7 @@ import type { Node, ReactFlowInstance } from '@xyflow/react'
 
 import { FlowNodeType } from '../../../constants'
 import { useWorkflowStore } from '../../../stores/useWorkflowStore'
-import type { FlowPosition } from '../types'
+import type { OnAddNodeFromEdge } from '../types'
 
 import { EdgeFactory } from './EdgeFactory'
 import { isSwitchCasePort } from './switchCaseHelpers'
@@ -48,13 +48,14 @@ function removeButtonEdgeClass(nodes: Node[], sourceId: string): Node[] {
   })
 }
 
-function applyFirstEdgeAfterPanelConnect(
-  eds: EdgeType[],
-  sourceId: string,
-  capturedSourceHandle: string | undefined,
-  capturedEdgeIdToReplace: string | null | undefined,
+function applyFirstEdgeAfterPanelConnect(params: {
+  eds: EdgeType[]
+  sourceId: string
+  capturedSourceHandle: string | undefined
+  capturedEdgeIdToReplace: string | null | undefined
   newEdge: EdgeType
-): EdgeType[] {
+}): EdgeType[] {
+  const { eds, sourceId, capturedSourceHandle, capturedEdgeIdToReplace, newEdge } = params
   const filtered = EdgeFactory.removeButtonEdge(sourceId, eds, capturedSourceHandle)
   const withoutOldEdge = capturedEdgeIdToReplace ? filtered.filter((e) => e.id !== capturedEdgeIdToReplace) : filtered
   return EdgeFactory.addEdge(newEdge, withoutOldEdge)
@@ -91,13 +92,7 @@ export type PanelConnectCapturedState = {
   capturedTargetHandle: string | undefined | null
   capturedEdgeIdToReplace: string | null | undefined
   capturedTargetNodeId: string | null | undefined
-  onAddNodeFromEdge: (
-    sourceId: string,
-    targetId?: string,
-    edgeId?: string,
-    handle?: string,
-    desiredPosition?: FlowPosition
-  ) => void
+  onAddNodeFromEdge: OnAddNodeFromEdge
 }
 
 /**
@@ -152,7 +147,15 @@ export function applyConnectFromPanelWhenTargetMeasured(
     onAddNode: onAddNodeFromEdge,
   })
 
-  flow.setEdges((eds) => applyFirstEdgeAfterPanelConnect(eds, sourceId, sourceHandle, capturedEdgeIdToReplace, newEdge))
+  flow.setEdges((eds) =>
+    applyFirstEdgeAfterPanelConnect({
+      eds,
+      sourceId,
+      capturedSourceHandle: sourceHandle,
+      capturedEdgeIdToReplace,
+      newEdge,
+    })
+  )
 
   if (capturedEdgeIdToReplace && capturedTargetNodeId) {
     const secondEdge = EdgeFactory.createEdge({

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/edgeConnectionHelpers.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/edgeConnectionHelpers.test.ts
@@ -360,7 +360,12 @@ describe('applyEdgeConnection', () => {
       activityReorderTarget: null,
     }
 
-    applyEdgeConnection(result, params, 'target', mockInstance)
+    applyEdgeConnection({
+      result,
+      params,
+      targetId: 'target',
+      reactFlowInstance: mockInstance,
+    })
 
     // Should not apply changes yet
     expect(setEdges).not.toHaveBeenCalled()
@@ -407,7 +412,13 @@ describe('applyEdgeConnection', () => {
       activityReorderTarget: null,
     }
 
-    applyEdgeConnection(result, params, 'target', mockInstance, onComplete)
+    applyEdgeConnection({
+      result,
+      params,
+      targetId: 'target',
+      reactFlowInstance: mockInstance,
+      onComplete: onComplete,
+    })
 
     expect(onComplete).toHaveBeenCalled()
   })
@@ -438,7 +449,12 @@ describe('applyEdgeConnection', () => {
       activityReorderTarget: null,
     }
 
-    applyEdgeConnection(result, params, 'target', mockInstance)
+    applyEdgeConnection({
+      result,
+      params,
+      targetId: 'target',
+      reactFlowInstance: mockInstance,
+    })
 
     // Fast-forward through all retry attempts
     vi.advanceTimersByTime(50 * 40)
@@ -475,7 +491,12 @@ describe('applyEdgeConnection', () => {
       activityReorderTarget: null,
     }
 
-    applyEdgeConnection(result, params, 'target', mockInstance)
+    applyEdgeConnection({
+      result,
+      params,
+      targetId: 'target',
+      reactFlowInstance: mockInstance,
+    })
 
     expect(setEdges).toHaveBeenCalled()
 
@@ -533,7 +554,12 @@ describe('applyEdgeConnection', () => {
       activityReorderTarget: null,
     }
 
-    applyEdgeConnection(result, params, 'target', mockInstance)
+    applyEdgeConnection({
+      result,
+      params,
+      targetId: 'target',
+      reactFlowInstance: mockInstance,
+    })
 
     expect(setNodes).toHaveBeenCalled()
 
@@ -592,7 +618,12 @@ describe('applyEdgeConnection', () => {
       activityReorderTarget: null,
     }
 
-    applyEdgeConnection(result, params, 'target', mockInstance)
+    applyEdgeConnection({
+      result,
+      params,
+      targetId: 'target',
+      reactFlowInstance: mockInstance,
+    })
 
     expect(setNodes).toHaveBeenCalled()
 
@@ -646,7 +677,12 @@ describe('applyEdgeConnection', () => {
       activityReorderTarget: null,
     }
 
-    applyEdgeConnection(result, params, 'target', mockInstance)
+    applyEdgeConnection({
+      result,
+      params,
+      targetId: 'target',
+      reactFlowInstance: mockInstance,
+    })
 
     expect(setNodes).toHaveBeenCalled()
 
@@ -691,7 +727,12 @@ describe('applyEdgeConnection', () => {
       activityReorderTarget: null,
     }
 
-    applyEdgeConnection(result, params, 'target', mockInstance)
+    applyEdgeConnection({
+      result,
+      params,
+      targetId: 'target',
+      reactFlowInstance: mockInstance,
+    })
 
     expect(setNodes).toHaveBeenCalled()
 
@@ -738,11 +779,21 @@ describe('applyEdgeConnection', () => {
 
       // Start 5 connections (max limit)
       for (let i = 0; i < 5; i++) {
-        applyEdgeConnection(result, params, `target-${i}`, mockInstance)
+        applyEdgeConnection({
+          result,
+          params,
+          targetId: `target-${i}`,
+          reactFlowInstance: mockInstance,
+        })
       }
 
       // 6th connection should be rejected
-      applyEdgeConnection(result, params, 'target-6', mockInstance)
+      applyEdgeConnection({
+        result,
+        params,
+        targetId: 'target-6',
+        reactFlowInstance: mockInstance,
+      })
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Edge connection rejected: max concurrent limit (5) reached')
@@ -778,7 +829,12 @@ describe('applyEdgeConnection', () => {
           setNodes: vi.fn(),
         } as unknown as ReactFlowInstance
 
-        applyEdgeConnection(result, params, `target-${i}`, mockInstance)
+        applyEdgeConnection({
+          result,
+          params,
+          targetId: `target-${i}`,
+          reactFlowInstance: mockInstance,
+        })
       }
 
       // All 5 should have succeeded (counter incremented then immediately decremented)
@@ -792,7 +848,12 @@ describe('applyEdgeConnection', () => {
         setNodes: vi.fn(),
       } as unknown as ReactFlowInstance
 
-      applyEdgeConnection(result, params, 'target-6', mockInstance)
+      applyEdgeConnection({
+        result,
+        params,
+        targetId: 'target-6',
+        reactFlowInstance: mockInstance,
+      })
       expect(setEdges).toHaveBeenCalledTimes(6)
     })
 
@@ -823,7 +884,12 @@ describe('applyEdgeConnection', () => {
       }
 
       // Start connection that will timeout
-      applyEdgeConnection(result, params, 'target', mockInstance)
+      applyEdgeConnection({
+        result,
+        params,
+        targetId: 'target',
+        reactFlowInstance: mockInstance,
+      })
 
       // Fast-forward through all retry attempts (timeout)
       vi.advanceTimersByTime(50 * 40)
@@ -833,7 +899,12 @@ describe('applyEdgeConnection', () => {
       mockInstance.getNodes = vi.fn(() => [measuredNode as FlowNode])
 
       // This should succeed (counter was decremented after timeout)
-      applyEdgeConnection(result, params, 'target2', mockInstance)
+      applyEdgeConnection({
+        result,
+        params,
+        targetId: 'target2',
+        reactFlowInstance: mockInstance,
+      })
       expect(setEdges).toHaveBeenCalled()
 
       vi.useRealTimers()

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/edgeConnectionHelpers.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/edgeConnectionHelpers.ts
@@ -3,7 +3,7 @@ import type { ReactFlowInstance, Node } from '@xyflow/react'
 
 import { FlowNodeType } from '../../../constants'
 import { generateUUID } from '../../../utils/generateUUID'
-import type { FlowPosition } from '../types'
+import type { OnAddNodeFromEdge } from '../types'
 
 import { EdgeFactory } from './EdgeFactory'
 import { isSwitchCasePort, SWITCH_CASE_PORT_PREFIX } from './switchCaseHelpers'
@@ -44,13 +44,7 @@ export type EdgeConnectionParams = {
   targetNodeId?: string | null
   sourceHandle?: string
   targetHandle?: string
-  onAddNode: (
-    sourceId: string,
-    targetId?: string,
-    edgeId?: string,
-    handle?: string,
-    desiredPosition?: FlowPosition
-  ) => void
+  onAddNode: OnAddNodeFromEdge
 }
 
 /**
@@ -209,20 +203,15 @@ export function resetPollingConnectionCounter(): void {
  * Waits for target node to be measured before creating edges.
  *
  * SECURITY: Limited to 5 concurrent connections to prevent client-side resource exhaustion.
- *
- * @param result - Connection result from calculateEdgeConnection
- * @param params - Original connection parameters
- * @param targetId - ID of the target node
- * @param reactFlowInstance - React Flow instance
- * @param onComplete - Callback when connection is complete
  */
-export function applyEdgeConnection(
-  result: EdgeConnectionResult,
-  params: EdgeConnectionParams,
-  targetId: string,
-  reactFlowInstance: ReactFlowInstance,
+export function applyEdgeConnection(options: {
+  result: EdgeConnectionResult
+  params: EdgeConnectionParams
+  targetId: string
+  reactFlowInstance: ReactFlowInstance
   onComplete?: () => void
-): void {
+}): void {
+  const { result, params, targetId, reactFlowInstance, onComplete } = options
   // SECURITY: Prevent DoS - reject if too many concurrent connections
   if (activeConnections.size >= MAX_CONCURRENT_CONNECTIONS) {
     // eslint-disable-next-line no-console

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/executionState/ExecutionStateEnricher.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/executionState/ExecutionStateEnricher.ts
@@ -153,20 +153,16 @@ export class ExecutionStateEnricher {
    * All nodes (including control flow) get their status from backend ActivityExecution
    * records. No inference from downstream nodes is performed.
    *
-   * @param activity - The activity to enrich
-   * @param executionStatus - Current execution status (null if not in execution view)
-   * @param activityStates - Map of activity IDs to their execution states from backend
-   * @param edges - All edges in the workflow
-   * @param options - Optional pre-resolved nodes and copy-to-editor skip allowlist
    * @returns Activity enriched with execution metadata
    */
-  enrichActivity(
-    activity: Activity,
-    executionStatus: string | null | undefined,
-    activityStates: Map<string, ActivityState>,
-    edges: EdgeConnection[],
+  enrichActivity(params: {
+    activity: Activity
+    executionStatus: string | null | undefined
+    activityStates: Map<string, ActivityState>
+    edges: EdgeConnection[]
     options?: EnrichActivityOptions
-  ): ActivityWithMetadata {
+  }): ActivityWithMetadata {
+    const { activity, executionStatus, activityStates, edges, options } = params
     const { preResolvedNodes, skipInferenceActivityIds } = options ?? {}
 
     // If not in execution view, return as-is
@@ -229,7 +225,13 @@ export class ExecutionStateEnricher {
 
     // Step 2: Check if node should be marked as skipped (allowlist-aware after copy-to-editor)
     if (
-      WorkflowTraversal.shouldMarkAsSkipped(activity.id, activityStates, edges, new Set(), skipInferenceActivityIds)
+      WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: activity.id,
+        activityStates,
+        edges,
+        visited: new Set(),
+        skipInferenceActivityIds,
+      })
     ) {
       enrichedActivity = {
         ...enrichedActivity,
@@ -334,13 +336,14 @@ export class ExecutionStateEnricher {
     return !!state && TERMINAL_ACTIVITY_STATUSES.includes(state.status)
   }
 
-  determineEdgeStatus(
-    edge: { source: string; target: string; sourceHandle?: string | null },
-    activityStates: Map<string, ActivityState>,
-    activities: Activity[] | undefined,
-    triggerDisplayToRealId: Map<string, string> | undefined,
+  determineEdgeStatus(params: {
+    edge: { source: string; target: string; sourceHandle?: string | null }
+    activityStates: Map<string, ActivityState>
+    activities: Activity[] | undefined
+    triggerDisplayToRealId: Map<string, string> | undefined
     edges: EdgeConnection[]
-  ): 'passed' | 'pending' {
+  }): 'passed' | 'pending' {
+    const { edge, activityStates, activities, triggerDisplayToRealId, edges } = params
     const targetStarted = this.targetHasStarted(edge.target, activityStates, edges)
 
     if (edge.source.startsWith('trigger-')) {

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/executionState/__tests__/ExecutionStateEnricher.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/executionState/__tests__/ExecutionStateEnricher.test.ts
@@ -19,7 +19,12 @@ describe('ExecutionStateEnricher', () => {
       const edges: EdgeConnection[] = []
       const activityStates = new Map<string, ActivityState>()
 
-      const result = enricher.enrichActivity(activity, null, activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: null,
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toEqual(activity)
       expect(result.__executionState).toBeUndefined()
@@ -35,7 +40,12 @@ describe('ExecutionStateEnricher', () => {
       const edges: EdgeConnection[] = []
       const activityStates = new Map<string, ActivityState>()
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(
         ((result as Record<string, unknown>).metadata as Record<string, unknown> | undefined)?.__showExecutionBadge
@@ -53,7 +63,12 @@ describe('ExecutionStateEnricher', () => {
       const edges: EdgeConnection[] = []
       const activityStates = new Map<string, ActivityState>()
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result.metadata).toEqual({
         customProp: 'value',
@@ -73,7 +88,12 @@ describe('ExecutionStateEnricher', () => {
         ['task-1', { activityId: 'task-1', status: 'running', startedAt: '2024-01-01T00:00:00Z', completedAt: null }],
       ])
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result.__executionState).toEqual({
         status: 'running',
@@ -98,7 +118,12 @@ describe('ExecutionStateEnricher', () => {
         ['loop-1', { activityId: 'loop-1', status: 'running', startedAt: '2024-01-01T00:00:00Z', completedAt: null }],
       ])
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result.__executionState?.status).toBe('running')
     })
@@ -121,7 +146,12 @@ describe('ExecutionStateEnricher', () => {
         // loop-1 has NO backend state
       ])
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       // Should NOT infer 'running' from downstream - should have no execution state
       expect(result.__executionState).toBeUndefined()
@@ -150,7 +180,12 @@ describe('ExecutionStateEnricher', () => {
         ],
       ])
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result.__executionState?.status).toBe('completed')
     })
@@ -180,7 +215,12 @@ describe('ExecutionStateEnricher', () => {
         // converge-1 has NO backend state
       ])
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       // Should NOT infer status from upstream - should have no execution state
       expect(result.__executionState).toBeUndefined()
@@ -209,7 +249,12 @@ describe('ExecutionStateEnricher', () => {
         ],
       ])
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result.__executionState?.status).toBe('completed')
     })
@@ -233,7 +278,12 @@ describe('ExecutionStateEnricher', () => {
         // cond-1 has NO backend state
       ])
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       // Should NOT infer 'completed' from downstream - should have no execution state
       expect(result.__executionState).toBeUndefined()
@@ -271,7 +321,12 @@ describe('ExecutionStateEnricher', () => {
         ],
       ])
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result.__executionState?.status).toBe('skipped')
     })
@@ -309,8 +364,14 @@ describe('ExecutionStateEnricher', () => {
       ])
       const allowlist = new Set(['cond-1', 'task-true', 'task-false'])
 
-      const result = enricher.enrichActivity(activity, 'completed', activityStates, edges, {
-        skipInferenceActivityIds: allowlist,
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'completed',
+        activityStates: activityStates,
+        edges: edges,
+        options: {
+          skipInferenceActivityIds: allowlist,
+        },
       })
 
       expect(result.__executionState?.status).toBe('skipped')
@@ -340,8 +401,14 @@ describe('ExecutionStateEnricher', () => {
       ])
       const allowlist = new Set(['task-1'])
 
-      const result = enricher.enrichActivity(activity, 'completed', activityStates, edges, {
-        skipInferenceActivityIds: allowlist,
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'completed',
+        activityStates: activityStates,
+        edges: edges,
+        options: {
+          skipInferenceActivityIds: allowlist,
+        },
       })
 
       expect(result.__executionState).toBeUndefined()
@@ -363,7 +430,12 @@ describe('ExecutionStateEnricher', () => {
       ]
       const activityStates = new Map<string, ActivityState>()
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       // Control nodes without backend state should not get a pending badge
       expect(result.__executionState).toBeUndefined()
@@ -433,7 +505,12 @@ describe('ExecutionStateEnricher', () => {
         ],
       ])
 
-      const result = enricher.enrichActivity(activity, 'failed', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'failed',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result.__executionState?.status).toBe('failed')
       expect(result.__executionState?.error_details).toBe('max_iterations exceeded')
@@ -449,7 +526,12 @@ describe('ExecutionStateEnricher', () => {
       const edges: EdgeConnection[] = []
       const activityStates = new Map<string, ActivityState>()
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       // Regular tasks without backend state shouldn't get a pending badge
       expect(result.__executionState).toBeUndefined()
@@ -478,7 +560,12 @@ describe('ExecutionStateEnricher', () => {
         ],
       ])
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result.__executionState?.status).toBe('completed')
     })
@@ -502,7 +589,12 @@ describe('ExecutionStateEnricher', () => {
         // approval-1 has NO backend state
       ])
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges)
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       // Should NOT infer 'completed' from downstream - should have no execution state
       expect(result.__executionState).toBeUndefined()
@@ -531,7 +623,13 @@ describe('ExecutionStateEnricher', () => {
       ])
       const edges: EdgeConnection[] = []
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges, { preResolvedNodes })
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+        options: { preResolvedNodes },
+      })
 
       expect(result.metadata?.__mockDataPinned).toBe(true)
       expect(result.metadata?.__showExecutionBadge).toBe(true)
@@ -548,7 +646,13 @@ describe('ExecutionStateEnricher', () => {
       const activityStates = new Map<string, ActivityState>()
       const edges: EdgeConnection[] = []
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges, { preResolvedNodes })
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+        options: { preResolvedNodes },
+      })
 
       expect(result.__executionState?.status).toBe('skipped')
       expect(result.metadata?.__mockDataPinned).toBe(true)
@@ -575,7 +679,13 @@ describe('ExecutionStateEnricher', () => {
       ])
       const edges: EdgeConnection[] = []
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges, { preResolvedNodes })
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+        options: { preResolvedNodes },
+      })
 
       expect(result.__executionState?.status).toBe('completed')
       expect(result.metadata?.__mockDataPinned).toBe(true)
@@ -592,7 +702,13 @@ describe('ExecutionStateEnricher', () => {
       const activityStates = new Map<string, ActivityState>()
       const edges: EdgeConnection[] = []
 
-      const result = enricher.enrichActivity(activity, 'running', activityStates, edges, { preResolvedNodes })
+      const result = enricher.enrichActivity({
+        activity: activity,
+        executionStatus: 'running',
+        activityStates: activityStates,
+        edges: edges,
+        options: { preResolvedNodes },
+      })
 
       expect(result.metadata?.__mockDataPinned).toBeUndefined()
     })
@@ -605,7 +721,13 @@ describe('ExecutionStateEnricher', () => {
         ['task-1', { activityId: 'task-1', status: 'running', startedAt: '2024-01-01T00:00:00Z', completedAt: null }],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('pending')
     })
@@ -625,7 +747,13 @@ describe('ExecutionStateEnricher', () => {
         ['task-2', { activityId: 'task-2', status: 'running', startedAt: '2024-01-01T00:01:00Z', completedAt: null }],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('passed')
     })
@@ -645,7 +773,13 @@ describe('ExecutionStateEnricher', () => {
         ['task-2', { activityId: 'task-2', status: 'skipped', startedAt: null, completedAt: null }],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('pending')
     })
@@ -656,7 +790,13 @@ describe('ExecutionStateEnricher', () => {
         ['task-1', { activityId: 'task-1', status: 'pending', startedAt: null, completedAt: null }],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('pending')
     })
@@ -665,7 +805,13 @@ describe('ExecutionStateEnricher', () => {
       const edge = { source: 'task-1', target: 'task-2' }
       const activityStates = new Map<string, ActivityState>()
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('pending')
     })
@@ -688,7 +834,13 @@ describe('ExecutionStateEnricher', () => {
         ],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('passed')
     })
@@ -708,7 +860,13 @@ describe('ExecutionStateEnricher', () => {
         ['task-true', { activityId: 'task-true', status: 'pending', startedAt: null, completedAt: null }],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('pending')
     })
@@ -728,7 +886,13 @@ describe('ExecutionStateEnricher', () => {
         ['task-false', { activityId: 'task-false', status: 'skipped', startedAt: null, completedAt: null }],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('pending')
     })
@@ -749,7 +913,13 @@ describe('ExecutionStateEnricher', () => {
         ['task-1', { activityId: 'task-1', status: 'running', startedAt: '2024-01-01T00:00:00Z', completedAt: null }],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, triggerMap, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: triggerMap,
+        edges: [],
+      })
 
       expect(result).toBe('passed')
     })
@@ -760,7 +930,13 @@ describe('ExecutionStateEnricher', () => {
         ['task-1', { activityId: 'task-1', status: 'pending', startedAt: null, completedAt: null }],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('pending')
     })
@@ -769,7 +945,13 @@ describe('ExecutionStateEnricher', () => {
       const edge = { source: 'trigger-0', target: 'task-1', sourceHandle: null }
       const activityStates = new Map<string, ActivityState>()
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('pending')
     })
@@ -783,7 +965,13 @@ describe('ExecutionStateEnricher', () => {
         ],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('passed')
     })
@@ -794,7 +982,13 @@ describe('ExecutionStateEnricher', () => {
         ['task-after', { activityId: 'task-after', status: 'pending', startedAt: null, completedAt: null }],
       ])
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('pending')
     })
@@ -809,7 +1003,13 @@ describe('ExecutionStateEnricher', () => {
       ])
       const activities: Activity[] = []
 
-      const result = enricher.determineEdgeStatus(edge, activityStates, activities, undefined, [])
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: activities,
+        triggerDisplayToRealId: undefined,
+        edges: [],
+      })
 
       expect(result).toBe('passed')
     })
@@ -862,7 +1062,13 @@ describe('ExecutionStateEnricher', () => {
       ])
 
       const edge = { source: 'body-1', target: 'body-2', sourceHandle: EdgeHandleEnum.SOURCE }
-      const result = enricher.determineEdgeStatus(edge, activityStates, undefined, undefined, edges)
+      const result = enricher.determineEdgeStatus({
+        edge: edge,
+        activityStates: activityStates,
+        activities: undefined,
+        triggerDisplayToRealId: undefined,
+        edges: edges,
+      })
 
       // body-1's latest iteration (#iter-1) is running, not terminal — edge should be pending
       expect(result).toBe('pending')

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/executionState/__tests__/traversal.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/executionState/__tests__/traversal.test.ts
@@ -167,7 +167,11 @@ describe('WorkflowTraversal', () => {
         ],
       ])
 
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-1', activityStates, edges)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-1',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toBe(false)
     })
@@ -178,7 +182,11 @@ describe('WorkflowTraversal', () => {
       ]
       const activityStates = new Map<string, ActivityState>()
 
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-1', activityStates, edges)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-1',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toBe(false) // Trigger nodes or orphans should not be skipped
     })
@@ -192,7 +200,11 @@ describe('WorkflowTraversal', () => {
         ['task-3', { activityId: 'task-3', status: 'pending', startedAt: null, completedAt: null }],
       ])
 
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-2', activityStates, edges)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-2',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toBe(false) // Execution could still reach this node
     })
@@ -224,7 +236,11 @@ describe('WorkflowTraversal', () => {
         // task-false never started - it's on the non-taken branch
       ])
 
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-false', activityStates, edges)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-false',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toBe(true)
     })
@@ -256,7 +272,11 @@ describe('WorkflowTraversal', () => {
         // task-approved never started - it's on the non-taken branch
       ])
 
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-approved', activityStates, edges)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-approved',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toBe(true)
     })
@@ -291,10 +311,16 @@ describe('WorkflowTraversal', () => {
       ])
 
       // First verify task-a is skipped
-      expect(WorkflowTraversal.shouldMarkAsSkipped('task-a', activityStates, edges)).toBe(true)
+      expect(
+        WorkflowTraversal.shouldMarkAsSkipped({ activityId: 'task-a', activityStates: activityStates, edges: edges })
+      ).toBe(true)
 
       // Then verify task-c is also skipped (cascading)
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-c', activityStates, edges)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-c',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toBe(true)
     })
@@ -326,7 +352,11 @@ describe('WorkflowTraversal', () => {
         // task-3 never started - both parents completed but didn't reach it
       ])
 
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-3', activityStates, edges)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-3',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toBe(true)
     })
@@ -348,7 +378,13 @@ describe('WorkflowTraversal', () => {
       ])
       const allowlist = new Set(['task-1', 'task-skipped'])
 
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-skipped', activityStates, edges, new Set(), allowlist)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-skipped',
+        activityStates,
+        edges,
+        visited: new Set(),
+        skipInferenceActivityIds: allowlist,
+      })
 
       expect(result).toBe(true)
     })
@@ -371,7 +407,13 @@ describe('WorkflowTraversal', () => {
       ])
       const allowlist = new Set(['task-1'])
 
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-new', activityStates, edges, new Set(), allowlist)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-new',
+        activityStates,
+        edges,
+        visited: new Set(),
+        skipInferenceActivityIds: allowlist,
+      })
 
       expect(result).toBe(false)
     })
@@ -384,7 +426,11 @@ describe('WorkflowTraversal', () => {
       const activityStates = new Map<string, ActivityState>()
 
       // Should not throw or hang
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-1', activityStates, edges)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-1',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toBe(false)
     })
@@ -397,7 +443,11 @@ describe('WorkflowTraversal', () => {
         ['task-1', { activityId: 'task-1', status: 'running', startedAt: '2024-01-01T00:00:00Z', completedAt: null }],
       ])
 
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-2', activityStates, edges)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-2',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toBe(false) // Parent is running, child could still execute
     })
@@ -410,7 +460,11 @@ describe('WorkflowTraversal', () => {
         ['task-1', { activityId: 'task-1', status: 'pending', startedAt: null, completedAt: null }],
       ])
 
-      const result = WorkflowTraversal.shouldMarkAsSkipped('task-2', activityStates, edges)
+      const result = WorkflowTraversal.shouldMarkAsSkipped({
+        activityId: 'task-2',
+        activityStates: activityStates,
+        edges: edges,
+      })
 
       expect(result).toBe(false) // Parent is pending, child could still execute
     })

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/executionState/traversal.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/executionState/traversal.ts
@@ -82,27 +82,23 @@ export class WorkflowTraversal {
    * When `skipInferenceActivityIds` is provided (copy-to-editor), only IDs in that set
    * may be inferred as skipped. Nodes added after the copy keep no execution status.
    *
-   * @param activityId - The activity ID to check
-   * @param activityStates - Map of activity states from execution store
-   * @param edges - All edges in the workflow
-   * @param visited - Set of visited node IDs to prevent infinite loops
-   * @param skipInferenceActivityIds - Optional allowlist of activity IDs from the copied run
    * @returns true if the node should be marked as skipped
    *
    * @example
    * // Check if a node on a conditional branch should be skipped
-   * const shouldSkip = WorkflowTraversal.shouldMarkAsSkipped(nodeId, states, edges)
+   * const shouldSkip = WorkflowTraversal.shouldMarkAsSkipped({ activityId: nodeId, activityStates: states, edges })
    * if (shouldSkip) {
    *   activity.__executionState = { status: 'skipped' }
    * }
    */
-  static shouldMarkAsSkipped(
-    activityId: string,
-    activityStates: Map<string, ActivityState>,
-    edges: EdgeConnection[],
-    visited: Set<string> = new Set(),
+  static shouldMarkAsSkipped(params: {
+    activityId: string
+    activityStates: Map<string, ActivityState>
+    edges: EdgeConnection[]
+    visited?: Set<string>
     skipInferenceActivityIds?: ReadonlySet<string>
-  ): boolean {
+  }): boolean {
+    const { activityId, activityStates, edges, visited = new Set(), skipInferenceActivityIds } = params
     // Nodes outside the copied-run allowlist must not inherit inferred Skipped status
     if (skipInferenceActivityIds && !skipInferenceActivityIds.has(activityId)) {
       return false
@@ -141,15 +137,13 @@ export class WorkflowTraversal {
 
     // Step 5: Check if all incoming nodes are either skipped or in terminal states
     // This handles cascading skips (parent skipped → children skipped)
-    const allIncomingSkippedOrTerminal = this.areAllIncomingNodesSkippedOrTerminal(
+    return this.areAllIncomingNodesSkippedOrTerminal({
       incomingEdges,
       activityStates,
       edges,
       visited,
-      skipInferenceActivityIds
-    )
-
-    return allIncomingSkippedOrTerminal
+      skipInferenceActivityIds,
+    })
   }
 
   /**
@@ -193,13 +187,14 @@ export class WorkflowTraversal {
    *
    * @private
    */
-  private static areAllIncomingNodesSkippedOrTerminal(
-    incomingEdges: EdgeConnection[],
-    activityStates: Map<string, ActivityState>,
-    edges: EdgeConnection[],
-    visited: Set<string>,
+  private static areAllIncomingNodesSkippedOrTerminal(params: {
+    incomingEdges: EdgeConnection[]
+    activityStates: Map<string, ActivityState>
+    edges: EdgeConnection[]
+    visited: Set<string>
     skipInferenceActivityIds?: ReadonlySet<string>
-  ): boolean {
+  }): boolean {
+    const { incomingEdges, activityStates, edges, visited, skipInferenceActivityIds } = params
     return incomingEdges.every((edge) => {
       const sourceState = activityStates.get(edge.source)
 
@@ -209,7 +204,13 @@ export class WorkflowTraversal {
       }
 
       // If source should be skipped, this counts too (cascading skip)
-      return this.shouldMarkAsSkipped(edge.source, activityStates, edges, new Set(visited), skipInferenceActivityIds)
+      return this.shouldMarkAsSkipped({
+        activityId: edge.source,
+        activityStates,
+        edges,
+        visited: new Set(visited),
+        skipInferenceActivityIds,
+      })
     })
   }
 }

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/validation/rules/validateVariableReferences.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/validation/rules/validateVariableReferences.ts
@@ -54,13 +54,14 @@ function getWorkflowInputNames(triggers: Activity[] | undefined): Set<string> {
   return names
 }
 
-function checkSchemaFieldReference(
-  ref: VariableReference,
-  activity: Activity,
-  fields: Set<string>,
-  namespace: string,
+function checkSchemaFieldReference(params: {
+  ref: VariableReference
+  activity: Activity
+  fields: Set<string>
+  namespace: string
   suggestionText: string
-): ValidationError | null {
+}): ValidationError | null {
+  const { ref, activity, fields, namespace, suggestionText } = params
   const fieldPath = ref.fullRef.substring(ref.namespace.length + 1)
   if (!fieldPath) return null
   const topLevelField = fieldPath.split('.')[0]
@@ -115,7 +116,13 @@ type RefContext = {
 
 function validateRef(ref: VariableReference, activity: Activity, ctx: RefContext): ValidationError | null {
   if (ref.namespace === 'trigger')
-    return checkSchemaFieldReference(ref, activity, ctx.schemaFields, ref.namespace, ctx.schemaSuggestion)
+    return checkSchemaFieldReference({
+      ref,
+      activity,
+      fields: ctx.schemaFields,
+      namespace: ref.namespace,
+      suggestionText: ctx.schemaSuggestion,
+    })
   if (KNOWN_NAMESPACES.has(ref.namespace)) return null
   return checkNodeReference(ref, activity, ctx.activityIds, ctx.upstreamIds)
 }

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/workflowDefinitionBuilder.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/workflowDefinitionBuilder.test.ts
@@ -16,7 +16,13 @@ function activity(id: string): Activity {
 
 describe('buildWorkflowDefinition', () => {
   it('builds basic workflow definition with minimal data', () => {
-    const result = buildWorkflowDefinition('Test Workflow', '', [], [], { edges: [] })
+    const result = buildWorkflowDefinition({
+      workflowName: 'Test Workflow',
+      workflowDescription: '',
+      activities: [],
+      triggers: [],
+      edges: [],
+    })
 
     expect(result).toEqual({
       schema_version: '2.0.0',
@@ -29,13 +35,25 @@ describe('buildWorkflowDefinition', () => {
   })
 
   it('includes description when provided', () => {
-    const result = buildWorkflowDefinition('Test Workflow', 'Test Description', [], [], { edges: [] })
+    const result = buildWorkflowDefinition({
+      workflowName: 'Test Workflow',
+      workflowDescription: 'Test Description',
+      activities: [],
+      triggers: [],
+      edges: [],
+    })
 
     expect(result.description).toBe('Test Description')
   })
 
   it('omits description when empty string', () => {
-    const result = buildWorkflowDefinition('Test Workflow', '', [], [], { edges: [] })
+    const result = buildWorkflowDefinition({
+      workflowName: 'Test Workflow',
+      workflowDescription: '',
+      activities: [],
+      triggers: [],
+      edges: [],
+    })
 
     expect(result.description).toBeUndefined()
   })
@@ -51,7 +69,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', [], triggers, { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: [],
+        triggers: triggers,
+        edges: [],
+      })
 
       expect(result.triggers).toEqual([
         {
@@ -72,7 +96,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', [], triggers, { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: [],
+        triggers: triggers,
+        edges: [],
+      })
 
       expect(result.triggers[0]).not.toHaveProperty('name')
     })
@@ -86,7 +116,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', [], triggers, { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: [],
+        triggers: triggers,
+        edges: [],
+      })
 
       expect(result.triggers[0].parameters).toEqual({})
     })
@@ -105,7 +141,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0]).toMatchObject({
         id: 'task-1',
@@ -127,7 +169,13 @@ describe('buildWorkflowDefinition', () => {
         } as Activity & { inputs: Record<string, unknown> },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0]).toHaveProperty('inputs')
       expect(result.nodes[0].inputs).toEqual({ param1: 'value1', param2: 'value2' })
@@ -142,7 +190,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0]).not.toHaveProperty('inputs')
     })
@@ -156,7 +210,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0]).not.toHaveProperty('name')
       expect(result.nodes[0]).not.toHaveProperty('settings')
@@ -173,7 +233,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0]).toHaveProperty('settings', { timeout: 300, continue_on_failure: true })
     })
@@ -192,7 +258,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0].parameters).toEqual({
         approver_users: ['alice', 'bob'],
@@ -213,7 +285,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0].parameters).toEqual({
         approver_groups: ['admins', 'reviewers'],
@@ -233,7 +311,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0].parameters).toEqual({
         approver_users: ['alice'],
@@ -254,7 +338,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0].parameters).toEqual({
         approver_users: ['alice', 'bob'],
@@ -273,7 +363,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       // Should remain unchanged for non-approval nodes
       expect(result.nodes[0].parameters).toEqual({
@@ -293,7 +389,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges,
+      })
 
       expect(result.edges[0]).toEqual({
         from: 'task-1',
@@ -312,7 +414,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges,
+      })
 
       expect(result.edges[0]).toEqual({
         from: 'loop-1',
@@ -332,7 +440,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges,
+      })
 
       expect(result.edges[0]).toEqual({
         from: 'task-1',
@@ -352,7 +466,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges,
+      })
 
       expect(result.edges[0]).toEqual({
         from: 'task-1',
@@ -372,7 +492,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges,
+      })
 
       expect(result.edges[0]).not.toHaveProperty('to_port')
     })
@@ -397,7 +523,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, triggers, { edges })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: triggers,
+        edges,
+      })
 
       expect(result.edges[0].from).toBe('webhook_trigger_1') // Mapped to definition ID
     })
@@ -420,7 +552,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, triggers, { edges })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: triggers,
+        edges,
+      })
 
       expect(result.edges[0].to).toBe('webhook_trigger_1') // Mapped to definition ID
     })
@@ -444,9 +582,15 @@ describe('buildWorkflowDefinition', () => {
       // SECURITY: Must throw instead of falling back to display ID
       // Display IDs (trigger-0) are ephemeral UI constructs and must never
       // appear in persisted workflow definitions sent to backend API
-      expect(() => buildWorkflowDefinition('Test', '', [], triggers, { edges })).toThrow(
-        /Trigger at index 0 is missing an ID.*Display IDs like "trigger-0" cannot be used/
-      )
+      expect(() =>
+        buildWorkflowDefinition({
+          workflowName: 'Test',
+          workflowDescription: '',
+          activities: [],
+          triggers: triggers,
+          edges,
+        })
+      ).toThrow(/Trigger at index 0 is missing an ID.*Display IDs like "trigger-0" cannot be used/)
     })
 
     it('uses source ID as-is when not a trigger reference', () => {
@@ -459,7 +603,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges,
+      })
 
       expect(result.edges[0].from).toBe('task-1')
       expect(result.edges[0].to).toBe('task-2')
@@ -479,7 +629,13 @@ describe('buildWorkflowDefinition', () => {
         { id: 'e3', source: 'trigger-2', target: 'task-3' },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, triggers, { edges })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: triggers,
+        edges,
+      })
 
       expect(result.edges[0].from).toBe('trigger_a')
       expect(result.edges[1].from).toBe('trigger_b')
@@ -520,7 +676,11 @@ describe('buildWorkflowDefinition', () => {
         { id: 'e3', source: 'task-1', target: 'loop-1', targetHandle: 'done' },
       ]
 
-      const result = buildWorkflowDefinition('Complex Workflow', 'A complex test workflow', activities, triggers, {
+      const result = buildWorkflowDefinition({
+        workflowName: 'Complex Workflow',
+        workflowDescription: 'A complex test workflow',
+        activities: activities,
+        triggers: triggers,
         edges,
       })
 
@@ -552,7 +712,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0].parameters.condition).toBe('not (${status} == "completed")')
     })
@@ -567,7 +733,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0].parameters.condition).toBe('not (${done} == true)')
     })
@@ -582,7 +754,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0].parameters.condition).toBe('${value} > 10')
     })
@@ -597,7 +775,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0].parameters.condition).toBe('not ((${a} > 5 and ${b} < 10))')
     })
@@ -612,7 +796,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0].parameters.code).toBe('if !done: pass')
     })
@@ -627,7 +817,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       // Should remain in backend format
       expect(result.nodes[0].parameters.condition).toBe('not (${value} == "test")')
@@ -643,7 +839,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       // UI: ${message.text} contains "Hello"
       // Backend: "Hello" in ${message.text}
@@ -660,7 +862,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       // UI: !(${email.body} contains "spam")
       // Backend: "spam" not in ${email.body}
@@ -677,7 +885,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       // Should transform both && to 'and' and 'contains' to 'in'
       expect(result.nodes[0].parameters.condition).toBe('(${age} >= 18 and "Smith" in ${name})')
@@ -699,7 +913,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       const cases = result.nodes[0].parameters.cases as Array<{ condition: string }>
       expect(cases[0].condition).toBe('not (${status} == "blocked")')
@@ -719,7 +939,13 @@ describe('buildWorkflowDefinition', () => {
         },
       ]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       const cases = result.nodes[0].parameters.cases as Array<{ condition: string }>
       expect(cases[0].condition).toBe('"admin" in ${name}')
@@ -731,7 +957,14 @@ describe('buildWorkflowDefinition', () => {
       const activities: Activity[] = [activity('task-1'), activity('task-2')]
       const nodePositions = { 'task-1': { x: 100, y: 200 }, 'task-2': { x: 300, y: 400 } }
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [], nodePositions })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+        nodePositions,
+      })
 
       expect(result.nodes[0].position).toEqual({ x: 100, y: 200 })
       expect(result.nodes[1].position).toEqual({ x: 300, y: 400 })
@@ -741,7 +974,14 @@ describe('buildWorkflowDefinition', () => {
       const triggers: Activity[] = [{ id: 'trigger_1', type: TriggerTypeEnum.MANUAL_TRIGGER, parameters: {} }]
       const nodePositions = { trigger_1: { x: 50, y: 75 } }
 
-      const result = buildWorkflowDefinition('Test', '', [], triggers, { edges: [], nodePositions })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: [],
+        triggers: triggers,
+        edges: [],
+        nodePositions,
+      })
 
       expect(result.triggers[0].position).toEqual({ x: 50, y: 75 })
     })
@@ -749,7 +989,11 @@ describe('buildWorkflowDefinition', () => {
     it('omits position when node has no stored position', () => {
       const activities: Activity[] = [activity('task-1')]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], {
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
         edges: [],
         nodePositions: { 'other-node': { x: 10, y: 20 } },
       })
@@ -760,7 +1004,13 @@ describe('buildWorkflowDefinition', () => {
     it('omits position when nodePositions is empty', () => {
       const activities: Activity[] = [activity('task-1')]
 
-      const result = buildWorkflowDefinition('Test', '', activities, [], { edges: [] })
+      const result = buildWorkflowDefinition({
+        workflowName: 'Test',
+        workflowDescription: '',
+        activities: activities,
+        triggers: [],
+        edges: [],
+      })
 
       expect(result.nodes[0]).not.toHaveProperty('position')
     })

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/workflowDefinitionBuilder.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/workflowDefinitionBuilder.ts
@@ -230,21 +230,17 @@ export function transformNodeParameters(type: string, parameters: Record<string,
  * - Converts React Flow handles to V2 port names (loop→iterate, done→complete)
  * - Extracts optional activity inputs using type-safe guards
  *
- * @param workflowName - Workflow name
- * @param workflowDescription - Optional workflow description
- * @param activities - Array of workflow activities (nodes)
- * @param triggers - Array of workflow triggers
- * @param edges - Array of workflow edges (connections)
  * @returns V2 workflow definition ready for API submission
  */
-export function buildWorkflowDefinition(
-  workflowName: string,
-  workflowDescription: string,
-  activities: Activity[],
-  triggers: Activity[],
-  graph: { edges: EdgeConnection[]; nodePositions?: Record<string, { x: number; y: number }> }
-) {
-  const { edges, nodePositions = {} } = graph
+export function buildWorkflowDefinition(params: {
+  workflowName: string
+  workflowDescription: string
+  activities: Activity[]
+  triggers: Activity[]
+  edges: EdgeConnection[]
+  nodePositions?: Record<string, { x: number; y: number }>
+}) {
+  const { workflowName, workflowDescription, activities, triggers, edges, nodePositions = {} } = params
   // SECURITY: Validate and sanitize workflow name and description
   if (!workflowName || workflowName.length > 255) {
     throw new Error('Workflow name is required and must be 255 characters or fewer.')

--- a/frontend/packages/syntara-ui/src/routes/builder/utils/workflowToGraph.ts
+++ b/frontend/packages/syntara-ui/src/routes/builder/utils/workflowToGraph.ts
@@ -3,6 +3,7 @@ import { MarkerType } from '@xyflow/react'
 
 import { formatScheduleSummary } from '../../../utils/triggerFormatting'
 import { BUTTON_EDGE_DEFAULT_STROKE } from '../edges/buttonEdgeStrokeColor'
+import type { OnAddNodeFromEdge } from '../types'
 
 /**
  * In v2, triggers are { id, type, name, parameters } nodes.
@@ -33,7 +34,7 @@ export type EdgeType = {
   targetHandle?: string
   selectable?: boolean
   data?: {
-    onAddNode?: (sourceNodeId: string, targetNodeId: string, edgeId: string) => void
+    onAddNode?: OnAddNodeFromEdge
     onButtonClick?: () => void
     isActive?: boolean
     isPending?: boolean


### PR DESCRIPTION
## Summary

Part 2 of 5 in the max-params stack.

Converts remaining workflow-builder helpers with 5 positional arguments to one object parameter.

## Test plan

- [ ] CI lint / typecheck / test
- [ ] Spot-check builder hooks and edge helpers

Stack: #519 → #515 → #516 → #517 → #518