### PR TITLE
fix(e2e): align approval undo test with Undo decision UI

### DIFF
--- a/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approvals.spec.ts
@@ -405,17 +405,21 @@ test.describe('Approval Workflow Operations', () => {
       await expect(approveButton).toBeVisible({ timeout: 15_000 })
       await approveButton.click()
 
-      // Step 4: Verify approval notes field appears
-      const approvalNotesInput = app.getByPlaceholder(/explain.*reason.*approving|optional.*note/i)
+      // Step 4: Verify approval notes field appears (Reject is replaced by Undo)
+      const approvalNotesInput = app.getByRole('textbox', { name: 'Approval notes' })
       await expect(approvalNotesInput).toBeVisible({ timeout: 10_000 })
+      await expect(app.getByRole('button', { name: 'Reject', exact: true })).not.toBeVisible()
 
-      // Step 5: Click "Reject" to undo the approve decision
+      // Step 5: Undo the approve selection, then choose Reject
+      await app.getByRole('button', { name: 'Undo decision' }).click()
+      await expect(approvalNotesInput).not.toBeVisible()
+
       const rejectButton = app.getByRole('button', { name: 'Reject', exact: true })
       await expect(rejectButton).toBeVisible({ timeout: 10_000 })
       await rejectButton.click()
 
       // Step 6: Verify rejection notes field appears (approval notes replaced)
-      const rejectionNotesInput = app.getByPlaceholder(/explain.*reason.*rejecting|optional.*note/i)
+      const rejectionNotesInput = app.getByRole('textbox', { name: 'Rejection notes' })
       await expect(rejectionNotesInput).toBeVisible({ timeout: 10_000 })
 
       // Step 7: Verify approval notes field is no longer visible


### PR DESCRIPTION
## Description

Konflux UI E2E fails `Approval Workflow Operations › user changes decision from approve to reject (undo)` because the review panel no longer keeps **Reject** after **Approve**. After Approve, the panel shows **Undo decision** instead.

Update that test to click Undo, then Reject, matching the current panel.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

- Update `user changes decision from approve to reject (undo)` in `e2e/workflows/approvals.spec.ts` to use **Undo decision**, then **Reject**
- Use accessible textbox names (`Approval notes` / `Rejection notes`) instead of placeholder regexes

## Out of Scope

- Other approvals E2E failures (bulk approve/reject timeouts, UI-29 Approve locator)

## Related Issues

Related to #522 (this failure is blocking Konflux UI E2E on that PR)

## How to Test

```bash
cd frontend/packages/syntara-ui
VITE_API_URL=https://localhost:8000 \
SYNTARA_E2E_SKIP_WEB_SERVER=1 \
SYNTARA_E2E_BASE_URL=http://localhost:5173 \
SYNTARA_E2E_PASSWORD=$(cat ../../../backend/.secrets/admin-password) \
npx playwright test e2e/workflows/approvals.spec.ts --grep "user changes decision from approve to reject"
```

## Frontend Checklist

- [x] I have run the affected Playwright spec against the real backend
- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Additional Notes

Local run of this spec passed (9.4s) against the real backend with Temporal.


Made with [Cursor](https://cursor.com)