### PR TITLE
refactor(ui): convert route helpers to object params

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/IdentityProvidersTab.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/IdentityProvidersTab.tsx
@@ -49,13 +49,19 @@ function tooltipWhenDenied(allowed: boolean, text: string) {
   return allowed ? undefined : { content: text }
 }
 
-function getRowActions(
-  provider: IdentityProvider,
-  onDelete: (provider: IdentityProvider) => void,
-  onRevoke: (provider: IdentityProvider) => void,
-  permissions: ReturnType<typeof useIdentityProviderPermissions>,
+function getRowActions({
+  provider,
+  onDelete,
+  onRevoke,
+  permissions,
+  onNavigate,
+}: {
+  provider: IdentityProvider
+  onDelete: (provider: IdentityProvider) => void
+  onRevoke: (provider: IdentityProvider) => void
+  permissions: ReturnType<typeof useIdentityProviderPermissions>
   onNavigate: (path: string) => void
-): KebabAction[] {
+}): KebabAction[] {
   const { id } = provider
   const canEdit = permissions.canUpdate && !!id
   const canDel = permissions.canDelete && !!id
@@ -192,9 +198,13 @@ function ProviderRow({
       </Td>
       <Td isActionCell>
         <SynKebabMenu
-          actions={getRowActions(provider, onDelete, onRevoke, permissions, (path) =>
-            detachPromise(navigate({ to: path }))
-          )}
+          actions={getRowActions({
+            provider,
+            onDelete,
+            onRevoke,
+            permissions,
+            onNavigate: (path) => detachPromise(navigate({ to: path })),
+          })}
           aria-label={`Actions for ${provider.name}`}
         />
       </Td>

--- a/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/ClaimMappingFields.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/authentication/identity-providers/ClaimMappingFields.tsx
@@ -78,13 +78,17 @@ function claimMappingHandleOpenChange(
   claimMappingOnOpenChange(setFilterValue, open)
 }
 
-function claimMappingTypeaheadChange(
-  setFilterValue: (value: string) => void,
-  setIsOpen: (value: boolean) => void,
-  isOpen: boolean,
-  _event: unknown,
+function claimMappingTypeaheadChange({
+  setFilterValue,
+  setIsOpen,
+  isOpen,
+  val,
+}: {
+  setFilterValue: (value: string) => void
+  setIsOpen: (value: boolean) => void
+  isOpen: boolean
   val: string
-): void {
+}): void {
   setFilterValue(val)
   if (!isOpen) setIsOpen(true)
 }
@@ -118,8 +122,8 @@ function ClaimMappingTypeaheadToggle({
     toggleClaimMenuExpanded(setIsOpen)
   }
 
-  function handleMainChange(event: unknown, val: string): void {
-    claimMappingTypeaheadChange(setFilterValue, setIsOpen, isOpen, event, val)
+  function handleMainChange(_event: unknown, val: string): void {
+    claimMappingTypeaheadChange({ setFilterValue, setIsOpen, isOpen, val })
   }
 
   function handleMainClick(): void {

--- a/frontend/packages/syntara-ui/src/routes/access-management/users/UserDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access-management/users/UserDetail.tsx
@@ -195,13 +195,19 @@ function UserDetailsTab({
 
 type UserTab = 'details' | 'groups' | 'identities' | 'roles' | 'permissions' | 'check-access'
 
-function computeVisibleTabs(
-  canReadGroups: boolean,
-  canReadIdentities: boolean,
-  canReadAssignments: boolean,
-  isOwnProfile: boolean,
+function computeVisibleTabs({
+  canReadGroups,
+  canReadIdentities,
+  canReadAssignments,
+  isOwnProfile,
+  isLoading,
+}: {
+  canReadGroups: boolean
+  canReadIdentities: boolean
+  canReadAssignments: boolean
+  isOwnProfile: boolean
   isLoading: boolean
-): UserTab[] {
+}): UserTab[] {
   const tabs: UserTab[] = ['details']
   if (isLoading || canReadGroups) tabs.push('groups')
   if (isLoading || canReadIdentities) tabs.push('identities')
@@ -359,7 +365,14 @@ export function UserDetail({ isMyProfile }: Readonly<UserDetailProps> = {}) {
   const isOwnProfile = !!userId && !!currentUserId && userId === currentUserId
 
   const validTabs = useMemo(
-    () => computeVisibleTabs(canReadGroups, canReadIdentities, canReadAssignments, isOwnProfile, permissionsLoading),
+    () =>
+      computeVisibleTabs({
+        canReadGroups,
+        canReadIdentities,
+        canReadAssignments,
+        isOwnProfile,
+        isLoading: permissionsLoading,
+      }),
     [canReadGroups, canReadIdentities, canReadAssignments, isOwnProfile, permissionsLoading]
   )
 

--- a/frontend/packages/syntara-ui/src/routes/access/TypeaheadSelect.tsx
+++ b/frontend/packages/syntara-ui/src/routes/access/TypeaheadSelect.tsx
@@ -44,13 +44,19 @@ type TypeaheadSelectProps = {
   isLoading?: boolean
 }
 
-function renderOptions(
-  options: TypeaheadOption[],
-  filterValue: string,
-  selected: string,
-  hasMore?: boolean,
+function renderOptions({
+  options,
+  filterValue,
+  selected,
+  hasMore,
+  isLoading,
+}: {
+  options: TypeaheadOption[]
+  filterValue: string
+  selected: string
+  hasMore?: boolean
   isLoading?: boolean
-) {
+}) {
   if (isLoading) {
     return <SelectOption isDisabled>Loading...</SelectOption>
   }
@@ -203,7 +209,7 @@ export function TypeaheadSelect({
       toggle={toggle}
     >
       <SelectList style={{ maxHeight: '200px', overflow: 'auto' }}>
-        {renderOptions(filteredOptions, filterValue, selected, hasMore, isLoading)}
+        {renderOptions({ options: filteredOptions, filterValue, selected, hasMore, isLoading })}
       </SelectList>
     </SynSelect>
   )

--- a/frontend/packages/syntara-ui/src/routes/approvals/ApprovalsTableBody.tsx
+++ b/frontend/packages/syntara-ui/src/routes/approvals/ApprovalsTableBody.tsx
@@ -56,13 +56,13 @@ function SelectCheckboxCell({
   isCheckingApproverList: boolean
   onSelectRow?: (approval: ApprovalWithDetails, checked: boolean) => void
 }>) {
-  const showDisabledWithTooltip = !isApprovalSelectable(
+  const showDisabledWithTooltip = !isApprovalSelectable({
     approval,
     canDecideOnThisApproval,
     canDecideBasedOnApproverList,
     isLoadingPermissions,
-    isCheckingApproverList
-  )
+    isCheckingApproverList,
+  })
 
   const disabledTooltip = getDisabledTooltip(approval.status ?? '', canDecideOnThisApproval)
 

--- a/frontend/packages/syntara-ui/src/routes/approvals/isApprovalSelectable.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/approvals/isApprovalSelectable.test.ts
@@ -13,106 +13,130 @@ describe('isApprovalSelectable', () => {
   it('returns true when all conditions are met', () => {
     const approval = mockApproval('pending')
     expect(
-      isApprovalSelectable(
+      isApprovalSelectable({
         approval,
-        true, // canDecideOnThisApproval
-        true, // canDecideBasedOnApproverList
-        false, // isLoadingPermissions
-        false // isCheckingApproverList
-      )
+        canDecideOnThisApproval: true,
+        canDecideBasedOnApproverList: true,
+        isLoadingPermissions: false,
+        isCheckingApproverList: false,
+      })
     ).toBe(true)
   })
 
   it('returns false when status is not pending', () => {
     const approval = mockApproval('approved')
-    expect(isApprovalSelectable(approval, true, true, false, false)).toBe(false)
+    expect(
+      isApprovalSelectable({
+        approval,
+        canDecideOnThisApproval: true,
+        canDecideBasedOnApproverList: true,
+        isLoadingPermissions: false,
+        isCheckingApproverList: false,
+      })
+    ).toBe(false)
   })
 
   it('returns false when isLoadingPermissions is true', () => {
     const approval = mockApproval('pending')
     expect(
-      isApprovalSelectable(
+      isApprovalSelectable({
         approval,
-        true,
-        true,
-        true, // isLoadingPermissions
-        false
-      )
+        canDecideOnThisApproval: true,
+        canDecideBasedOnApproverList: true,
+        isLoadingPermissions: true,
+        isCheckingApproverList: false,
+      })
     ).toBe(false)
   })
 
   it('returns false when isCheckingApproverList is true', () => {
     const approval = mockApproval('pending')
     expect(
-      isApprovalSelectable(
+      isApprovalSelectable({
         approval,
-        true,
-        true,
-        false,
-        true // isCheckingApproverList
-      )
+        canDecideOnThisApproval: true,
+        canDecideBasedOnApproverList: true,
+        isLoadingPermissions: false,
+        isCheckingApproverList: true,
+      })
     ).toBe(false)
   })
 
   it('returns false when canDecideOnThisApproval is false', () => {
     const approval = mockApproval('pending')
     expect(
-      isApprovalSelectable(
+      isApprovalSelectable({
         approval,
-        false, // canDecideOnThisApproval
-        true,
-        false,
-        false
-      )
+        canDecideOnThisApproval: false,
+        canDecideBasedOnApproverList: true,
+        isLoadingPermissions: false,
+        isCheckingApproverList: false,
+      })
     ).toBe(false)
   })
 
   it('returns false when canDecideBasedOnApproverList is false', () => {
     const approval = mockApproval('pending')
     expect(
-      isApprovalSelectable(
+      isApprovalSelectable({
         approval,
-        true,
-        false, // canDecideBasedOnApproverList
-        false,
-        false
-      )
+        canDecideOnThisApproval: true,
+        canDecideBasedOnApproverList: false,
+        isLoadingPermissions: false,
+        isCheckingApproverList: false,
+      })
     ).toBe(false)
   })
 
   it('returns false when both permissions are false', () => {
     const approval = mockApproval('pending')
     expect(
-      isApprovalSelectable(
+      isApprovalSelectable({
         approval,
-        false, // canDecideOnThisApproval
-        false, // canDecideBasedOnApproverList
-        false,
-        false
-      )
+        canDecideOnThisApproval: false,
+        canDecideBasedOnApproverList: false,
+        isLoadingPermissions: false,
+        isCheckingApproverList: false,
+      })
     ).toBe(false)
   })
 
   it('returns false when both loading states are true', () => {
     const approval = mockApproval('pending')
     expect(
-      isApprovalSelectable(
+      isApprovalSelectable({
         approval,
-        true,
-        true,
-        true, // isLoadingPermissions
-        true // isCheckingApproverList
-      )
+        canDecideOnThisApproval: true,
+        canDecideBasedOnApproverList: true,
+        isLoadingPermissions: true,
+        isCheckingApproverList: true,
+      })
     ).toBe(false)
   })
 
   it('returns false for rejected status', () => {
     const approval = mockApproval('rejected')
-    expect(isApprovalSelectable(approval, true, true, false, false)).toBe(false)
+    expect(
+      isApprovalSelectable({
+        approval,
+        canDecideOnThisApproval: true,
+        canDecideBasedOnApproverList: true,
+        isLoadingPermissions: false,
+        isCheckingApproverList: false,
+      })
+    ).toBe(false)
   })
 
   it('returns false for timed_out status', () => {
     const approval = mockApproval('timed_out')
-    expect(isApprovalSelectable(approval, true, true, false, false)).toBe(false)
+    expect(
+      isApprovalSelectable({
+        approval,
+        canDecideOnThisApproval: true,
+        canDecideBasedOnApproverList: true,
+        isLoadingPermissions: false,
+        isCheckingApproverList: false,
+      })
+    ).toBe(false)
   })
 })

--- a/frontend/packages/syntara-ui/src/routes/approvals/isApprovalSelectable.ts
+++ b/frontend/packages/syntara-ui/src/routes/approvals/isApprovalSelectable.ts
@@ -6,13 +6,19 @@ import type { ApprovalWithDetails } from './Approvals'
  *
  * @returns true if the approval checkbox should be enabled, false if disabled
  */
-export function isApprovalSelectable(
-  approval: ApprovalWithDetails,
-  canDecideOnThisApproval: boolean,
-  canDecideBasedOnApproverList: boolean,
-  isLoadingPermissions: boolean,
+export function isApprovalSelectable({
+  approval,
+  canDecideOnThisApproval,
+  canDecideBasedOnApproverList,
+  isLoadingPermissions,
+  isCheckingApproverList,
+}: {
+  approval: ApprovalWithDetails
+  canDecideOnThisApproval: boolean
+  canDecideBasedOnApproverList: boolean
+  isLoadingPermissions: boolean
   isCheckingApproverList: boolean
-): boolean {
+}): boolean {
   // Not pending → not selectable
   if (approval.status !== 'pending') return false
 

--- a/frontend/packages/syntara-ui/src/routes/approvals/useSelectableApprovalIds.ts
+++ b/frontend/packages/syntara-ui/src/routes/approvals/useSelectableApprovalIds.ts
@@ -46,13 +46,13 @@ export function useSelectableApprovalIds(
       const canDecideBasedOnApproverList = computeCanDecideOnApproval(approval, currentUsername, userGroupsForCheck)
 
       if (
-        isApprovalSelectable(
+        isApprovalSelectable({
           approval,
           canDecideOnThisApproval,
           canDecideBasedOnApproverList,
-          isLoadingDecideProjects,
-          isLoadingUserGroups
-        )
+          isLoadingPermissions: isLoadingDecideProjects,
+          isCheckingApproverList: isLoadingUserGroups,
+        })
       ) {
         set.add(approval.id)
       }

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/form/credentialFormUtils.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/form/credentialFormUtils.test.ts
@@ -171,7 +171,13 @@ describe('validateEditModeRequiredDynamicField', () => {
     const setError = makeSetError()
     const field: FieldDefinition = { id: 'host', label: 'Host', type: 'string' }
 
-    const result = validateEditModeRequiredDynamicField('host', 'example.com', field, new Set(), setError)
+    const result = validateEditModeRequiredDynamicField({
+      requiredId: 'host',
+      val: 'example.com',
+      field,
+      touchedSecrets: new Set(),
+      setError,
+    })
 
     expect(result).toBe(true)
     expect(setError).not.toHaveBeenCalled()
@@ -181,7 +187,13 @@ describe('validateEditModeRequiredDynamicField', () => {
     const setError = makeSetError()
     const field: FieldDefinition = { id: 'host', label: 'Host', type: 'string' }
 
-    const result = validateEditModeRequiredDynamicField('host', '', field, new Set(), setError)
+    const result = validateEditModeRequiredDynamicField({
+      requiredId: 'host',
+      val: '',
+      field,
+      touchedSecrets: new Set(),
+      setError,
+    })
 
     expect(result).toBe(false)
     expect(setError).toHaveBeenCalledWith('inputs.host', { message: 'Host is required' })
@@ -191,7 +203,13 @@ describe('validateEditModeRequiredDynamicField', () => {
     const setError = makeSetError()
     const field: FieldDefinition = { id: 'token', label: 'Token', type: 'string', secret: true }
 
-    const result = validateEditModeRequiredDynamicField('token', '', field, new Set(), setError)
+    const result = validateEditModeRequiredDynamicField({
+      requiredId: 'token',
+      val: '',
+      field,
+      touchedSecrets: new Set(),
+      setError,
+    })
 
     expect(result).toBe(true)
     expect(setError).not.toHaveBeenCalled()
@@ -202,7 +220,13 @@ describe('validateEditModeRequiredDynamicField', () => {
     const field: FieldDefinition = { id: 'token', label: 'Token', type: 'string', secret: true }
     const touchedSecrets = new Set(['token'])
 
-    const result = validateEditModeRequiredDynamicField('token', '', field, touchedSecrets, setError)
+    const result = validateEditModeRequiredDynamicField({
+      requiredId: 'token',
+      val: '',
+      field,
+      touchedSecrets,
+      setError,
+    })
 
     expect(result).toBe(false)
     expect(setError).toHaveBeenCalledWith('inputs.token', { message: 'Token is required' })
@@ -213,7 +237,13 @@ describe('validateEditModeRequiredDynamicField', () => {
     const field: FieldDefinition = { id: 'token', label: 'Token', type: 'string', secret: true }
     const touchedSecrets = new Set(['token'])
 
-    const result = validateEditModeRequiredDynamicField('token', 'new-value', field, touchedSecrets, setError)
+    const result = validateEditModeRequiredDynamicField({
+      requiredId: 'token',
+      val: 'new-value',
+      field,
+      touchedSecrets,
+      setError,
+    })
 
     expect(result).toBe(true)
     expect(setError).not.toHaveBeenCalled()
@@ -223,7 +253,13 @@ describe('validateEditModeRequiredDynamicField', () => {
     const setError = makeSetError()
     const field: FieldDefinition = { id: 'host', label: 'Host', type: 'string' }
 
-    const result = validateEditModeRequiredDynamicField('host', null, field, new Set(), setError)
+    const result = validateEditModeRequiredDynamicField({
+      requiredId: 'host',
+      val: null,
+      field,
+      touchedSecrets: new Set(),
+      setError,
+    })
 
     expect(result).toBe(false)
     expect(setError).toHaveBeenCalledWith('inputs.host', { message: 'Host is required' })

--- a/frontend/packages/syntara-ui/src/routes/configuration/credentials/form/credentialFormUtils.ts
+++ b/frontend/packages/syntara-ui/src/routes/configuration/credentials/form/credentialFormUtils.ts
@@ -49,13 +49,19 @@ export function getDefaultInputs(credType: CredentialType | undefined): Record<s
 }
 
 /** Validate a required dynamic field in edit mode — skips untouched secret fields to preserve existing encrypted values. */
-export function validateEditModeRequiredDynamicField(
-  requiredId: string,
-  val: unknown,
-  field: FieldDefinition | undefined,
-  touchedSecrets: Set<string>,
+export function validateEditModeRequiredDynamicField({
+  requiredId,
+  val,
+  field,
+  touchedSecrets,
+  setError,
+}: {
+  requiredId: string
+  val: unknown
+  field: FieldDefinition | undefined
+  touchedSecrets: Set<string>
   setError: UseFormSetError<CredentialFormData>
-): boolean {
+}): boolean {
   const isSecret = field?.secret === true
   if (isSecret) {
     if (touchedSecrets.has(requiredId) && (val == null || val === '')) {
@@ -195,7 +201,13 @@ function validateRequiredField(
   const field = typeInputs?.fields.find((f) => f.id === fieldId)
 
   if (isEditMode) {
-    return validateEditModeRequiredDynamicField(fieldId, val, field, touchedSecrets, setError)
+    return validateEditModeRequiredDynamicField({
+      requiredId: fieldId,
+      val,
+      field,
+      touchedSecrets,
+      setError,
+    })
   }
   return validateCreateModeRequiredDynamicField(fieldId, val, field, setError)
 }

--- a/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationDetail.tsx
+++ b/frontend/packages/syntara-ui/src/routes/configuration/integrations/IntegrationDetail.tsx
@@ -254,13 +254,19 @@ function ResourcesFooter({
   )
 }
 
-function getFooterState(
-  isLLM: boolean,
-  modelsState: ReturnType<typeof useIntegrationModelsState>,
-  toolsDirty: boolean,
-  isToolsSaving: boolean,
+function getFooterState({
+  isLLM,
+  modelsState,
+  toolsDirty,
+  isToolsSaving,
+  handleToolsSave,
+}: {
+  isLLM: boolean
+  modelsState: ReturnType<typeof useIntegrationModelsState>
+  toolsDirty: boolean
+  isToolsSaving: boolean
   handleToolsSave: () => void
-) {
+}) {
   if (isLLM) {
     return {
       isDirty: modelsState.isDirty,
@@ -340,7 +346,7 @@ export function IntegrationDetail() {
   // Models state (LLM providers)
   const modelsState = useIntegrationModelsState(integrationId, isLLM)
 
-  const footerState = getFooterState(isLLM, modelsState, toolsDirty, isToolsSaving, handleToolsSave)
+  const footerState = getFooterState({ isLLM, modelsState, toolsDirty, isToolsSaving, handleToolsSave })
 
   const queryState = useQueryState(query, {
     title: 'Error loading integration',

--- a/frontend/packages/syntara-ui/src/routes/workflows/execution/utils/activityState.ts
+++ b/frontend/packages/syntara-ui/src/routes/workflows/execution/utils/activityState.ts
@@ -119,13 +119,19 @@ function resolveActivityId(
  * @param activityArray - Optional array for index-based lookups
  * @throws Error if operation is invalid or path doesn't exist
  */
-function applyAddOperation(
-  activities: Map<string, ActivityState>,
-  resolvedId: string,
-  field: string,
-  value: unknown,
+function applyAddOperation({
+  activities,
+  resolvedId,
+  field,
+  value,
+  existing,
+}: {
+  activities: Map<string, ActivityState>
+  resolvedId: string
+  field: string
+  value: unknown
   existing: ActivityState | undefined
-): void {
+}): void {
   if (value === undefined) {
     throw new Error(`Operation 'add' requires a value`)
   }
@@ -141,13 +147,19 @@ function applyAddOperation(
   activities.set(resolvedId, applyFieldUpdate(existing, field, value))
 }
 
-function applyReplaceOperation(
-  activities: Map<string, ActivityState>,
-  resolvedId: string,
-  field: string,
-  value: unknown,
+function applyReplaceOperation({
+  activities,
+  resolvedId,
+  field,
+  value,
+  existing,
+}: {
+  activities: Map<string, ActivityState>
+  resolvedId: string
+  field: string
+  value: unknown
   existing: ActivityState | undefined
-): void {
+}): void {
   if (value === undefined) {
     throw new Error(`Operation 'replace' requires a value`)
   }
@@ -224,10 +236,10 @@ export function applyOperation(
 
   switch (op) {
     case 'add':
-      applyAddOperation(activities, resolvedId, field, value, existing)
+      applyAddOperation({ activities, resolvedId, field, value, existing })
       break
     case 'replace':
-      applyReplaceOperation(activities, resolvedId, field, value, existing)
+      applyReplaceOperation({ activities, resolvedId, field, value, existing })
       break
     case 'remove':
       applyRemoveOperation(activities, resolvedId, field, existing)


### PR DESCRIPTION
## Summary

Part 3 of 5 in the max-params stack.

Converts remaining access, approvals, configuration, and execution helpers with 5 positional arguments to one object parameter.

## Test plan

- [ ] CI lint / typecheck / test

Stack: #519 → #515 → #516 → #517 → #518