### PR TITLE
fix(e2e): align approvals undo tests with side panel flow

### DIFF
--- a/frontend/packages/syntara-ui/e2e/helpers/approvals.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/approvals.ts
@@ -81,5 +81,5 @@ export async function navigateToApprovalAndOpen(app: Page, approvalName: string)
   await expect(approvalLink).toBeVisible({ timeout: 15_000 })
   await approvalLink.click()
 
-  await waitForApprovalPanel(app)
+  await waitForApprovalPanel(app, 30_000)
 }

--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -8,7 +8,7 @@
  */
 import { type Page } from '../fixtures'
 import { test, expect, toAppUrl } from '../fixtures'
-import { applyApprovalNameFilter } from '../helpers/approvals'
+import { applyApprovalNameFilter, navigateToApprovalAndOpen } from '../helpers/approvals'
 import { APP_TITLE } from '../helpers/appTitle'
 import { addApprovalNodeWithBranch } from '../helpers/v2-nodes'
 import { runWorkflowFromBuilder, waitForExecutionPaused } from '../helpers/workflow-run'
@@ -371,120 +371,49 @@ test.describe('Approval Workflow Operations', () => {
   })
 
   test('user changes decision from approve to reject (undo)', async ({ app }) => {
-    // Create a pending approval to test undo behavior
     const approval = await createPendingApproval(app)
 
     try {
-      // Navigate to approvals page
-      await app.goto(toAppUrl('/approvals'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+      await navigateToApprovalAndOpen(app, approval.approvalName)
 
-      const table = app.getByRole('grid', { name: 'Approvals table' })
-      await table.waitFor({ state: 'visible', timeout: 15_000 })
-
-      // Filter to show only our test approval
-      await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      // Wait for filter chip to confirm filter was applied and table to refresh
-      await expect(app.getByRole('search', { name: 'Filters' }).getByRole('list', { name: 'Name' })).toBeVisible({
-        timeout: 15_000,
-      })
-
-      // Step 1: Click on the pending approval to open side panel
-      const approvalLink = table.getByRole('link', { name: approval.approvalName })
-      await approvalLink.waitFor({ state: 'visible', timeout: 10_000 })
-      await approvalLink.click()
-
-      // Step 2: Verify navigation to execution detail with side panel
-      await expect(app).toHaveURL(/\/executions\/[^?]+\?approval=/, { timeout: 15_000 })
-      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
-
-      // Step 3: Click "Approve" button
       const approveButton = app.getByRole('button', { name: 'Approve', exact: true })
-      await expect(approveButton).toBeVisible({ timeout: 15_000 })
-      await approveButton.click()
-
-      // Step 4: Verify approval notes field appears
-      const approvalNotesInput = app.getByPlaceholder(/explain.*reason.*approving|optional.*note/i)
-      await expect(approvalNotesInput).toBeVisible({ timeout: 10_000 })
-
-      // Step 5: Click "Reject" to undo the approve decision
       const rejectButton = app.getByRole('button', { name: 'Reject', exact: true })
+      await expect(approveButton).toBeEnabled({ timeout: 15_000 })
+
+      await approveButton.click()
+      await expect(app.getByPlaceholder(/explain the reason for approving/i)).toBeVisible({ timeout: 10_000 })
+      // Pending approve hides the action buttons; undo clears the draft before choosing reject.
+      await expect(rejectButton).not.toBeVisible()
+
+      await app.getByRole('button', { name: 'Undo decision' }).click()
+      await expect(approveButton).toBeVisible({ timeout: 10_000 })
       await expect(rejectButton).toBeVisible({ timeout: 10_000 })
+
       await rejectButton.click()
-
-      // Step 6: Verify rejection notes field appears (approval notes replaced)
-      const rejectionNotesInput = app.getByPlaceholder(/explain.*reason.*rejecting|optional.*note/i)
-      await expect(rejectionNotesInput).toBeVisible({ timeout: 10_000 })
-
-      // Step 7: Verify approval notes field is no longer visible
-      await expect(approvalNotesInput).not.toBeVisible()
-
-      // Step 8: Verify "Submit decision" button is available for rejection
-      const submitButton = app.getByRole('button', { name: 'Submit decision' })
-      await expect(submitButton).toBeVisible({ timeout: 10_000 })
-
-      // NOTE: This test verifies undo behavior (switching between approve/reject)
-      // without actually submitting to avoid mutating approval state
+      await expect(app.getByPlaceholder(/explain the reason for rejecting/i)).toBeVisible({ timeout: 10_000 })
+      await expect(app.getByRole('button', { name: 'Submit decision' })).toBeVisible({ timeout: 10_000 })
     } finally {
-      // Cleanup: delete created workflow
       await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
     }
   })
 
   test('user clears decision with explicit undo button', async ({ app }) => {
-    // Create a pending approval to test undo/clear behavior
     const approval = await createPendingApproval(app)
 
     try {
-      // Navigate to approvals page
-      await app.goto(toAppUrl('/approvals'))
-      await expect(app.getByRole('heading', { level: 1, name: 'Approvals' })).toBeVisible()
+      await navigateToApprovalAndOpen(app, approval.approvalName)
 
-      const table = app.getByRole('grid', { name: 'Approvals table' })
-      await table.waitFor({ state: 'visible', timeout: 15_000 })
-
-      // Filter to show only our test approval
-      await app.getByPlaceholder('Filter by name').fill(approval.approvalName)
-      await app.getByRole('button', { name: 'Apply filter' }).click()
-
-      // Click on the pending approval
-      const approvalLink = table.getByRole('link', { name: approval.approvalName })
-      await approvalLink.waitFor({ state: 'visible', timeout: 10_000 })
-      await approvalLink.click()
-      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
-
-      // Step 1: Click "Approve"
       const approveButton = app.getByRole('button', { name: 'Approve', exact: true })
+      await expect(approveButton).toBeEnabled({ timeout: 15_000 })
       await approveButton.click()
-      await expect(app.getByPlaceholder(/explain.*reason.*approving/i)).toBeVisible()
+      await expect(app.getByPlaceholder(/explain the reason for approving/i)).toBeVisible({ timeout: 10_000 })
 
-      // Step 2: Look for "Undo decision" or "Clear" button
-      const undoButton = app.getByRole('button', { name: /undo.*decision|clear.*selection/i })
-      const hasUndoButton = await undoButton.isVisible().catch(() => false)
+      await app.getByRole('button', { name: 'Undo decision' }).click()
 
-      if (hasUndoButton) {
-        await undoButton.click()
-
-        // Step 3: Verify both approve and reject buttons are visible again
-        await expect(app.getByRole('button', { name: 'Approve', exact: true })).toBeVisible()
-        await expect(app.getByRole('button', { name: 'Reject', exact: true })).toBeVisible()
-
-        // Step 4: Verify notes field is cleared
-        const notesField = app.getByPlaceholder(/explain.*reason/i)
-        await expect(notesField).not.toBeVisible()
-      } else {
-        // If no explicit undo button exists, verify switching between approve/reject acts as undo
-        const rejectButton = app.getByRole('button', { name: 'Reject', exact: true })
-        await expect(rejectButton).toBeVisible()
-
-        // Clicking reject after approve is the undo mechanism
-        await rejectButton.click()
-        await expect(app.getByPlaceholder(/explain.*reason.*rejecting/i)).toBeVisible()
-      }
+      await expect(approveButton).toBeVisible({ timeout: 10_000 })
+      await expect(app.getByRole('button', { name: 'Reject', exact: true })).toBeVisible()
+      await expect(app.getByPlaceholder(/explain the reason for approving/i)).not.toBeVisible()
     } finally {
-      // Cleanup: delete created workflow
       await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
     }
   })

--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -8,7 +8,7 @@
  */
 import { type Page } from '../fixtures'
 import { test, expect, toAppUrl } from '../fixtures'
-import { applyApprovalNameFilter, navigateToApprovalAndOpen } from '../helpers/approvals'
+import { applyApprovalNameFilter, dismissConnectionBanner, navigateToApprovalAndOpen } from '../helpers/approvals'
 import { APP_TITLE } from '../helpers/appTitle'
 import { addApprovalNodeWithBranch } from '../helpers/v2-nodes'
 import { runWorkflowFromBuilder, waitForExecutionPaused } from '../helpers/workflow-run'
@@ -371,26 +371,29 @@ test.describe('Approval Workflow Operations', () => {
   })
 
   test('user changes decision from approve to reject (undo)', async ({ app }) => {
+    test.slow()
     const approval = await createPendingApproval(app)
 
     try {
       await navigateToApprovalAndOpen(app, approval.approvalName)
+      await dismissConnectionBanner(app)
 
       const approveButton = app.getByRole('button', { name: 'Approve', exact: true })
       const rejectButton = app.getByRole('button', { name: 'Reject', exact: true })
-      await expect(approveButton).toBeEnabled({ timeout: 15_000 })
+      await expect(approveButton).not.toHaveAttribute('aria-disabled', 'true', { timeout: 20_000 })
 
       await approveButton.click()
-      await expect(app.getByPlaceholder(/explain the reason for approving/i)).toBeVisible({ timeout: 10_000 })
+      await expect(app.getByPlaceholder(/Explain the reason for approving/i)).toBeVisible({ timeout: 10_000 })
       // Pending approve hides the action buttons; undo clears the draft before choosing reject.
       await expect(rejectButton).not.toBeVisible()
 
       await app.getByRole('button', { name: 'Undo decision' }).click()
       await expect(approveButton).toBeVisible({ timeout: 10_000 })
       await expect(rejectButton).toBeVisible({ timeout: 10_000 })
+      await expect(rejectButton).not.toHaveAttribute('aria-disabled', 'true', { timeout: 20_000 })
 
       await rejectButton.click()
-      await expect(app.getByPlaceholder(/explain the reason for rejecting/i)).toBeVisible({ timeout: 10_000 })
+      await expect(app.getByPlaceholder(/Explain the reason for rejecting/i)).toBeVisible({ timeout: 10_000 })
       await expect(app.getByRole('button', { name: 'Submit decision' })).toBeVisible({ timeout: 10_000 })
     } finally {
       await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
@@ -398,21 +401,23 @@ test.describe('Approval Workflow Operations', () => {
   })
 
   test('user clears decision with explicit undo button', async ({ app }) => {
+    test.slow()
     const approval = await createPendingApproval(app)
 
     try {
       await navigateToApprovalAndOpen(app, approval.approvalName)
+      await dismissConnectionBanner(app)
 
       const approveButton = app.getByRole('button', { name: 'Approve', exact: true })
-      await expect(approveButton).toBeEnabled({ timeout: 15_000 })
+      await expect(approveButton).not.toHaveAttribute('aria-disabled', 'true', { timeout: 20_000 })
       await approveButton.click()
-      await expect(app.getByPlaceholder(/explain the reason for approving/i)).toBeVisible({ timeout: 10_000 })
+      await expect(app.getByPlaceholder(/Explain the reason for approving/i)).toBeVisible({ timeout: 10_000 })
 
       await app.getByRole('button', { name: 'Undo decision' }).click()
 
       await expect(approveButton).toBeVisible({ timeout: 10_000 })
       await expect(app.getByRole('button', { name: 'Reject', exact: true })).toBeVisible()
-      await expect(app.getByPlaceholder(/explain the reason for approving/i)).not.toBeVisible()
+      await expect(app.getByPlaceholder(/Explain the reason for approving/i)).not.toBeVisible()
     } finally {
       await apiRequest(app, 'delete', `/workflows/${approval.workflowId}`).catch(() => {})
     }

--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -483,8 +483,10 @@ test.describe('Approval Workflow Operations', () => {
   })
 
   test('UI-29: self-contained approve flow via approvals queue', async ({ app }) => {
-    // Create a workflow with an approval node so we control the approval name
-    const workflowName = buildUniqueName('e2e-approve')
+    // Create a workflow with an approval node so we control the approval name.
+    // Avoid 'approve' in the workflow name — getByRole({ name: 'Approve' }) is a
+    // substring match and collides with the workflow link button on execution detail.
+    const workflowName = buildUniqueName('e2e-ui29')
     const approvalNodeName = buildUniqueName('gate')
     const { id: workflowId } = await createWorkflowViaApi(app, workflowName, [
       { id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} },
@@ -520,8 +522,8 @@ test.describe('Approval Workflow Operations', () => {
       await expect(app).toHaveURL(/\/executions\/[^?]+\?approval=/)
       await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible({ timeout: 15_000 })
 
-      // Approve with notes
-      await app.getByRole('button', { name: 'Approve' }).click()
+      // Approve with notes (exact: true — workflow link names must not substring-match)
+      await app.getByRole('button', { name: 'Approve', exact: true }).click()
       await app.getByPlaceholder(/Explain the reason for approving/i).fill('Approved in E2E test')
       await app.getByRole('button', { name: 'Submit decision' }).click()
 


### PR DESCRIPTION
## Description

konflux and github compose e2e were failing on `approvals.spec.ts` undo coverage because the test expected reject to stay visible after clicking approve. `ApprovalDetailContent` hides approve/reject once a draft decision is selected and exposes **Undo decision** instead.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

- [x] update `user changes decision from approve to reject (undo)` to undo the approve draft, then select reject
- [x] simplify `user clears decision with explicit undo button` to match the same side panel state machine
- [x] reuse `navigateToApprovalAndOpen` for both tests

## Out of Scope

- other approval e2e flakes (temporal pause timing, bulk flows)
- quarantine entries in syntara-ci

## Related Issues

Related to konflux failures on open frontend PRs (e.g. #512, #513).

## How to Test

1. run compose e2e `workflows/approvals.spec.ts` (or full suite)
2. confirm undo tests pass when opening a pending approval from the approvals list

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes