### PR TITLE
fix(ui): scope workflow runs name search to project

### DIFF
--- a/frontend/packages/syntara-ui/src/routes/executions/Executions.tsx
+++ b/frontend/packages/syntara-ui/src/routes/executions/Executions.tsx
@@ -32,9 +32,9 @@ import {
 import { FlatExecutionsTableBody, GroupedExecutionsTableBody } from './ExecutionsTableBody'
 import { executionDefaultSort, executionTableColumns } from './executionTableColumns'
 
-function buildFilterFieldDefinitions(executions: Execution[]): FilterFieldDefinition[] {
+function buildFilterFieldDefinitions(executions: Execution[], projectId: string | null): FilterFieldDefinition[] {
   return [
-    getExecutionWorkflowFilterDefinition(),
+    getExecutionWorkflowFilterDefinition(projectId),
     getExecutionStatusFilterDefinition(),
     getExecutionVersionFilterFromExecutions(executions),
     getExecutionCreatedAtFilterDefinition(),
@@ -88,7 +88,10 @@ export default function Executions() {
 
   useCursorReset(executions.length, hasActiveFilters, cursor, executionsQuery.isFetching, resetPagination)
 
-  const filterFieldDefinitions = useMemo(() => buildFilterFieldDefinitions(executions), [executions])
+  const filterFieldDefinitions = useMemo(
+    () => buildFilterFieldDefinitions(executions, selectedProjectId),
+    [executions, selectedProjectId]
+  )
 
   const builtinProjectIds = useMemo(
     () => new Set(projectsForGrouping.filter((p) => p.is_builtin).map((p) => p.id)),

--- a/frontend/packages/syntara-ui/src/routes/executions/executionFilters.test.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/executionFilters.test.ts
@@ -12,9 +12,31 @@ import {
   transformWorkflowsToOptions,
 } from './executionFilters'
 
+type WorkflowListResponse = {
+  data?: { resources?: Array<{ id?: string | null; name?: string | null }> }
+}
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn<(...args: unknown[]) => Promise<WorkflowListResponse>>(),
+}))
+
+vi.mock('../../client', () => ({
+  workflowFetchClient: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
 describe('executionFilters', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockGet.mockResolvedValue({
+      data: {
+        resources: [
+          { id: 'wf-in-project', name: 'In Project Workflow' },
+          { id: 'wf-other', name: 'Other Workflow' },
+        ],
+      },
+    })
   })
 
   describe('getExecutionWorkflowFilterDefinition', () => {
@@ -48,33 +70,74 @@ describe('executionFilters', () => {
     it('asyncOptions is an async function', () => {
       const definition = getExecutionWorkflowFilterDefinition()
 
-      // Verify it's an async function
       expect(definition.asyncOptions).toBeInstanceOf(Function)
       expect(definition.asyncOptions!('test')).toBeInstanceOf(Promise)
     })
 
-    it('asyncOptions handles search parameter correctly', async () => {
-      // We can't easily mock openapi-fetch, but we can test the function behavior
-      // by verifying it returns a promise and handles the searchValue parameter
+    it('asyncOptions queries workflows with name search when no project is selected', async () => {
       const definition = getExecutionWorkflowFilterDefinition()
 
-      // Test with search value
-      const resultWithSearch = definition.asyncOptions!('test-search')
-      expect(resultWithSearch).toBeInstanceOf(Promise)
+      const options = await definition.asyncOptions!('deploy')
 
-      // Test with empty search value
-      const resultWithoutSearch = definition.asyncOptions!('')
-      expect(resultWithoutSearch).toBeInstanceOf(Promise)
+      expect(mockGet).toHaveBeenCalledWith('/workflows', {
+        params: {
+          query: {
+            limit: 50,
+            'name[contains]': 'deploy',
+          },
+        },
+      })
+      expect(options).toEqual([
+        { value: 'wf-in-project', label: 'In Project Workflow' },
+        { value: 'wf-other', label: 'Other Workflow' },
+      ])
+    })
 
-      // Test with whitespace-only search value
-      const resultWithWhitespace = definition.asyncOptions!('   ')
-      expect(resultWithWhitespace).toBeInstanceOf(Promise)
+    it('asyncOptions scopes the typeahead query to the selected project', async () => {
+      const definition = getExecutionWorkflowFilterDefinition('project-123')
 
-      // All should resolve to arrays (even if empty due to network issues in test)
-      const [r1, r2, r3] = await Promise.all([resultWithSearch, resultWithoutSearch, resultWithWhitespace])
-      expect(Array.isArray(r1)).toBe(true)
-      expect(Array.isArray(r2)).toBe(true)
-      expect(Array.isArray(r3)).toBe(true)
+      await definition.asyncOptions!('deploy')
+
+      expect(mockGet).toHaveBeenCalledWith('/workflows', {
+        params: {
+          query: {
+            limit: 50,
+            'name[contains]': 'deploy',
+            project_id: 'project-123',
+          },
+        },
+      })
+    })
+
+    it('asyncOptions omits name[contains] for empty or whitespace search', async () => {
+      const definition = getExecutionWorkflowFilterDefinition('project-123')
+
+      await definition.asyncOptions!('')
+      await definition.asyncOptions!('   ')
+
+      expect(mockGet).toHaveBeenNthCalledWith(1, '/workflows', {
+        params: {
+          query: {
+            limit: 50,
+            project_id: 'project-123',
+          },
+        },
+      })
+      expect(mockGet).toHaveBeenNthCalledWith(2, '/workflows', {
+        params: {
+          query: {
+            limit: 50,
+            project_id: 'project-123',
+          },
+        },
+      })
+    })
+
+    it('asyncOptions returns an empty list when the workflows request fails', async () => {
+      mockGet.mockRejectedValueOnce(new Error('network error'))
+      const definition = getExecutionWorkflowFilterDefinition('project-123')
+
+      await expect(definition.asyncOptions!('deploy')).resolves.toEqual([])
     })
   })
 

--- a/frontend/packages/syntara-ui/src/routes/executions/executionFilters.ts
+++ b/frontend/packages/syntara-ui/src/routes/executions/executionFilters.ts
@@ -26,21 +26,25 @@ export function transformWorkflowsToOptions(
 /**
  * Returns filter definition for filtering executions by workflow with server-side typeahead
  *
+ * @param projectId - When set, scopes the typeahead to workflows in that project
+ *   (same project selector used by the Workflow Runs table). Omit or pass null when
+ *   viewing all projects.
  * @returns FilterFieldDefinition configured for workflow filtering with async SELECT type
  *
  * @remarks
  * Uses server-side typeahead via asyncOptions to support filtering by any workflow,
- * not just the first page of results. Queries /workflows with name[contains] parameter.
+ * not just the first page of results. Queries /workflows with name[contains] and,
+ * when a project is selected, project_id so options match the current project scope.
  * Uses the shared authenticated workflowFetchClient from client.tsx.
  *
  * @example
  * ```typescript
- * const filterDef = getExecutionWorkflowFilterDefinition()
- * // User types "deploy" → queries /workflows?name[contains]=deploy
+ * const filterDef = getExecutionWorkflowFilterDefinition(selectedProjectId)
+ * // User types "deploy" → queries /workflows?name[contains]=deploy&project_id=<id>
  * // Generates query param: workflow_id=workflow-123
  * ```
  */
-export const getExecutionWorkflowFilterDefinition = (): FilterFieldDefinition => ({
+export const getExecutionWorkflowFilterDefinition = (projectId?: string | null): FilterFieldDefinition => ({
   key: 'workflow_id',
   label: 'Workflow name',
   type: FilterTypeEnum.SELECT,
@@ -51,6 +55,10 @@ export const getExecutionWorkflowFilterDefinition = (): FilterFieldDefinition =>
 
     if (searchValue.trim()) {
       params['name[contains]'] = searchValue.trim()
+    }
+
+    if (projectId) {
+      params.project_id = projectId
     }
 
     try {


### PR DESCRIPTION
## Description

Workflow Runs "Search workflows" typeahead listed workflows from every project. the runs table already scopes with the selected project, but the name filter hit `GET /workflows` with only `name[contains]`. this passes `project_id` when a project is selected (All projects stays unscoped).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] pass selected project id into the workflow name typeahead query
- [x] unit tests for scoped vs unscoped filter definitions

## Out of Scope

other tables. Approvals has no workflow-name typeahead; this was the only Search workflows async typeahead.

## Related Issues

Fixes AAP-85275

## How to Test

1. log in (demo / coffee on local mock)
2. open Workflow Runs (`/executions`)
3. select a project (e.g. default), filter by Workflow name, open Search workflows
4. confirm the dropdown only lists that project's workflows
5. switch to another project (e.g. alice-sandbox) and confirm the list changes with no overlap
6. All projects should show the union

## Screenshots / Demo (if applicable)

![default project, Search workflows scoped](https://github.com/user-attachments/assets/03d8923c-28a8-459a-88e2-667fc37946a2)

![alice-sandbox project, Search workflows scoped](https://github.com/user-attachments/assets/020af3b1-4dba-4960-8350-a1209d9472b9)

![All projects, Search workflows union](https://github.com/user-attachments/assets/e2983195-d0fd-4ebb-b906-c827c9467207)
