### PR TITLE
fix(e2e,backend): fix every live merge-queue flake from the 10-11 Sep sweep

### DIFF
--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -14,7 +14,7 @@ import contextlib
 import sys
 from collections.abc import AsyncGenerator, Generator
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
@@ -810,24 +810,43 @@ components:
     sys.path.remove(str(syntara_dir.parent))
 
 
-async def _wait_for_server(host: str, port: int) -> None:
-    """Poll until the server is accepting TCP connections."""
-    async with asyncio.timeout(10.0):
-        while True:
-            try:
-                _, writer = await asyncio.open_connection(host, port)
-                writer.close()
-                await writer.wait_closed()
-                return
-            except OSError:
-                await asyncio.sleep(0.1)
+class ExampleAppServer(NamedTuple):
+    """A running uvicorn instance serving the websocket example app."""
+
+    project_root: Path
+    app: FastAPI
+    ws_base_url: str
+    """``ws://127.0.0.1:{port}`` for the port this worker's server actually bound."""
+
+
+async def _wait_for_started(server: Server) -> None:
+    """Poll until uvicorn reports it has bound its listening socket.
+
+    Deliberately not a TCP probe. The fixture used to bind a hard-coded port and
+    poll it with ``open_connection``, which under ``-n auto`` saw *another*
+    worker's server on that port and reported success while this worker's uvicorn
+    had already exited with EADDRINUSE. Every test in that worker then talked to
+    the other worker's server and was disconnected with close code 1012 —
+    uvicorn's graceful-shutdown code — the moment the other worker's fixture tore
+    down. ``server.started`` is per-instance, so it cannot be satisfied by a
+    stranger's socket.
+    """
+    for _ in range(200):
+        if server.started:
+            return
+        await asyncio.sleep(0.05)
+    msg = "websocket example server did not bind within 10s"
+    raise TimeoutError(msg)
 
 
 @pytest_asyncio.fixture
-async def example_app_server(websocket_example_app: tuple[Path, FastAPI]) -> AsyncGenerator[tuple[Path, FastAPI], None]:
+async def example_app_server(websocket_example_app: tuple[Path, FastAPI]) -> AsyncGenerator[ExampleAppServer, None]:
     """Create Server with Websocket example channels."""
     project_root, app = websocket_example_app
-    config = Config(app, host="127.0.0.1", port=9999, log_level="error")
+    # port=0 lets the kernel pick a free port, so parallel xdist workers cannot
+    # collide. The real port is read back from the bound socket below, mirroring
+    # `tests/integration/core/tls/conftest.py`.
+    config = Config(app, host="127.0.0.1", port=0, log_level="error")
     server = Server(config)
 
     async def _serve_without_sys_exit() -> None:
@@ -846,7 +865,7 @@ async def example_app_server(websocket_example_app: tuple[Path, FastAPI]) -> Asy
     server_task = asyncio.create_task(_serve_without_sys_exit())
 
     try:
-        await _wait_for_server("127.0.0.1", 9999)
+        await _wait_for_started(server)
     except (TimeoutError, OSError):
         if server_task.done() and not server_task.cancelled():
             try:
@@ -858,7 +877,8 @@ async def example_app_server(websocket_example_app: tuple[Path, FastAPI]) -> Asy
             await server_task
         pytest.fail("Server failed to start within timeout")
 
-    yield project_root, app
+    port = server.servers[0].sockets[0].getsockname()[1]
+    yield ExampleAppServer(project_root, app, f"ws://127.0.0.1:{port}")
 
     # Shutdown server gracefully
     server.should_exit = True

--- a/backend/tests/integration/core/websocket/test_json_validation.py
+++ b/backend/tests/integration/core/websocket/test_json_validation.py
@@ -7,24 +7,22 @@ by returning appropriate error responses.
 import asyncio
 import json
 from datetime import UTC, datetime
-from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from fastapi import FastAPI
 from websockets import connect as websocket_connect
 
 from syntara.core.websocket.manager import get_connection_lifecycle_manager
+from tests.integration.conftest import ExampleAppServer
 
 
 class TestWebSocketJsonValidation:
     """Tests for WebSocket JSON validation error handling."""
 
     @pytest.mark.asyncio
-    async def test_non_json_text_input_chat_endpoint(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_non_json_text_input_chat_endpoint(self, example_app_server: ExampleAppServer) -> None:
         """Test that non-JSON text input returns validation error on chat endpoint."""
-        _ = example_app_server
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/chat") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/chat") as websocket:
             # Send non-JSON text
             await websocket.send("asd")
 
@@ -48,10 +46,9 @@ class TestWebSocketJsonValidation:
             assert timestamp.tzinfo is not None
 
     @pytest.mark.asyncio
-    async def test_non_json_text_input_coffee_endpoint(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_non_json_text_input_coffee_endpoint(self, example_app_server: ExampleAppServer) -> None:
         """Test that non-JSON text input returns validation error on coffee endpoint."""
-        _ = example_app_server
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/coffee") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/coffee") as websocket:
             # Send non-JSON text
             await websocket.send("invalid input")
 
@@ -68,10 +65,9 @@ class TestWebSocketJsonValidation:
             assert response["error"] == "INVALID_REQUEST"
 
     @pytest.mark.asyncio
-    async def test_malformed_json_missing_quote(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_malformed_json_missing_quote(self, example_app_server: ExampleAppServer) -> None:
         """Test that malformed JSON (missing quote) returns validation error."""
-        _ = example_app_server
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/chat") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/chat") as websocket:
             # Send malformed JSON (missing closing quote)
             await websocket.send('{"message": "hello}')
 
@@ -86,9 +82,9 @@ class TestWebSocketJsonValidation:
             assert "timestamp" in response
 
     @pytest.mark.asyncio
-    async def test_malformed_json_invalid_structure(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_malformed_json_invalid_structure(self, example_app_server: ExampleAppServer) -> None:
         """Test that malformed JSON (invalid structure) returns validation error."""
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/chat") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/chat") as websocket:
             # Send malformed JSON (invalid structure)
             await websocket.send("{invalid}")
 
@@ -103,10 +99,9 @@ class TestWebSocketJsonValidation:
             assert "timestamp" in response
 
     @pytest.mark.asyncio
-    async def test_connection_continues_after_json_error(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_connection_continues_after_json_error(self, example_app_server: ExampleAppServer) -> None:
         """Test that WebSocket connection continues after JSON validation error."""
-        _ = example_app_server
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/chat") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/chat") as websocket:
             # Send invalid JSON
             await websocket.send("invalid")
 
@@ -132,9 +127,9 @@ class TestWebSocketJsonValidation:
                 assert response["reply"] == "HELLO"
 
     @pytest.mark.asyncio
-    async def test_multiple_json_errors_in_sequence(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_multiple_json_errors_in_sequence(self, example_app_server: ExampleAppServer) -> None:
         """Test that multiple JSON errors can be handled in sequence."""
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/chat") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/chat") as websocket:
             # Send multiple invalid JSON messages
             for i in range(3):
                 await websocket.send(f"invalid{i}")
@@ -152,10 +147,9 @@ class TestWebSocketJsonValidation:
             assert "reply" in response
 
     @pytest.mark.asyncio
-    async def test_empty_string_as_json(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_empty_string_as_json(self, example_app_server: ExampleAppServer) -> None:
         """Test that empty string returns JSON validation error."""
-        _ = example_app_server
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/chat") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/chat") as websocket:
             # Send empty string
             await websocket.send("")
 
@@ -170,10 +164,9 @@ class TestWebSocketJsonValidation:
             assert "timestamp" in response
 
     @pytest.mark.asyncio
-    async def test_json_error_timestamp_is_recent(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_json_error_timestamp_is_recent(self, example_app_server: ExampleAppServer) -> None:
         """Test that error timestamp is recent and in correct timezone."""
-        _ = example_app_server
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/chat") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/chat") as websocket:
             # Record time before sending
             before = datetime.now(UTC)
 
@@ -197,10 +190,9 @@ class TestWebSocketJsonValidation:
             assert error_timestamp.tzinfo is not None
 
     @pytest.mark.asyncio
-    async def test_error_message_contains_useful_information(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_error_message_contains_useful_information(self, example_app_server: ExampleAppServer) -> None:
         """Test that error message contains useful debugging information."""
-        _ = example_app_server
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/chat") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/chat") as websocket:
             # Send invalid JSON
             await websocket.send("{bad json}")
 
@@ -217,7 +209,7 @@ class TestWebSocketJsonValidation:
             assert any(keyword in message_lower for keyword in ["json", "format", "invalid", "parse", "decode"])
 
     @pytest.mark.asyncio
-    async def test_validation_error_updates_activity_timestamp(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    async def test_validation_error_updates_activity_timestamp(self, example_app_server: ExampleAppServer) -> None:
         """Test that ValidationError updates the lifecycle manager activity timestamp.
 
         This verifies that even invalid JSON messages count as connection activity,
@@ -230,7 +222,7 @@ class TestWebSocketJsonValidation:
         # server-side among any other "chat" connections.
         user_agent = f"test-{uuid4()}"
         async with websocket_connect(
-            "ws://127.0.0.1:9999/ws/testcomp/v1/chat", user_agent_header=user_agent
+            f"{example_app_server.ws_base_url}/ws/testcomp/v1/chat", user_agent_header=user_agent
         ) as websocket:
             # Send valid message first to establish connection
             await websocket.send(json.dumps({"message": "hello"}))

--- a/backend/tests/integration/core/websocket/test_multi_module_component.py
+++ b/backend/tests/integration/core/websocket/test_multi_module_component.py
@@ -8,19 +8,17 @@ handler files (ws/*.py), ensuring:
 - WebSocket endpoint creation and execution
 """
 
-from pathlib import Path
-
-from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 from syntara.core.websocket.endpoint_factory import _HANDLER_MODULE_CACHE, scan_handler_specs
 from syntara.core.websocket.interceptor import ValidationInterceptor
+from tests.integration.conftest import ExampleAppServer
 
 
 class TestMultiModuleComponent:
     """Integration tests for multi-module component support."""
 
-    def test_scan_discovers_all_files(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    def test_scan_discovers_all_files(self, example_app_server: ExampleAppServer) -> None:
         """Test that scan_handler_specs discovers all handler files."""
         _ = example_app_server
         specs = scan_handler_specs()
@@ -35,7 +33,7 @@ class TestMultiModuleComponent:
         assert "coffee" in channels
         assert "events" in channels
 
-    def test_cache_maps_channels_to_modules(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    def test_cache_maps_channels_to_modules(self, example_app_server: ExampleAppServer) -> None:
         """Test that _HANDLER_MODULE_CACHE correctly maps channels to their modules."""
         _ = example_app_server
         scan_handler_specs()
@@ -58,9 +56,9 @@ class TestMultiModuleComponent:
         assert "handlers1" in channel_modules["chat"].__name__
         assert "handlers2" in channel_modules["events"].__name__
 
-    def test_endpoints_created_for_all_channels(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    def test_endpoints_created_for_all_channels(self, example_app_server: ExampleAppServer) -> None:
         """Test that WebSocket endpoints are created for all channels."""
-        _, app = example_app_server
+        app = example_app_server.app
 
         # Collect paths from top-level routes and included routers
         websocket_paths: set[str] = set()
@@ -76,9 +74,9 @@ class TestMultiModuleComponent:
         assert "/ws/testcomp/v1/coffee" in websocket_paths
         assert "/ws/testcomp/v1/events" in websocket_paths
 
-    def test_chat_endpoint_uses_handlers1(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    def test_chat_endpoint_uses_handlers1(self, example_app_server: ExampleAppServer) -> None:
         """Test that chat endpoint uses handler from handlers1.py."""
-        _, app = example_app_server
+        app = example_app_server.app
 
         with TestClient(app) as client, client.websocket_connect("/ws/testcomp/v1/chat") as websocket:
             # Send chat message
@@ -92,9 +90,9 @@ class TestMultiModuleComponent:
             assert response["type"] == "echo"
             assert response["handler"] == "handlers1"
 
-    def test_coffee_endpoint_uses_handlers1(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    def test_coffee_endpoint_uses_handlers1(self, example_app_server: ExampleAppServer) -> None:
         """Test that coffee endpoint uses handler from handlers1.py."""
-        _, app = example_app_server
+        app = example_app_server.app
 
         with TestClient(app) as client, client.websocket_connect("/ws/testcomp/v1/coffee") as websocket:
             # Send coffee request
@@ -107,9 +105,9 @@ class TestMultiModuleComponent:
             assert response["output"] == "espresso"
             assert response["handler"] == "handlers1"
 
-    def test_events_endpoint_uses_handlers2(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    def test_events_endpoint_uses_handlers2(self, example_app_server: ExampleAppServer) -> None:
         """Test that events endpoint uses handler from handlers2.py."""
-        _, app = example_app_server
+        app = example_app_server.app
 
         with TestClient(app) as client, client.websocket_connect("/ws/testcomp/v1/events") as websocket:
             # Send events request
@@ -123,7 +121,7 @@ class TestMultiModuleComponent:
             assert response["group"] == "log"
             assert response["handler"] == "handlers2"
 
-    def test_validation_succeeds_for_multi_module(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    def test_validation_succeeds_for_multi_module(self, example_app_server: ExampleAppServer) -> None:
         """Test that ValidationInterceptor validates each module correctly."""
         _ = example_app_server
         specs = scan_handler_specs()
@@ -143,9 +141,9 @@ class TestMultiModuleComponent:
         assert len(interceptor.validation_results) > 0
         assert all(result.is_valid for result in interceptor.validation_results)
 
-    def test_all_endpoints_work_concurrently(self, example_app_server: tuple[Path, FastAPI]) -> None:
+    def test_all_endpoints_work_concurrently(self, example_app_server: ExampleAppServer) -> None:
         """Test that all endpoints from different modules work concurrently."""
-        _, app = example_app_server
+        app = example_app_server.app
 
         with (
             TestClient(app) as client,

--- a/backend/tests/integration/core/websocket/test_receive_only_channels.py
+++ b/backend/tests/integration/core/websocket/test_receive_only_channels.py
@@ -7,24 +7,21 @@ Bidirectional channels continue using TestClient for consistency with existing t
 """
 
 import json
-from pathlib import Path
 
 import pytest
-from fastapi import FastAPI
 from websockets import connect as websocket_connect
+
+from tests.integration.conftest import ExampleAppServer
 
 
 class TestReceiveOnlyChannelIntegration:
     """Integration tests for receive-only channel behavior."""
 
     @pytest.mark.asyncio
-    async def test_receive_only_channel_sends_events_via_on_connect(
-        self, example_app_server: tuple[Path, FastAPI]
-    ) -> None:
+    async def test_receive_only_channel_sends_events_via_on_connect(self, example_app_server: ExampleAppServer) -> None:
         """Events sent through on_connect handler."""
-        _ = example_app_server
         # Connect to receive-only tokens channel with real WebSocket client
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/tokens") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/tokens") as websocket:
             # Receive first token (no send required)
             token0_str = await websocket.recv()
             token0 = json.loads(token0_str)
@@ -50,12 +47,11 @@ class TestReceiveOnlyChannelIntegration:
 
     @pytest.mark.asyncio
     async def test_receive_only_channel_stays_alive_until_disconnect(
-        self, example_app_server: tuple[Path, FastAPI]
+        self, example_app_server: ExampleAppServer
     ) -> None:
         """Connection maintained until all messages sent."""
-        _ = example_app_server
         # Connect to receive-only tokens channel
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/tokens") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/tokens") as websocket:
             # Receive all 5 tokens sent by on_connect
             tokens_received = []
             for i in range(5):
@@ -69,11 +65,10 @@ class TestReceiveOnlyChannelIntegration:
             assert len(tokens_received) == 5
 
     @pytest.mark.asyncio
-    async def test_bidirectional_channel_still_requires_handler(self, example_app_server: tuple[Path, FastAPI]) -> None:
-        _ = example_app_server
+    async def test_bidirectional_channel_still_requires_handler(self, example_app_server: ExampleAppServer) -> None:
         """Existing behavior unchanged (regression)."""
         # Connect to bidirectional chat channel using real WebSocket client
-        async with websocket_connect("ws://127.0.0.1:9999/ws/testcomp/v1/chat") as websocket:
+        async with websocket_connect(f"{example_app_server.ws_base_url}/ws/testcomp/v1/chat") as websocket:
             # Send chat message (bidirectional)
             await websocket.send(json.dumps({"message": "hello there"}))
 

--- a/frontend/packages/syntara-ui/e2e/access-management.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/access-management.spec.ts
@@ -26,12 +26,17 @@ import {
   type SeededPolicy,
   type SeededUser,
 } from './seeds/iam'
+import { createSeedBucket } from './seeds/seed-bucket'
 import { ensureProject, getAuthToken } from './utils/api'
 
 const ACCESS_URL = '/system-administration/access-management'
 
-const seededUsers: SeededUser[] = []
-const seededPolicies: SeededPolicy[] = []
+// Buckets, not bare arrays: `fullyParallel: true` lets a worker run this file's
+// `beforeAll`/`afterAll` around more than one group of its tests, and the module
+// holding them is imported only once, so a list that is only ever pushed to hands
+// later tests a resource an earlier `afterAll` already deleted.
+const seededUsers = createSeedBucket<SeededUser>('access-management users')
+const seededPolicies = createSeedBucket<SeededPolicy>('access-management policies')
 
 test.beforeAll(async ({ browser }) => {
   const page = await browser.newPage()
@@ -41,12 +46,12 @@ test.beforeAll(async ({ browser }) => {
     const prefix = buildUniqueName('e2e-am')
 
     for (let i = 1; i <= 2; i++) {
-      seededUsers.push(await createUserViaApi(page, { username: `${prefix}-user-${i}`, token }))
+      seededUsers.add(await createUserViaApi(page, { username: `${prefix}-user-${i}`, token }))
     }
 
     const project = await ensureProject(page)
     if (!project) throw new Error('access-management beforeAll: could not ensure project')
-    seededPolicies.push(await createPolicyViaApi(page, project.id, { name: `${prefix}-policy`, token }))
+    seededPolicies.add(await createPolicyViaApi(page, project.id, { name: `${prefix}-policy`, token }))
   } finally {
     await page.close()
   }
@@ -54,10 +59,12 @@ test.beforeAll(async ({ browser }) => {
 
 test.afterAll(async ({ browser }) => {
   const page = await browser.newPage()
-  for (const policy of seededPolicies) {
+  // Drain, so a later round in this worker starts from an empty bucket and no
+  // resource is deleted twice.
+  for (const policy of seededPolicies.drain()) {
     await deletePolicyViaApi(page, policy.projectId, policy.id)
   }
-  for (const user of seededUsers) {
+  for (const user of seededUsers.drain()) {
     await deleteUserViaApi(page, user.id)
   }
   await page.close()
@@ -298,11 +305,12 @@ test.describe('Access Management — Shareable URLs', () => {
 
 test.describe('Access Management — User Detail Tabs', () => {
   test('detail sub-tabs sync to URL', async ({ app }) => {
-    expect(seededUsers.length, 'Failed to seed users via API').toBeGreaterThan(0)
+    expect(seededUsers.size(), 'Failed to seed users via API').toBeGreaterThan(0)
 
     // Users tab filter placeholder is "Filter by username", not "Filter by name". Go by seeded ID.
-    await app.goto(toAppUrl(`${ACCESS_URL}/users/${seededUsers[0].id}`))
-    await expect(app).toHaveURL(new RegExp(`${ACCESS_URL}/users/${seededUsers[0].id}`))
+    const seededUser = seededUsers.latest()
+    await app.goto(toAppUrl(`${ACCESS_URL}/users/${seededUser.id}`))
+    await expect(app).toHaveURL(new RegExp(`${ACCESS_URL}/users/${seededUser.id}`))
 
     // Click Groups sub-tab if available
     const groupsTab = app.getByRole('tab', { name: /Groups/i })
@@ -363,8 +371,8 @@ test.describe('Access Management — Policies Tab Columns', () => {
   })
 
   test('project-scoped policies show a clickable project link', async ({ app }) => {
-    expect(seededPolicies.length, 'Failed to create a project-scoped policy via API').toBeGreaterThan(0)
-    const policy = seededPolicies[0]
+    expect(seededPolicies.size(), 'Failed to create a project-scoped policy via API').toBeGreaterThan(0)
+    const policy = seededPolicies.latest()
 
     const table = app.getByRole('grid', { name: 'Policies' })
     await app.getByPlaceholder('Filter by name').fill(policy.name)

--- a/frontend/packages/syntara-ui/e2e/api-token-refresh-helper.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/api-token-refresh-helper.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression tests for the stale-token retry in `apiRequest`.
+ *
+ * The whole suite authenticates as the same `admin` account, and `POST
+ * /auth/logout` increments that account's `token_version`, invalidating every
+ * access token it holds. A spec that logs out therefore ages the token another
+ * worker's `beforeAll` fetched once and is still reusing across dozens of seed
+ * calls — the backend answers `401 {"code":"TOKEN_STALE","retryable":true}` and,
+ * before this retry existed, the seeding hook died mid-loop.
+ *
+ * The race between workers is not reproducible on demand, so these tests assert
+ * the invariant the fix establishes — a stale token is refreshed and the request
+ * replayed — against a stub backend that revokes tokens when told to.
+ */
+import { test, expect, type Page } from './fixtures'
+import { apiRequest, apiUrl } from './utils/api'
+
+/** The verbatim body the backend returned in CI (run 34382665277). */
+const STALE_TOKEN_BODY = {
+  type: 'https://api.example.com/errors/unauthorized',
+  title: 'Unauthorized',
+  detail: 'Token is outdated, please refresh',
+  code: 'TOKEN_STALE',
+  retryable: true,
+  instance: 'https://localhost/api/v1/users',
+}
+
+/** A 401 that is *not* a stale token — wrong credentials, and not retryable. */
+const FORBIDDEN_BODY = {
+  type: 'https://api.example.com/errors/unauthorized',
+  title: 'Unauthorized',
+  detail: 'Not authenticated',
+  code: 'NOT_AUTHENTICATED',
+  retryable: false,
+}
+
+function stubResponse(status: number, body: unknown) {
+  const text = JSON.stringify(body)
+  return {
+    status: () => status,
+    ok: () => status >= 200 && status < 300,
+    text: () => Promise.resolve(text),
+    json: () => Promise.resolve(JSON.parse(text) as unknown),
+  }
+}
+
+/**
+ * Minimal stand-in for the backend's token-version check.
+ *
+ * Tokens carry the version they were issued at; `revokeTokens()` is the logout
+ * another worker performs, and any request presenting an older token afterwards
+ * gets the same 401 the real middleware returns.
+ */
+function createStubBackend() {
+  const seeded: unknown[] = []
+  let tokenVersion = 1
+  let logins = 0
+
+  const respondTo = (url: string, headers: Record<string, string> | undefined, data: unknown) => {
+    if (url === apiUrl('/auth/login')) {
+      logins += 1
+      return stubResponse(200, { access_token: `admin-token-v${tokenVersion}` })
+    }
+
+    const token = headers?.['Authorization']?.replace('Bearer ', '') ?? null
+    if (token === null) return stubResponse(401, FORBIDDEN_BODY)
+    if (token !== `admin-token-v${tokenVersion}`) return stubResponse(401, STALE_TOKEN_BODY)
+
+    seeded.push(data)
+    return stubResponse(201, { id: `user-${seeded.length}`, username: 'seeded' })
+  }
+
+  const request = {
+    get: (url: string, options?: { headers?: Record<string, string> }) =>
+      Promise.resolve(respondTo(url, options?.headers, undefined)),
+    post: (url: string, options?: { headers?: Record<string, string>; data?: unknown }) =>
+      Promise.resolve(respondTo(url, options?.headers, options?.data)),
+    patch: (url: string, options?: { headers?: Record<string, string>; data?: unknown }) =>
+      Promise.resolve(respondTo(url, options?.headers, options?.data)),
+    delete: (url: string, options?: { headers?: Record<string, string> }) =>
+      Promise.resolve(respondTo(url, options?.headers, undefined)),
+  }
+
+  return {
+    page: { request, waitForTimeout: () => Promise.resolve() } as unknown as Page,
+    issueToken: () => `admin-token-v${tokenVersion}`,
+    /** Another worker logged the shared admin account out. */
+    revokeTokens: () => {
+      tokenVersion += 1
+    },
+    get logins() {
+      return logins
+    },
+    get seeded() {
+      return seeded
+    },
+  }
+}
+
+test.describe('apiRequest stale-token retry', () => {
+  // Pure helper — no page, no login, no backend.
+  test('re-authenticates and replays when a cached token has gone stale', async () => {
+    const backend = createStubBackend()
+    const cachedToken = backend.issueToken()
+
+    backend.revokeTokens()
+
+    const resp = await apiRequest(backend.page, 'post', '/users', {
+      token: cachedToken,
+      data: { username: 'e2e-pag-user-15' },
+    })
+
+    expect(resp.status()).toBe(201)
+    expect(backend.seeded).toHaveLength(1)
+    // Exactly one extra login: the retry, not a login per attempt.
+    expect(backend.logins).toBe(1)
+  })
+
+  test('does not re-authenticate when the request succeeds', async () => {
+    const backend = createStubBackend()
+
+    const resp = await apiRequest(backend.page, 'post', '/users', {
+      token: backend.issueToken(),
+      data: { username: 'e2e-pag-user-1' },
+    })
+
+    expect(resp.status()).toBe(201)
+    expect(backend.logins).toBe(0)
+  })
+
+  test('surfaces a 401 that is not a stale token instead of retrying it', async () => {
+    const backend = createStubBackend()
+
+    const resp = await apiRequest(backend.page, 'get', '/users', { token: '' })
+
+    expect(resp.status()).toBe(401)
+    // A genuine auth failure must stay visible; retrying it would only hide it.
+    expect(backend.logins).toBe(0)
+  })
+})

--- a/frontend/packages/syntara-ui/e2e/api-token-refresh-helper.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/api-token-refresh-helper.spec.ts
@@ -34,11 +34,15 @@ const FORBIDDEN_BODY = {
   retryable: false,
 }
 
-function stubResponse(status: number, body: unknown) {
+function stubResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
   const text = JSON.stringify(body)
   return {
     status: () => status,
     ok: () => status >= 200 && status < 300,
+    // `apiRequest` reads `X-Auth-Failure-Type` before falling back to the body,
+    // so the stub has to answer `headers()` — without it every 401 path throws a
+    // TypeError and the test errors rather than failing.
+    headers: () => headers,
     text: () => Promise.resolve(text),
     json: () => Promise.resolve(JSON.parse(text) as unknown),
   }
@@ -51,10 +55,15 @@ function stubResponse(status: number, body: unknown) {
  * another worker performs, and any request presenting an older token afterwards
  * gets the same 401 the real middleware returns.
  */
-function createStubBackend() {
+function createStubBackend({ emitFailureHeader = false }: { emitFailureHeader?: boolean } = {}) {
   const seeded: unknown[] = []
   let tokenVersion = 1
   let logins = 0
+
+  // The metrics middleware normally strips `X-Auth-Failure-Type` before the
+  // response reaches a client, which is why the body `code` is the path that
+  // actually fires in CI. Both are worth pinning.
+  const staleHeaders: Record<string, string> = emitFailureHeader ? { 'x-auth-failure-type': 'stale_token' } : {}
 
   const respondTo = (url: string, headers: Record<string, string> | undefined, data: unknown) => {
     if (url === apiUrl('/auth/login')) {
@@ -64,7 +73,7 @@ function createStubBackend() {
 
     const token = headers?.['Authorization']?.replace('Bearer ', '') ?? null
     if (token === null) return stubResponse(401, FORBIDDEN_BODY)
-    if (token !== `admin-token-v${tokenVersion}`) return stubResponse(401, STALE_TOKEN_BODY)
+    if (token !== `admin-token-v${tokenVersion}`) return stubResponse(401, STALE_TOKEN_BODY, staleHeaders)
 
     seeded.push(data)
     return stubResponse(201, { id: `user-${seeded.length}`, username: 'seeded' })
@@ -113,6 +122,21 @@ test.describe('apiRequest stale-token retry', () => {
     expect(resp.status()).toBe(201)
     expect(backend.seeded).toHaveLength(1)
     // Exactly one extra login: the retry, not a login per attempt.
+    expect(backend.logins).toBe(1)
+  })
+
+  test('recognises the stale token from the X-Auth-Failure-Type header alone', async () => {
+    const backend = createStubBackend({ emitFailureHeader: true })
+    const cachedToken = backend.issueToken()
+
+    backend.revokeTokens()
+
+    const resp = await apiRequest(backend.page, 'post', '/users', {
+      token: cachedToken,
+      data: { username: 'e2e-pag-user-16' },
+    })
+
+    expect(resp.status()).toBe(201)
     expect(backend.logins).toBe(1)
   })
 

--- a/frontend/packages/syntara-ui/e2e/authentication-group-mapping.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/authentication-group-mapping.spec.ts
@@ -22,6 +22,19 @@ import { createIdentityProviderViaApi, deleteIdentityProviderViaApi, findIdentit
 const VALID_JMESPATH = "groups[?starts_with(@, 'syntara-')]"
 const INVALID_JMESPATH = '[[[bad'
 
+/**
+ * Narrow the identity providers list to one provider before asserting on its row.
+ *
+ * The table is a single unfiltered page of 20 sorted by `name` ascending, so a
+ * provider created here renders only while fewer than 20 sort before it. Other
+ * specs seed providers in bulk — `pagination.spec.ts` creates 21 in its
+ * `beforeAll` — which under `fullyParallel` silently moves this row to page 2.
+ */
+async function filterProvidersByName(app: Page, providerName: string): Promise<void> {
+  await app.getByPlaceholder('Filter by name').fill(providerName)
+  await app.getByRole('button', { name: 'Apply filter' }).click()
+}
+
 async function createMappingTestProvider(app: Page, namePrefix: string): Promise<string> {
   const provider = await createIdentityProviderViaApi(app, {
     name: buildUniqueName(namePrefix),
@@ -157,6 +170,7 @@ test.describe('UI-13: JMESPath filter — entry and validation error', () => {
         await app.getByRole('button', { name: /Add provider/i }).click()
 
         await expect(app.getByText('Identity provider created')).toBeVisible()
+        await filterProvidersByName(app, providerName)
         await expect(app.getByRole('row', { name: new RegExp(providerName) })).toBeVisible()
 
         const created = await findIdentityProviderByName(app, providerName)
@@ -185,6 +199,7 @@ test.describe('UI-14: Claim data configuration screen', () => {
       await app.getByRole('button', { name: /Add provider/i }).click()
 
       await expect(app.getByText('Identity provider created')).toBeVisible()
+      await filterProvidersByName(app, providerName)
       await expect(app.getByRole('row', { name: new RegExp(providerName) })).toBeVisible()
 
       const created = await findIdentityProviderByName(app, providerName)

--- a/frontend/packages/syntara-ui/e2e/builder-import.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/builder-import.spec.ts
@@ -117,7 +117,7 @@ test.skip('import as new workflow creates a new workflow and navigates', async (
     await dialog.getByRole('button', { name: 'Import' }).click()
     await expect(dialog).not.toBeVisible()
 
-    await expect(app).toHaveURL(/workflow-builder\/.+/)
+    await expect(app).toHaveURL(/workflow-builder\/(?!new)/)
     expect(app.url()).not.toBe(originalUrl)
 
     await expect(app.getByText('Workflow imported')).toBeVisible()

--- a/frontend/packages/syntara-ui/e2e/builder.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/builder.spec.ts
@@ -3,6 +3,7 @@ import { APP_TITLE } from './helpers/appTitle'
 import {
   buildUniqueName,
   clickAddConnectedStep,
+  clickSaveAndWait,
   closeNodeEditorPanel,
   createBasicWorkflowViaApi,
   fillCodeEditor,
@@ -41,10 +42,12 @@ test('user creates and saves a multi-node workflow', async ({ app }) => {
     // Act - Save workflow (select project first to avoid name reset)
     await selectProjectIfRequired(app)
     await app.getByPlaceholder('Workflow name').fill(workflowName)
-    await app.getByRole('button', { name: 'Save' }).click()
+
+    // Gate on the create response: `toHaveURL(/workflow-builder\/.+/)` also matched
+    // the literal `new`, so the goto below used to abort the POST it raced.
+    await clickSaveAndWait(app)
 
     // Assert - Workflow is persisted in workflows list
-    await expect(app).toHaveURL(/workflow-builder\/.+/)
     await app.goto(toAppUrl('/workflows'))
     await app.getByPlaceholder('Filter by name').fill(workflowName)
     await app.getByRole('button', { name: 'Apply filter' }).click()
@@ -77,7 +80,10 @@ test('user edits an existing workflow and changes persist', async ({ app }) => {
     await app.getByRole('link', { name: workflowName, exact: true }).click()
 
     await app.getByPlaceholder('Workflow name').fill(updatedName)
-    await app.getByRole('button', { name: 'Save' }).click()
+
+    // A rename never changes the URL, so the PATCH response is the only signal
+    // that the change reached the server before the goto tears the page down.
+    await clickSaveAndWait(app)
 
     // Assert - Updated name persists
     await app.goto(toAppUrl('/workflows'))

--- a/frontend/packages/syntara-ui/e2e/credential-enable-disable.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-enable-disable.spec.ts
@@ -8,6 +8,7 @@ import {
   filterCredentialByName,
   goToCredentialsList,
   navigateToCredentialDetail,
+  openDisableDialogFromRow,
   waitForDisableDialogReady,
 } from './helpers/credentials'
 
@@ -28,12 +29,8 @@ test.describe('Credential Enable/Disable State Management', () => {
       await goToCredentialsList(app)
       await filterCredentialByName(app, name)
       const row = app.getByRole('row', { name: new RegExp(name) })
-      await row.waitFor({ state: 'visible', timeout: 10_000 })
-      await listRowToggle(row).click({ force: true })
-
-      const dialog = app.getByRole('dialog')
+      const dialog = await openDisableDialogFromRow(app, row, name)
       await expect(dialog).toBeVisible()
-      await waitForDisableDialogReady(dialog, name)
     } finally {
       await deleteCredentialByName(app, name)
     }
@@ -45,10 +42,7 @@ test.describe('Credential Enable/Disable State Management', () => {
       await goToCredentialsList(app)
       await filterCredentialByName(app, name)
       const row = app.getByRole('row', { name: new RegExp(name) })
-      await listRowToggle(row).click({ force: true })
-
-      const dialog = app.getByRole('dialog')
-      await waitForDisableDialogReady(dialog, name)
+      const dialog = await openDisableDialogFromRow(app, row, name)
       await expect(dialog.getByText(/You can re-enable the credential at any time/)).toBeVisible()
       await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeVisible()
     } finally {
@@ -62,10 +56,7 @@ test.describe('Credential Enable/Disable State Management', () => {
       await goToCredentialsList(app)
       await filterCredentialByName(app, name)
       const row = app.getByRole('row', { name: new RegExp(name) })
-      await listRowToggle(row).click({ force: true })
-
-      const dialog = app.getByRole('dialog')
-      await waitForDisableDialogReady(dialog)
+      const dialog = await openDisableDialogFromRow(app, row)
       await dialog.getByRole('button', { name: 'Disable' }).click()
 
       await expect(dialog).not.toBeVisible()
@@ -81,10 +72,7 @@ test.describe('Credential Enable/Disable State Management', () => {
       await goToCredentialsList(app)
       await filterCredentialByName(app, name)
       const row = app.getByRole('row', { name: new RegExp(name) })
-      await listRowToggle(row).click({ force: true })
-
-      const dialog = app.getByRole('dialog')
-      await waitForDisableDialogReady(dialog)
+      const dialog = await openDisableDialogFromRow(app, row)
       await dialog.getByRole('button', { name: 'Cancel' }).click()
 
       await expect(dialog).not.toBeVisible()

--- a/frontend/packages/syntara-ui/e2e/credential-enable-disable.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/credential-enable-disable.spec.ts
@@ -1,36 +1,22 @@
+import { type Locator } from '@playwright/test'
+
 import { type Page, test, expect, toAppUrl } from './fixtures'
 import {
   createTestCredential,
   deleteCredentialByName,
+  disableCredentialFromRow,
+  filterCredentialByName,
   goToCredentialsList,
   navigateToCredentialDetail,
+  waitForDisableDialogReady,
 } from './helpers/credentials'
 
-async function filterCredentialByName(app: Page, name: string) {
-  await app.getByPlaceholder('Filter by keyword').fill(name)
-  await app.getByRole('button', { name: 'Apply filter' }).click()
-}
-
-function listRowToggle(row: import('@playwright/test').Locator) {
+function listRowToggle(row: Locator) {
   return row.getByRole('switch')
 }
 
 function detailPageToggle(app: Page) {
   return app.getByRole('switch', { name: /enabled/i })
-}
-
-/** Wait until usage checks finish so the Disable action is actually clickable. */
-async function waitForDisableDialogReady(dialog: import('@playwright/test').Locator, credentialName?: string) {
-  await expect(dialog.getByText('Disable credential?')).toBeVisible()
-  // The spinner only clears once the affected-workflows and affected-integrations
-  // API calls both resolve — give it extra time under CI load
-  await expect(dialog.getByText(/Checking for workflows and integrations/)).toHaveCount(0, {
-    timeout: 25_000,
-  })
-  if (credentialName) {
-    await expect(dialog.getByText(new RegExp(credentialName))).toBeVisible()
-  }
-  await expect(dialog.getByRole('button', { name: 'Disable' })).toBeEnabled()
 }
 
 test.describe('Credential Enable/Disable State Management', () => {
@@ -169,11 +155,10 @@ test.describe('Credential Enable/Disable State Management', () => {
       await goToCredentialsList(app)
       await filterCredentialByName(app, name)
       const row = app.getByRole('row', { name: new RegExp(name) })
-      await listRowToggle(row).click({ force: true })
-      const dialog = app.getByRole('dialog')
-      await waitForDisableDialogReady(dialog)
-      await dialog.getByRole('button', { name: 'Disable' }).click()
-      await expect(listRowToggle(row)).not.toBeChecked()
+      // Gate on the PATCH: the switch flips optimistically, so `not.toBeChecked()`
+      // alone is satisfied before the request goes out and the goto below would
+      // abort it — leaving the credential enabled on the server.
+      await disableCredentialFromRow(app, row)
 
       // Navigate away and back
       await app.goto(toAppUrl('/workflows'))

--- a/frontend/packages/syntara-ui/e2e/eda-trigger.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/eda-trigger.spec.ts
@@ -18,6 +18,7 @@ import { addEdaTrigger } from './helpers/v2-nodes'
 import {
   buildUniqueName,
   clickAddConnectedStep,
+  clickSaveAndWait,
   closeNodeEditorPanel,
   deleteWorkflow,
   fillCodeEditor,
@@ -30,7 +31,7 @@ test.describe('EDA Trigger', () => {
     const workflowName = buildUniqueName('e2e-eda')
     const webhookPath = 'github-deployments'
 
-    await ensureProject(app)
+    const project = await ensureProject(app)
     const sa = await createServiceAccountViaApi(app, buildUniqueName('sa-eda'))
     await app.goto(toAppUrl('/workflow-builder/new'))
 
@@ -48,10 +49,14 @@ test.describe('EDA Trigger', () => {
       await closeNodeEditorPanel(app)
 
       // Save workflow (select project right before save)
-      await selectProjectIfRequired(app)
+      // Pin the workflow to the service account's own project. `ensureProject`
+      // puts the account in `default`, but an unnamed `selectProjectIfRequired`
+      // picks whichever project the dropdown lists first — and the backend
+      // rejects the save with "Service account(s) not found in this project"
+      // whenever those differ. The weak URL guard used to hide that 422.
+      await selectProjectIfRequired(app, project?.name)
       await app.getByPlaceholder('Workflow name').fill(workflowName)
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
+      await clickSaveAndWait(app)
 
       // Verify workflow appears in list
       await app.goto(toAppUrl('/workflows'))

--- a/frontend/packages/syntara-ui/e2e/helpers/credentials.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/credentials.ts
@@ -133,6 +133,54 @@ export async function waitForDisableDialogReady(dialog: Locator, credentialName?
   await expect(dialog.getByRole('button', { name: 'Disable' })).toBeEnabled()
 }
 
+/** Per-attempt budget for landing the Enabled switch click. */
+const DISABLE_TOGGLE_CLICK_TIMEOUT = 5_000
+/** Per-attempt budget for the confirmation dialog to appear after the click. */
+const DISABLE_DIALOG_TIMEOUT = 5_000
+/** Total budget for getting the confirmation dialog open. */
+const DISABLE_DIALOG_RETRY_TIMEOUT = 30_000
+
+/**
+ * Flip a credential's Enabled switch from its list row and return the disable
+ * confirmation dialog, ready to act on.
+ *
+ * PatternFly's `Switch` hides its `<input>` behind a styled span, so every caller
+ * has to click it with `force: true` — which skips the actionability wait
+ * entirely, including the stability check that would otherwise have held the
+ * click until the row stopped moving. The row is re-rendered whenever the
+ * credentials query resolves, and `filterCredentialByName` returns as soon as it
+ * has pressed *Apply filter*, without waiting for the filtered page to land. A
+ * forced click inside that window hits a row React is replacing: no `onChange`
+ * runs, no dialog opens, and the caller fails up to 25s later inside
+ * `waitForDisableDialogReady` on a dialog that was never there.
+ *
+ * Re-opening on a miss is the same remedy `triggerVerifyWorkflow` uses for the
+ * builder kebab. The click is skipped whenever the dialog is already up, so a
+ * slow open is waited out rather than toggled back — `openDisableDialog` is
+ * idempotent, but a second forced click would land on the modal backdrop.
+ */
+export async function openDisableDialogFromRow(app: Page, row: Locator, credentialName?: string): Promise<Locator> {
+  const dialog = app.getByRole('dialog')
+  const title = dialog.getByText('Disable credential?')
+
+  await expect(async () => {
+    if (!(await title.isVisible().catch(() => false))) {
+      await expect(row).toBeVisible({ timeout: DISABLE_TOGGLE_CLICK_TIMEOUT })
+      // Swallow the click failure: Playwright retries a click on its own when the
+      // element detaches, so an unbounded one would sit inside a single attempt
+      // for the whole retry budget instead of letting `toPass` start over.
+      await row
+        .getByRole('switch')
+        .click({ force: true, timeout: DISABLE_TOGGLE_CLICK_TIMEOUT })
+        .catch(() => {})
+    }
+    await expect(title).toBeVisible({ timeout: DISABLE_DIALOG_TIMEOUT })
+  }).toPass({ timeout: DISABLE_DIALOG_RETRY_TIMEOUT, intervals: [500, 1_000, 2_000] })
+
+  await waitForDisableDialogReady(dialog, credentialName)
+  return dialog
+}
+
 /**
  * Flip a credential's Enabled switch off from its list row, returning once the
  * server has recorded it.
@@ -151,9 +199,7 @@ export async function waitForDisableDialogReady(dialog: Locator, credentialName?
  * otherwise consume most of this wait.
  */
 export async function disableCredentialFromRow(app: Page, row: Locator): Promise<void> {
-  await row.getByRole('switch', { name: 'Enabled' }).click({ force: true })
-  const dialog = app.getByRole('dialog')
-  await waitForDisableDialogReady(dialog)
+  const dialog = await openDisableDialogFromRow(app, row)
 
   const patchDone = app.waitForResponse(isCredentialPatchResponse, { timeout: CREDENTIAL_PATCH_TIMEOUT })
   await dialog.getByRole('button', { name: 'Disable' }).click()

--- a/frontend/packages/syntara-ui/e2e/helpers/credentials.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/credentials.ts
@@ -109,20 +109,65 @@ async function createTestCredentialViaUi(app: Page, name: string): Promise<boole
   }
 }
 
-async function disableCredential(app: Page, name: string): Promise<void> {
-  await goToCredentialsList(app)
-  await app.getByPlaceholder('Filter by keyword').fill(name)
-  await app.getByRole('button', { name: 'Apply filter' }).click()
-  const row = app.getByRole('row', { name: new RegExp(name) })
-  const patchDone = app.waitForResponse(
-    (resp) => resp.url().includes('/credentials/') && resp.request().method() === 'PATCH'
+/** Per-attempt budget for the enable/disable PATCH to come back. */
+const CREDENTIAL_PATCH_TIMEOUT = 20_000
+
+/** The PATCH that the Enabled switch issues (`PATCH /api/v1/credentials/{id}`). */
+export function isCredentialPatchResponse(response: Response): boolean {
+  return (
+    response.request().method() === 'PATCH' && /\/api\/v1\/credentials\/[^/]+$/.test(new URL(response.url()).pathname)
   )
+}
+
+/** Wait until the usage checks finish so the Disable action is actually clickable. */
+export async function waitForDisableDialogReady(dialog: Locator, credentialName?: string): Promise<void> {
+  await expect(dialog.getByText('Disable credential?')).toBeVisible()
+  // The spinner only clears once the affected-workflows and affected-integrations
+  // API calls both resolve — give it extra time under CI load
+  await expect(dialog.getByText(/Checking for workflows and integrations/)).toHaveCount(0, {
+    timeout: 25_000,
+  })
+  if (credentialName) {
+    await expect(dialog.getByText(new RegExp(credentialName))).toBeVisible()
+  }
+  await expect(dialog.getByRole('button', { name: 'Disable' })).toBeEnabled()
+}
+
+/**
+ * Flip a credential's Enabled switch off from its list row, returning once the
+ * server has recorded it.
+ *
+ * The switch is driven by `useOptimisticCredentialEnabled`, a correct React 19
+ * `useOptimistic` + `startTransition` Action: it flips the UI *before* the PATCH
+ * is issued and rolls back on failure. So `not.toBeChecked()` is satisfied by
+ * optimistic state alone, and any navigation that follows tears the document
+ * down mid-request — the server never records the change, and because
+ * `queryClient` sets no `staleTime` the return trip refetches and renders the
+ * credential still enabled.
+ *
+ * The response wait is armed immediately before the Disable click, not before
+ * the toggle click: between the two sits the affected-workflows and
+ * affected-integrations usage check, which is budgeted 25s on its own and would
+ * otherwise consume most of this wait.
+ */
+export async function disableCredentialFromRow(app: Page, row: Locator): Promise<void> {
   await row.getByRole('switch', { name: 'Enabled' }).click({ force: true })
   const dialog = app.getByRole('dialog')
+  await waitForDisableDialogReady(dialog)
+
+  const patchDone = app.waitForResponse(isCredentialPatchResponse, { timeout: CREDENTIAL_PATCH_TIMEOUT })
   await dialog.getByRole('button', { name: 'Disable' }).click()
-  await patchDone
+
+  const response = await patchDone
+  expect(response.ok(), `PATCH /credentials returned ${response.status()}`).toBe(true)
   await expect(dialog).not.toBeVisible()
   await expect(row.getByRole('switch')).not.toBeChecked()
+}
+
+async function disableCredential(app: Page, name: string): Promise<void> {
+  await goToCredentialsList(app)
+  await filterCredentialByName(app, name)
+  await disableCredentialFromRow(app, app.getByRole('row', { name: new RegExp(name) }))
 }
 
 /**

--- a/frontend/packages/syntara-ui/e2e/helpers/patternfly.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/patternfly.ts
@@ -1,4 +1,6 @@
-import type { Page } from '../fixtures'
+import type { Locator } from '@playwright/test'
+
+import { expect, type Page } from '../fixtures'
 
 /**
  * PatternFly 6 widgets that do not expose a stable ARIA role.
@@ -42,4 +44,33 @@ export function paginationFooterForTable(page: Page, gridName: string) {
  */
 export function filterChipGroup(page: Page, categoryName: string) {
   return page.getByRole('search', { name: 'Filters' }).getByRole('list', { name: categoryName })
+}
+
+/** Budget for a PF button to become actionable, and for the click itself. */
+const ARIA_DISABLED_CLICK_TIMEOUT = 10_000
+
+/**
+ * Click a PatternFly button that may be rendered with `isAriaDisabled`.
+ *
+ * PF uses `isAriaDisabled` rather than `disabled` so the button keeps focus and
+ * can carry an explanatory tooltip, and Playwright resolves its "enabled"
+ * actionability check through `aria-disabled`. With no `actionTimeout` in
+ * `playwright.config.ts`, `click()` on such a button waits out the whole test
+ * timeout and the run reports "Test timeout exceeded" with no failing assertion
+ * to explain it. Two of these have already done exactly that: the approval
+ * panel's Previous/Next at the ends of the list (`ApprovalNavigationHeader`),
+ * and `ApprovalActionButtons`' Review approval while the panel is open.
+ *
+ * Bounding both the readiness wait and the click turns that into a fast failure
+ * that names the button. Note this does NOT make an oscillating disabled state
+ * safe — where the app can flip the button back to disabled under the test, the
+ * caller still needs a `toPass` whose success condition is the end state rather
+ * than the click.
+ */
+export async function clickWhenEnabled(
+  target: Locator,
+  { timeout = ARIA_DISABLED_CLICK_TIMEOUT }: { timeout?: number } = {}
+): Promise<void> {
+  await expect(target).toBeEnabled({ timeout })
+  await target.click({ timeout })
 }

--- a/frontend/packages/syntara-ui/e2e/helpers/patternfly.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/patternfly.ts
@@ -74,3 +74,43 @@ export async function clickWhenEnabled(
   await expect(target).toBeEnabled({ timeout })
   await target.click({ timeout })
 }
+
+/** Per-attempt budget for landing the kebab click. */
+const KEBAB_CLICK_TIMEOUT = 5_000
+/** Per-attempt budget for the menu to render once the kebab has been clicked. */
+const KEBAB_MENU_TIMEOUT = 5_000
+/** Total budget for getting the menu open. */
+const KEBAB_RETRY_TIMEOUT = 30_000
+
+/**
+ * Open a table row's kebab menu, returning once `probeItem` is on the page.
+ *
+ * A row is re-rendered whenever the list query behind it resolves — a filter
+ * being applied, a cursor page landing, a refetch after a mutation — and a click
+ * that lands while React is replacing the row is simply lost. The menu never
+ * opens, and the caller fails much later on a missing `menuitem` with nothing in
+ * the trace to say why. `force: true` makes that strictly more likely, because it
+ * skips the actionability wait that would otherwise have held the click until the
+ * row was stable; every row kebab in the suite is clicked that way today.
+ *
+ * Re-opening on a miss is the same remedy `triggerVerifyWorkflow` uses for the
+ * builder kebab. The toggle is only clicked while the menu is closed, since
+ * clicking it again would toggle it shut — so a menu that is merely slow is
+ * waited out rather than dismissed.
+ */
+export async function openRowKebab(row: Locator, probeItem: RegExp | string): Promise<void> {
+  const page = row.page()
+  const kebab = row.getByRole('button', { name: /Actions|Kebab toggle/i })
+  const item = page.getByRole('menuitem', { name: probeItem })
+
+  await expect(async () => {
+    if (!(await item.isVisible().catch(() => false))) {
+      await expect(row).toBeVisible({ timeout: KEBAB_CLICK_TIMEOUT })
+      // Swallow the click failure: Playwright retries a click on its own when the
+      // element detaches, so an unbounded one would sit inside a single attempt
+      // for the whole retry budget instead of letting `toPass` start over.
+      await kebab.click({ timeout: KEBAB_CLICK_TIMEOUT }).catch(() => {})
+    }
+    await expect(item).toBeVisible({ timeout: KEBAB_MENU_TIMEOUT })
+  }).toPass({ timeout: KEBAB_RETRY_TIMEOUT, intervals: [500, 1_000, 2_000] })
+}

--- a/frontend/packages/syntara-ui/e2e/helpers/v2-nodes.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/v2-nodes.ts
@@ -534,39 +534,50 @@ export async function addSwitchNodeWithCases(page: Page, name: string, cases: Sw
   // The form defaults to 2 cases. Fill the visible ones first.
   const defaultCaseCount = 2
 
-  for (let i = 0; i < Math.min(cases.length, defaultCaseCount); i++) {
+  /**
+   * Fill one case, and do not return until the form has actually taken the value.
+   *
+   * The inputs are `react-hook-form` `Controller` fields, and "Add path" calls
+   * `useFieldArray`'s `append`, which snapshots the current form state. A `fill`
+   * whose `onChange` has not reached that state yet is therefore dropped by the
+   * very next `append` — silently, and only for the case filled immediately
+   * before it. That is exactly the shape of the CI failure: in the three-case
+   * test, case index 1 arrived at the API as `""` while 0 and 2 were correct,
+   * because 0 and 2 have other interactions after them and 1 does not.
+   *
+   * Asserting the value back closes the window: these are controlled inputs, so
+   * the DOM only reads back the new value once React has re-rendered from form
+   * state — if the change had not been committed, the re-render would have reset
+   * the field.
+   */
+  const fillCase = async (i: number) => {
     // ExpressionBuilder uses a PatternFly MenuToggle — click to open, then select option
     await page
       .getByLabel(/Expression editor mode/i)
       .nth(i)
       .click()
     await page.getByRole('option', { name: 'Custom expression', exact: true }).click()
-    await page
-      .getByLabel(/Raw expression/i)
-      .nth(i)
-      .fill(cases[i].condition)
-    const label0 = cases[i].label
-    if (label0) {
-      await page.getByLabel(`Path ${i + 1} name`).fill(label0)
+
+    const rawExpression = page.getByLabel(/Raw expression/i).nth(i)
+    await rawExpression.fill(cases[i].condition)
+    await expect(rawExpression).toHaveValue(cases[i].condition)
+
+    const label = cases[i].label
+    if (label) {
+      const labelInput = page.getByLabel(`Path ${i + 1} name`)
+      await labelInput.fill(label)
+      await expect(labelInput).toHaveValue(label)
     }
+  }
+
+  for (let i = 0; i < Math.min(cases.length, defaultCaseCount); i++) {
+    await fillCase(i)
   }
 
   // Add extra cases beyond the default 2
   for (let i = defaultCaseCount; i < cases.length; i++) {
     await page.getByRole('button', { name: 'Add path' }).click()
-    await page
-      .getByLabel(/Expression editor mode/i)
-      .nth(i)
-      .click()
-    await page.getByRole('option', { name: 'Custom expression', exact: true }).click()
-    await page
-      .getByLabel(/Raw expression/i)
-      .nth(i)
-      .fill(cases[i].condition)
-    const labelN = cases[i].label
-    if (labelN) {
-      await page.getByLabel(`Path ${i + 1} name`).fill(labelN)
-    }
+    await fillCase(i)
   }
 
   // Remove surplus default cases (working from the last index downward to avoid re-indexing)

--- a/frontend/packages/syntara-ui/e2e/helpers/workflow-save.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/workflow-save.ts
@@ -1,0 +1,114 @@
+/**
+ * Helpers for persisting a workflow from the builder toolbar.
+ */
+import { type Response } from '@playwright/test'
+
+import { expect, type Page } from '../fixtures'
+
+/**
+ * Budget for landing the Save click.
+ *
+ * `SaveWorkflowButton` renders `isAriaDisabled` whenever the workflow is clean,
+ * the node editor is open, or a save is already in flight, and Playwright
+ * resolves its "enabled" actionability check through `aria-disabled`. With no
+ * `actionTimeout` in `playwright.config.ts`, a bare `click()` on that button
+ * waits out the entire test timeout and the run reports "Test timeout exceeded"
+ * with no failing assertion to explain it.
+ */
+const SAVE_CLICK_TIMEOUT = 10_000
+
+/**
+ * Budget for the create/update request to come back.
+ *
+ * Deliberately larger than the 15s URL guard it replaces: `wait-node.spec.ts`
+ * failed honestly at 15s under three workers, which is the save genuinely being
+ * slow rather than the gate being wrong.
+ */
+const SAVE_RESPONSE_TIMEOUT = 30_000
+
+/**
+ * Budget for the toolbar to leave its pending state after the response.
+ *
+ * This covers the part of the save that happens in the browser rather than on
+ * the wire — marking the store clean, invalidating the workflow queries and,
+ * on create, routing to `/workflow-builder/<id>`.
+ */
+const SAVE_SETTLE_TIMEOUT = 10_000
+
+/**
+ * The two requests a Save click can produce, and nothing else under /workflows.
+ *
+ * Create is `POST /api/v1/workflows` and update is
+ * `PATCH /api/v1/workflows/{workflow_id}` (`BuilderContent.tsx:204` and `:207`).
+ * A glob cannot express this: `**\/api/v1/workflows/*` also matches the
+ * `POST /workflows/validate` that "Verify workflow" sends, every
+ * `GET /workflows/{id}` the builder refetches and the version-publish POSTs.
+ * Anchoring on method plus path shape is what keeps those out.
+ */
+export function isWorkflowSaveResponse(response: Response): boolean {
+  const method = response.request().method()
+  const { pathname } = new URL(response.url())
+  if (method === 'POST') return /\/api\/v1\/workflows$/.test(pathname)
+  if (method === 'PATCH') return /\/api\/v1\/workflows\/[^/]+$/.test(pathname)
+  return false
+}
+
+/**
+ * Click the builder's Save button and return once the server has the change.
+ *
+ * The URL is not a usable gate. On create the builder does navigate from
+ * `/workflow-builder/new` to `/workflow-builder/<id>`, but the guard most
+ * callers wrote — `/workflow-builder\/.+/` — matches the literal `new` segment,
+ * so it passes the instant the click is dispatched and before any request goes
+ * out. On an existing workflow there is no navigation at all, so *no* URL guard
+ * can work: even the `(?!new)` form is a no-op there. Either way the caller then
+ * runs `goto('/workflows')`, which aborts the in-flight write and the row the
+ * test is about never appears.
+ *
+ * Gating on the response covers both shapes, and it is the only signal that
+ * exists for the rename case.
+ *
+ * Ordering matters twice over. The enabled assertion comes first because it
+ * cannot itself trigger the request, so nothing is left pending if it throws.
+ * The response wait is armed before the click because a mock-API create comes
+ * back in single-digit milliseconds — arming after `click()` resolves loses the
+ * race outright — and its rejection is swallowed up front so a throwing click
+ * cannot leave an unhandled rejection behind.
+ */
+export async function clickSaveAndWait(
+  page: Page,
+  { timeout = SAVE_RESPONSE_TIMEOUT }: { timeout?: number } = {}
+): Promise<void> {
+  const wasNew = /\/workflow-builder\/new(?:[?#]|$)/.test(page.url())
+  const saveButton = page.getByRole('button', { name: 'Save', exact: true })
+
+  await expect(saveButton).toBeEnabled({ timeout: SAVE_CLICK_TIMEOUT })
+
+  const savePromise: Promise<Response | null> = page
+    .waitForResponse(isWorkflowSaveResponse, { timeout })
+    .catch(() => null)
+
+  await saveButton.click({ timeout: SAVE_CLICK_TIMEOUT })
+
+  const response = await savePromise
+  if (!response) {
+    throw new Error(`Save produced no POST /workflows or PATCH /workflows/{id} response within ${timeout}ms`)
+  }
+  if (!response.ok()) {
+    const body = await response.text().catch(() => '(unreadable)')
+    throw new Error(
+      `Save failed: ${response.request().method()} ${new URL(response.url()).pathname} ` +
+        `returned ${response.status()}: ${body}`
+    )
+  }
+
+  // The label is `Saving...` while the mutation is pending, so an exact-name
+  // `Save` locator only resolves again once the save's onSuccess has run.
+  await expect(saveButton).toBeVisible({ timeout: SAVE_SETTLE_TIMEOUT })
+
+  // Create is the only case where the URL is evidence of anything — and then it
+  // is `(?!new)`, never `.+`.
+  if (wasNew) {
+    await expect(page).toHaveURL(/workflow-builder\/(?!new)/, { timeout: SAVE_SETTLE_TIMEOUT })
+  }
+}

--- a/frontend/packages/syntara-ui/e2e/helpers/workflow-verify.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/workflow-verify.ts
@@ -6,8 +6,10 @@ import { expect, type Page } from '../fixtures'
 /** Glob for the workflow validation endpoint that "Verify workflow" posts to. */
 export const VALIDATE_ROUTE = '**/api/v1/workflows/validate'
 
+/** Per-attempt budget for landing each of the two clicks. */
+const VERIFY_CLICK_TIMEOUT = 5_000
 /** Per-attempt budget for the validate response to come back. */
-const VERIFY_REQUEST_TIMEOUT = 15_000
+const VERIFY_REQUEST_TIMEOUT = 10_000
 /** Total budget for landing the menu click and getting a response. */
 const VERIFY_RETRY_TIMEOUT = 30_000
 
@@ -17,13 +19,25 @@ const VERIFY_RETRY_TIMEOUT = 30_000
  *
  * Two separate races make a bare open-kebab-then-click flaky:
  *   1. The menu can close or re-render between the two clicks, so the click lands
- *      on a detaching item and no request is ever sent.
+ *      on a detaching item and no request is ever sent. The builder refetches the
+ *      workflow, its versions and its executions right after a save, and that
+ *      re-render tears the open menu down.
  *   2. On a loaded cluster the request itself can outlast a fixed banner wait.
  *
  * Gating on the response covers both: a swallowed click produces no response and
- * is retried, while a slow one is simply waited out. `handleVerify` always POSTs
- * and only renders the banner once that response settles, so callers can assert on
- * the banner immediately after this resolves.
+ * is retried, while a slow one is simply waited out.
+ *
+ * Both clicks get an explicit timeout and have their failure swallowed, because
+ * Playwright retries a click on its own when the element detaches mid-action. An
+ * unbounded click therefore stays inside a single `toPass` attempt for the whole
+ * retry budget — the menu it waits on is already closed and never comes back, so
+ * the only way out is to fall through to the response check and let `toPass`
+ * re-open the kebab from scratch.
+ *
+ * Note that `handleVerify` does not always POST: it returns early when the builder
+ * store has no current workflow, and again when `buildWorkflowDefinition` throws
+ * (that path renders the "Verification failed" banner without a request). Neither
+ * is reachable from the saved workflow every caller starts from.
  */
 export async function triggerVerifyWorkflow(page: Page) {
   await expect(async () => {
@@ -38,9 +52,9 @@ export async function triggerVerifyWorkflow(page: Page) {
 
     // Only click the kebab when the menu is closed — clicking it while open toggles it shut
     if (!(await verifyItem.isVisible().catch(() => false))) {
-      await kebab.click()
+      await kebab.click({ timeout: VERIFY_CLICK_TIMEOUT }).catch(() => {})
     }
-    await verifyItem.click()
+    await verifyItem.click({ timeout: VERIFY_CLICK_TIMEOUT }).catch(() => {})
 
     if (!(await response)) {
       throw new Error('Verify workflow did not produce a /workflows/validate response')

--- a/frontend/packages/syntara-ui/e2e/helpers/workflows.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/workflows.ts
@@ -301,6 +301,26 @@ async function trySelectRealProject(page: Page): Promise<boolean> {
         await options.first().waitFor({ state: 'visible', timeout: 3_000 })
       }
 
+      // Prefer `default` — the project `ensureProject` guarantees, and the only
+      // one no spec deletes. Taking whatever sorts first instead means picking a
+      // project another worker created and is about to clean up: the builder
+      // holds its id, the delete lands, and the save then fails with
+      // `404 {"detail":"Project <id> not found"}`. That was invisible before
+      // saves were gated on the response, because the weak URL guard passed
+      // regardless.
+      //
+      // Matched on the *accessible* name, not `textContent`. The option renders
+      // name and description as adjacent nodes with no separator, so
+      // `textContent` reads `defaultDefault project` and no anchored match on it
+      // can work; the accessible name joins them with a space. Anchoring matters
+      // either way — a bare `default` also matches the built-in project's
+      // "Default project for built-in workflows" description.
+      const preferred = page.getByRole('option', { name: /^default(\s|$)/ })
+      if ((await preferred.count()) === 1) {
+        await preferred.click()
+        return
+      }
+
       const allOptions = await options.all()
       for (const option of allOptions) {
         const text = await option.textContent()

--- a/frontend/packages/syntara-ui/e2e/helpers/workflows.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/workflows.ts
@@ -330,6 +330,18 @@ async function createProjectViaDropdown(page: Page) {
   await expect(dialog).not.toBeVisible({ timeout: 15_000 })
 }
 
+/**
+ * Every step of the UI cleanup fallback is bounded by this.
+ *
+ * `playwright.config.ts` deliberately sets no `actionTimeout`, so an action with
+ * no explicit timeout of its own waits out the entire test timeout. That is
+ * survivable inside a test body, where the wait is for something the test needs;
+ * it is not survivable here, because this helper runs from a `finally` and a
+ * stalled cleanup turns a test whose assertions all passed into a bare
+ * "Test timeout of 120000ms exceeded" with no failing assertion to explain it.
+ */
+export const CLEANUP_ACTION_TIMEOUT = 10_000
+
 /** Delete a workflow by unique name. Prefers API delete; falls back to UI kebab flow. */
 export async function deleteWorkflow(page: Page, workflowName: string) {
   if (page.isClosed()) return
@@ -341,27 +353,38 @@ export async function deleteWorkflow(page: Page, workflowName: string) {
     }
 
     await page.goto(toAppUrl('/workflows'))
-    await page.getByPlaceholder('Filter by name').fill(workflowName)
-    await page.getByRole('button', { name: 'Apply filter' }).click()
+
+    // Reaching here means the API lookup found nothing, which is the common case
+    // rather than the exotic one: the workflow was renamed during the test, or an
+    // earlier cleanup call already deleted it. The list is then often empty, and
+    // an empty project renders the "No workflows yet" empty state — which has no
+    // filter toolbar at all. Waiting for the filter to appear is therefore the
+    // step that must be bounded, not just the interactions that follow it.
+    const nameFilter = page.getByPlaceholder('Filter by name')
+    await nameFilter.waitFor({ state: 'visible', timeout: CLEANUP_ACTION_TIMEOUT })
+    await nameFilter.fill(workflowName, { timeout: CLEANUP_ACTION_TIMEOUT })
+    await page.getByRole('button', { name: 'Apply filter' }).click({ timeout: CLEANUP_ACTION_TIMEOUT })
 
     const table = page.getByRole('grid', { name: 'Workflows table' })
     const row = table.getByRole('row', { name: new RegExp(workflowName) })
     const isVisible = await expect(row.first())
-      .toBeVisible()
+      .toBeVisible({ timeout: CLEANUP_ACTION_TIMEOUT })
       .then(() => true)
       .catch(() => false)
     if (isVisible) {
       await row
         .getByRole('button', { name: /Actions|Kebab toggle/i })
         .first()
-        .click({ force: true })
-      await page.getByRole('menuitem', { name: 'Delete workflow' }).click()
-      await page.getByRole('checkbox', { name: /I understand this workflow/i }).check()
-      await page.getByRole('button', { name: 'Delete' }).click()
+        .click({ force: true, timeout: CLEANUP_ACTION_TIMEOUT })
+      await page.getByRole('menuitem', { name: 'Delete workflow' }).click({ timeout: CLEANUP_ACTION_TIMEOUT })
+      await page
+        .getByRole('checkbox', { name: /I understand this workflow/i })
+        .check({ timeout: CLEANUP_ACTION_TIMEOUT })
+      await page.getByRole('button', { name: 'Delete' }).click({ timeout: CLEANUP_ACTION_TIMEOUT })
 
       // Wait for deletion to complete - delete dialog should close
       const deleteDialog = page.getByRole('dialog', { name: /Delete workflow/i })
-      await expect(deleteDialog).not.toBeVisible({ timeout: 10000 })
+      await expect(deleteDialog).not.toBeVisible({ timeout: CLEANUP_ACTION_TIMEOUT })
     }
   } catch {
     // Best-effort cleanup — don't fail the test

--- a/frontend/packages/syntara-ui/e2e/helpers/workflows.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/workflows.ts
@@ -236,6 +236,11 @@ export async function selectFirstProject(page: Page) {
   await expect(page.getByPlaceholder('Select a project')).not.toBeVisible()
 }
 
+/** Escape a literal string for embedding in a RegExp. */
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 /**
  * Select a project in the builder toolbar.
  * Required for new workflows on the real backend (Save is disabled without a project).
@@ -265,7 +270,11 @@ export async function selectProjectIfRequired(page: Page, projectName?: string) 
   await page.getByRole('option').first().waitFor({ state: 'visible', timeout: 10_000 })
 
   if (projectName) {
-    const option = page.getByRole('option', { name: projectName })
+    // Anchor at the start of the option's accessible name. Each option reads
+    // "<name> <description>", so a plain substring match for `default` also
+    // matches the built-in project's "Default project for ..." description and
+    // resolves to two elements.
+    const option = page.getByRole('option', { name: new RegExp(`^${escapeForRegExp(projectName)}(\\s|$)`) })
     await option.waitFor({ state: 'visible', timeout: 15_000 })
     await option.click()
   } else {

--- a/frontend/packages/syntara-ui/e2e/helpers/workflows.ts
+++ b/frontend/packages/syntara-ui/e2e/helpers/workflows.ts
@@ -10,9 +10,11 @@ import {
 } from '../utils/api'
 
 import { clickAddConnectedStep } from './add-connected-step'
+import { clickSaveAndWait } from './workflow-save'
 
 export { createBasicWorkflowViaApi, publishWorkflowViaApi }
 export { clickAddConnectedStep }
+export { clickSaveAndWait, isWorkflowSaveResponse } from './workflow-save'
 
 export const buildUniqueName = (prefix: string) => `${prefix}-${Date.now()}-${randomUUID()}`
 
@@ -498,10 +500,10 @@ export async function createBasicWorkflow(page: Page, workflowName: string, acti
   await selectProjectIfRequired(page)
 
   await page.getByPlaceholder('Workflow name').fill(workflowName)
-  await page.getByRole('button', { name: 'Save' }).click()
 
-  // Must navigate away from /new — .+ alone would match "new" and give a false pass
-  await expect(page).toHaveURL(/workflow-builder\/(?!new)/, { timeout: 15_000 })
+  // Gate on the create response, not the URL: the builder routes to
+  // /workflow-builder/<id> before the POST has necessarily landed.
+  await clickSaveAndWait(page)
 }
 
 /**
@@ -524,12 +526,17 @@ export async function startWorkflowWithTrigger(page: Page) {
   await expect(page.getByRole('button', { name: 'Create', exact: true })).not.toBeAttached({ timeout: 10_000 })
 }
 
-/** Save the workflow with the given name. Waits for URL to confirm persistence. */
-export async function saveWorkflow(page: Page, workflowName: string, { timeout = 15_000 } = {}) {
+/**
+ * Name and save the workflow, returning once the server has the change.
+ *
+ * The old `toHaveURL(/workflow-builder\/(?!new)/)` gate only ever meant anything
+ * on create; on an already-saved workflow the URL never changes, so it resolved
+ * without waiting for the PATCH at all. See `clickSaveAndWait`.
+ */
+export async function saveWorkflow(page: Page, workflowName: string, { timeout = 30_000 } = {}) {
   await selectProjectIfRequired(page)
   await page.getByPlaceholder('Workflow name').fill(workflowName)
-  await page.getByRole('button', { name: 'Save' }).click()
-  await expect(page).toHaveURL(/workflow-builder\/(?!new)/, { timeout })
+  await clickSaveAndWait(page, { timeout })
 }
 
 /**
@@ -552,8 +559,7 @@ export async function createWorkflowWithTrigger(page: Page, workflowName: string
   const nameInput = page.getByPlaceholder('Workflow name')
   await nameInput.clear()
   await nameInput.fill(workflowName)
-  await page.getByRole('button', { name: 'Save' }).click()
-  await expect(page).toHaveURL(/workflow-builder\/(?!new)/, { timeout: 15_000 })
+  await clickSaveAndWait(page)
 
   await expect(page.getByText('Manual trigger')).toBeVisible()
   await expect(page.getByRole('button', { name: 'Reset layout', exact: true })).toBeVisible()

--- a/frontend/packages/syntara-ui/e2e/patternfly-helper.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/patternfly-helper.spec.ts
@@ -10,7 +10,7 @@
  * both halves of that behaviour are pinned.
  */
 import { test, expect, toAppUrl, type Page } from './fixtures'
-import { clickWhenEnabled } from './helpers/patternfly'
+import { clickWhenEnabled, openRowKebab } from './helpers/patternfly'
 
 const BECOMES_ENABLED_FIXTURE = '/e2e-fixtures/pf-becomes-enabled'
 const STAYS_DISABLED_FIXTURE = '/e2e-fixtures/pf-stays-disabled'
@@ -79,5 +79,68 @@ test.describe('clickWhenEnabled helper', () => {
     ])
 
     expect(settled, 'an aria-disabled button must fail fast, not consume the test timeout').toBe('rejected')
+  })
+})
+
+const KEBAB_FIXTURE = '/e2e-fixtures/pf-row-kebab'
+const KEBAB_OPEN_FIXTURE = '/e2e-fixtures/pf-row-kebab-open'
+
+/**
+ * A row kebab whose *first* click is swallowed.
+ *
+ * That is what a click landing on a row React is in the middle of replacing looks
+ * like from the outside: the button is there, the click reports success, and no
+ * menu ever appears. `openRowKebab` has to notice and open it again.
+ */
+const KEBAB_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <table>
+      <tbody>
+        <tr>
+          <td>e2e-perm-idp</td>
+          <td><button type="button" id="kebab" aria-label="Actions">Kebab</button></td>
+        </tr>
+      </tbody>
+    </table>
+    <div id="menu" hidden><button type="button" role="menuitem" aria-disabled="true">Edit provider</button></div>
+    <output id="count">0</output>
+    <script>
+      let clicks = 0
+      document.getElementById('kebab').addEventListener('click', () => {
+        clicks += 1
+        document.getElementById('count').textContent = String(clicks)
+        if (clicks < 2) return
+        const menu = document.getElementById('menu')
+        menu.hidden = !menu.hidden
+      })
+    </script>
+  </body>
+</html>`
+
+/** The same row, but with the menu already open — clicking again would close it. */
+const KEBAB_OPEN_HTML = KEBAB_HTML.replace('<div id="menu" hidden>', '<div id="menu">')
+
+test.describe('openRowKebab helper', () => {
+  test('re-opens the kebab when the first click is swallowed', async ({ page }) => {
+    await serveFixture(page, KEBAB_FIXTURE, KEBAB_HTML)
+
+    await openRowKebab(page.getByRole('row').filter({ hasText: 'e2e-perm-idp' }), /Edit provider/i)
+
+    await expect(page.getByRole('menuitem', { name: /Edit provider/i })).toBeVisible()
+    // 2, not 1 — a single click is exactly what the IdP spec did, and it left the
+    // menu closed. If this ever reads 1 the retry has stopped being load-bearing.
+    await expect(page.getByRole('status')).toHaveText('2')
+  })
+
+  test('does not click a kebab whose menu is already open', async ({ page }) => {
+    await serveFixture(page, KEBAB_OPEN_FIXTURE, KEBAB_OPEN_HTML)
+
+    await openRowKebab(page.getByRole('row').filter({ hasText: 'e2e-perm-idp' }), /Edit provider/i)
+
+    await expect(page.getByRole('menuitem', { name: /Edit provider/i })).toBeVisible()
+    // A click here would toggle the menu shut — the exact regression the
+    // `isVisible` guard in the helper exists to prevent.
+    await expect(page.getByRole('status')).toHaveText('0')
   })
 })

--- a/frontend/packages/syntara-ui/e2e/patternfly-helper.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/patternfly-helper.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression tests for the `clickWhenEnabled` helper itself.
+ *
+ * PatternFly renders a disabled button with `aria-disabled` rather than
+ * `disabled`, and Playwright honours that in its actionability wait. With no
+ * `actionTimeout` configured, a bare `click()` on one of those buttons waits out
+ * the entire test budget and the run reports "Test timeout exceeded" with no
+ * failing assertion — which is exactly how the approval specs burned 120s and
+ * 360s in the merge queue. These drive the helper against a synthetic page so
+ * both halves of that behaviour are pinned.
+ */
+import { test, expect, toAppUrl, type Page } from './fixtures'
+import { clickWhenEnabled } from './helpers/patternfly'
+
+const BECOMES_ENABLED_FIXTURE = '/e2e-fixtures/pf-becomes-enabled'
+const STAYS_DISABLED_FIXTURE = '/e2e-fixtures/pf-stays-disabled'
+
+/**
+ * A button that drops `aria-disabled` after 1.5s.
+ *
+ * The click handler is wired the way `ApprovalActionButtons` wires it — only
+ * while enabled — so a helper that force-clicked through `aria-disabled` would
+ * fire nothing and the counter would stay at 0.
+ */
+const BECOMES_ENABLED_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <button type="button" id="act" aria-disabled="true">Review approval</button>
+    <output id="count">0</output>
+    <script>
+      const button = document.getElementById('act')
+      const bump = () => {
+        const out = document.getElementById('count')
+        out.textContent = String(Number(out.textContent) + 1)
+      }
+      button.addEventListener('click', () => {
+        if (button.getAttribute('aria-disabled') !== 'true') bump()
+      })
+      setTimeout(() => button.removeAttribute('aria-disabled'), 1500)
+    </script>
+  </body>
+</html>`
+
+/** A button that is `aria-disabled` for the life of the page. */
+const STAYS_DISABLED_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <button type="button" aria-disabled="true">Next approval</button>
+  </body>
+</html>`
+
+async function serveFixture(page: Page, path: string, html: string): Promise<void> {
+  await page.route(`**${path}`, (route) => route.fulfill({ status: 200, contentType: 'text/html', body: html }))
+  await page.goto(toAppUrl(path))
+}
+
+test.describe('clickWhenEnabled helper', () => {
+  // No login needed: the helper is driven against a synthetic page, not the app.
+  test('waits for the button to drop aria-disabled, then clicks it exactly once', async ({ page }) => {
+    await serveFixture(page, BECOMES_ENABLED_FIXTURE, BECOMES_ENABLED_HTML)
+
+    await clickWhenEnabled(page.getByRole('button', { name: 'Review approval' }))
+
+    // Exactly 1 — 0 would mean the helper clicked through `aria-disabled` and the
+    // app's handler ignored it, which is a silent no-op the caller cannot see.
+    await expect(page.getByRole('status')).toHaveText('1')
+  })
+
+  test('gives up instead of hanging on a permanently aria-disabled button', async ({ page }) => {
+    test.setTimeout(60_000)
+    await serveFixture(page, STAYS_DISABLED_FIXTURE, STAYS_DISABLED_HTML)
+
+    const settled = await Promise.race([
+      clickWhenEnabled(page.getByRole('button', { name: 'Next approval' })).then(
+        () => 'resolved' as const,
+        () => 'rejected' as const
+      ),
+      page.waitForTimeout(20_000).then(() => 'still-waiting' as const),
+    ])
+
+    expect(settled, 'an aria-disabled button must fail fast, not consume the test timeout').toBe('rejected')
+  })
+})

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -293,6 +293,20 @@ test.describe('Permission gating — Route guards', () => {
 
 // ── Action gating — Workflows ────────────────────────────────────────────
 
+/**
+ * Narrow the workflows list to one workflow before asserting on its row.
+ *
+ * The table is a single page of 20 sorted `-updated_at` with no filter applied,
+ * so under `fullyParallel` a row seeded by this spec is pushed off page 1 within
+ * seconds by other specs saving their own workflows — every builder save bumps
+ * `updated_at`. Without this the assertion that follows is a race against the
+ * rest of the suite.
+ */
+async function filterWorkflowsByName(page: Page, workflowName: string): Promise<void> {
+  await page.getByPlaceholder('Filter by name').fill(workflowName)
+  await page.getByRole('button', { name: 'Apply filter' }).click()
+}
+
 test.describe('Permission gating — Workflow actions', () => {
   test('viewer: Create workflow button is disabled with tooltip', async ({ app, viewerApp }) => {
     const { id: workflowId } = await createTestWorkflow(app)
@@ -364,6 +378,10 @@ test.describe('Permission gating — Workflow actions', () => {
       await viewerApp.goto(toAppUrl('/workflows'))
       await expect(viewerApp.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
 
+      await filterWorkflowsByName(viewerApp, workflow.name)
+
+      await filterWorkflowsByName(viewerApp, workflow.name)
+
       const workflowRow = viewerApp
         .getByRole('grid', { name: 'Workflows table' })
         .getByRole('row', { name: new RegExp(workflow.name) })
@@ -411,6 +429,8 @@ test.describe('Permission gating — Workflow actions', () => {
     try {
       await auditorApp.goto(toAppUrl('/workflows'))
       await expect(auditorApp.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
+
+      await filterWorkflowsByName(auditorApp, workflow.name)
 
       const workflowRow = auditorApp
         .getByRole('grid', { name: 'Workflows table' })
@@ -514,8 +534,7 @@ test.describe('Permission gating — Project actions', () => {
       // `fullyParallel` the workflow seeded above is pushed off page 1 by other
       // specs' newer workflows within seconds and the group header never renders.
       // Filtering to this workflow puts its group back on the page deterministically.
-      await viewerApp.getByPlaceholder('Filter by name').fill(workflowName)
-      await viewerApp.getByRole('button', { name: 'Apply filter' }).click()
+      await filterWorkflowsByName(viewerApp, workflowName)
       await expect(viewerApp.getByRole('row').filter({ hasText: workflowName })).toBeVisible({ timeout: 15_000 })
 
       // Find project row — viewer sees project ID instead of name in group headers
@@ -581,8 +600,7 @@ test.describe('Permission gating — Project actions', () => {
       // `fullyParallel` the workflow seeded above is pushed off page 1 by other
       // specs' newer workflows within seconds and the group header never renders.
       // Filtering to this workflow puts its group back on the page deterministically.
-      await auditorApp.getByPlaceholder('Filter by name').fill(workflowName)
-      await auditorApp.getByRole('button', { name: 'Apply filter' }).click()
+      await filterWorkflowsByName(auditorApp, workflowName)
       await expect(auditorApp.getByRole('row').filter({ hasText: workflowName })).toBeVisible({ timeout: 15_000 })
 
       // Find project row — auditor sees project ID instead of name in group headers

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -29,9 +29,13 @@ import {
   deleteCredentialViaApi,
   deleteGroupViaApi,
   deleteIdentityProviderViaApi,
+  deleteProjectViaApi,
   deleteServiceAccountViaApi,
   deleteUserViaApi,
+  deleteWorkflowViaApi,
   ensureProject,
+  findProjectIdByName,
+  findWorkflowIdByName,
   getAuthToken,
 } from './utils/api'
 
@@ -492,13 +496,22 @@ test.describe('Permission gating — Project actions', () => {
         },
       })
       if (!createWorkflowResp.ok()) throw new Error('Workflow creation failed')
-      const workflow = (await createWorkflowResp.json()) as { id: string }
 
       // Navigate to All projects view as viewer
       await viewerApp.goto(toAppUrl('/workflows'))
       const projectSelector = viewerApp.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
       await viewerApp.getByRole('option', { name: 'All projects' }).click()
+
+      // The project row is a group header synthesised from whatever workflows the
+      // page happened to fetch (`useWorkflowGrouping`) — there is no projects query
+      // behind it. That fetch is one page of 20 sorted by `-updated_at`, so under
+      // `fullyParallel` the workflow seeded above is pushed off page 1 by other
+      // specs' newer workflows within seconds and the group header never renders.
+      // Filtering to this workflow puts its group back on the page deterministically.
+      await viewerApp.getByPlaceholder('Filter by name').fill(workflowName)
+      await viewerApp.getByRole('button', { name: 'Apply filter' }).click()
+      await expect(viewerApp.getByRole('row').filter({ hasText: workflowName })).toBeVisible({ timeout: 15_000 })
 
       // Find project row — viewer sees project ID instead of name in group headers
       const projectRow = viewerApp.getByRole('row').filter({ hasText: new RegExp(`${projectName}|${project.id}`) })
@@ -507,29 +520,18 @@ test.describe('Permission gating — Project actions', () => {
       // Viewer has no project write permissions — kebab is completely hidden
       const projectKebab = projectRow.getByRole('button', { name: /Actions for.*project/i })
       await expect(projectKebab).not.toBeVisible()
-
-      // Clean up
-      await apiRequest(app, 'delete', `/workflows/${workflow.id}`)
-      await apiRequest(app, 'delete', `/projects/${project.id}`)
-    } catch (error) {
-      // Best-effort cleanup on failure
-      try {
-        const listResp = await apiRequest(app, 'get', '/workflows')
-        if (listResp.ok()) {
-          const list = (await listResp.json()) as { resources: Array<{ id: string; name: string }> }
-          const wf = list.resources.find((w) => w.name === workflowName)
-          if (wf) await apiRequest(app, 'delete', `/workflows/${wf.id}`)
-        }
-        const projListResp = await apiRequest(app, 'get', '/projects')
-        if (projListResp.ok()) {
-          const projList = (await projListResp.json()) as { resources: Array<{ id: string; name: string }> }
-          const proj = projList.resources.find((p) => p.name === projectName)
-          if (proj) await apiRequest(app, 'delete', `/projects/${proj.id}`)
-        }
-      } catch {
-        // Ignore cleanup errors
-      }
-      throw error
+    } finally {
+      // `finally`, not `catch` + rethrow: the happy path deleted inline and the
+      // catch path duplicated it, so a failure between the two leaked both
+      // resources — and the fallback listed `/workflows` and `/projects`
+      // unfiltered, which under `fullyParallel` frequently does not even contain
+      // them. Every leaked workflow then crowds page 1 for later runs, which is
+      // what made this flake self-reinforcing. Both lookups are filtered now and
+      // both paths run here.
+      const leakedWorkflowId = await findWorkflowIdByName(app, workflowName)
+      if (leakedWorkflowId) await deleteWorkflowViaApi(app, leakedWorkflowId)
+      const leakedProjectId = await findProjectIdByName(app, projectName)
+      if (leakedProjectId) await deleteProjectViaApi(app, leakedProjectId)
     }
   })
 
@@ -561,13 +563,22 @@ test.describe('Permission gating — Project actions', () => {
         },
       })
       if (!createWorkflowResp.ok()) throw new Error('Workflow creation failed')
-      const workflow = (await createWorkflowResp.json()) as { id: string }
 
       // Navigate to All projects view as auditor
       await auditorApp.goto(toAppUrl('/workflows'))
       const projectSelector = auditorApp.getByRole('textbox', { name: 'Project' })
       await projectSelector.click()
       await auditorApp.getByRole('option', { name: 'All projects' }).click()
+
+      // The project row is a group header synthesised from whatever workflows the
+      // page happened to fetch (`useWorkflowGrouping`) — there is no projects query
+      // behind it. That fetch is one page of 20 sorted by `-updated_at`, so under
+      // `fullyParallel` the workflow seeded above is pushed off page 1 by other
+      // specs' newer workflows within seconds and the group header never renders.
+      // Filtering to this workflow puts its group back on the page deterministically.
+      await auditorApp.getByPlaceholder('Filter by name').fill(workflowName)
+      await auditorApp.getByRole('button', { name: 'Apply filter' }).click()
+      await expect(auditorApp.getByRole('row').filter({ hasText: workflowName })).toBeVisible({ timeout: 15_000 })
 
       // Find project row — auditor sees project ID instead of name in group headers
       const projectRow = auditorApp.getByRole('row').filter({ hasText: new RegExp(`${projectName}|${project.id}`) })
@@ -576,29 +587,18 @@ test.describe('Permission gating — Project actions', () => {
       // Auditor has no project write permissions — kebab is completely hidden
       const projectKebab = projectRow.getByRole('button', { name: /Actions for.*project/i })
       await expect(projectKebab).not.toBeVisible()
-
-      // Clean up
-      await apiRequest(app, 'delete', `/workflows/${workflow.id}`)
-      await apiRequest(app, 'delete', `/projects/${project.id}`)
-    } catch (error) {
-      // Best-effort cleanup on failure
-      try {
-        const listResp = await apiRequest(app, 'get', '/workflows')
-        if (listResp.ok()) {
-          const list = (await listResp.json()) as { resources: Array<{ id: string; name: string }> }
-          const wf = list.resources.find((w) => w.name === workflowName)
-          if (wf) await apiRequest(app, 'delete', `/workflows/${wf.id}`)
-        }
-        const projListResp = await apiRequest(app, 'get', '/projects')
-        if (projListResp.ok()) {
-          const projList = (await projListResp.json()) as { resources: Array<{ id: string; name: string }> }
-          const proj = projList.resources.find((p) => p.name === projectName)
-          if (proj) await apiRequest(app, 'delete', `/projects/${proj.id}`)
-        }
-      } catch {
-        // Ignore cleanup errors
-      }
-      throw error
+    } finally {
+      // `finally`, not `catch` + rethrow: the happy path deleted inline and the
+      // catch path duplicated it, so a failure between the two leaked both
+      // resources — and the fallback listed `/workflows` and `/projects`
+      // unfiltered, which under `fullyParallel` frequently does not even contain
+      // them. Every leaked workflow then crowds page 1 for later runs, which is
+      // what made this flake self-reinforcing. Both lookups are filtered now and
+      // both paths run here.
+      const leakedWorkflowId = await findWorkflowIdByName(app, workflowName)
+      if (leakedWorkflowId) await deleteWorkflowViaApi(app, leakedWorkflowId)
+      const leakedProjectId = await findProjectIdByName(app, projectName)
+      if (leakedProjectId) await deleteProjectViaApi(app, leakedProjectId)
     }
   })
 

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -1030,14 +1030,22 @@ test.describe('Permission gating — Identity Provider actions', () => {
       await auditorApp.goto(toAppUrl(`${AUTH_URL}`))
       await expect(auditorApp.getByRole('heading', { name: 'Identity Providers', level: 1 })).toBeVisible()
 
+      // The identity-providers table is one unfiltered page of 20 sorted by `name`
+      // ascending, so the row seeded above only appears while fewer than 20
+      // providers sort before it. `pagination.spec.ts` seeds 21 named
+      // `e2e-pag-…-idp-N`, and `e2e-pag` sorts before `e2e-perm`, so for as long as
+      // that spec's `beforeAll`/`afterAll` window overlaps this test the row is on
+      // page 2 and never renders. Filtering by name puts it back deterministically.
+      await auditorApp.getByPlaceholder('Filter by name').fill(idpName)
+      await auditorApp.getByRole('button', { name: 'Apply filter' }).click()
+
       const idpRow = auditorApp
         .getByRole('grid', { name: 'Identity providers table' })
         .getByRole('row', { name: new RegExp(idpName) })
       await expect(idpRow).toBeVisible({ timeout: 15_000 })
-      // The identity-providers table refetches while the auditor page settles, so a
-      // single forced click here is regularly swallowed by the row being replaced —
-      // the menu never opens and all three assertions below fail on a missing
-      // `menuitem`. This is the same dequeue seen on PRs that touch no frontend code.
+      // A forced click skips every actionability wait, so it lands even while the
+      // list query is replacing the row — the handler never runs and the menu stays
+      // shut.
       await openRowKebab(idpRow, /Edit provider/i)
 
       await expect(auditorApp.getByRole('menuitem', { name: /Edit provider/i })).toHaveAttribute(

--- a/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/permission-gating.spec.ts
@@ -18,6 +18,7 @@
  */
 
 import { type Page, test, expect, toAppUrl, appBaseUrl } from './fixtures'
+import { openRowKebab } from './helpers/patternfly'
 import { buildUniqueName } from './helpers/workflows'
 import {
   apiRequest,
@@ -367,8 +368,10 @@ test.describe('Permission gating — Workflow actions', () => {
         .getByRole('grid', { name: 'Workflows table' })
         .getByRole('row', { name: new RegExp(workflow.name) })
       await expect(workflowRow).toBeVisible({ timeout: 15_000 })
-      const kebab = workflowRow.getByRole('button', { name: /Actions|Kebab toggle/i })
-      await kebab.click({ force: true })
+      // A forced click skips every actionability wait, so it lands even while the
+      // list query is replacing the row — the handler never runs, the menu stays
+      // shut, and each assertion below fails on a missing `menuitem`.
+      await openRowKebab(workflowRow, /Edit workflow/i)
 
       await expect(viewerApp.getByRole('menuitem', { name: /Edit workflow/i })).toHaveAttribute('aria-disabled', 'true')
       await expect(viewerApp.getByRole('menuitem', { name: /Run published version/i })).toHaveAttribute(
@@ -413,8 +416,10 @@ test.describe('Permission gating — Workflow actions', () => {
         .getByRole('grid', { name: 'Workflows table' })
         .getByRole('row', { name: new RegExp(workflow.name) })
       await expect(workflowRow).toBeVisible({ timeout: 15_000 })
-      const kebab = workflowRow.getByRole('button', { name: /Actions|Kebab toggle/i })
-      await kebab.click({ force: true })
+      // A forced click skips every actionability wait, so it lands even while the
+      // list query is replacing the row — the handler never runs, the menu stays
+      // shut, and each assertion below fails on a missing `menuitem`.
+      await openRowKebab(workflowRow, /Edit workflow/i)
 
       await expect(auditorApp.getByRole('menuitem', { name: /Edit workflow/i })).toHaveAttribute(
         'aria-disabled',
@@ -718,8 +723,10 @@ test.describe('Permission gating — Credential actions', () => {
         .getByRole('grid', { name: 'Credentials table' })
         .getByRole('row', { name: new RegExp(credential.name) })
       await expect(credRow).toBeVisible({ timeout: 15_000 })
-      const kebab = credRow.getByRole('button', { name: /Actions|Kebab toggle/i })
-      await kebab.click({ force: true })
+      // A forced click skips every actionability wait, so it lands even while the
+      // list query is replacing the row — the handler never runs, the menu stays
+      // shut, and each assertion below fails on a missing `menuitem`.
+      await openRowKebab(credRow, /Edit credential/i)
 
       await expect(viewerApp.getByRole('menuitem', { name: /Edit credential/i })).toHaveAttribute(
         'aria-disabled',
@@ -747,8 +754,10 @@ test.describe('Permission gating — Credential actions', () => {
         .getByRole('grid', { name: 'Credentials table' })
         .getByRole('row', { name: new RegExp(credential.name) })
       await expect(credRow).toBeVisible({ timeout: 15_000 })
-      const kebab = credRow.getByRole('button', { name: /Actions|Kebab toggle/i })
-      await kebab.click({ force: true })
+      // A forced click skips every actionability wait, so it lands even while the
+      // list query is replacing the row — the handler never runs, the menu stays
+      // shut, and each assertion below fails on a missing `menuitem`.
+      await openRowKebab(credRow, /Edit credential/i)
 
       await expect(auditorApp.getByRole('menuitem', { name: /Edit credential/i })).toHaveAttribute(
         'aria-disabled',
@@ -1025,8 +1034,11 @@ test.describe('Permission gating — Identity Provider actions', () => {
         .getByRole('grid', { name: 'Identity providers table' })
         .getByRole('row', { name: new RegExp(idpName) })
       await expect(idpRow).toBeVisible({ timeout: 15_000 })
-      const kebab = idpRow.getByRole('button', { name: /Actions|Kebab toggle/i })
-      await kebab.click({ force: true })
+      // The identity-providers table refetches while the auditor page settles, so a
+      // single forced click here is regularly swallowed by the row being replaced —
+      // the menu never opens and all three assertions below fail on a missing
+      // `menuitem`. This is the same dequeue seen on PRs that touch no frontend code.
+      await openRowKebab(idpRow, /Edit provider/i)
 
       await expect(auditorApp.getByRole('menuitem', { name: /Edit provider/i })).toHaveAttribute(
         'aria-disabled',

--- a/frontend/packages/syntara-ui/e2e/run-step.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/run-step.spec.ts
@@ -14,61 +14,61 @@
  * - Dialog state resets when closed
  */
 
-import { type Page, test, expect, toAppUrl } from './fixtures'
+import { type Page, test, expect } from './fixtures'
 import {
   buildUniqueName,
-  clickAddConnectedStep,
-  clickSaveAndWait,
-  closeNodeEditorPanel,
   createBasicWorkflowViaApi,
   deleteWorkflow,
   fillCodeEditor,
   openWorkflowInBuilder,
-  selectProjectIfRequired,
-  triggerLayout,
   waitForUIReady,
 } from './helpers/workflows'
-import { ensureProject } from './utils/api'
+import { createWorkflowViaApi, deleteWorkflowViaApi } from './utils/api'
 
-/** Create trigger → First action → Second action workflow from scratch. */
-async function createTwoNodeWorkflow(app: Page, workflowName: string) {
-  await ensureProject(app)
-  await app.goto(toAppUrl('/workflow-builder/new'))
-  await expect(app.getByRole('heading', { name: 'Select a trigger node' })).toBeVisible()
+/** Per-attempt budget for each kebab interaction, so one stuck click cannot eat the whole retry budget. */
+const KEBAB_CLICK_TIMEOUT = 5_000
 
-  // Add manual trigger
-  await app.getByRole('button', { name: 'Manual trigger' }).click()
-  await app.getByRole('textbox', { name: 'Name', exact: true }).fill('Manual trigger')
-  await app.getByRole('button', { name: 'Create' }).click()
-
-  // Add first action node
-  const firstPanel = await clickAddConnectedStep(app)
-  await firstPanel.getByRole('button', { name: 'Action', exact: true }).click()
-  await firstPanel.getByRole('button', { name: 'Script', exact: true }).click()
-  await app.getByRole('textbox', { name: 'Name', exact: true }).fill('First action')
-  await fillCodeEditor(app, { value: 'print("first")' })
-  await app.getByRole('button', { name: 'Create' }).click()
-  await closeNodeEditorPanel(app)
-
-  // Add second action node
-  const secondPanel = await clickAddConnectedStep(app)
-  await secondPanel.getByRole('button', { name: 'Action', exact: true }).click()
-  await secondPanel.getByRole('button', { name: 'Script', exact: true }).click()
-  await app.getByRole('textbox', { name: 'Name', exact: true }).fill('Second action')
-  await fillCodeEditor(app, { value: 'print("second")' })
-  await app.getByRole('button', { name: 'Create' }).click()
-  await closeNodeEditorPanel(app)
-
-  // Save
-  await selectProjectIfRequired(app)
-  await app.getByPlaceholder('Workflow name').fill(workflowName)
-  await clickSaveAndWait(app)
-  await triggerLayout(app)
+/**
+ * Trigger → First action → Second action, created via the API.
+ *
+ * The UI equivalent this replaced ended with `triggerLayout`, and "Reset layout"
+ * calls `onLayout({ markDirty: true })`. Every later "Run step" click therefore
+ * ran a save first (`useRunStepDialog`), and `handleRunStep` returns silently
+ * when that save resolves false — so the dialog simply never opened and
+ * `openRunStepDialog` retried a no-op click until its budget ran out. Loading an
+ * API-created workflow auto-layouts with `markDirty: false`, so there is nothing
+ * to save and no save to fail. `run-step.spec.ts`'s own siblings already moved
+ * to this pattern for exactly this reason.
+ */
+async function createTwoNodeWorkflowViaApi(app: Page, workflowName: string): Promise<{ id: string }> {
+  const { id } = await createWorkflowViaApi(
+    app,
+    workflowName,
+    [{ id: 'trigger_1', type: 'manual_trigger', name: 'Manual trigger', parameters: {} }],
+    [
+      {
+        id: 'action_1',
+        type: 'script',
+        name: 'First action',
+        parameters: { language: 'python', code: 'print("first")' },
+      },
+      {
+        id: 'action_2',
+        type: 'script',
+        name: 'Second action',
+        parameters: { language: 'python', code: 'print("second")' },
+      },
+    ],
+    [
+      { from: 'trigger_1', to: 'action_1' },
+      { from: 'action_1', to: 'action_2' },
+    ]
+  )
+  await openWorkflowInBuilder(app, workflowName, id)
   await expect(
     app.locator('[role="group"][aria-roledescription="node"]').filter({ hasText: 'Second action' })
-  ).toBeVisible({
-    timeout: 15_000,
-  })
+  ).toBeVisible({ timeout: 15_000 })
+  return { id }
 }
 
 /**
@@ -85,13 +85,13 @@ async function openNodeKebabMenu(app: Page, nodeText: string) {
   // Ensure node is expanded so the kebab is reachable
   const expandToggle = node.getByTestId('node-expand-toggle')
   if ((await expandToggle.count()) > 0) {
-    await expandToggle.click()
+    await expandToggle.click({ timeout: KEBAB_CLICK_TIMEOUT })
   }
 
   const kebabButton = node.getByLabel('Step actions menu')
   await expect(kebabButton).toBeVisible({ timeout: 10_000 })
-  await kebabButton.click()
-  await expect(app.getByRole('menuitem', { name: 'Run step' })).toBeVisible({ timeout: 5_000 })
+  await kebabButton.click({ timeout: KEBAB_CLICK_TIMEOUT })
+  await expect(app.getByRole('menuitem', { name: 'Run step' })).toBeVisible({ timeout: KEBAB_CLICK_TIMEOUT })
 }
 
 /**
@@ -112,8 +112,8 @@ async function openRunStepDialog(app: Page, nodeText: string) {
       await app.keyboard.press('Escape')
     }
     await openNodeKebabMenu(app, nodeText)
-    await app.getByRole('menuitem', { name: 'Run step' }).click({ force: true })
-    await expect(dialogHeading).toBeVisible({ timeout: 5_000 })
+    await app.getByRole('menuitem', { name: 'Run step' }).click({ force: true, timeout: KEBAB_CLICK_TIMEOUT })
+    await expect(dialogHeading).toBeVisible({ timeout: KEBAB_CLICK_TIMEOUT })
   }).toPass({ timeout: 30_000, intervals: [500, 1_000, 2_000] })
 }
 
@@ -163,11 +163,15 @@ test.describe('Run Step', () => {
     }
   })
 
-  // Skip: kebab menu DOM detaches during canvas layout animation causing flaky timeout in CI
+  // Still skipped, but no longer for the dirty-builder reason the old comment gave:
+  // against a real backend `getByRole('button', { name: 'Set mock data' })` resolves
+  // to three elements — the dialog's own button plus the Input and Output panels'
+  // link toggles. Unchanged sibling tests fail the same way, so this is a separate
+  // pre-existing locator problem, not something this workflow migration can settle.
   test.skip('transitions to mock data editor when "Set mock data" is clicked', async ({ app }) => {
     // Arrange - Create workflow with two nodes so second node has a predecessor to mock
     const workflowName = buildUniqueName('e2e-run-step-mock')
-    await createTwoNodeWorkflow(app, workflowName)
+    const { id } = await createTwoNodeWorkflowViaApi(app, workflowName)
 
     try {
       await openRunStepDialog(app, 'Second action')
@@ -178,7 +182,7 @@ test.describe('Run Step', () => {
       const dialog = app.getByLabel('Set mock data for Second action')
       await expect(dialog.getByRole('button', { name: 'Run', exact: true })).toBeVisible()
     } finally {
-      await deleteWorkflow(app, workflowName)
+      await deleteWorkflowViaApi(app, id)
     }
   })
 
@@ -231,8 +235,8 @@ test.describe('Run Step', () => {
   })
 
   test('closes dialog when Cancel is clicked from mock editor', async ({ app }) => {
-    // Use API-created single-node workflow — createTwoNodeWorkflow + Second action
-    // kebab is flaky in CI (same reason the "transitions to mock data editor" test is skipped).
+    // Single-node workflow via the API — the builder opens clean, so no save runs
+    // ahead of the kebab click.
     const workflowName = buildUniqueName('e2e-run-step-cancel-mock')
     const { id } = await createBasicWorkflowViaApi(app, workflowName, 'Test action')
     await openWorkflowInBuilder(app, workflowName, id)
@@ -274,7 +278,7 @@ test.describe('Run Step', () => {
   test('executes workflow when "Run all previous steps" is clicked', async ({ app }) => {
     // Arrange - Create workflow with two nodes
     const workflowName = buildUniqueName('e2e-run-step-all')
-    await createTwoNodeWorkflow(app, workflowName)
+    const { id } = await createTwoNodeWorkflowViaApi(app, workflowName)
 
     try {
       // Act - Open Run step dialog on second node
@@ -287,7 +291,7 @@ test.describe('Run Step', () => {
       // Assert - Dialog closes after execution completes (dialog closing IS the success signal)
       await expect(app.getByRole('heading', { name: 'Run Second action?' })).not.toBeVisible()
     } finally {
-      await deleteWorkflow(app, workflowName)
+      await deleteWorkflowViaApi(app, id)
     }
   })
 
@@ -316,14 +320,15 @@ test.describe('Run Step', () => {
       // Assert - Dialog remains open
       await expect(app.getByRole('heading', { name: 'Set mock data for Test action' })).toBeVisible()
     } finally {
-      await deleteWorkflow(app, workflowName)
+      await deleteWorkflowViaApi(app, id)
     }
   })
 
+  // Skipped for the same ambiguous "Set mock data" locator as above.
   test.skip('dialog state resets when closed and reopened', async ({ app }) => {
     // Arrange - Create workflow with two nodes
     const workflowName = buildUniqueName('e2e-run-step-reset')
-    await createTwoNodeWorkflow(app, workflowName)
+    const { id } = await createTwoNodeWorkflowViaApi(app, workflowName)
 
     try {
       // Act 1 - Open mock editor on second node
@@ -342,7 +347,7 @@ test.describe('Run Step', () => {
       // Assert - Dialog resets to choice screen
       await expect(app.getByRole('heading', { name: 'Run Second action?' })).toBeVisible()
     } finally {
-      await deleteWorkflow(app, workflowName)
+      await deleteWorkflowViaApi(app, id)
     }
   })
 })

--- a/frontend/packages/syntara-ui/e2e/run-step.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/run-step.spec.ts
@@ -18,11 +18,12 @@ import { type Page, test, expect, toAppUrl } from './fixtures'
 import {
   buildUniqueName,
   clickAddConnectedStep,
+  clickSaveAndWait,
   closeNodeEditorPanel,
   createBasicWorkflowViaApi,
   deleteWorkflow,
-  openWorkflowInBuilder,
   fillCodeEditor,
+  openWorkflowInBuilder,
   selectProjectIfRequired,
   triggerLayout,
   waitForUIReady,
@@ -61,8 +62,7 @@ async function createTwoNodeWorkflow(app: Page, workflowName: string) {
   // Save
   await selectProjectIfRequired(app)
   await app.getByPlaceholder('Workflow name').fill(workflowName)
-  await app.getByRole('button', { name: 'Save' }).click()
-  await expect(app).toHaveURL(/workflow-builder\/.+/)
+  await clickSaveAndWait(app)
   await triggerLayout(app)
   await expect(
     app.locator('[role="group"][aria-roledescription="node"]').filter({ hasText: 'Second action' })

--- a/frontend/packages/syntara-ui/e2e/seed-bucket-helper.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/seed-bucket-helper.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression tests for the `createSeedBucket` helper itself.
+ *
+ * Under `fullyParallel: true` a worker can run a spec file's file-scope
+ * `beforeAll`/`afterAll` more than once while the module holding the seed list is
+ * imported only once, so a second seeding round has to start from an empty list.
+ * These tests replay that sequence directly instead of waiting for CI to hand a
+ * worker two non-contiguous groups of the same file.
+ */
+import { test, expect } from './fixtures'
+import { createSeedBucket } from './seeds/seed-bucket'
+
+type Policy = { id: string }
+
+test.describe('createSeedBucket', () => {
+  // Pure helper — no page, no login, no backend.
+  test('a second seeding round does not inherit the first round’s resources', () => {
+    const bucket = createSeedBucket<Policy>('policies')
+
+    // Round 1: beforeAll seeds, tests run, afterAll deletes what it seeded.
+    bucket.add({ id: 'policy-round-1' })
+    expect(bucket.drain()).toEqual([{ id: 'policy-round-1' }])
+
+    // Round 2, same worker, same module instance: the bucket must start empty,
+    // otherwise the round-1 policy — already deleted by round 1's afterAll — is
+    // still the head of the list and a test that reaches for it finds nothing.
+    bucket.add({ id: 'policy-round-2' })
+    expect(bucket.all()).toEqual([{ id: 'policy-round-2' }])
+    expect(bucket.size()).toBe(1)
+    expect(bucket.latest()).toEqual({ id: 'policy-round-2' })
+  })
+
+  test('drain returns the current round’s resources exactly once', () => {
+    const bucket = createSeedBucket<Policy>('policies')
+
+    bucket.add({ id: 'a' })
+    bucket.add({ id: 'b' })
+
+    // afterAll deletes these two…
+    expect(bucket.drain()).toEqual([{ id: 'a' }, { id: 'b' }])
+    // …and a second afterAll must not ask the API to delete them again (the
+    // repeat DELETE answers 404, which is how the double-delete showed up in CI).
+    expect(bucket.drain()).toEqual([])
+  })
+
+  test('latest names the newest resource and an empty bucket fails loudly', () => {
+    const bucket = createSeedBucket<Policy>('policies')
+
+    expect(() => bucket.latest()).toThrow('policies: nothing seeded in this round')
+
+    bucket.add({ id: 'older' })
+    bucket.add({ id: 'newer' })
+    expect(bucket.latest()).toEqual({ id: 'newer' })
+  })
+})

--- a/frontend/packages/syntara-ui/e2e/seeds/seed-bucket.ts
+++ b/frontend/packages/syntara-ui/e2e/seeds/seed-bucket.ts
@@ -1,0 +1,56 @@
+/**
+ * A per-round record of the resources a file-scope `beforeAll` seeded.
+ *
+ * `playwright.config.ts` sets `fullyParallel: true`, so a spec file's tests are
+ * handed out test-by-test and a worker can receive two non-contiguous groups of
+ * them. Playwright runs the file-scope `beforeAll`/`afterAll` around *each*
+ * group, but the module the hooks live in is imported once per worker, so plain
+ * module-level state survives from one group to the next. A `const seeded: T[] =
+ * []` that is only ever pushed to therefore accumulates entries that the
+ * matching `afterAll` has already deleted, and `seeded[0]` ends up naming a
+ * resource that no longer exists — the test looks for it and finds nothing.
+ *
+ * A bucket keeps each seeding round self-contained:
+ *
+ * - `drain()` hands `afterAll` exactly what the current round created and leaves
+ *   the bucket empty, so nothing is deleted twice and nothing carries over;
+ * - `latest()` always names a resource from the round the running test belongs
+ *   to, even if a stale entry somehow survived.
+ */
+export type SeedBucket<T> = {
+  /** Record a freshly seeded resource and return it unchanged. */
+  add(resource: T): T
+  /** Every resource seeded in the current round, oldest first. */
+  all(): readonly T[]
+  /** How many resources the current round seeded. */
+  size(): number
+  /** The most recently seeded resource. Throws when the bucket is empty. */
+  latest(): T
+  /** Return the current round's resources and empty the bucket. */
+  drain(): T[]
+}
+
+export function createSeedBucket<T>(label: string): SeedBucket<T> {
+  const resources: T[] = []
+
+  return {
+    add(resource) {
+      resources.push(resource)
+      return resource
+    },
+    all() {
+      return [...resources]
+    },
+    size() {
+      return resources.length
+    },
+    latest() {
+      const newest = resources.at(-1)
+      if (newest === undefined) throw new Error(`${label}: nothing seeded in this round`)
+      return newest
+    },
+    drain() {
+      return resources.splice(0)
+    },
+  }
+}

--- a/frontend/packages/syntara-ui/e2e/session-revocation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/session-revocation.spec.ts
@@ -11,6 +11,7 @@
 import { type Page } from './fixtures'
 import { test, expect, toAppUrl } from './fixtures'
 import { MINIMAL_OIDC_PROVIDER_CONFIGURATION } from './helpers/identity-providers'
+import { openRowKebab } from './helpers/patternfly'
 import { buildUniqueName } from './helpers/workflows'
 import { createIdentityProviderViaApi, deleteIdentityProviderViaApi } from './utils/api'
 import { fulfill, mockCanIAllowed, mockUsersForRevocation, revokeTargetUserResponse } from './utils/mockData'
@@ -22,9 +23,22 @@ const TOKEN_REVOCATION_URL = '/system-administration/access-management/token-rev
 const IDP_DELETE_ACK_LABEL =
   /I understand this identity provider and its linked identities will be permanently deleted/i
 
+/**
+ * Open a provider's Delete dialog from the identity providers list.
+ *
+ * The table is one unfiltered page of 20 sorted by `name` ascending, so the
+ * provider seeded by these tests only renders while fewer than 20 providers sort
+ * before it — and `pagination.spec.ts` seeds 21 of them in its `beforeAll`.
+ * Filtering by name first puts the row on the page deterministically, and it also
+ * makes the post-delete `toHaveCount(0)` assertion mean something: unfiltered, it
+ * is satisfied by a row that was never on page 1 in the first place.
+ */
 async function openDeleteDialogFromList(app: Page, providerName: string) {
   await app.goto(toAppUrl(AUTHENTICATION_URL))
   await expect(app.getByRole('heading', { level: 1, name: 'Identity Providers' })).toBeVisible()
+
+  await app.getByPlaceholder('Filter by name').fill(providerName)
+  await app.getByRole('button', { name: 'Apply filter' }).click()
 
   const table = app.getByRole('grid', { name: 'Identity providers table' })
   await expect(table).toBeVisible()
@@ -32,7 +46,7 @@ async function openDeleteDialogFromList(app: Page, providerName: string) {
   const providerRow = table.getByRole('row', { name: new RegExp(providerName) })
   await expect(providerRow).toBeVisible()
 
-  await providerRow.getByRole('button', { name: /Actions|Kebab toggle/i }).click({ force: true })
+  await openRowKebab(providerRow, /Delete provider/i)
   await app.getByRole('menuitem', { name: 'Delete provider' }).click()
 }
 

--- a/frontend/packages/syntara-ui/e2e/utils/api-core.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api-core.ts
@@ -45,14 +45,9 @@ export async function getAuthToken(app: Page): Promise<string | null> {
   return null
 }
 
-/** Make an authenticated API request */
-export async function apiRequest(
-  app: Page,
-  method: 'get' | 'post' | 'patch' | 'delete',
-  path: string,
-  options?: { data?: unknown; token?: string }
-) {
-  const token = options?.token ?? (await getAuthToken(app))
+type ApiMethod = 'get' | 'post' | 'patch' | 'delete'
+
+async function sendApiRequest(app: Page, method: ApiMethod, path: string, token: string | null, data?: unknown) {
   const headers: Record<string, string> = {}
   if (token) headers['Authorization'] = `Bearer ${token}`
 
@@ -60,12 +55,58 @@ export async function apiRequest(
     return app.request.get(apiUrl(path), { headers })
   }
   if (method === 'post') {
-    return app.request.post(apiUrl(path), { headers, data: options?.data })
+    return app.request.post(apiUrl(path), { headers, data })
   }
   if (method === 'patch') {
-    return app.request.patch(apiUrl(path), { headers, data: options?.data })
+    return app.request.patch(apiUrl(path), { headers, data })
   }
   return app.request.delete(apiUrl(path), { headers })
+}
+
+/**
+ * Did the backend reject this request because the token predates a
+ * ``token_version`` bump?
+ *
+ * ``POST /auth/logout`` increments the user's ``token_version``, which
+ * invalidates every access token that user holds — not just the session that
+ * logged out. Since the whole E2E suite authenticates as the same ``admin``
+ * account, one worker running a spec that logs out ages every other worker's
+ * cached token. The backend flags this case specifically, and marks it
+ * ``retryable``.
+ */
+async function isStaleTokenRejection(resp: { status(): number; text(): Promise<string> }): Promise<boolean> {
+  if (resp.status() !== 401) return false
+  try {
+    return (await resp.text()).includes('TOKEN_STALE')
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Make an authenticated API request.
+ *
+ * Seed helpers fetch one token in `beforeAll` and reuse it across dozens of
+ * sequential calls, so a token that goes stale halfway through leaves the spec
+ * dead in a hook with `HTTP 401 {"code":"TOKEN_STALE",…}`. Re-authenticate once
+ * and replay the request — that is precisely what the backend's `retryable: true`
+ * asks the client to do, and one extra login is far cheaper than a failed run.
+ */
+export async function apiRequest(
+  app: Page,
+  method: ApiMethod,
+  path: string,
+  options?: { data?: unknown; token?: string }
+) {
+  const token = options?.token ?? (await getAuthToken(app))
+  const resp = await sendApiRequest(app, method, path, token, options?.data)
+
+  if (!(await isStaleTokenRejection(resp))) return resp
+
+  const refreshed = await getAuthToken(app)
+  if (!refreshed || refreshed === token) return resp
+
+  return sendApiRequest(app, method, path, refreshed, options?.data)
 }
 
 /**

--- a/frontend/packages/syntara-ui/e2e/utils/api-core.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api-core.ts
@@ -139,6 +139,26 @@ export async function ensureProject(app: Page, name = 'default'): Promise<{ id: 
   }
 }
 
+/**
+ * Look up a project ID by exact name. Returns null when it cannot be found.
+ *
+ * Mirrors `findWorkflowIdByName`, but lists and matches client-side because
+ * `/projects` is not known to support `name[contains]` — `ensureProject` above
+ * already takes the same `?limit=100` approach.
+ */
+export async function findProjectIdByName(app: Page, name: string): Promise<string | null> {
+  try {
+    const token = await getAuthToken(app)
+    if (!token) return null
+    const resp = await apiRequest(app, 'get', '/projects?limit=100', { token })
+    if (!resp.ok()) return null
+    const body = (await resp.json()) as { resources?: Array<{ id: string; name: string }> }
+    return body.resources?.find((project) => project.name === name)?.id ?? null
+  } catch {
+    return null
+  }
+}
+
 /** Create a project via the API. Returns the project ID. */
 export async function createProjectViaApi(app: Page, name: string, description?: string): Promise<{ id: string }> {
   const token = await getAuthToken(app)

--- a/frontend/packages/syntara-ui/e2e/utils/api.ts
+++ b/frontend/packages/syntara-ui/e2e/utils/api.ts
@@ -5,7 +5,15 @@
  * etc.). This file re-exports everything so existing spec files can continue to
  * import from './utils/api' without changes.
  */
-export { apiUrl, getAuthToken, apiRequest, ensureProject, createProjectViaApi, deleteProjectViaApi } from './api-core'
+export {
+  apiUrl,
+  getAuthToken,
+  apiRequest,
+  ensureProject,
+  createProjectViaApi,
+  deleteProjectViaApi,
+  findProjectIdByName,
+} from './api-core'
 export { createCredentialViaApi, deleteCredentialViaApi, listCredentialsByName } from './api-credentials'
 export {
   createWorkflowViaApi,

--- a/frontend/packages/syntara-ui/e2e/v2-workflow-migration.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/v2-workflow-migration.spec.ts
@@ -36,7 +36,13 @@ import {
   deleteLlmIntegration,
 } from './helpers/v2-nodes'
 import { addConvergeNode } from './helpers/v2-nodes-converge'
-import { buildUniqueName, selectProjectIfRequired, deleteWorkflow, triggerLayout } from './helpers/workflows'
+import {
+  buildUniqueName,
+  clickSaveAndWait,
+  selectProjectIfRequired,
+  deleteWorkflow,
+  triggerLayout,
+} from './helpers/workflows'
 import { apiRequest, createWorkflowViaApi, deleteWorkflowViaApi } from './utils/api'
 
 /** Inline v2 schema type (formerly in toV2Definition.ts stub, now replaced by generated contracts). */
@@ -371,8 +377,7 @@ test.describe('V2 Workflow Schema Migration', () => {
     await addScriptNode(app, 'Test script', 'print("test")')
     await selectProjectIfRequired(app)
     await app.getByPlaceholder('Workflow name').fill(workflowName)
-    await app.getByRole('button', { name: 'Save' }).click()
-    await expect(app).toHaveURL(/workflow-builder\/.+/)
+    await clickSaveAndWait(app)
 
     // Navigate to workflows list, find the saved workflow, and reopen it.
     // This is more reliable than page.reload() which can lose session context.

--- a/frontend/packages/syntara-ui/e2e/v2-workflow-migration.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/v2-workflow-migration.spec.ts
@@ -43,7 +43,7 @@ import {
   deleteWorkflow,
   triggerLayout,
 } from './helpers/workflows'
-import { apiRequest, createWorkflowViaApi, deleteWorkflowViaApi } from './utils/api'
+import { apiRequest, createWorkflowViaApi, deleteWorkflowViaApi, ensureProject } from './utils/api'
 
 /** Inline v2 schema type (formerly in toV2Definition.ts stub, now replaced by generated contracts). */
 type V2WorkflowDefinition = {
@@ -111,7 +111,7 @@ test.describe('V2 Workflow Schema Migration', () => {
     const saveRequestPromise = app.waitForRequest((req) => req.url().includes('/workflows') && req.method() === 'POST')
     await selectProjectIfRequired(app)
     await app.getByPlaceholder('Workflow name').fill(workflowName)
-    await app.getByRole('button', { name: 'Save' }).click()
+    await clickSaveAndWait(app)
     const saveRequest = await saveRequestPromise
     const def = getV2DefFromRequest(saveRequest)
 
@@ -151,6 +151,7 @@ test.describe('V2 Workflow Schema Migration', () => {
 
     // Create LLM integration for agentic node
     const llmIntegrationName = buildUniqueName('test-llm-integration')
+    const project = await ensureProject(app)
     const llmIntegration = await createLlmIntegration(app, llmIntegrationName)
 
     try {
@@ -169,9 +170,14 @@ test.describe('V2 Workflow Schema Migration', () => {
       const saveRequestPromise = app.waitForRequest(
         (req) => req.url().includes('/workflows') && req.method() === 'POST'
       )
-      await selectProjectIfRequired(app)
+      // Pin the workflow to the LLM credential's project. `createLlmIntegration`
+      // seeds the credential under `ensureProject`'s `default`, while an unnamed
+      // `selectProjectIfRequired` picks whichever project the dropdown lists
+      // first — and the backend rejects the save with "One or more credential
+      // references are invalid or belong to a different project" when they differ.
+      await selectProjectIfRequired(app, project?.name)
       await app.getByPlaceholder('Workflow name').fill(workflowName)
-      await app.getByRole('button', { name: 'Save' }).click()
+      await clickSaveAndWait(app)
       const saveRequest = await saveRequestPromise
       const def = getV2DefFromRequest(saveRequest)
 
@@ -199,7 +205,6 @@ test.describe('V2 Workflow Schema Migration', () => {
       expect(def.edges.length).toBeGreaterThanOrEqual(5)
 
       // Verify workflow appears in workflows list
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
       await app.goto(toAppUrl('/workflows'))
       await app.getByPlaceholder('Filter by name').fill(workflowName)
       await app.getByRole('button', { name: 'Apply filter' }).click()
@@ -234,7 +239,7 @@ test.describe('V2 Workflow Schema Migration', () => {
       )
       await selectProjectIfRequired(app)
       await app.getByPlaceholder('Workflow name').fill(workflowName)
-      await app.getByRole('button', { name: 'Save' }).click()
+      await clickSaveAndWait(app)
       const saveRequest = await saveRequestPromise
       const def = getV2DefFromRequest(saveRequest)
 
@@ -434,15 +439,14 @@ test.describe('V2 Workflow Schema Migration', () => {
       await addScriptNode(app, 'Original script', 'print("original")')
       await selectProjectIfRequired(app)
       await app.getByPlaceholder('Workflow name').fill(workflowName)
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/workflow-builder\/(?!new)/)
+      await clickSaveAndWait(app)
 
       // Add a second node (edit the workflow)
       await addScriptNode(app, 'Added script', 'print("added")')
 
       // Re-save and capture the PATCH payload
       const patchPromise = app.waitForRequest((req) => req.url().includes('/workflows/') && req.method() === 'PATCH')
-      await app.getByRole('button', { name: 'Save' }).click()
+      await clickSaveAndWait(app)
       const patchRequest = await patchPromise
       const editedDef = getV2DefFromRequest(patchRequest)
 
@@ -479,7 +483,7 @@ test.describe('V2 Workflow Schema Migration', () => {
       const savePromise = app.waitForRequest((req) => req.url().includes('/workflows') && req.method() === 'POST')
       await selectProjectIfRequired(app)
       await app.getByPlaceholder('Workflow name').fill(workflowName)
-      await app.getByRole('button', { name: 'Save' }).click()
+      await clickSaveAndWait(app)
       const saveRequest = await savePromise
       const savedDef = getV2DefFromRequest(saveRequest)
 
@@ -489,7 +493,6 @@ test.describe('V2 Workflow Schema Migration', () => {
       expect(conditionEdges.length).toBeGreaterThanOrEqual(1)
 
       // Navigate away and reload the workflow
-      await expect(app).toHaveURL(/workflow-builder\/(?!new)/)
       await app.goto(toAppUrl('/workflows'))
       await app.getByPlaceholder('Filter by name').fill(workflowName)
       await app.getByRole('button', { name: 'Apply filter' }).click()

--- a/frontend/packages/syntara-ui/e2e/webhook-trigger.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/webhook-trigger.spec.ts
@@ -19,6 +19,7 @@ import { addWebhookTrigger } from './helpers/v2-nodes'
 import {
   buildUniqueName,
   clickAddConnectedStep,
+  clickSaveAndWait,
   closeNodeEditorPanel,
   deleteWorkflow,
   fillCodeEditor,
@@ -31,7 +32,7 @@ test.describe('Webhook Trigger', () => {
     const workflowName = buildUniqueName('e2e-webhook')
     const webhookPath = 'jira-updates'
 
-    await ensureProject(app)
+    const project = await ensureProject(app)
     const sa = await createServiceAccountViaApi(app, buildUniqueName('sa-webhook'))
     await app.goto(toAppUrl('/workflow-builder/new'))
 
@@ -49,10 +50,14 @@ test.describe('Webhook Trigger', () => {
       await closeNodeEditorPanel(app)
 
       // Save workflow (select project right before save)
-      await selectProjectIfRequired(app)
+      // Pin the workflow to the service account's own project. `ensureProject`
+      // puts the account in `default`, but an unnamed `selectProjectIfRequired`
+      // picks whichever project the dropdown lists first — and the backend
+      // rejects the save with "Service account(s) not found in this project"
+      // whenever those differ. The weak URL guard used to hide that 422.
+      await selectProjectIfRequired(app, project?.name)
       await app.getByPlaceholder('Workflow name').fill(workflowName)
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
+      await clickSaveAndWait(app)
 
       // Verify workflow appears in list
       await app.goto(toAppUrl('/workflows'))
@@ -151,7 +156,7 @@ test.describe('Webhook Trigger', () => {
   test('webhook form normalizes path on submit', async ({ app }) => {
     const workflowName = buildUniqueName('e2e-webhook-norm')
 
-    await ensureProject(app)
+    const project = await ensureProject(app)
     const sa = await createServiceAccountViaApi(app, buildUniqueName('sa-webhook'))
     await app.goto(toAppUrl('/workflow-builder/new'))
 
@@ -169,10 +174,14 @@ test.describe('Webhook Trigger', () => {
       await closeNodeEditorPanel(app)
 
       // Save and verify canvas shows normalized path (lowercase, no leading slash)
-      await selectProjectIfRequired(app)
+      // Pin the workflow to the service account's own project. `ensureProject`
+      // puts the account in `default`, but an unnamed `selectProjectIfRequired`
+      // picks whichever project the dropdown lists first — and the backend
+      // rejects the save with "Service account(s) not found in this project"
+      // whenever those differ. The weak URL guard used to hide that 422.
+      await selectProjectIfRequired(app, project?.name)
       await app.getByPlaceholder('Workflow name').fill(workflowName)
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
+      await clickSaveAndWait(app)
 
       const triggerNode = app
         .locator('[role="group"][aria-roledescription="node"]')
@@ -188,7 +197,7 @@ test.describe('Webhook Trigger', () => {
     const workflowName = buildUniqueName('e2e-webhook-canvas')
     const webhookPath = 'api-v2-events'
 
-    await ensureProject(app)
+    const project = await ensureProject(app)
     const sa = await createServiceAccountViaApi(app, buildUniqueName('sa-webhook'))
     await app.goto(toAppUrl('/workflow-builder/new'))
 
@@ -206,10 +215,14 @@ test.describe('Webhook Trigger', () => {
       await closeNodeEditorPanel(app)
 
       // Save workflow
-      await selectProjectIfRequired(app)
+      // Pin the workflow to the service account's own project. `ensureProject`
+      // puts the account in `default`, but an unnamed `selectProjectIfRequired`
+      // picks whichever project the dropdown lists first — and the backend
+      // rejects the save with "Service account(s) not found in this project"
+      // whenever those differ. The weak URL guard used to hide that 422.
+      await selectProjectIfRequired(app, project?.name)
       await app.getByPlaceholder('Workflow name').fill(workflowName)
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
+      await clickSaveAndWait(app)
 
       // Verify trigger node on canvas shows webhook path detail
       const triggerNode = app

--- a/frontend/packages/syntara-ui/e2e/workflow-cleanup-helper.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflow-cleanup-helper.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression test for the `deleteWorkflow` cleanup helper itself.
+ *
+ * The helper prefers an API delete and only falls back to the UI when the name
+ * lookup finds nothing — which is the ordinary case in a `finally` block, because
+ * the workflow was renamed during the test or an earlier cleanup call already
+ * removed it. When the project is then empty the Workflows page renders the
+ * "No workflows yet" empty state, which has no filter toolbar, and the helper's
+ * unbounded `fill('Filter by name')` used to wait out the entire test timeout —
+ * failing a test whose assertions had all passed.
+ *
+ * This drives the helper against a synthetic empty-state page so the hang is
+ * reproduced on demand rather than whenever CI happens to leave the list empty.
+ */
+import { test, expect, toAppUrl } from './fixtures'
+import { buildUniqueName, deleteWorkflow } from './helpers/workflows'
+
+/**
+ * The Workflows page as it renders with nothing to list: a heading, a call to
+ * action, and deliberately no "Filter by name" input — that absence is the whole
+ * hazard.
+ */
+const EMPTY_STATE_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <h1>Workflows</h1>
+    <h2>No workflows yet</h2>
+    <p>Create your first workflow to get started.</p>
+    <button type="button">Create workflow</button>
+  </body>
+</html>`
+
+test.describe('deleteWorkflow helper', () => {
+  // No login needed: the helper is driven against a synthetic page, not the app.
+  test('gives up instead of hanging when the workflow list is empty', async ({ page }) => {
+    test.setTimeout(60_000)
+
+    // A name nothing was ever seeded under, so the helper's API lookup returns
+    // null and it takes the UI fallback — exactly the path CI took.
+    const missingWorkflow = buildUniqueName('e2e-cleanup-missing')
+
+    await page.route(toAppUrl('/workflows'), (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: EMPTY_STATE_HTML })
+    )
+
+    const settled = await Promise.race([
+      deleteWorkflow(page, missingWorkflow).then(() => 'returned' as const),
+      page.waitForTimeout(20_000).then(() => 'still-waiting' as const),
+    ])
+
+    expect(settled, 'deleteWorkflow must give up on the missing filter toolbar, not consume the test timeout').toBe(
+      'returned'
+    )
+
+    // And it must stay best-effort: giving up is not an error the caller sees.
+    await expect(page.getByRole('heading', { name: 'No workflows yet' })).toBeVisible()
+  })
+})

--- a/frontend/packages/syntara-ui/e2e/workflow-save-helper.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflow-save-helper.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression tests for the `clickSaveAndWait` helper itself.
+ *
+ * Every builder spec used to gate a save on `toHaveURL(/workflow-builder\/.+/)`.
+ * `.+` matches the literal `new` segment, so that assertion passed the instant
+ * the click was dispatched and before any request went out; the test then
+ * navigated away and aborted the write. On a rename there is no navigation at
+ * all, so no URL guard is even possible. The helper replaces both with a wait on
+ * the create/update response, and these tests pin that against a synthetic page
+ * rather than waiting for the race to resurface in the merge queue.
+ */
+import { test, expect, toAppUrl, type Page } from './fixtures'
+import { clickSaveAndWait, isWorkflowSaveResponse } from './helpers/workflow-save'
+
+const CREATE_FIXTURE = '/e2e-fixtures/workflow-save-create'
+const UPDATE_FIXTURE = '/e2e-fixtures/workflow-save-update'
+const DISABLED_FIXTURE = '/e2e-fixtures/workflow-save-disabled'
+const FAILING_FIXTURE = '/e2e-fixtures/workflow-save-failing'
+
+const WORKFLOW_UUID = '11111111-2222-3333-4444-555555555555'
+
+/**
+ * The create path, with the URL deliberately racing the request.
+ *
+ * The button pushes `/workflow-builder/<id>` synchronously and only POSTs 800ms
+ * later, which is the ordering that made the old URL guard a false pass. A
+ * `POST /workflows/validate` goes out first so the helper has a near-miss to
+ * reject — the Verify action fires exactly that request against a path a naive
+ * `**\/api/v1/workflows*` glob would match.
+ */
+const CREATE_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <button type="button" onclick="save()">Save</button>
+    <script>
+      function save() {
+        void fetch('/api/v1/workflows/validate', { method: 'POST' })
+        history.pushState({}, '', '/workflow-builder/${WORKFLOW_UUID}')
+        setTimeout(() => {
+          void fetch('/api/v1/workflows', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: 'created' }),
+          })
+        }, 800)
+      }
+    </script>
+  </body>
+</html>`
+
+/** The rename path: a PATCH after a delay, and no navigation ever. */
+const UPDATE_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <button type="button" onclick="save()">Save</button>
+    <script>
+      function save() {
+        setTimeout(() => {
+          void fetch('/api/v1/workflows/${WORKFLOW_UUID}', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: 'renamed' }),
+          })
+        }, 800)
+      }
+    </script>
+  </body>
+</html>`
+
+/**
+ * A Save button that stays `aria-disabled` forever and fires nothing.
+ *
+ * PatternFly renders the real button this way whenever the workflow is clean or
+ * the node editor is open, and Playwright honours `aria-disabled` in its
+ * actionability wait — so an unbounded click here would consume the whole test.
+ */
+const DISABLED_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <button type="button" aria-disabled="true">Save</button>
+  </body>
+</html>`
+
+/** A save the server rejects, which must not read as "persisted". */
+const FAILING_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <button type="button" onclick="void fetch('/api/v1/workflows', { method: 'POST' })">Save</button>
+  </body>
+</html>`
+
+/** Serve one synthetic page and record every request the helper cares about. */
+async function serveFixture(
+  page: Page,
+  path: string,
+  html: string,
+  { saveStatus = 201 }: { saveStatus?: number } = {}
+): Promise<string[]> {
+  const seen: string[] = []
+  await page.route(`**${path}`, (route) => route.fulfill({ status: 200, contentType: 'text/html', body: html }))
+  await page.route('**/api/v1/workflows**', (route) => {
+    const request = route.request()
+    const { pathname } = new URL(request.url())
+    seen.push(`${request.method()} ${pathname}`)
+    const isValidate = pathname.endsWith('/validate')
+    return route.fulfill({
+      status: isValidate ? 200 : saveStatus,
+      contentType: 'application/json',
+      body: JSON.stringify(isValidate ? { valid: true, errors: [] } : { id: WORKFLOW_UUID }),
+    })
+  })
+  return seen
+}
+
+test.describe('clickSaveAndWait helper', () => {
+  // No login needed: the helper is driven against synthetic pages, not the app.
+  test('waits for the create POST rather than the URL change', async ({ page }) => {
+    const seen = await serveFixture(page, CREATE_FIXTURE, CREATE_HTML)
+
+    await page.goto(toAppUrl(CREATE_FIXTURE))
+    await clickSaveAndWait(page)
+
+    // The old `toHaveURL(/workflow-builder\/.+/)` gate would have resolved here
+    // with only the validate call on the wire.
+    expect(seen, 'the create POST must have landed before the helper returned').toContain('POST /api/v1/workflows')
+  })
+
+  test('waits for the update PATCH when the URL never changes', async ({ page }) => {
+    const seen = await serveFixture(page, UPDATE_FIXTURE, UPDATE_HTML)
+
+    await page.goto(toAppUrl(UPDATE_FIXTURE))
+    const urlBefore = page.url()
+    await clickSaveAndWait(page)
+
+    expect(page.url(), 'a rename does not navigate — this is why no URL guard can work').toBe(urlBefore)
+    expect(seen).toContain(`PATCH /api/v1/workflows/${WORKFLOW_UUID}`)
+  })
+
+  test('gives up instead of hanging when Save stays aria-disabled', async ({ page }) => {
+    test.setTimeout(60_000)
+    await serveFixture(page, DISABLED_FIXTURE, DISABLED_HTML)
+    await page.goto(toAppUrl(DISABLED_FIXTURE))
+
+    const settled = await Promise.race([
+      clickSaveAndWait(page).then(
+        () => 'resolved' as const,
+        () => 'rejected' as const
+      ),
+      page.waitForTimeout(30_000).then(() => 'still-waiting' as const),
+    ])
+
+    expect(settled, 'an aria-disabled Save must fail fast, not consume the test timeout').toBe('rejected')
+  })
+
+  test('surfaces a failed save instead of treating it as persisted', async ({ page }) => {
+    await serveFixture(page, FAILING_FIXTURE, FAILING_HTML, { saveStatus: 500 })
+    await page.goto(toAppUrl(FAILING_FIXTURE))
+
+    await expect(clickSaveAndWait(page)).rejects.toThrow(/500/)
+  })
+
+  test('isWorkflowSaveResponse ignores every neighbouring /workflows request', () => {
+    const stub = (method: string, url: string) =>
+      ({ request: () => ({ method: () => method }), url: () => url }) as never
+
+    expect(isWorkflowSaveResponse(stub('POST', 'https://app/api/v1/workflows'))).toBe(true)
+    expect(isWorkflowSaveResponse(stub('PATCH', `https://app/api/v1/workflows/${WORKFLOW_UUID}`))).toBe(true)
+
+    // The Verify action posts this, and it is what a `/api/v1/workflows*` glob
+    // would wrongly accept as a save.
+    expect(isWorkflowSaveResponse(stub('POST', 'https://app/api/v1/workflows/validate'))).toBe(false)
+    expect(isWorkflowSaveResponse(stub('GET', `https://app/api/v1/workflows/${WORKFLOW_UUID}`))).toBe(false)
+    expect(
+      isWorkflowSaveResponse(stub('POST', `https://app/api/v1/workflows/${WORKFLOW_UUID}/versions/1/publish`))
+    ).toBe(false)
+  })
+})

--- a/frontend/packages/syntara-ui/e2e/workflow-verification.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflow-verification.spec.ts
@@ -17,19 +17,19 @@ import { test, expect } from './fixtures'
 import { WCAG_TAGS } from './fixtures/accessibility'
 import { triggerVerifyWorkflow, VALIDATE_ROUTE } from './helpers/workflow-verify'
 import {
-  buildUniqueName,
-  createBasicWorkflowViaApi,
-  openWorkflowInBuilder,
-  createWorkflowWithTrigger,
   addScriptNode,
   addScriptNodeUnconnected,
+  buildUniqueName,
+  clickSaveAndWait,
+  createBasicWorkflowViaApi,
+  createWorkflowWithTrigger,
   deleteWorkflow,
+  openWorkflowInBuilder,
 } from './helpers/workflows'
 import { deleteWorkflowViaApi } from './utils/api'
 
 const VERIFY_BANNER_TIMEOUT = 20_000
 const ERROR_BADGE_TIMEOUT = 5_000
-const SAVE_URL_TIMEOUT = 15_000
 
 function getWorkflowIdFromUrl(app: Page): string {
   const id = app.url().match(/workflow-builder\/([^/?]+)/)?.[1]
@@ -341,8 +341,7 @@ test.describe('Variable reference validation', () => {
     try {
       await addScriptNode(app, 'Ref step', 'echo ${nonexistent_node.result}')
 
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: SAVE_URL_TIMEOUT })
+      await clickSaveAndWait(app)
 
       await triggerVerifyWorkflow(app)
 
@@ -372,8 +371,7 @@ test.describe('Variable reference validation', () => {
 
       await addScriptNodeUnconnected(app, 'Isolated step', `echo \${${upstreamNodeId}.result}`)
 
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: SAVE_URL_TIMEOUT })
+      await clickSaveAndWait(app)
 
       await triggerVerifyWorkflow(app)
 
@@ -396,8 +394,7 @@ test.describe('Variable reference validation', () => {
     try {
       await addScriptNode(app, 'Field ref step', 'echo ${trigger.missing_field}')
 
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: SAVE_URL_TIMEOUT })
+      await clickSaveAndWait(app)
 
       await mockValidateEndpoint(app, {
         valid: false,

--- a/frontend/packages/syntara-ui/e2e/workflow-verify-helper.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflow-verify-helper.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for the `triggerVerifyWorkflow` helper itself.
+ *
+ * The builder refetches the workflow, its versions and its executions right after
+ * a save, and that re-render can tear down an already-open kebab menu. The helper
+ * is supposed to survive that by re-opening the menu and clicking again, so these
+ * tests drive it against a synthetic page that reproduces the tear-down on demand
+ * rather than waiting for the race to show up in CI.
+ */
+import { test, expect, toAppUrl } from './fixtures'
+import { triggerVerifyWorkflow, VALIDATE_ROUTE } from './helpers/workflow-verify'
+
+const FIXTURE_PATH = '/e2e-fixtures/verify-kebab'
+
+/**
+ * Minimal stand-in for the builder toolbar kebab.
+ *
+ * The first time the menu opens, the item removes itself as soon as the mouse
+ * reaches it — Playwright has already judged it visible, enabled and stable by
+ * then, so the click is swallowed and reported as "element was detached from the
+ * DOM, retrying", exactly like the post-save re-render does in CI. Every later
+ * open behaves normally and posts to the validate endpoint.
+ */
+const FIXTURE_HTML = `<!doctype html>
+<html lang="en">
+  <body>
+    <button type="button" aria-label="Workflow actions" onclick="openMenu()">…</button>
+    <div id="menu-slot"></div>
+    <script>
+      let detachArmed = true
+      function openMenu() {
+        const slot = document.getElementById('menu-slot')
+        slot.innerHTML =
+          '<div role="menu">' +
+          '<button type="button" role="menuitem" onclick="verify()">Verify workflow</button>' +
+          '</div>'
+        if (detachArmed) {
+          slot.querySelector('[role="menuitem"]').addEventListener('mousemove', () => {
+            detachArmed = false
+            slot.innerHTML = ''
+          })
+        }
+      }
+      function verify() {
+        document.getElementById('menu-slot').innerHTML = ''
+        void fetch('/api/v1/workflows/validate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ workflow_definition: {} }),
+        })
+      }
+    </script>
+  </body>
+</html>`
+
+test.describe('triggerVerifyWorkflow helper', () => {
+  // No login needed: the helper is driven against a synthetic page, not the app.
+  test('re-opens the kebab and posts to validate after the menu detaches mid-click', async ({ page }) => {
+    const validateRequests: string[] = []
+
+    await page.route(`**${FIXTURE_PATH}`, (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: FIXTURE_HTML })
+    )
+    await page.route(VALIDATE_ROUTE, (route) => {
+      validateRequests.push(route.request().url())
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ valid: true, errors: [] }),
+      })
+    })
+
+    await page.goto(toAppUrl(FIXTURE_PATH))
+    await expect(page.getByRole('button', { name: 'Workflow actions' })).toBeVisible()
+
+    // The first open is swallowed by the detach, so this only resolves if the helper
+    // gives up on that click in time to re-open the menu and click again.
+    await triggerVerifyWorkflow(page)
+
+    expect(validateRequests).toHaveLength(1)
+  })
+})

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-multi-navigation.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, toAppUrl } from '../fixtures'
 import { dismissConnectionBanner, waitForApprovalPanel } from '../helpers/approvals'
+import { clickWhenEnabled } from '../helpers/patternfly'
 import { buildUniqueName } from '../helpers/workflows'
 import {
   apiRequest,
@@ -9,6 +10,9 @@ import {
   pollExecutionStatus,
   publishWorkflowViaApi,
 } from '../utils/api'
+
+/** Per-step budget inside the navigation retry, so a stomped attempt fails fast. */
+const NAV_STEP_TIMEOUT = 5_000
 
 test('multi-approval navigation: Previous/Next buttons and deep-link counter', async ({ app }) => {
   test.slow()
@@ -60,30 +64,46 @@ test('multi-approval navigation: Previous/Next buttons and deep-link counter', a
     const panelHeading = app.getByRole('heading', { name: /Review approval/i })
 
     const deepLink1 = toAppUrl(`/executions/${executionId}?approval=${approvalIds[0]}&history=closed`)
-    await app.goto(deepLink1)
+    const prevButton = app.getByRole('button', { name: 'Previous approval' })
+    const nextButton = app.getByRole('button', { name: 'Next approval' })
+
+    /**
+     * `useAutoApprovalDetection` fires once per node entering WAITING, so two
+     * parallel approval nodes fire it twice. Each landing reaches
+     * `handleDetected` in `useExecutionApprovalPanel`, which hard-overwrites the
+     * selected index via `setApprovalsAndIndex` — it has no notion that the user
+     * (here, the test) navigated in between. A detection arriving between the
+     * Next click and the "2 of 2" assertion snaps the panel back to "1 of 2",
+     * and the Previous button the test then reaches for is `isAriaDisabled`.
+     * Playwright honours `aria-disabled` in its actionability wait, and with no
+     * `actionTimeout` that click waits out the whole (slow) test budget — the
+     * observed 360s.
+     *
+     * Re-running the whole sequence from a fresh deep-link is the honest fix:
+     * the detections are bounded at one per node and serialised by the hook, so
+     * a retry lands after they are done. `clickWhenEnabled` keeps a stomped
+     * attempt from hanging instead of retrying.
+     *
+     * `toBeDisabled` / `toBeEnabled` below are real assertions, not no-ops —
+     * Playwright resolves both through `aria-disabled`.
+     */
     await expect(async () => {
       await app.goto(deepLink1)
       await waitForApprovalPanel(app)
       await dismissConnectionBanner(app)
-      await expect(panelHeading.getByText('1 of 2')).toBeVisible({ timeout: 5_000 })
+      await expect(panelHeading.getByText('1 of 2')).toBeVisible({ timeout: NAV_STEP_TIMEOUT })
+      await expect(prevButton).toBeDisabled({ timeout: NAV_STEP_TIMEOUT })
+
+      // Navigate forward to second approval
+      await clickWhenEnabled(nextButton, { timeout: NAV_STEP_TIMEOUT })
+      await expect(panelHeading.getByText('2 of 2')).toBeVisible({ timeout: NAV_STEP_TIMEOUT })
+      await expect(nextButton).toBeDisabled({ timeout: NAV_STEP_TIMEOUT })
+
+      // Navigate backward to first approval
+      await clickWhenEnabled(prevButton, { timeout: NAV_STEP_TIMEOUT })
+      await expect(panelHeading.getByText('1 of 2')).toBeVisible({ timeout: NAV_STEP_TIMEOUT })
+      await expect(nextButton).toBeEnabled({ timeout: NAV_STEP_TIMEOUT })
     }).toPass({ timeout: 60_000, intervals: [5_000] })
-
-    const prevButton = app.getByRole('button', { name: 'Previous approval' })
-    const nextButton = app.getByRole('button', { name: 'Next approval' })
-    await expect(prevButton).toBeDisabled()
-    await expect(nextButton).toBeEnabled()
-
-    // Navigate forward to second approval
-    await nextButton.click()
-    await expect(panelHeading.getByText('2 of 2')).toBeVisible({ timeout: 10_000 })
-    await expect(prevButton).toBeEnabled()
-    await expect(nextButton).toBeDisabled()
-
-    // Navigate backward to first approval
-    await prevButton.click()
-    await expect(panelHeading.getByText('1 of 2')).toBeVisible({ timeout: 10_000 })
-    await expect(prevButton).toBeDisabled()
-    await expect(nextButton).toBeEnabled()
 
     // --- Part 2: Deep-link directly to second approval, verify counter ---
     const deepLink2 = toAppUrl(`/executions/${executionId}?approval=${approvalIds[1]}&history=closed`)

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-node.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-node.spec.ts
@@ -148,7 +148,6 @@ test.describe('Approval Node Configuration', () => {
       await saveWorkflow(app, workflowName)
 
       // Assert - Verify workflow is persisted
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
       await expect(app.getByPlaceholder('Workflow name')).toHaveValue(workflowName)
 
       // Verify the node is still visible after save
@@ -236,7 +235,6 @@ test.describe('Approval Node Configuration', () => {
         await saveWorkflow(app, workflowName)
 
         // Assert - Verify workflow is persisted
-        await expect(app).toHaveURL(/workflow-builder\/.+/)
         await verifyNodeVisible(app, `Approval fallback ${decision}`)
       }
     } finally {
@@ -286,7 +284,6 @@ test.describe('Approval Node Configuration', () => {
 
       // Save the workflow
       await saveWorkflow(app, workflowName)
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
     } finally {
       // Cleanup
       await deleteWorkflow(app, workflowName)

--- a/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/approval-side-panel.spec.ts
@@ -22,6 +22,9 @@ import {
   publishWorkflowViaApi,
 } from '../utils/api'
 
+/** Per-attempt budget for the Review approval click and the panel to come back. */
+const REVIEW_REOPEN_TIMEOUT = 5_000
+
 test.describe('Approval Side Panel', () => {
   test.skip(!process.env['SYNTARA_E2E_HAS_TEMPORAL_WORKER'], 'Temporal worker unavailable (globalSetup probe)')
 
@@ -152,15 +155,37 @@ test.describe('Approval Side Panel', () => {
 
     test('run history and approval panel are mutually exclusive', async ({ app }) => {
       const historyHeading = app.getByRole('heading', { name: 'Run history' })
+      const reviewHeading = app.getByRole('heading', { name: 'Review Approval' })
+      const reviewBtn = app.getByRole('button', { name: 'Review approval' })
+
       await expect(historyHeading).not.toBeVisible()
 
       await app.getByRole('button', { name: /Run history/i }).click()
       await expect(historyHeading).toBeVisible()
-      await expect(app.getByRole('heading', { name: 'Review Approval' })).not.toBeVisible()
+      await expect(reviewHeading).not.toBeVisible()
 
-      const reviewBtn = app.getByRole('button', { name: 'Review approval' })
-      await reviewBtn.click()
-      await expect(app.getByRole('heading', { name: 'Review Approval' })).toBeVisible()
+      /**
+       * `toggleHistoryCard` sets `panelOpen = false`, but `useAutoApprovalDetection`
+       * can asynchronously set it back to `true` afterwards. The Review approval
+       * button is `isAriaDisabled={isLoading || isDisabled}` with `isDisabled`
+       * being "the approval panel is open" (`ApprovalActionButtons`), and
+       * Playwright's actionability wait honours `aria-disabled` — so a bare
+       * `click()` against a re-opened panel waits out the whole test timeout,
+       * which is the observed 120s.
+       *
+       * The click is swallowed and the *outcome* is the success condition,
+       * because detection re-opening the panel reaches the same end state the
+       * click was after. `clickWhenEnabled` alone would not do: once the panel is
+       * open the button never becomes enabled again, so the helper would fail
+       * fast rather than hang — better, but still a failure.
+       */
+      await expect(async () => {
+        if (await reviewBtn.isEnabled().catch(() => false)) {
+          await reviewBtn.click({ timeout: REVIEW_REOPEN_TIMEOUT }).catch(() => {})
+        }
+        await expect(reviewHeading).toBeVisible({ timeout: REVIEW_REOPEN_TIMEOUT })
+      }).toPass({ timeout: 30_000, intervals: [1_000, 2_000] })
+
       await expect(historyHeading).not.toBeVisible()
     })
   })

--- a/frontend/packages/syntara-ui/e2e/workflows/builder.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/builder.spec.ts
@@ -432,7 +432,7 @@ test('catalog panel can be closed without adding a node', async ({ app }) => {
 
     await expect(panel).not.toBeVisible()
 
-    await expect(app).toHaveURL(/workflow-builder\/.+/)
+    await expect(app).toHaveURL(/workflow-builder\/(?!new)/)
   } finally {
     await deleteWorkflow(app, workflowName)
   }

--- a/frontend/packages/syntara-ui/e2e/workflows/conditional-node.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/conditional-node.spec.ts
@@ -48,7 +48,6 @@ test('user adds Conditional node and saves workflow', async ({ app }) => {
     await saveWorkflow(app, workflowName)
 
     // Assert - Verify workflow is persisted
-    await expect(app).toHaveURL(/workflow-builder\/.+/)
     await expect(app.getByPlaceholder('Workflow name')).toHaveValue(workflowName)
 
     // Verify the node is still visible after save
@@ -177,7 +176,6 @@ test('user configures Conditional node with if/else-if/else branches', async ({ 
     await saveWorkflow(app, workflowName)
 
     // Verify workflow is persisted
-    await expect(app).toHaveURL(/workflow-builder\/.+/)
 
     // Verify output handles on the canvas (at least 2 for if/else-if)
     const conditionalNode = app
@@ -274,7 +272,6 @@ test('user adds condition group to create complex conditional logic', async ({ a
     await saveWorkflow(app, workflowName)
 
     // Verify workflow is persisted
-    await expect(app).toHaveURL(/workflow-builder\/.+/)
     await expect(app.getByPlaceholder('Workflow name')).toHaveValue(workflowName)
   } finally {
     await deleteWorkflow(app, workflowName)

--- a/frontend/packages/syntara-ui/e2e/workflows/create.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/create.spec.ts
@@ -13,7 +13,7 @@
  */
 
 import { test, expect, toAppUrl } from '../fixtures'
-import { buildUniqueName, deleteWorkflow, selectProjectIfRequired } from '../helpers/workflows'
+import { buildUniqueName, clickSaveAndWait, deleteWorkflow, selectProjectIfRequired } from '../helpers/workflows'
 
 test.describe('Workflows - Create New Workflow', () => {
   test('user creates a new workflow with name and description', async ({ app }) => {
@@ -159,8 +159,7 @@ test.describe('Workflows - Create New Workflow', () => {
       const name1Input = app.getByPlaceholder('Workflow name')
       await name1Input.clear()
       await name1Input.fill(workflow1Name)
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15000 })
+      await clickSaveAndWait(app)
 
       // Go back and create second workflow
       await app.goto(toAppUrl('/workflows'))
@@ -175,8 +174,7 @@ test.describe('Workflows - Create New Workflow', () => {
       const name2Input = app.getByPlaceholder('Workflow name')
       await name2Input.clear()
       await name2Input.fill(workflow2Name)
-      await app.getByRole('button', { name: 'Save' }).click()
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15000 })
+      await clickSaveAndWait(app)
 
       // Verify both workflows exist in the table
       await app.goto(toAppUrl('/workflows'))

--- a/frontend/packages/syntara-ui/e2e/workflows/create.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/create.spec.ts
@@ -43,10 +43,7 @@ test.describe('Workflows - Create New Workflow', () => {
       await workflowNameInput.clear()
       await workflowNameInput.fill(workflowName)
 
-      await app.getByRole('button', { name: 'Save' }).click()
-
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15000 })
-      await expect(app).not.toHaveURL(/workflow-builder\/new/)
+      await clickSaveAndWait(app)
 
       await app.goto(toAppUrl('/workflows'))
       await expect(app.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible()
@@ -99,11 +96,7 @@ test.describe('Workflows - Create New Workflow', () => {
       await workflowNameInput.clear()
       await workflowNameInput.fill(customName)
 
-      const saveButton = app.getByRole('button', { name: 'Save' })
-      await expect(saveButton).toBeVisible()
-      await saveButton.click()
-
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15000 })
+      await clickSaveAndWait(app)
       await expect(app.getByPlaceholder('Workflow name')).toHaveValue(customName)
     } finally {
       await deleteWorkflow(app, customName)
@@ -128,10 +121,7 @@ test.describe('Workflows - Create New Workflow', () => {
       const nameInput = app.getByPlaceholder('Workflow name')
       await nameInput.clear()
       await nameInput.fill(workflowName)
-      await app.getByRole('button', { name: 'Save' }).click()
-
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15000 })
-      await expect(app).not.toHaveURL(/workflow-builder\/new/)
+      await clickSaveAndWait(app)
 
       await expect(app.getByPlaceholder('Workflow name')).toHaveValue(workflowName)
 

--- a/frontend/packages/syntara-ui/e2e/workflows/incomplete-node-validation.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/incomplete-node-validation.spec.ts
@@ -15,7 +15,13 @@
 import { test, expect, toAppUrl, type Page } from '../fixtures'
 import { addManualTrigger, openAddNodePanel } from '../helpers/v2-nodes'
 import { triggerVerifyWorkflow } from '../helpers/workflow-verify'
-import { buildUniqueName, selectProjectIfRequired, closeNodeEditorPanel, addNodePanel } from '../helpers/workflows'
+import {
+  addNodePanel,
+  buildUniqueName,
+  clickSaveAndWait,
+  closeNodeEditorPanel,
+  selectProjectIfRequired,
+} from '../helpers/workflows'
 import { ensureProject, apiRequest } from '../utils/api'
 
 const VERIFY_BANNER_TIMEOUT = 20_000
@@ -70,8 +76,7 @@ test.describe('UI-32: Workflow Verification — Missing Required Configuration',
       // Save and capture the workflow ID for reliable API-based cleanup
       await selectProjectIfRequired(app)
       await app.getByPlaceholder('Workflow name').fill(workflowName)
-      await app.getByRole('button', { name: 'Save', exact: true }).click()
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15_000 })
+      await clickSaveAndWait(app)
       workflowId = app.url().match(/workflow-builder\/([a-f0-9-]{36})/)?.[1]
 
       // Verification is a separate action from save — trigger it via the kebab menu.

--- a/frontend/packages/syntara-ui/e2e/workflows/loop-nodes.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/loop-nodes.spec.ts
@@ -45,7 +45,6 @@ test.describe('Loop Node Configuration [UI-16]', () => {
       await verifyNodeVisible(app, 'While loop')
       await saveWorkflow(app, workflowName)
 
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
       await expect(app.getByPlaceholder('Workflow name')).toHaveValue(workflowName)
       await verifyNodeVisible(app, 'While loop')
     } finally {
@@ -67,7 +66,6 @@ test.describe('Loop Node Configuration [UI-16]', () => {
       await verifyNodeVisible(app, 'For each loop')
       await saveWorkflow(app, workflowName)
 
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
       await expect(app.getByPlaceholder('Workflow name')).toHaveValue(workflowName)
       await verifyNodeVisible(app, 'For each loop')
     } finally {
@@ -243,7 +241,6 @@ test.describe('Loop Node Configuration [UI-16]', () => {
 
         await saveWorkflow(app, workflowName)
 
-        await expect(app).toHaveURL(/workflow-builder\/.+/)
         await expect(app.getByPlaceholder('Workflow name')).toHaveValue(workflowName)
       } finally {
         await deleteWorkflow(app, workflowName)

--- a/frontend/packages/syntara-ui/e2e/workflows/manual-trigger.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/manual-trigger.spec.ts
@@ -48,7 +48,7 @@ test.describe('Manual Trigger', () => {
       await app.getByRole('link', { name: workflowName, exact: true }).click()
 
       // Wait for builder to load
-      await expect(app).toHaveURL(/workflow-builder\/.+/, { timeout: 15_000 })
+      await expect(app).toHaveURL(/workflow-builder\/(?!new)/, { timeout: 15_000 })
 
       // Click Layout to position nodes within the viewport so both are visible
       const layoutButton = app.getByRole('button', { name: 'Reset layout', exact: true })

--- a/frontend/packages/syntara-ui/e2e/workflows/node-configuration.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/node-configuration.spec.ts
@@ -28,7 +28,6 @@ test('AI agent node configuration form renders with tools, output, and LLM', asy
     await saveWorkflow(app, workflowName)
 
     // Assert - Verify workflow is persisted
-    await expect(app).toHaveURL(/workflow-builder\/.+/)
     await expect(app.getByPlaceholder('Workflow name')).toHaveValue(workflowName)
 
     // Verify the node is still visible after save

--- a/frontend/packages/syntara-ui/e2e/workflows/node-editor-panels.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/node-editor-panels.spec.ts
@@ -37,12 +37,29 @@ async function layoutCanvas(app: Page) {
   }
 }
 
-/** Click a React Flow node by its visible text label. */
+/**
+ * Click a React Flow node by its visible text label and wait for its editor to open.
+ *
+ * `layoutCanvas` above ends with "Fit view" plus a fixed 500ms sleep, so under CI
+ * load the click can land while the React Flow viewport is still transforming.
+ * The click is then lost: no editor opens, and the caller fails much later on a
+ * missing panel heading with nothing in the trace to explain it.
+ *
+ * Retrying the open is the same remedy `openNodeForEditing` already uses for the
+ * double-click path. The success condition is the editor showing *this* node —
+ * the Name field carries the clicked node's name — rather than merely "a panel is
+ * open", which would be satisfied by the previous node's editor in the tests that
+ * click several nodes in a row.
+ */
 async function clickNode(app: Page, nodeText: string) {
   await layoutCanvas(app)
   const node = app.locator('[role="group"][aria-roledescription="node"]').filter({ hasText: nodeText })
-  await expect(node).toBeVisible({ timeout: 5_000 })
-  await node.click()
+  const nameInput = app.getByRole('textbox', { name: 'Name', exact: true })
+  await expect(async () => {
+    await expect(node).toBeVisible({ timeout: 5_000 })
+    await node.click({ timeout: 5_000 })
+    await expect(nameInput).toHaveValue(nodeText, { timeout: 5_000 })
+  }).toPass({ timeout: 30_000, intervals: [500, 1_000, 2_000] })
 }
 
 test.describe('Node editor panels', () => {

--- a/frontend/packages/syntara-ui/e2e/workflows/table.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/table.spec.ts
@@ -71,7 +71,7 @@ test.describe('Workflows Table - Display and Navigation', () => {
 
       await workflowRow.getByRole('link', { name: workflowName, exact: true }).click()
 
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
+      await expect(app).toHaveURL(/workflow-builder\/(?!new)/)
       await expect(app.getByPlaceholder('Workflow name')).toHaveValue(workflowName)
     } finally {
       await deleteWorkflowViaApi(app, workflow.id)

--- a/frontend/packages/syntara-ui/e2e/workflows/wait-node.spec.ts
+++ b/frontend/packages/syntara-ui/e2e/workflows/wait-node.spec.ts
@@ -40,8 +40,8 @@ test.describe('Wait Node Configuration', () => {
       await verifyNodeVisible(app, 'Wait 30s')
 
       // Save and verify persistence
+      // saveWorkflow now gates on the create response, so no URL guard is needed
       await saveWorkflow(app, workflowName)
-      await expect(app).toHaveURL(/workflow-builder\/.+/)
 
       // Reopen to verify configuration persisted
       await openNodeForEditing(app, 'Wait 30s')

--- a/frontend/packages/syntara-ui/eslint.config.js
+++ b/frontend/packages/syntara-ui/eslint.config.js
@@ -576,6 +576,19 @@ export default tseslint.config(
           message:
             'Do not use PatternFly CSS class selectors in locator(). Use semantic Playwright locators instead: getByRole, getByLabel, getByPlaceholder, getByText, or getByTestId.',
         },
+        // `/workflow-builder\/.+/` reads as "we navigated to a saved workflow", but
+        // `.+` matches the literal path segment `new` — so the assertion passes the
+        // instant Save is clicked, before any request is sent. And an existing
+        // workflow never changes URL at all, so no URL gate can work on the PATCH
+        // path. Matches only patterns that mention workflow-builder AND contain
+        // `.+`; the `(?!new)` forms and the deliberate `/workflow-builder\/new/`
+        // and bare `/workflow-builder/` route checks have no `.+` and are exempt.
+        {
+          selector:
+            'CallExpression[callee.property.name="toHaveURL"] > .arguments:first-child[type="Literal"][regex.pattern=/workflow-builder/][regex.pattern=/\\.\\+/]:not([regex.pattern=/\\(\\?!new/])',
+          message:
+            'Do not gate a workflow save on toHaveURL(/workflow-builder\\/.+/) — `.+` matches the literal `new` segment, so the assertion passes before the save request is sent, and an existing workflow never changes URL at all. Use clickSaveAndWait() from e2e/helpers/workflow-save.ts.',
+        },
       ],
       // Targets Playwright locator.first() / .nth() -- not standard JS/Array methods,
       // so false positives on non-Playwright code are rare in E2E specs.


### PR DESCRIPTION
## Summary — every test fixed

| # | Test | Symptom | Cause | §  |
|---|---|---|---|---|
| 1 | `workflows/incomplete-node-validation.spec.ts:55` (UI-32) | verify never POSTed; 30 s retry budget held one lost attempt | unbounded `click()` on a detached menu item parked for the whole budget | §1 |
| 2 | `access-management.spec.ts:341,349,365` | "No results found" — seeded policy already deleted | module-scope seed array accumulated across `beforeAll`/`afterAll` re-entry | §2 |
| 3 | `builder-unsaved-changes.spec.ts:139` | test timeout at 120 s with every assertion already passed | cleanup's unbounded `fill('Filter by name')` hung on the empty state's missing toolbar | §3 |
| 4 | `pagination.spec.ts:171` | `HTTP 401 TOKEN_STALE` mid-seed | another worker's UI logout bumped the shared admin token version | §4 |
| 5 | `builder.spec.ts:12` | saved workflow missing from `/workflows` | `toHaveURL(/workflow-builder\/.+/)` — `.+` matches the literal `new` | §5 |
| 6 | `builder.spec.ts:66` | renamed workflow missing from `/workflows` | **no wait at all** — a rename never changes the URL, so no URL guard is possible | §5 |
| 7 | `workflows/create.spec.ts:144` | second workflow missing from the table | same weak guard, twice | §5 |
| 8 | `v2-workflow-migration.spec.ts:365` | workflow missing after reload | same weak guard | §5 |
| 9 | `workflows/wait-node.spec.ts:102` | failed twice at the full 15 s | correct `(?!new)` guard, but the save genuinely exceeds 15 s under load | §5 |
| 10 | `credential-enable-disable.spec.ts:165` | credential still enabled after navigating back | optimistic switch asserted before the PATCH was issued; `goto` aborted it | §7 |
| 11 | `permission-gating.spec.ts:536` (auditor) | project group-header row never rendered | unfiltered 20-row `-updated_at` page; seeded workflow evicted by parallel workers | §8 |
| 12 | `permission-gating.spec.ts:~470` (viewer) | latent — identical structure | same | §8 |
| 13 | `workflows/approval-multi-navigation.spec.ts:13` | **360 s timeout, no failing assertion** | `useAutoApprovalDetection` reset the index; the click hit an `aria-disabled` button and hung | §9 |
| 14 | `workflows/approval-side-panel.spec.ts:153` | **120 s timeout, no failing assertion** | detection re-opened the panel; **Review approval** went `aria-disabled` and the click hung | §9 |
| 15 | `run-step.spec.ts:274` | dialog never opened; 30 s retry burned | builder left dirty by `triggerLayout`, so `handleRunStep`'s pre-save failed and returned silently | §10 |
| 16 | `core/websocket/test_receive_only_channels.py` (2 tests) | `ConnectionClosedError: received 1012` | hard-coded port 9999 shared across 8 xdist workers | §11 |
| 17 | `core/websocket/test_json_validation.py` (2 tests) | `1012`, and `Cannot get the new connection from lifecycle_manager` | same shared port; the lifecycle manager is a per-process singleton | §11 |
| 18 | `permission-gating.spec.ts:1014` (auditor IdP) | menu never opened; three `toHaveAttribute` assertions on a missing `menuitem` | `click({ force: true })` on a row the list query was replacing — no actionability wait, no retry | §12 |
| 19 | `credential-enable-disable.spec.ts:69` | dialog never opened; failure 25 s later inside `waitForDisableDialogReady` | same forced click, on the Enabled switch | §13 |
| 20 | `permission-gating.spec.ts:1014` (auditor IdP) — **the real cause** | seeded IdP row never rendered | unfiltered page of 20 sorted by `name`; `pagination.spec.ts` seeds 21 that sort ahead of it | §14 |
| 21 | `session-revocation.spec.ts:146` | latent — same table, same lookup; and its post-delete `toHaveCount(0)` could not fail | same | §14 |
| 22 | `authentication-group-mapping.spec.ts:160,188` | latent — third reader of the identity providers list, missed by §14 | same | §15 |
| 23 | `permission-gating.spec.ts:369,417,458` | latent — workflow rows on an unfiltered `-updated_at` page of 20, missed by §8 | same | §15 |

**Also fixed, found by the sweep rather than reported by it** — these were failing or silently passing on a failed save, and the honest response gate surfaced them:

| Test | What was wrong |
|---|---|
| `eda-trigger.spec.ts:30` | save 422'd (`Service account(s) not found in this project`) and the test passed anyway; fails on unmodified `devel` too |
| `webhook-trigger.spec.ts:151` | same 422, hidden the same way — the follow-up assertion only read canvas state |
| `v2-workflow-migration.spec.ts:147` | save 422'd on the LLM credential's project |
| 27 latent weak-guard sites across 17 spec files | the same assertion that cannot fail, not yet observed flaking — swept, and now blocked by an ESLint rule |

## Description

PR #532 started as four cross-worker E2E flakes. It was then dequeued from the merge queue by a *different* flake, which prompted a sweep of every `merge_group` run from 10–11 Sep 2026: 13 failing `CI Frontend E2E` runs and 5 failing `CI Backend` runs, 34 distinct failing tests. Excluding the four already fixed here, the ones already quarantined in `syntara-ci`, and one fixed by #523, **10 frontend and 3 backend tests were still live** — any of them able to dequeue any PR.

This PR now fixes all of them bar one, plus the ones the Konflux runs surfaced afterwards (§12–§14) and the ones a follow-up audit found (§15). Twelve commits, one per fix.

None is a product regression. They cluster into four shared mechanisms, and fixing the mechanism fixed every test that shared it:

| Mechanism | Fixed in |
|---|---|
| An assertion that could not fail — `.+` matching the literal `new` | §5, §6 |
| Optimistic UI mistaken for a completed write | §7 |
| PatternFly `isAriaDisabled` + no `actionTimeout` → a click that hangs for the whole test | §1, §9 |
| Tests that assume they are alone under `fullyParallel` | §2, §3, §4, §8 |
| A forced click that lands on a row being re-rendered, with nothing to retry it | §12, §13 |
| Asserting on an unfiltered, paginated list | §8, §14, §15 |
| Backend: a test server on a hard-coded port, shared across 8 xdist workers | §11 |

### 1. `triggerVerifyWorkflow` — a swallowed click ate the whole retry budget

`triggerVerifyWorkflow` is meant to survive the builder tearing down an open kebab menu: a swallowed click produces no validate response, so `toPass` re-opens the menu and clicks again. It never got the chance.

`verifyItem.click()` was called with no timeout and `playwright.config.ts` sets no `actionTimeout`, so Playwright's own auto-retry-on-detach parks the call for the entire 30 s budget. Control never reaches the response check on line 45, the kebab is never re-opened, and a budget meant to hold two or three attempts holds exactly one — the one that was already lost.

That is what failed UI-32 on [run 34482923027](https://github.com/syntara-orchestration/syntara/actions/runs/34482923027/job/102892260100) (`e2e/workflows/incomplete-node-validation.spec.ts:55`). Evidence from that run:

- The backend never saw the request. `POST /api/v1/workflows/validate` appears in the service logs at 14:16:28, 14:17:50 and 14:22:02 — nothing during either verify window (14:18:53→14:19:23, 14:19:32→14:20:03). Both UI-32 workflows were created and loaded with 200s.
- The Playwright trace, identical on attempt 1 and the retry:

  ```
  click getByRole('button', { name: 'Workflow actions' })  -> click action done
  click getByRole('menuitem', { name: /verify workflow/i })
    locator resolved to <button role="menuitem" class="pf-v6-c-menu__item">
    attempting click action
    waiting for element to be visible, enabled and stable
    element is visible, enabled and stable
    scrolling into view if needed / done scrolling
    element was detached from the DOM, retrying      <-- menu torn down
  (no further entries — the click never returns)
  waitForResponse **/api/v1/workflows/validate -> Timeout 15000ms exceeded
  ```

The builder refetches the workflow, its versions and its executions right after a save, and that re-render is what tears the open menu down.

### 2. `access-management.spec.ts:365` — a seed array that outlived its `afterAll`

`playwright.config.ts` sets `fullyParallel: true`, so a spec file's tests are handed out individually and a worker can receive two non-contiguous groups from the same file. Playwright runs the file-scope `beforeAll`/`afterAll` around **each** group, but the module holding `seededPolicies` is imported once per worker. The array was only ever pushed to, so it accumulated entries that the matching `afterAll` had already deleted — and `seededPolicies[0]` named one of them.

From [run 34382665277](https://github.com/syntara-orchestration/syntara/actions/runs/34382665277/job/102615498234), policy `8349d14f-0cf4-40f7-b558-31c6c9b2068a` (`e2e-am-1788982818895-…-policy`):

```
19:40:20.99  Created policy name=e2e-am-1788982818895-…-policy
19:40:28.62  DELETE /api/v1/projects/74c1c862…/policies/8349d14f…  204   <-- afterAll
19:40:47.60  GET /api/v1/policies?…&name[contains]=e2e-am-1788982818895-…  200 74   <-- the test
19:41:03.96  DELETE /api/v1/projects/74c1c862…/policies/8349d14f…  404   <-- deleted twice
```

That GET is the **only** one in the whole log with that filter: the app fetched once, got an empty page, rendered "No results found", and `expect(...).toBeVisible({timeout: 15_000})` then polled a DOM that was never going to change. The `error-context.md` snapshot confirms `heading "No results found"` under the Policies tab. `Created policy name=e2e-am-…` appears **7 times** in that run for a 15-test file on 3 workers — the hook re-entry is not exotic, it is the norm.

The two neighbouring tests in that describe (`:341`, `:349`) were retried in the same run for the same reason.

### 3. `builder-unsaved-changes.spec.ts:139` — cleanup consumed the test timeout

Every assertion in the test body passed by 10.1 s of a 120 s budget. The `finally` killed it.

`deleteWorkflow` prefers an API delete and falls back to the UI when the name lookup finds nothing — the ordinary case here, because the test renames the workflow and then asks cleanup to delete both names. The list is then often empty, and an empty project renders the "No workflows yet" empty state, which has **no filter toolbar**. The helper's `fill('Filter by name')` carried no timeout, `playwright.config.ts` sets no `actionTimeout`, and the surrounding `try/catch` could not help because nothing rejected — the call simply never returned.

Trace from that run, and the page snapshot at the timeout:

```
12444  fetch  DELETE …/workflows/<renamed>            <- 204, API path worked
12614  fetch  GET …/workflows?name[contains]=<original name>&limit=50   <- empty
12886  goto   http://localhost:8080/workflows
13170  fill   internal:attr=[placeholder="Filter by name"i]
13177    waiting for getByPlaceholder('Filter by name')
# HUNG — started and never returned
```

```yaml
- heading "No workflows yet" [level=2]
- generic: Create your first workflow to get started.
- button "Create workflow"
```

### 4. `pagination.spec.ts:171` — a logout in another worker aged the seed token

`beforeAll` fetches one admin token and reuses it across ~78 sequential seed calls (22 workflows, 2 credentials, 2 integrations, 16 users, 15 groups, 21 IdPs). The whole suite authenticates as the same `admin` account, and `POST /auth/logout` calls `store.increment_token_version()` (`backend/src/syntara/auth/router.py:880`), which invalidates **every** access token that user holds — not just the session logging out. `permission-cache-user-switch.spec.ts` performs a real UI logout as admin in its real-backend branch, and the stale-token middleware (`backend/src/syntara/auth/middleware.py:345`) then rejects everyone else's cached token:

```
Error: createUserViaApi failed for e2e-pag-…-user-15: HTTP 401
{"detail":"Token is outdated, please refresh","code":"TOKEN_STALE","retryable":true}
   at seeds/iam.ts:55
   at pagination.spec.ts:80
```

Different index in each run (user-15 in 34382665277, user-12 in 34377476513) — the loop dies wherever the logout happens to land. The backend marks the failure `retryable: true`; nothing was retrying it.


### 5. Workflow saves gated on the URL, not the save response

Five specs clicked **Save**, asserted `toHaveURL(/workflow-builder\/.+/)`, then navigated to `/workflows` and expected the row. `.+` matches the literal `new` segment, so the assertion was satisfied the instant the click was dispatched — before any request went out. The `goto` then tore the document down and aborted the in-flight create.

Tightening the regex is not enough, for two independent reasons:

- `builder.spec.ts:66` saves an **existing** workflow. The URL never changes there, so *no* URL guard can work — and it had no wait at all.
- `workflows/wait-node.spec.ts` already used the correct `(?!new)` form and still failed twice at the full 15 s. The save genuinely exceeds 15 s under merge-queue load.

New `e2e/helpers/workflow-save.ts` waits on the create/update response instead. The method+path predicate is deliberate: a `**/api/v1/workflows*` glob also matches the `POST /workflows/validate` that the Verify action fires. The helper asserts the button is enabled first, because PatternFly renders Save with `isAriaDisabled` — see §9 for why an unbounded click on one of those is a 60 s hang rather than a failure.

`saveWorkflow` was upgraded in place, fixing all 32 of its call sites at once, as were the two inlined copies in `createBasicWorkflow` and `createWorkflowWithTrigger`.

### 6. The same weak guard, 32 times — swept, and linted

The weak form appeared 32 times across 17 spec files. Five flaked; the other 27 were latent. Each site was triaged rather than mechanically re-regexed, because `(?!new)` is still a no-op on the PATCH path:

- **Load-bearing** after a Save click → replaced with `clickSaveAndWait`. This includes the three saves in `workflow-verification.spec.ts`, which save an existing workflow, where the guard was doing nothing whatsoever.
- **Decorative** (following a now-gated `saveWorkflow`) → deleted.
- **Not a save** (asserting we navigated into a saved workflow after clicking a link or importing) → strengthened to `(?!new)`.

A `no-restricted-syntax` rule in `frontend/packages/syntara-ui/eslint.config.js` now blocks the form. The esquery selector matches only patterns naming `workflow-builder` **and** containing `.+`, so the deliberate `/workflow-builder\/new/` assertions and the bare `/workflow-builder/` route checks stay legal — verified by running eslint against a file still carrying the weak form before the replacements.

**Gating honestly then surfaced three saves that were failing with a 422 and passing anyway**, because `.+` matched the `new` the builder never left and the follow-up assertion only read canvas state:

- `eda-trigger` and `webhook-trigger` seed a service account under `ensureProject`'s `default` project, but let an unnamed `selectProjectIfRequired` pick whichever project the dropdown lists first. When those differ the backend rejects the save with `Service account(s) not found in this project`. Both now pin the project.
- `v2-workflow-migration`'s all-executors test has the same mismatch for the LLM credential (`One or more credential references are invalid or belong to a different project`).
- Passing a name to `selectProjectIfRequired` was itself ambiguous: each option's accessible name is `"<name> <description>"`, so a substring match for `default` also matched the built-in project's `"Default project for …"` and resolved to two elements. It now anchors at the start.

`eda-trigger` fails on unmodified `devel` in the same environment and passes on this branch — a bonus fix that fell out of the sweep.

### 7. `credential-enable-disable.spec.ts:165` — optimistic UI is not a completed write

The test disabled a credential, asserted the switch was off, navigated to `/workflows`, came back and expected it still off.

**The product is not at fault.** `useOptimisticCredentialEnabled` is a correct React 19 `useOptimistic` + `startTransition` Action: it flips the switch immediately, awaits the PATCH, awaits the refetch, rolls back on failure, and raises an error toast. The test races it — the first `not.toBeChecked()` is satisfied by optimistic state *before the PATCH is issued*, and `goto('/workflows')` aborts the in-flight request. `queryClient` sets no `staleTime`, so the return trip refetches and honestly renders `enabled: true`.

The idiom already existed in `helpers/credentials.ts` but armed `waitForResponse` before the **toggle** click rather than the **Disable** click, with the 25 s affected-workflows/affected-integrations usage check in between and no explicit timeout — so it sat about 5 s from expiring for a reason unrelated to the PATCH. The extracted helper arms immediately before Disable and asserts the response is ok. A private `filterCredentialByName` shadowing the identical exported one is gone too.

### 8. `permission-gating.spec.ts:536` — asserting on an unfiltered, paginated list

The test seeds a project plus one workflow, switches to *All projects*, and asserts the project's group-header row carries no kebab.

That row is not backed by a projects query — it is synthesised from whatever workflows the page fetched (`useWorkflowGrouping`). The fetch is a single page of 20 sorted `-updated_at`, and the test applied no name filter, so under `fullyParallel` with three workers the seeded workflow is pushed off page 1 by other specs within seconds and the group header never renders.

The cleanup was the other half. `try`/`catch` + rethrow duplicated the inline deletes, so a failure between the two leaked both resources — and the fallback listed `/workflows` and `/projects` **unfiltered**, which under parallel load frequently does not contain them. Every flaky run therefore left another workflow crowding page 1 for later runs, making the flake self-reinforcing. Now `finally`, with filtered lookups (`findWorkflowIdByName`, new `findProjectIdByName`).

The viewer test at `:~470` is structurally identical and was latent; both are fixed.

### 9. The approval specs — clicking `aria-disabled` buttons hangs for the whole test

`approval-multi-navigation.spec.ts` and `approval-side-panel.spec.ts` timed out at the full budget — 360 s and 120 s — **with no failing assertion to explain either**.

`useAutoApprovalDetection` fires once per node entering WAITING and lands in `handleDetected`, which hard-overwrites `currentIndex` via `setApprovalsAndIndex` and forces `setPanelOpen(true)`. It is WebSocket-driven, so it races whatever the test just did: in *multi-navigation* two parallel approval nodes fire it twice, snapping the index back; in *side-panel* it re-opens a panel `toggleHistoryCard` just closed, which makes **Review approval** `isAriaDisabled` again.

The flake is not the dangerous part — the failure mode is. These buttons use PF `isAriaDisabled`, which leaves a perfectly resolvable element. Playwright honours `aria-disabled` in its actionability wait, and with no `actionTimeout` configured a `click()` on one hangs for the entire test where a fast assertion failure would have cost 10 s.

So: bound every such click (`clickWhenEnabled` in `e2e/helpers/patternfly.ts`), and make the **outcome** the success condition rather than the click. *multi-navigation* re-runs the whole navigate-and-assert sequence from a fresh deep link under `toPass`; *side-panel* swallows the click and asserts the panel came back, because detection re-opening it reaches the same end state. `clickWhenEnabled` alone would not do there — once the panel is open the button never becomes enabled again, so it would fail fast rather than hang: better, but still a failure.

Note the existing `toBeDisabled()` / `toBeEnabled()` assertions in *multi-navigation* are real, not no-ops — Playwright resolves both through `aria-disabled`. They were left alone.

### 10. `run-step.spec.ts:274` — a dirty builder made every Run step click a silent no-op

The reported `5000ms` is an inner assertion inside `openRunStepDialog`'s `.toPass({ timeout: 30_000 })`, so the helper actually burned 30 s.

`createTwoNodeWorkflow` built the workflow through the UI and ended with `triggerLayout` — and "Reset layout" calls `onLayout({ markDirty: true })`, leaving the store dirty. Every later **Run step** click therefore ran a save first inside `handleRunStep`, which **returns silently** when that save resolves false. The dialog never opened, and `toPass` just retried the same failing save three more times.

The fix is the pattern this file's own siblings already use and document: build the workflow with `createWorkflowViaApi` + `openWorkflowInBuilder`. Loading an API-created workflow auto-layouts with `markDirty: false`, so there is nothing to save and no save to fail. The kebab clicks are bounded too, for the reason `workflow-verify.ts` documents: an unbounded click inside a `toPass` attempt keeps that attempt alive for the whole retry budget, so the retry never happens.

### 11. Backend: a websocket test server on a hard-coded port, shared across 8 xdist workers

Four integration tests (two in `test_receive_only_channels.py`, two in `test_json_validation.py`) failed with `ConnectionClosedError: received 1012 (service restart)`.

**1012 is not infrastructure noise** — it is uvicorn's own graceful-shutdown close code. The app's own close codes are all different (1001, POLICY_VIOLATION, TRY_AGAIN_LATER), so something was shutting a *server* down under a live test.

`example_app_server` is function-scoped and bound a hard-coded port 9999, while the integration job runs `-n auto` with `PYTEST_XDIST_AUTO_NUM_WORKERS: "8"`. Worker A binds 9999; worker B's uvicorn gets EADDRINUSE and exits — but `_wait_for_server` only probed TCP, so it saw *A's* socket and yielded as if healthy. B's test then talked to A's server, and A's teardown closed every connection including B's.

That also explains `Failed: Cannot get the new connection from lifecycle_manager`: `get_connection_lifecycle_manager()` is a per-process singleton, so a connection registered in A's process is invisible to B's assertion, forever. `db7e3c914` patched that symptom with a unique User-Agent poll; the shared port was left in place, which is why it came back on a different path.

The fix is the pattern this repo already uses correctly in `tests/integration/core/tls/conftest.py`: bind `port=0` and read the real port back off the bound socket. The readiness probe now waits on `server.started` — per-instance, so it cannot be satisfied by a stranger's socket.

### 12. `permission-gating.spec.ts` — five row kebabs opened with a single forced click

`auditor: IdP row actions are aria-disabled` failed the Konflux UI run on this branch ([103413869346](https://github.com/syntara-orchestration/syntara/runs/103413869346), 685/746). It is a flake, not a regression from this PR, and the evidence is unusually clean:

- The Konflux run **two hours earlier on this same branch was 746/746, 0 failed**, on a frontend tree that is byte-identical — `git diff` between the two heads is three files: `ci-backend.yml`, `CONTRIBUTING.md` and a deleted doc, none of which the UI job reads.
- The test itself is untouched by this PR.
- The same test fails on Renovate dependency bumps that change no frontend code at all (#137, #147, #159, #167, #229) — 62 issues and PRs in this repo mention it.

The mechanism: `kebab.click({ force: true })` followed immediately by `toHaveAttribute` on the menu items. `force: true` skips every actionability check, including the stability wait, so the click lands even while React is replacing the row underneath it — which the list query does on every refetch, filter application and cursor page. The handler never runs, the menu stays shut, and all three assertions fail on a `menuitem` that was never rendered, with nothing in the trace to say why.

`openRowKebab` re-opens on a miss, the same remedy `triggerVerifyWorkflow` uses for the builder kebab. It only clicks while the menu is closed, so a menu that is merely slow is waited out rather than toggled shut, and it bounds the click so a detaching element cannot consume the whole retry budget inside one attempt (the §1 failure mode).

Four other sites in the same file are the same code with a different row. They get the same treatment rather than waiting their turn to flake.

### 13. `credential-enable-disable.spec.ts` — the same forced click, on the Enabled switch

`cancel disable keeps credential enabled` failed the same Konflux run, and the same byte-identical-tree argument applies. Its body is untouched by this PR.

All four list-row tests in the spec opened the confirmation dialog identically: one `click({ force: true })` on the Enabled switch, then a blind wait on the dialog. Here `force: true` is unavoidable — PatternFly's `Switch` hides its `<input>` behind a styled span — but it still skips the stability check. `filterCredentialByName` returns as soon as it has pressed *Apply filter*, without waiting for the filtered page to land, so a click inside that window hits a row React is replacing: no `onChange` runs, no dialog opens, and the test fails up to 25 s later inside `waitForDisableDialogReady` on a dialog that was never there.

`openDisableDialogFromRow` retries the open, skipping the click whenever the dialog is already up so a slow open is waited out rather than toggled back. It also collapses four copies of the open-then-wait sequence into one place.

The describe is `mode: 'serial'`, so this one test failing skipped the four after it — which accounts for the entire six-test delta between the two Konflux runs (691 passed / 55 skipped → 685 passed / 2 failed / 59 skipped).

### 14. The identity providers list — an unfiltered page of 20, and a bulk seeder

`auditor: IdP row actions are aria-disabled` kept failing after §12 landed, because the kebab was never the problem. The failure is one line earlier:

```
Error: expect(locator).toBeVisible() failed
Locator: getByRole('grid', { name: 'Identity providers table' })
         .getByRole('row', { name: /e2e-perm-idp-…/ })
Error: element(s) not found
```

The identity providers table is a single unfiltered page of 20 sorted by `name` ascending (`useCursorPagination`'s default limit + `initialSortIndex: 0`, `'asc'`). The seeded row renders only while fewer than 20 providers sort before it.

`pagination.spec.ts` seeds **21** identity providers in its `beforeAll`, named `e2e-pag-<ts>-<uuid>-idp-N`. `e2e-pag` sorts before `e2e-perm`, so for the whole of that spec's `beforeAll`/`afterAll` window page 1 is full and the seeded row sits on page 2. Under `fullyParallel` whether the two overlap is pure timing — which is exactly why this fails on some runs and not others, and why it fails on Renovate dependency bumps that change no frontend code.

**Reproduced deterministically.** Seed 21 providers under a name that sorts ahead, and the test fails on that assertion every time; with the name filter applied first it passes 3/3 against the same state.

`session-revocation.spec.ts` reads the same list the same way, so it carries the same latent flake — confirmed red 3/3 under the equivalent seed, and 30/30 green after. (A **third** reader turned up later, in §15.) Filtering there also repairs an assertion that could not fail: unfiltered, its post-delete

```ts
await expect(table.getByRole('row', { name: providerName })).toHaveCount(0)
```

is satisfied by a row that was never on page 1 to begin with — the §6 class of bug, in a different costume.

This is the mechanism §8 fixed for the workflows list, in the table this PR's own Out of Scope section admitted had not been audited. It has now fired, twice.

### 15. Audit of the remaining paginated tables

§14 made it clear this class was not confined to one table, so the users, groups, credentials and integrations lists were swept for the same pattern: a row located by a seeded name, on an unfiltered page, in a table another spec seeds in bulk.

| Table | Page | Default sort | Bulk seeders | Verdict |
|---|---|---|---|---|
| Users | 20 | `username` asc | `pagination.spec.ts` 16, `access-pagination.spec.ts` 3 | **clean** — every list-row test either filters or mocks `**/api/v1/users**` |
| Groups | 20 | `name` asc | `pagination.spec.ts` 15, `access-pagination.spec.ts` 3 | **clean** — `group-membership.spec.ts` filters; `builtin-groups.spec.ts` reads `auditors`, which sorts ahead of every `e2e-*` name |
| Integrations | 20 | `name` asc | `integration-filtering.spec.ts` **22**, `pagination.spec.ts` 2 | **clean** — every real-backend spec filters; the two unfiltered reads are `test.skip(isRealBackend)` mock-API fixtures |
| Credentials | 20 | `created_at` **desc** | none | **clean by construction** — newest first, so a just-created row is at the top; it would take 20 credentials created in the seconds between create and assert to displace it |

The audit found nothing wrong in those four. It did find two gaps in fixes already in this PR:

- **The identity providers list has three readers, not two.** §14 said it had covered both. `authentication-group-mapping.spec.ts` asserts on the unfiltered list twice more, right after creating a provider through the wizard. Now filtered — which keeps the assertion honest, since the row still has to exist under the filter.
- **§8 missed three lookups in the file it was fixing.** It filtered the workflows list before the two project group-header assertions but left the three workflow-row lookups at `:369`, `:417` and `:458` alone, in the same spec. Those are *more* exposed than the ones it fixed: the table is sorted `-updated_at` and every builder save in the suite bumps `updated_at`, so a row seeded there is pushed off page 1 by unrelated specs within seconds.

Verified: `permission-gating.spec.ts` Workflow/Project/Identity Provider actions 36/36, `authentication-group-mapping.spec.ts` 14/14, under `--repeat-each` against a live backend.

Still unswept, and named here rather than silently left: the **service accounts** table has the same shape (page of 20, `asc`) and three unfiltered row reads in `service-accounts-list.spec.ts` and `service-accounts-integration.spec.ts`. No bulk seeder for it exists in the suite today, so it is latent rather than live.

### 16. The builder picked whichever project sorted first

The compose E2E job surfaced `wait-node.spec.ts:102` failing with

```
Save failed: POST /api/v1/workflows returned 404:
{"detail":"Project 088f6dc8-… not found","code":"RESOURCE_NOT_FOUND"}
```

That message comes from `clickSaveAndWait` (§5), and the gate is doing exactly what it was added for. `trySelectRealProject` clicked whichever real project sorted first in the dropdown — under `fullyParallel` routinely one another worker had just created and was about to delete. The builder holds its id, the delete lands, the save 404s. Before saves were response-gated this was invisible: the weak URL guard passed on a save that never happened.

`ensureProject` already guarantees a project named `default`, and nothing in the suite deletes it — the two specs that delete projects each create their own uniquely named one. Preferring it makes the selection deterministic.

**The first attempt at this fix was silently inert, and the verification caught it.** Matching on `textContent` cannot work: the option renders its name and description as adjacent nodes with *no separator*, so the text reads `defaultDefault project` and no anchored match fires. The **accessible** name joins them with a space, so `/^default(\s|$)/` resolves to exactly one option. Anchoring is needed either way — a bare `default` also matches the built-in project's "Default project for built-in workflows".

Falls back to the previous first-real-option scan when no `default` exists, so a fresh database is unaffected.

Verified against a live backend with a competitor project seeded under a name that sorts ahead of `default`: selection lands on `default` **3/3** (it landed on the competitor before the fix); wait-node + builder + create + switch-node **50/50** at `--repeat-each=2`; ai-agent-node + approval-node + conditional-node + loop-nodes **26/26**.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

One commit per fix, in the order above.

**Original four (§1–§4)**

- [x] `e2e/helpers/workflow-verify.ts`: bound both clicks with `VERIFY_CLICK_TIMEOUT` (5 s) and swallow their rejection, so a detached menu costs one bounded attempt instead of the whole budget; `VERIFY_REQUEST_TIMEOUT` 15 s → 10 s so three attempts fit the unchanged 30 s retry budget
- [x] `e2e/seeds/seed-bucket.ts` (new) + `e2e/access-management.spec.ts`: `drain()` hands `afterAll` exactly what the current round seeded and empties the bucket, so a later round in the same worker starts clean
- [x] `e2e/helpers/workflows.ts`: `deleteWorkflow` waits for the filter toolbar and bounds every UI-fallback action with `CLEANUP_ACTION_TIMEOUT` (10 s)
- [x] `e2e/utils/api-core.ts`: `apiRequest` re-authenticates once and replays a request rejected with `TOKEN_STALE`; a 401 that is not a stale token is returned untouched

**Sweep (§5–§11)**

- [x] `e2e/helpers/workflow-save.ts` (new): `clickSaveAndWait`, `isWorkflowSaveResponse`
- [x] `e2e/helpers/workflows.ts`: response-gate `saveWorkflow`, `createBasicWorkflow`, `createWorkflowWithTrigger`; anchor the named project-option match
- [x] 17 spec files: every weak `toHaveURL(/workflow-builder\/.+/)` replaced, deleted or strengthened
- [x] `frontend/packages/syntara-ui/eslint.config.js`: `no-restricted-syntax` rule blocking the weak form
- [x] `e2e/helpers/credentials.ts`: `disableCredentialFromRow`, `isCredentialPatchResponse`, exported `waitForDisableDialogReady`
- [x] `e2e/helpers/patternfly.ts`: `clickWhenEnabled`
- [x] `e2e/utils/api-core.ts`: `findProjectIdByName`
- [x] `e2e/run-step.spec.ts`: API-built two-node workflow, bounded kebab clicks, corrected skip reasons
- [x] `backend/tests/integration/conftest.py` + three websocket test files: `port=0`, `ExampleAppServer.ws_base_url`, `server.started` readiness probe
- [x] Two new regression specs: `workflow-save-helper.spec.ts`, `patternfly-helper.spec.ts` — each observed red before its fix and green after, bringing the total added by this PR to six

**Konflux follow-up (§12–§13)**

- [x] `e2e/helpers/patternfly.ts`: `openRowKebab` — retries the open, only clicks while the menu is closed
- [x] `e2e/patternfly-helper.spec.ts`: two more tests, pinning the retry and the already-open guard; both fail against a single forced click
- [x] `e2e/permission-gating.spec.ts`: all five row kebabs use it
- [x] `e2e/helpers/credentials.ts`: `openDisableDialogFromRow`; `disableCredentialFromRow` now uses it
- [x] `e2e/credential-enable-disable.spec.ts`: all four list-row tests use it
- [x] `e2e/permission-gating.spec.ts`: filter the identity providers list by name before locating the seeded row (§14)
- [x] `e2e/session-revocation.spec.ts`: same filter in `openDeleteDialogFromList`; use `openRowKebab` (§14)
- [x] `e2e/permission-gating.spec.ts`: local `filterWorkflowsByName`, used at all five workflows-list sites (§15)
- [x] `e2e/authentication-group-mapping.spec.ts`: local `filterProvidersByName`, used at both identity-providers-list sites (§15)
- [x] No new dependencies

## Out of Scope

- **The audit write p95 baseline.** `audit/test_outbox_write_throughput.py::test_baseline_p95_within_threshold` failed at p95 314.3 ms against a 200 ms baseline. Raising `AUDIT_PERF_P95_BASELINE_MS` in CI would stop it dequeuing PRs, but it would not make the assertion meaningful: the test takes 200 serial samples with no warmup and `audit_perf_engine` uses `NullPool`, so each iteration opens a fresh asyncpg connection *inside* `measure_latency_async`. Its p95 is the tenth-slowest connection setup, not a write. The real fix is to move connection acquisition out of the measured block; deliberately left for someone to do properly rather than papered over here. This is the one live flake from the sweep that this PR does not address.

- **Quarantine lives in a different repo.** `docs/ci/test-quarantine.md` routes quarantine entries to `syntara-orchestration/syntara-ci` (`playwright.md`, `backend.md`), consumed via `SYNTARA_XFAIL_SOURCE`. Nothing can be quarantined from this PR. No fix here proved unsafe, so no companion quarantine PR was opened.
- **The 16 `xpass` entries CI reported** (quarantined tests that now pass) should be removed from `playwright.md` — a separate `syntara-ci` PR.
- **`run-step.spec.ts`'s ambiguous `Set mock data` locator.** The two tests skipped for the §10 cause were migrated and tried. The target test passes on the new foundation; those two still fail, but on a different, pre-existing problem — against a real backend `getByRole('button', { name: 'Set mock data' })` resolves to three elements (the dialog's button plus the Input and Output panel link toggles), and **unchanged sibling tests fail identically**. They stay skipped with the reason corrected, rather than being un-skipped unverified.
- **The product-side races behind §1 and §9.** `handleDetected` stealing the reviewer's position when a second approval arrives is arguably a product bug — a reviewer reading "1 of 2" gets yanked to a newly-arrived approval. The one-line fix would be to preserve the current approval's index when the panel is already open. Worth a ticket; not folded into a flake PR.
- **`POST /auth/logout` invalidating every token the user holds**, not just the session logging out.
- **The other specs using the accumulate-forever module-array pattern** — `pagination.spec.ts` alone has six.
- **Note:** the project-selection race this section previously listed as a follow-up is now **fixed** — see §16.

- **The service accounts table.** §15 swept users, groups, credentials and integrations and found them clean. Service accounts has the same shape and three unfiltered row reads, but no bulk seeder exists for it in the suite, so it is latent rather than live and is left for a follow-up.

## Related Issues

- Related to the UI-32 failure on #478 — that PR did not cause it.
- §1–§4 were found on #523 but are not that branch's fault: all the specs are untouched by it, and every mechanism is triggered by unrelated specs running in parallel.
- §5–§11 come from a sweep of every `merge_group` run on 10–11 Sep 2026: 13 failing `CI Frontend E2E` runs and 5 failing `CI Backend` runs.
- §12–§13 come from Konflux run [103413869346](https://github.com/syntara-orchestration/syntara/runs/103413869346) on this branch. Konflux is not a required check, but the tests are live flakes that dequeue other PRs.
- §14 comes from the next Konflux run on this branch (692/748, 1 failed), which showed §12's fix had addressed the wrong layer of the same test.

## How to Test

These are load-dependent races, so a single serial pass proves nothing. Run the affected specs repeated and in parallel:

```bash
# from frontend/packages/syntara-ui, against a real backend
npx playwright test \
  e2e/workflow-save-helper.spec.ts e2e/patternfly-helper.spec.ts \
  e2e/builder.spec.ts e2e/workflows/create.spec.ts \
  e2e/v2-workflow-migration.spec.ts e2e/workflows/wait-node.spec.ts \
  e2e/credential-enable-disable.spec.ts e2e/permission-gating.spec.ts \
  e2e/run-step.spec.ts e2e/eda-trigger.spec.ts e2e/webhook-trigger.spec.ts \
  --repeat-each=3 --workers=3
```

```bash
# from backend/ — this is what fails today
uv run pytest tests/integration/core/websocket/ -n 8
```

### Results

**E2E, `--repeat-each=3 --workers=3` against a real backend: 286 passed, 18 skipped, 14 failed.** All 14 failures are the five pre-existing `run-step.spec.ts` locator-ambiguity tests described under Out of Scope — the same five fail identically on unmodified `devel` in the same environment. Every flake this PR targets that could be exercised passed all three repeats.

**Backend websocket, `-n 8`:** reproduces `Failed: Cannot get the new connection from lifecycle_manager` at `test_json_validation.py:249` before the change; green across three consecutive runs after it (33 tests).

**§12–§13, `--repeat-each=3 --workers=3` against a real backend:** `credential-enable-disable.spec.ts` 24/24 passed; the 14 kebab-opening tests in `permission-gating.spec.ts` 42/42 passed.

**§14, red then green against a deliberately adversarial list** (21 identity providers seeded under a name that sorts ahead of each test's own): `permission-gating.spec.ts` IdP row test 0/1 before, 3/3 after; `session-revocation.spec.ts` 0/3 before on the affected test, 30/30 after with `--repeat-each=3 --workers=3`.

**Helper specs:** each of the six was run against the pre-fix implementation and observed red, then green after. For `clickSaveAndWait`, three of its four behavioural tests fail against the old URL-guard behaviour, and the fourth fails when the `response.ok()` check is removed — so none is decorative.

### Not verified locally

- **§9, the two approval specs.** Both need a working execution engine to reach a paused execution, and this workstation's stack has none (`execution_engine=false`); they skip. Their tests are structural (bounded clicks plus a `toPass` retry) and the new `clickWhenEnabled` has its own red/green spec, but the specs themselves were not exercised end-to-end.
- **`make lint` at the repo root** fails in the `frontend: eslint` pre-commit hook with `The provided path in your eslintrc.json - <repo root>/package.json is not a valid path`. **Pre-existing and environmental** — reproduced identically on an unmodified baseline worktree at `5c6369c2c`. `npm run lint` from `frontend/` is clean (0 errors), as is `uv run ruff check src/ tests/`.

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`) — ran the affected suite, `tests/integration/core/websocket/`, with `-n 8` (green ×3). The full suite was not run.
- [x] I have run `make lint` and code passes all checks — `uv run ruff check src/ tests/`: clean (see the repo-root `make lint` note above)
- [x] I have run `make format` to ensure consistent formatting — `ruff format --check`: 2530 files already formatted
- [x] I have run `make typecheck` and all types are correct — `mypy --strict src/ tests/`: no issues in 2532 source files
- [x] I have added tests for new functionality — the change *is* test infrastructure; the fix is proven red-before/green-after
- [x] Database migrations are included if schema changed _(no schema change)_
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [x] I have run `npm test` and all tests pass (in `frontend/`) — E2E results above; this change touches no `src/` code, so the vitest suite is unaffected
- [x] I have run `npm run lint` and code passes all checks — 0 errors (229 pre-existing warnings, none new)
- [x] I have run `npm run tsc` and there are no type errors
- [x] I have added tests (unit / E2E) for new functionality — six helper regression specs
- [x] Accessibility has been considered — the fixtures use real roles and `aria-disabled` semantics, and `clickWhenEnabled` exists precisely because `aria-disabled` is the accessible way PatternFly disables a focusable control
- [ ] Screenshots or screen recordings are attached for UI changes

`npm run format:check`: all matched files use Prettier code style.

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts`

_No UI changes — test-support code and one ESLint rule._

## General Checklist

- [x] Code follows the project's coding conventions
- [x] I have updated relevant documentation _(no user- or developer-facing docs change; the corrected `run-step.spec.ts` skip reasons are the only prose touched)_
- [x] No secrets or credentials are included in this PR
- [x] Breaking changes are documented with migration steps _(none)_

## Additional Notes

The real proof for the load-dependent races is the merge queue itself: a green local run is necessary but not sufficient. Worth watching the next few `merge_group` runs after merge and re-running the sweep against them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





