### PR TITLE
chore(lint): set max-params to error at 4

### DIFF
--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -144,7 +144,7 @@ These thresholds are based on industry standards (Code Complete, SonarQube, Biom
 | `max-lines-per-function` | 200 lines/function | Extract helpers instead of writing monoliths                 |
 | `complexity`             | 20 (cyclomatic)    | Break complex branching into smaller functions               |
 | `max-depth`              | 4 levels           | Use early returns instead of deep nesting                    |
-| `max-params`             | 5 parameters       | Use an options object for functions with many inputs         |
+| `max-params`             | 4 parameters       | Use an options object for functions with many inputs         |
 | `max-nested-callbacks`   | 4 levels           | Flatten nested callbacks with named functions or async/await |
 
 We also enforce modern TypeScript, React, and import hygiene rules as CI-blocking `error`s:

--- a/frontend/packages/syntara-ui/eslint.config.js
+++ b/frontend/packages/syntara-ui/eslint.config.js
@@ -299,7 +299,9 @@ export default tseslint.config(
       // Aligns with Sonar typescript:S3358 (nested ternary). Matches SonarCloud carve-outs (e.g. separate JSX `{}` blocks).
       'sonarjs/no-nested-conditional': 'error',
       'max-depth': ['error', 4],
-      'max-params': ['error', 5],
+      // Lowered from `['error', 5]`. Functions with 5+ separate positional params must take one
+      // object parameter instead (named args at the call site; order does not matter).
+      'max-params': ['error', 4],
       // Limit nested functions/callbacks (e.g. hooks → timeout → setState updater). Complements max-depth
       // and aligns with Sonar-style “deeply nested functions” maintainability rules. Tests disable this.
       'max-nested-callbacks': ['error', 4],


### PR DESCRIPTION
## Summary

Part 5 of 5 in the max-params stack.

Sets ESLint `max-params` to `['error', 4]` and updates CONTRIBUTING.md. Does not add a coding-standards skill section.

## Test plan

- [ ] CI lint / typecheck / test
- [ ] Confirm `npx eslint . --quiet` is clean at threshold 4

Stack: #519 → #515 → #516 → #517 → #518