### PR TITLE
refactor(e2e): convert test helpers to object params

### DIFF
--- a/frontend/packages/syntara-ui/e2e/authorization/fixtures.ts
+++ b/frontend/packages/syntara-ui/e2e/authorization/fixtures.ts
@@ -283,13 +283,19 @@ export async function addGroupMemberApi(page: Page, groupId: string, userId: str
   if (!resp.ok()) throw new Error(`Failed to add member: ${resp.status()}`)
 }
 
-export async function assignProjectRoleApi(
-  page: Page,
-  projectId: string,
-  userId: string,
-  roleName: string,
+export async function assignProjectRoleApi({
+  page,
+  projectId,
+  userId,
+  roleName,
+  token,
+}: {
+  page: Page
+  projectId: string
+  userId: string
+  roleName: string
   token?: string
-): Promise<{ id: string }> {
+}): Promise<{ id: string }> {
   const t = token ?? (await getAuthToken(page))
   if (!t) throw new Error('No token')
   const resp = await apiRequest(page, 'post', `/projects/${projectId}/role_assignments`, {

--- a/frontend/packages/syntara-ui/e2e/authorization/journey-self-service.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/authorization/journey-self-service.spec.ts
@@ -75,7 +75,12 @@ test.describe('Self-service delegation journey', () => {
       const teamLead = await createUserApi(app, `lead-${suffix}`)
       createdUserIds.push(teamLead.id)
 
-      await assignProjectRoleApi(app, project.id, teamLead.id, delegationRole)
+      await assignProjectRoleApi({
+        page: app,
+        projectId: project.id,
+        userId: teamLead.id,
+        roleName: delegationRole,
+      })
 
       // 4. Admin verifies setup in UI
       await loginViaUI(app, 'admin', adminPassword)
@@ -109,7 +114,13 @@ test.describe('Self-service delegation journey', () => {
 
       // 7. Team lead assigns project-user to new hire — refresh token
       teamLeadToken = await loginAsUserApi(app, teamLead.username)
-      const assignment = await assignProjectRoleApi(app, project.id, newHire.id, 'project-user', teamLeadToken)
+      const assignment = await assignProjectRoleApi({
+        page: app,
+        projectId: project.id,
+        userId: newHire.id,
+        roleName: 'project-user',
+        token: teamLeadToken,
+      })
 
       // 8. New hire logs in and sees the workflow
       const newHireToken = await loginAsUserApi(app, newHire.username)

--- a/frontend/packages/syntara-ui/e2e/authorization/journey-team-onboarding.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/authorization/journey-team-onboarding.spec.ts
@@ -100,8 +100,8 @@ test.describe('Team onboarding journey', () => {
 
       // 5. Assign roles: group gets reader, alice gets writer, bob gets operator
       await assignGroupProjectRoleApi(app, project.id, group.id, readerRole)
-      await assignProjectRoleApi(app, project.id, alice.id, writerRole)
-      await assignProjectRoleApi(app, project.id, bob.id, operatorRole)
+      await assignProjectRoleApi({ page: app, projectId: project.id, userId: alice.id, roleName: writerRole })
+      await assignProjectRoleApi({ page: app, projectId: project.id, userId: bob.id, roleName: operatorRole })
 
       // 6. Admin verifies in UI
       await loginViaUI(app, 'admin', adminPassword)

--- a/frontend/packages/syntara-ui/e2e/authorization/roles-assignments.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/authorization/roles-assignments.spec.ts
@@ -44,7 +44,12 @@ test.describe('AAP-76528: Roles & Assignments', () => {
     const project = await ensureProject(app)
     if (!project) throw new Error('Could not ensure project for SA assignment')
 
-    const assignment = await assignProjectRoleApi(app, project.id, sa.id, 'project-user')
+    const assignment = await assignProjectRoleApi({
+      page: app,
+      projectId: project.id,
+      userId: sa.id,
+      roleName: 'project-user',
+    })
     try {
       await app.goto(toAppUrl(`${ACCESS_URL}/assignments`))
       await expect(app.getByRole('heading', { level: 1, name: 'Access Management' })).toBeVisible()

--- a/frontend/packages/syntara-ui/e2e/builder-project-validation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/builder-project-validation.spec.ts
@@ -164,9 +164,11 @@ test.describe('Builder save validation — project required', () => {
    */
   test('project selector is disabled when editing an existing workflow', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-proj-immutable')
-    const { id: workflowId } = await createWorkflowViaApi(app, workflowName, [
-      { id: 'trigger', name: 'Manual trigger', type: 'manual_trigger', parameters: {} },
-    ])
+    const { id: workflowId } = await createWorkflowViaApi({
+      app,
+      name: workflowName,
+      triggers: [{ id: 'trigger', name: 'Manual trigger', type: 'manual_trigger', parameters: {} }],
+    })
 
     try {
       await app.goto(toAppUrl(`/workflow-builder/${workflowId}`))

--- a/frontend/packages/syntara-ui/e2e/execution-details-filtering.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/execution-details-filtering.spec.ts
@@ -212,11 +212,11 @@ test.describe('Execution Details — Activity Filtering', { tag: '@pr-check' }, 
       const page = await browser.newPage()
       try {
         const workflowName = buildUniqueName('e2e-act-filter')
-        ;({ id: workflowId } = await createWorkflowViaApi(
-          page,
-          workflowName,
-          [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-          [
+        ;({ id: workflowId } = await createWorkflowViaApi({
+          app: page,
+          name: workflowName,
+          triggers: [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+          nodes: [
             {
               id: 'check_temperature',
               type: 'script',
@@ -236,12 +236,12 @@ test.describe('Execution Details — Activity Filtering', { tag: '@pr-check' }, 
               parameters: { language: 'python', code: 'print("hot")' },
             },
           ],
-          [
+          edges: [
             { from: 'trigger_manual', to: 'check_temperature' },
             { from: 'check_temperature', to: 'temperature_routing' },
             { from: 'temperature_routing', to: 'hot_weather', from_port: 'true' },
-          ]
-        ))
+          ],
+        }))
         executionId = await createExecutionViaApi(page, workflowId)
       } finally {
         await page.close()
@@ -377,11 +377,11 @@ test.describe('Execution Details — Activity Filtering', { tag: '@pr-check' }, 
       const page = await browser.newPage()
       try {
         const workflowName = buildUniqueName('e2e-act-status')
-        ;({ id: workflowId } = await createWorkflowViaApi(
-          page,
-          workflowName,
-          [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-          [
+        ;({ id: workflowId } = await createWorkflowViaApi({
+          app: page,
+          name: workflowName,
+          triggers: [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+          nodes: [
             {
               id: 'staging_tests',
               type: 'script',
@@ -395,11 +395,11 @@ test.describe('Execution Details — Activity Filtering', { tag: '@pr-check' }, 
               parameters: { approvers: [], message: 'Approve deployment' },
             },
           ],
-          [
+          edges: [
             { from: 'trigger_manual', to: 'staging_tests' },
             { from: 'staging_tests', to: 'approval_gate' },
-          ]
-        ))
+          ],
+        }))
         executionId = await createExecutionViaApi(page, workflowId)
       } finally {
         await page.close()

--- a/frontend/packages/syntara-ui/e2e/global-setup.ts
+++ b/frontend/packages/syntara-ui/e2e/global-setup.ts
@@ -51,13 +51,19 @@ async function authenticate(ctx: APIRequestContext): Promise<string | null> {
   }
 }
 
-async function api(
-  ctx: APIRequestContext,
-  token: string,
-  method: string,
-  path: string,
+async function api({
+  ctx,
+  token,
+  method,
+  path,
+  data,
+}: {
+  ctx: APIRequestContext
+  token: string
+  method: string
+  path: string
   data?: unknown
-): Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }> {
+}): Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }> {
   const resp = await ctx.fetch(apiUrl(path), {
     method,
     headers: { Authorization: `Bearer ${token}` },
@@ -89,37 +95,49 @@ async function probeExecutionEngine(
   let createdProjectId: string | null = null
 
   try {
-    const projectsResp = await api(ctx, token, 'GET', '/projects')
+    const projectsResp = await api({ ctx, token, method: 'GET', path: '/projects' })
     if (!projectsResp.ok) return result
     const projects = (await projectsResp.json()) as { resources: Array<{ id: string }> }
     let projectId = projects.resources?.[0]?.id
 
     if (!projectId) {
-      const createProject = await api(ctx, token, 'POST', '/projects', {
-        name: 'e2e-probe',
-        description: 'Health probe project',
+      const createProject = await api({
+        ctx,
+        token,
+        method: 'POST',
+        path: '/projects',
+        data: {
+          name: 'e2e-probe',
+          description: 'Health probe project',
+        },
       })
       if (!createProject.ok) return result
       projectId = ((await createProject.json()) as { id: string }).id
       createdProjectId = projectId
     }
 
-    const createResp = await api(ctx, token, 'POST', '/workflows', {
-      name: `__e2e_probe_${Date.now()}`,
-      project_id: projectId,
-      workflow_definition: {
-        schema_version: '2.0.0',
-        name: '__e2e_probe',
-        triggers: [{ id: 't1', type: 'manual_trigger', name: 'Probe trigger', parameters: {} }],
-        nodes: [
-          {
-            id: 'n1',
-            type: 'script',
-            name: 'Probe script',
-            parameters: { language: 'python', code: 'print("probe")' },
-          },
-        ],
-        edges: [{ from: 't1', to: 'n1' }],
+    const createResp = await api({
+      ctx,
+      token,
+      method: 'POST',
+      path: '/workflows',
+      data: {
+        name: `__e2e_probe_${Date.now()}`,
+        project_id: projectId,
+        workflow_definition: {
+          schema_version: '2.0.0',
+          name: '__e2e_probe',
+          triggers: [{ id: 't1', type: 'manual_trigger', name: 'Probe trigger', parameters: {} }],
+          nodes: [
+            {
+              id: 'n1',
+              type: 'script',
+              name: 'Probe script',
+              parameters: { language: 'python', code: 'print("probe")' },
+            },
+          ],
+          edges: [{ from: 't1', to: 'n1' }],
+        },
       },
     })
     if (!createResp.ok) return result
@@ -127,9 +145,15 @@ async function probeExecutionEngine(
     const workflowId = workflow.id
 
     try {
-      await api(ctx, token, 'POST', `/workflows/${workflowId}/versions/${workflow.current_version}/publish`, {})
+      await api({
+        ctx,
+        token,
+        method: 'POST',
+        path: `/workflows/${workflowId}/versions/${workflow.current_version}/publish`,
+        data: {},
+      })
 
-      const runResp = await api(ctx, token, 'POST', `/workflows/${workflowId}/run`, {})
+      const runResp = await api({ ctx, token, method: 'POST', path: `/workflows/${workflowId}/run`, data: {} })
       if (!runResp.ok) {
         // API explicitly rejected the run request — engine is positively down
         result.executionEngineDown = true
@@ -145,7 +169,7 @@ async function probeExecutionEngine(
       let finalStatus = 'pending'
       for (let i = 0; i < 30; i++) {
         await sleep(2000)
-        const statusResp = await api(ctx, token, 'GET', `/executions/${executionId}`)
+        const statusResp = await api({ ctx, token, method: 'GET', path: `/executions/${executionId}` })
         if (!statusResp.ok) return result
         const exec = (await statusResp.json()) as { status: string }
         finalStatus = exec.status
@@ -157,13 +181,13 @@ async function probeExecutionEngine(
         result.temporalWorkerDown = true
       }
     } finally {
-      await api(ctx, token, 'DELETE', `/workflows/${workflowId}`).catch(() => {})
+      await api({ ctx, token, method: 'DELETE', path: `/workflows/${workflowId}` }).catch(() => {})
     }
   } catch {
     // Network/unexpected error — inconclusive, leave fail-open defaults
   } finally {
     if (createdProjectId) {
-      await api(ctx, token, 'DELETE', `/projects/${createdProjectId}`).catch(() => {})
+      await api({ ctx, token, method: 'DELETE', path: `/projects/${createdProjectId}` }).catch(() => {})
     }
   }
 

--- a/frontend/packages/syntara-ui/e2e/utils/api-workflows.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api-workflows.ts
@@ -9,13 +9,19 @@ type WorkflowStepDef = { id: string; type: string; name?: string; parameters: Re
 type WorkflowEdgeDef = { from: string; to: string; from_port?: string }
 
 /** Create a workflow via the API. Returns the new workflow ID. */
-export async function createWorkflowViaApi(
-  app: Page,
-  name: string,
-  triggers: WorkflowStepDef[],
-  nodes: WorkflowStepDef[] = [],
-  edges: WorkflowEdgeDef[] = []
-): Promise<{
+export async function createWorkflowViaApi({
+  app,
+  name,
+  triggers,
+  nodes = [],
+  edges = [],
+}: {
+  app: Page
+  name: string
+  triggers: WorkflowStepDef[]
+  nodes?: WorkflowStepDef[]
+  edges?: WorkflowEdgeDef[]
+}): Promise<{
   /** UUID of the created workflow. */
   id: string
   /** Version number of the initial draft, as returned by POST /workflows (`current_version`). Pass to `publishWorkflowViaApi` to avoid a separate GET. */
@@ -87,11 +93,11 @@ export async function createBasicWorkflowViaApi(
   name: string,
   actionName = 'Script'
 ): Promise<{ id: string; name: string; versionNumber: number }> {
-  const { id, versionNumber } = await createWorkflowViaApi(
+  const { id, versionNumber } = await createWorkflowViaApi({
     app,
     name,
-    [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-    [
+    triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+    nodes: [
       {
         id: 'action_1',
         type: 'script',
@@ -99,8 +105,8 @@ export async function createBasicWorkflowViaApi(
         parameters: { language: 'python', code: 'print("hello")' },
       },
     ],
-    [{ from: 'trigger_1', to: 'action_1' }]
-  )
+    edges: [{ from: 'trigger_1', to: 'action_1' }],
+  })
   return { id, name, versionNumber }
 }
 

--- a/frontend/packages/syntara-ui/e2e/v2-workflow-migration.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/v2-workflow-migration.spec.ts
@@ -283,11 +283,11 @@ test.describe('V2 Workflow Schema Migration', () => {
     const workflowName = buildUniqueName('v2-comprehensive')
 
     // Create workflow via API with all 9 v2 node types
-    const { id: workflowId } = await createWorkflowViaApi(
+    const { id: workflowId } = await createWorkflowViaApi({
       app,
-      workflowName,
-      [{ id: 'trigger_1', type: 'manual_trigger', name: 'Start workflow', parameters: {} }],
-      [
+      name: workflowName,
+      triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Start workflow', parameters: {} }],
+      nodes: [
         {
           id: 'node_1',
           type: 'script',
@@ -313,7 +313,7 @@ test.describe('V2 Workflow Schema Migration', () => {
         },
         { id: 'node_8', type: 'converge', name: 'Merge results', parameters: { strategy: 'all' } },
       ],
-      [
+      edges: [
         { from: 'trigger_1', to: 'node_1' },
         { from: 'node_1', to: 'node_2' },
         { from: 'node_2', to: 'node_3' },
@@ -323,8 +323,8 @@ test.describe('V2 Workflow Schema Migration', () => {
         { from: 'node_6', to: 'node_7', from_port: 'true' },
         { from: 'node_7', to: 'node_7_body', from_port: 'iterate' },
         { from: 'node_7', to: 'node_8', from_port: 'complete' },
-      ]
-    )
+      ],
+    })
 
     try {
       const getResp = await apiRequest(app, 'get', `/workflows/${workflowId}`)

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
@@ -25,7 +25,13 @@ test('multi-approval navigation: Previous/Next buttons and deep-link counter', a
     { from: `approval_${i + 1}`, to: `post_${i + 1}`, from_port: 'approved' },
   ])
 
-  const { id: workflowId, versionNumber } = await createWorkflowViaApi(app, workflowName, triggers, nodes, edges)
+  const { id: workflowId, versionNumber } = await createWorkflowViaApi({
+    app,
+    name: workflowName,
+    triggers,
+    nodes,
+    edges,
+  })
 
   try {
     await publishWorkflowViaApi(app, workflowId, versionNumber)

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -46,7 +46,7 @@ test.describe('Approval Side Panel', () => {
         { from: 'approval_1', to: 'post_1', from_port: 'approved' },
       ]
 
-      const result = await createWorkflowViaApi(page, workflowName, triggers, nodes, edges)
+      const result = await createWorkflowViaApi({ app: page, name: workflowName, triggers, nodes, edges })
       workflowId = result.id
       await publishWorkflowViaApi(page, workflowId, result.versionNumber)
 
@@ -195,13 +195,13 @@ test.describe('Approval Side Panel', () => {
         { from: 'approval_1', to: 'post_1', from_port: 'approved' },
       ]
 
-      const { id: localWorkflowId, versionNumber } = await createWorkflowViaApi(
+      const { id: localWorkflowId, versionNumber } = await createWorkflowViaApi({
         app,
-        localWorkflowName,
+        name: localWorkflowName,
         triggers,
         nodes,
-        edges
-      )
+        edges,
+      })
 
       try {
         await publishWorkflowViaApi(app, localWorkflowId, versionNumber)
@@ -242,13 +242,13 @@ test.describe('Approval Side Panel', () => {
         { from: 'approval_1', to: 'post_1', from_port: 'approved' },
       ]
 
-      const { id: localWorkflowId, versionNumber } = await createWorkflowViaApi(
+      const { id: localWorkflowId, versionNumber } = await createWorkflowViaApi({
         app,
-        localWorkflowName,
+        name: localWorkflowName,
         triggers,
         nodes,
-        edges
-      )
+        edges,
+      })
 
       try {
         await publishWorkflowViaApi(app, localWorkflowId, versionNumber)

--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -38,11 +38,11 @@ async function createPendingApproval(
   const approvalName = buildUniqueName(namePrefix)
 
   // Create the complete workflow via API: trigger → approval → approved-branch script
-  const { id: workflowId, versionNumber } = await createWorkflowViaApi(
+  const { id: workflowId, versionNumber } = await createWorkflowViaApi({
     app,
-    workflowName,
-    [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-    [
+    name: workflowName,
+    triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+    nodes: [
       { id: 'approval_1', type: 'approval', name: approvalName, parameters: {} },
       {
         id: 'script_1',
@@ -51,11 +51,11 @@ async function createPendingApproval(
         parameters: { language: 'python', code: 'print("approved")' },
       },
     ],
-    [
+    edges: [
       { from: 'trigger_1', to: 'approval_1' },
       { from: 'approval_1', to: 'script_1', from_port: 'approved' },
-    ]
-  )
+    ],
+  })
 
   // Publish the workflow so it can be run
   await publishWorkflowViaApi(app, workflowId, versionNumber)
@@ -96,11 +96,11 @@ async function createPendingApprovalLight(
   const approvalName = buildUniqueName(namePrefix)
   const hasTemporal = !!process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER']
 
-  const { id: workflowId, versionNumber } = await createWorkflowViaApi(
+  const { id: workflowId, versionNumber } = await createWorkflowViaApi({
     app,
-    workflowName,
-    [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-    [
+    name: workflowName,
+    triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+    nodes: [
       { id: 'approval_1', type: 'approval', name: approvalName, parameters: {} },
       {
         id: 'script_1',
@@ -109,11 +109,11 @@ async function createPendingApprovalLight(
         parameters: { language: 'python', code: 'print("approved")' },
       },
     ],
-    [
+    edges: [
       { from: 'trigger_1', to: 'approval_1' },
       { from: 'approval_1', to: 'script_1', from_port: 'approved' },
-    ]
-  )
+    ],
+  })
 
   await publishWorkflowViaApi(app, workflowId, versionNumber)
 
@@ -552,9 +552,11 @@ test.describe('Approval Workflow Operations', () => {
     // Create a workflow with an approval node so we control the approval name
     const workflowName = buildUniqueName('e2e-approve')
     const approvalNodeName = buildUniqueName('gate')
-    const { id: workflowId } = await createWorkflowViaApi(app, workflowName, [
-      { id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} },
-    ])
+    const { id: workflowId } = await createWorkflowViaApi({
+      app,
+      name: workflowName,
+      triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+    })
     await openWorkflowInBuilder(app, workflowName, workflowId)
 
     try {

--- a/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/cancel-execution.spec.ts
@@ -39,11 +39,11 @@ test.beforeAll(async ({ browser }) => {
     if (!token) throw new Error('Could not obtain auth token')
 
     const sleepName = buildUniqueName('e2e-cancel-sleep')
-    ;({ id: sleepWorkflowId } = await createWorkflowViaApi(
-      page,
-      sleepName,
-      [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-      [
+    ;({ id: sleepWorkflowId } = await createWorkflowViaApi({
+      app: page,
+      name: sleepName,
+      triggers: [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+      nodes: [
         {
           id: 'long_wait',
           type: 'wait',
@@ -51,8 +51,8 @@ test.beforeAll(async ({ browser }) => {
           parameters: { duration: 300 },
         },
       ],
-      [{ from: 'trigger_manual', to: 'long_wait' }]
-    ))
+      edges: [{ from: 'trigger_manual', to: 'long_wait' }],
+    }))
 
     const runResp = await apiRequest(page, 'post', '/executions', {
       token,
@@ -65,11 +65,11 @@ test.beforeAll(async ({ browser }) => {
     }
 
     const echoName = buildUniqueName('e2e-cancel-echo')
-    ;({ id: echoWorkflowId } = await createWorkflowViaApi(
-      page,
-      echoName,
-      [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-      [
+    ;({ id: echoWorkflowId } = await createWorkflowViaApi({
+      app: page,
+      name: echoName,
+      triggers: [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+      nodes: [
         {
           id: 'quick_wait',
           type: 'wait',
@@ -77,8 +77,8 @@ test.beforeAll(async ({ browser }) => {
           parameters: { duration: 1 },
         },
       ],
-      [{ from: 'trigger_manual', to: 'quick_wait' }]
-    ))
+      edges: [{ from: 'trigger_manual', to: 'quick_wait' }],
+    }))
 
     const echoRunResp = await apiRequest(page, 'post', '/executions', {
       token,

--- a/frontend/packages/syntara-ui/e2e/workflows/manual-run-canvas.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/manual-run-canvas.spec.ts
@@ -34,13 +34,15 @@ test.skip('clicking Run and confirming opens the live run details panel', async 
   test.setTimeout(120_000)
   const workflowName = buildUniqueName('e2e-manual-run')
   // validateMinimumWorkflow requires: trigger + at least one node + an edge connecting them
-  const { id: workflowId } = await createWorkflowViaApi(
+  const { id: workflowId } = await createWorkflowViaApi({
     app,
-    workflowName,
-    [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-    [{ id: 'action_1', type: 'script', name: 'Test step', parameters: { language: 'python', code: "print('hi')" } }],
-    [{ from: 'trigger_1', to: 'action_1' }]
-  )
+    name: workflowName,
+    triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+    nodes: [
+      { id: 'action_1', type: 'script', name: 'Test step', parameters: { language: 'python', code: "print('hi')" } },
+    ],
+    edges: [{ from: 'trigger_1', to: 'action_1' }],
+  })
   try {
     await openBuilderById(app, workflowId)
     await expect(app.getByText('Manual trigger')).toBeVisible({ timeout: 30_000 })
@@ -61,11 +63,11 @@ test.skip('clicking Run and confirming opens the live run details panel', async 
 test.skip('node status badges show success after execution completes', async ({ app }) => {
   test.setTimeout(120_000)
   const workflowName = buildUniqueName('e2e-manual-run-badge')
-  const { id: workflowId } = await createWorkflowViaApi(
+  const { id: workflowId } = await createWorkflowViaApi({
     app,
-    workflowName,
-    [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-    [
+    name: workflowName,
+    triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+    nodes: [
       {
         id: 'action_1',
         type: 'script',
@@ -73,8 +75,8 @@ test.skip('node status badges show success after execution completes', async ({ 
         parameters: { language: 'python', code: "print('hi')" },
       },
     ],
-    [{ from: 'trigger_1', to: 'action_1' }]
-  )
+    edges: [{ from: 'trigger_1', to: 'action_1' }],
+  })
   try {
     await openBuilderById(app, workflowId)
     await expect(app.getByText('Manual trigger')).toBeVisible({ timeout: 30_000 })
@@ -91,11 +93,11 @@ test.skip('node status badges show success after execution completes', async ({ 
 test.skip('failed nodes show an error status badge', async ({ app }) => {
   test.setTimeout(120_000)
   const workflowName = buildUniqueName('e2e-manual-run-fail')
-  const { id: workflowId } = await createWorkflowViaApi(
+  const { id: workflowId } = await createWorkflowViaApi({
     app,
-    workflowName,
-    [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-    [
+    name: workflowName,
+    triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+    nodes: [
       {
         id: 'action_1',
         type: 'script',
@@ -103,8 +105,8 @@ test.skip('failed nodes show an error status badge', async ({ app }) => {
         parameters: { language: 'python', code: 'raise Exception("fail")' },
       },
     ],
-    [{ from: 'trigger_1', to: 'action_1' }]
-  )
+    edges: [{ from: 'trigger_1', to: 'action_1' }],
+  })
   try {
     await openBuilderById(app, workflowId)
     await expect(app.getByText('Manual trigger')).toBeVisible({ timeout: 30_000 })

--- a/frontend/packages/syntara-ui/e2e/workflows/multiple-triggers.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/multiple-triggers.spec.ts
@@ -21,9 +21,11 @@ const SECONDARY_TRIGGER_NAME = 'Secondary trigger'
 test.describe('Multiple triggers', () => {
   test('shows Run button (not dropdown) when workflow has a single trigger', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-single-trigger')
-    const { id: workflowId } = await createWorkflowViaApi(app, workflowName, [
-      { id: 'trigger_1', type: 'manual_trigger', name: TRIGGER_NAME, parameters: {} },
-    ])
+    const { id: workflowId } = await createWorkflowViaApi({
+      app,
+      name: workflowName,
+      triggers: [{ id: 'trigger_1', type: 'manual_trigger', name: TRIGGER_NAME, parameters: {} }],
+    })
     try {
       await openBuilderById(app, workflowId)
       await expect(app.getByText(TRIGGER_NAME)).toBeVisible({ timeout: 30_000 })
@@ -38,10 +40,14 @@ test.describe('Multiple triggers', () => {
 
   test('shows Run dropdown listing all trigger names when workflow has multiple triggers', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-multi-trigger')
-    const { id: workflowId } = await createWorkflowViaApi(app, workflowName, [
-      { id: 'trigger_1', type: 'manual_trigger', name: TRIGGER_NAME, parameters: {} },
-      { id: 'trigger_2', type: 'manual_trigger', name: SECONDARY_TRIGGER_NAME, parameters: {} },
-    ])
+    const { id: workflowId } = await createWorkflowViaApi({
+      app,
+      name: workflowName,
+      triggers: [
+        { id: 'trigger_1', type: 'manual_trigger', name: TRIGGER_NAME, parameters: {} },
+        { id: 'trigger_2', type: 'manual_trigger', name: SECONDARY_TRIGGER_NAME, parameters: {} },
+      ],
+    })
     try {
       await openBuilderById(app, workflowId)
       await expect(app.getByText(TRIGGER_NAME)).toBeVisible({ timeout: 30_000 })
@@ -58,10 +64,14 @@ test.describe('Multiple triggers', () => {
 
   test('selecting a trigger from the Run dropdown opens the run confirmation dialog', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-trigger-select')
-    const { id: workflowId } = await createWorkflowViaApi(app, workflowName, [
-      { id: 'trigger_1', type: 'manual_trigger', name: TRIGGER_NAME, parameters: {} },
-      { id: 'trigger_2', type: 'manual_trigger', name: SECONDARY_TRIGGER_NAME, parameters: {} },
-    ])
+    const { id: workflowId } = await createWorkflowViaApi({
+      app,
+      name: workflowName,
+      triggers: [
+        { id: 'trigger_1', type: 'manual_trigger', name: TRIGGER_NAME, parameters: {} },
+        { id: 'trigger_2', type: 'manual_trigger', name: SECONDARY_TRIGGER_NAME, parameters: {} },
+      ],
+    })
     try {
       await openBuilderById(app, workflowId)
       await expect(app.getByText(TRIGGER_NAME)).toBeVisible({ timeout: 30_000 })
@@ -80,10 +90,14 @@ test.describe('Multiple triggers', () => {
 
   test('shows "Trigger N" fallback name for triggers without an explicit name', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-fallback-name')
-    const { id: workflowId } = await createWorkflowViaApi(app, workflowName, [
-      { id: 'trigger_1', type: 'manual_trigger', name: TRIGGER_NAME, parameters: {} },
-      { id: 'trigger_2', type: 'manual_trigger', parameters: {} }, // no name — falls back to "Trigger 2"
-    ])
+    const { id: workflowId } = await createWorkflowViaApi({
+      app,
+      name: workflowName,
+      triggers: [
+        { id: 'trigger_1', type: 'manual_trigger', name: TRIGGER_NAME, parameters: {} },
+        { id: 'trigger_2', type: 'manual_trigger', parameters: {} }, // no name — falls back to "Trigger 2"
+      ],
+    })
     try {
       await openBuilderById(app, workflowId)
       await expect(app.getByText(TRIGGER_NAME)).toBeVisible({ timeout: 30_000 })

--- a/frontend/packages/syntara-ui/e2e/workflows/retry-execution.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/retry-execution.spec.ts
@@ -38,11 +38,11 @@ test.beforeAll(async ({ browser }) => {
     if (!token) throw new Error('Could not obtain auth token')
 
     const name = buildUniqueName('e2e-retry')
-    ;({ id: workflowId } = await createWorkflowViaApi(
-      page,
+    ;({ id: workflowId } = await createWorkflowViaApi({
+      app: page,
       name,
-      [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-      [
+      triggers: [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+      nodes: [
         {
           id: 'echo_node',
           type: 'script',
@@ -50,8 +50,8 @@ test.beforeAll(async ({ browser }) => {
           parameters: { language: 'bash', code: 'echo done' },
         },
       ],
-      [{ from: 'trigger_manual', to: 'echo_node' }]
-    ))
+      edges: [{ from: 'trigger_manual', to: 'echo_node' }],
+    }))
 
     const runResp = await apiRequest(page, 'post', '/executions', {
       token,

--- a/frontend/packages/syntara-ui/e2e/workflows/workflow-execution.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/workflow-execution.spec.ts
@@ -27,11 +27,11 @@ test.describe.skip('Test Single Step from Canvas', () => {
   test.beforeEach(async ({ app }) => {
     const workflowName = buildUniqueName('e2e-single-node-execution')
 
-    ;({ id: workflowId } = await createWorkflowViaApi(
+    ;({ id: workflowId } = await createWorkflowViaApi({
       app,
-      workflowName,
-      [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-      [
+      name: workflowName,
+      triggers: [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+      nodes: [
         {
           id: 'hello_node',
           type: 'script',
@@ -45,11 +45,11 @@ test.describe.skip('Test Single Step from Canvas', () => {
           parameters: { language: 'python', code: 'print("${hello_node.stdout} and goodbye")' },
         },
       ],
-      [
+      edges: [
         { from: 'trigger_manual', to: 'hello_node' },
         { from: 'hello_node', to: 'goodbye_node' },
-      ]
-    ))
+      ],
+    }))
   })
 
   test.afterEach(async ({ app }) => {
@@ -99,11 +99,11 @@ test.describe.skip('Test Single Step from Canvas', () => {
 test.skip('running execution displays real-time per-node status on the canvas', async ({ app }) => {
   const workflowName = buildUniqueName('e2e-node-live-status')
 
-  const { id: workflowId } = await createWorkflowViaApi(
+  const { id: workflowId } = await createWorkflowViaApi({
     app,
-    workflowName,
-    [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-    [
+    name: workflowName,
+    triggers: [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+    nodes: [
       {
         id: 'hello_node',
         type: 'script',
@@ -117,11 +117,11 @@ test.skip('running execution displays real-time per-node status on the canvas', 
         parameters: { language: 'python', code: 'import time\ntime.sleep(3)\nprint("goodbye")' },
       },
     ],
-    [
+    edges: [
       { from: 'trigger_manual', to: 'hello_node' },
       { from: 'hello_node', to: 'goodbye_node' },
-    ]
-  )
+    ],
+  })
 
   try {
     await openBuilderById(app, workflowId)
@@ -144,11 +144,11 @@ test.skip('running execution displays real-time per-node status on the canvas', 
 test.skip('failed node details including error messages are displayed', async ({ app }) => {
   const workflowName = buildUniqueName('e2e-failed-node')
 
-  const { id: workflowId } = await createWorkflowViaApi(
+  const { id: workflowId } = await createWorkflowViaApi({
     app,
-    workflowName,
-    [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
-    [
+    name: workflowName,
+    triggers: [{ id: 'trigger_manual', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+    nodes: [
       {
         id: 'failing_node',
         type: 'script',
@@ -156,8 +156,8 @@ test.skip('failed node details including error messages are displayed', async ({
         parameters: { language: 'python', code: 'raise Exception("Node configured to fail.")' },
       },
     ],
-    [{ from: 'trigger_manual', to: 'failing_node' }]
-  )
+    edges: [{ from: 'trigger_manual', to: 'failing_node' }],
+  })
 
   try {
     await openBuilderById(app, workflowId)


### PR DESCRIPTION
## Summary

Part 4 of 5 in the max-params stack.

Converts e2e helpers and specs that pass 5 positional arguments to one object parameter.

## Test plan

- [ ] CI lint / typecheck / test

Stack: #519 → #515 → #516 → #517 → #518