### PR TITLE
fix(backend): pin pyrefly and narrow OIDC claim mapping

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -753,7 +753,7 @@ typecheck: ## Run type checking only with mypy
 .PHONY: typecheck-pyrefly
 typecheck-pyrefly: ## Run type checking with pyrefly (~3s, used in pre-commit)
 	@echo "🔍 Running type checking (pyrefly)..."
-	uv run --with pyrefly pyrefly check
+	uv run pyrefly check
 	@echo "✅ Type checking completed"
 
 .PHONY: check-migrations

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
     "pytest-xdist>=3.8.0",
     "ruff>=0.1.0,<0.14.4",
     "mypy>=1.6.0,<1.19",
+    "pyrefly>=1.3.0,<1.4.0",
     "httpx>=0.25.0",  # for testing FastAPI
     "respx>=0.20.0",  # for mocking httpx requests
     "websockets>=12.0",  # for WebSocket client testing

--- a/backend/src/syntara/auth/services/oidc_service.py
+++ b/backend/src/syntara/auth/services/oidc_service.py
@@ -499,20 +499,19 @@ class OIDCService:
             (and optionally groups)
 
         """
-        if claim_mapping is None:
-            claim_mapping = OIDCClaimMapping()
+        mapping = claim_mapping or OIDCClaimMapping()
 
         result: dict[str, str | None] = {
-            "sub": id_token_claims.get(claim_mapping.subject),
-            "email": id_token_claims.get(claim_mapping.email),
-            "given_name": id_token_claims.get(claim_mapping.first_name),
-            "family_name": id_token_claims.get(claim_mapping.last_name),
+            "sub": id_token_claims.get(mapping.subject),
+            "email": id_token_claims.get(mapping.email),
+            "given_name": id_token_claims.get(mapping.first_name),
+            "family_name": id_token_claims.get(mapping.last_name),
             # Hardcoded: "name" is a standard OIDC claim used only as a fallback
             # when given_name/family_name aren't available.  Custom mappings
-            # (e.g. Azure AD "displayName") are handled via claim_mapping.first_name,
+            # (e.g. Azure AD "displayName") are handled via mapping.first_name,
             # which takes priority in _auto_create_user.
             "name": id_token_claims.get("name"),
-            "preferred_username": id_token_claims.get(claim_mapping.username),
+            "preferred_username": id_token_claims.get(mapping.username),
         }
 
         identity_claims = {"sub", "email"}

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2718,6 +2718,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pyrefly"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/82/df301034ff7705b51ab212039958910434e1e9bd4765cde435538221fc35/pyrefly-1.3.0.tar.gz", hash = "sha256:e96a0bf3abdc41cf40f7d2ef274bb610f4e6e4b387b366aea102902839073388", size = 6678024, upload-time = "2026-09-11T00:41:37.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/98/47bf19b6caef77852c7e1c03d71ef48a5f452bf041503d883e0bca6fc4c8/pyrefly-1.3.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dd6c61e4c307eaaf3cf25fb329c4e7c9ff0376c42d5900362be2fd3333578a69", size = 15088089, upload-time = "2026-09-11T00:41:11.046Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/77/454615aa5db04903c99ced321295e32242c4b188be1a08f40b617ed72984/pyrefly-1.3.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:14c56defaa804747f18e03d11b539e71b71c8251a2b9f58e73dea80e2f6adfd9", size = 14431422, upload-time = "2026-09-11T00:41:13.61Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f2/142e190b9432f802682b0b0794f71e2010e936de0541492cc43678d647af/pyrefly-1.3.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64285b1261681933f97cb11f3ba2e4445ff02a266707e4e2b7a279db0424c9f2", size = 14880659, upload-time = "2026-09-11T00:41:15.947Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2f/60598fe38f29f22d11d9f4b5c7fee1cbbb0d5b0cb7db6b373761d57f5f75/pyrefly-1.3.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:46a90d6e48415dfa5d8d9c94ea5b9b61d7149dab87348952f2e000cf45145664", size = 16116073, upload-time = "2026-09-11T00:41:18.547Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/0a/33e49756fe3341dbb13789622cb8c9b6350d2710ceb47b8b0521f134ceea/pyrefly-1.3.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0cc33b35204b8e1b09396313024580d25a041de2f2f527e6496fc099282b967", size = 16049648, upload-time = "2026-09-11T00:41:21.255Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/be59429726af4c0c3585951a937232d957182364cd2a621f74f4298a176e/pyrefly-1.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e94ff692911596d257462320a2ef1435c93c20c80d631404961282f4cc22a6cc", size = 15439725, upload-time = "2026-09-11T00:41:23.572Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/73/bb834e88afea6c0de6960be2102c0cc1d817193c1efc3f6db9b450df191c/pyrefly-1.3.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5705bec5438aa4e3b65b0d2ea7613f6bdbdc57f8848bd4b7940bbab37f230d8c", size = 14900386, upload-time = "2026-09-11T00:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/64/1adbc6ece9090bbd2e4ed1300918ab709166119426a21102639912ea65bb/pyrefly-1.3.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fe60cb6d7cdf6c9bb236c0a7efc4b9839cfe7ef834b07d637862f95a642699ef", size = 15478065, upload-time = "2026-09-11T00:41:28.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5c/e1351611d2e205718394237381220ab70f0e21cb297db024eafead19acf9/pyrefly-1.3.0-py3-none-win32.whl", hash = "sha256:4fb4cd5e5007e99208e44f749edaf37a03c0a56c98da7422c2dd60fde0f294b0", size = 14130445, upload-time = "2026-09-11T00:41:30.401Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/92/1d78e2ab1f9f1055ea43164d336903c95e608bede06ed182dc4b4f2c5390/pyrefly-1.3.0-py3-none-win_amd64.whl", hash = "sha256:f809fa5b447012adb8861efeb8f6435146788a39d9251d79dc38731a5d241893", size = 15067598, upload-time = "2026-09-11T00:41:32.582Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6f/459f56dc345c32f8597acef13675e7e67679fb56bc3fd8f0a280eaeb8c02/pyrefly-1.3.0-py3-none-win_arm64.whl", hash = "sha256:3a3fb7c07dfb9b43d4205d8e85a83aaefc85377d0437dc8469c132836a8a7e5d", size = 14347403, upload-time = "2026-09-11T00:41:35.01Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3613,6 +3632,7 @@ dev = [
     { name = "pre-commit" },
     { name = "psutil" },
     { name = "pyan3" },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -3692,6 +3712,7 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0" },
     { name = "pypandoc", specifier = ">=1.14" },
     { name = "pypdf", specifier = ">=6.15.0" },
+    { name = "pyrefly", marker = "extra == 'dev'", specifier = ">=1.3.0,<1.4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -3743,7 +3764,7 @@ dev = [
 
 [[package]]
 name = "syntara-api-client"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "src/api_client" }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Description

pyrefly 1.3.0 (released Sep 11) started flagging `extract_user_claims` in `oidc_service.py`: reassigning the optional `claim_mapping` parameter does not narrow for pyrefly, so pre-commit fails with `missing-attribute` on `NoneType`. merge queue runs that pull a fresh pyrefly hit this even when the PR branch passed on a cached older version.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- narrow `claim_mapping` via `mapping = claim_mapping or OIDCClaimMapping()` in `extract_user_claims`
- add `pyrefly>=1.3.0,<1.4.0` to backend dev deps and lock it in `uv.lock`
- switch `make typecheck-pyrefly` from ephemeral `uv run --with pyrefly` to `uv run pyrefly check`

## Out of Scope

- other pyrefly findings elsewhere in the backend (none surfaced on this pass)
- pinning other ephemeral `--with` tools

## Related Issues

Related to #532 (merge queue pre-commit failure)

## How to Test

```bash
cd backend
make install
make typecheck-pyrefly
```

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [x] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes