### PR TITLE
fix(ci): allow breaking-change-approved label to override patch expectation

### DIFF
--- a/backend/scripts/openapi/check-breaking-changes.py
+++ b/backend/scripts/openapi/check-breaking-changes.py
@@ -382,8 +382,9 @@ def evaluate_gate(
       * Breaking changes without the approval label -> blocked, full stop.
       * Any meaningful spec change without an info.version bump -> blocked.
       * A bump using the wrong segment -> blocked (names the expected segment).
-      * Approved breaking change (minor bump) or non-breaking change (correct
-        segment) -> allowed.
+      * The ``breaking-change-approved`` label with a minor bump -> allowed, even
+        when oasdiff did not flag the change as breaking or expected a patch bump.
+      * Non-breaking change with the correct segment -> allowed.
     """
     version_bumped = version_bump_type is not None
 
@@ -419,6 +420,16 @@ def evaluate_gate(
             ),
         )
 
+    if breaking_approved and version_bump_type == "minor":
+        return GateDecision(
+            allowed=True,
+            code="breaking_approved",
+            message=(
+                f"ALLOWED: Breaking change permitted via the '{BREAKING_CHANGE_APPROVED_LABEL}' "
+                "label (privileged override) with a minor version bump."
+            ),
+        )
+
     if expected_bump_type is not None and version_bump_type != expected_bump_type:
         return GateDecision(
             allowed=False,
@@ -434,16 +445,6 @@ def evaluate_gate(
                     "one; a new major version is a new spec at a new URL path. "
                 )
                 + f"Set info.version to a '{expected_bump_type}' increment."
-            ),
-        )
-
-    if has_breaking:
-        return GateDecision(
-            allowed=True,
-            code="breaking_approved",
-            message=(
-                f"ALLOWED: Breaking change permitted via the '{BREAKING_CHANGE_APPROVED_LABEL}' "
-                "label (privileged override) with a minor version bump."
             ),
         )
 

--- a/backend/tests/unit/scripts/test_check_breaking_changes.py
+++ b/backend/tests/unit/scripts/test_check_breaking_changes.py
@@ -457,6 +457,18 @@ class TestEvaluateGate:
         assert decision.allowed is True
         assert decision.code == "breaking_approved"
 
+    def test_breaking_approved_minor_bump_allowed_when_expected_patch(self):
+        # oasdiff may miss a breaking change; leadership approval + minor bump is enough.
+        decision = self._decide(
+            has_breaking=False,
+            has_changes=True,
+            version_bump_type="minor",
+            expected_bump_type="patch",
+            breaking_approved=True,
+        )
+        assert decision.allowed is True
+        assert decision.code == "breaking_approved"
+
     def test_breaking_approved_with_major_bump_blocked(self):
         # An approved in-place breaking change must be a minor bump, not major.
         decision = self._decide(
@@ -542,6 +554,24 @@ class TestMainGate:
         assert result["breaking_approved"] is True
         assert result["version_bumped"] is True
         assert result["expected_bump_type"] == "minor"
+        assert result["gate_code"] == "breaking_approved"
+
+    def test_breaking_change_with_approval_label_minor_bump_not_flagged_breaking(self, monkeypatch, tmp_path):
+        code, result = _run_main(
+            monkeypatch,
+            tmp_path,
+            base_version="1.1.0",
+            head_version="1.2.0",
+            has_breaking=False,
+            changelog="",
+            changelog_entries=[],
+            head_description="approved change oasdiff did not flag as breaking",
+            pr_labels='["breaking-change-approved"]',
+        )
+        assert code == 0
+        assert result["breaking_approved"] is True
+        assert result["version_bump_type"] == "minor"
+        assert result["expected_bump_type"] == "patch"
         assert result["gate_code"] == "breaking_approved"
 
     def test_breaking_change_approved_but_major_bump_blocked(self, monkeypatch, tmp_path):


### PR DESCRIPTION

## Description

When leadership approves an in-place breaking change with a minor bump, the gate should pass even if oasdiff classifies the diff as spec-only. If the PR has breaking-change-approved and the version bump is minor, the gate passes before the segment-mismatch check — even when oasdiff did not flag a breaking change or expected patch.

  Still blocked without the label, without a version bump, or with a major bump when
  approved.
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [ ] List the specific changes made
- [ ] Include any new dependencies or configuration changes

## Out of Scope

<!-- What this PR intentionally does NOT include, to set reviewer expectations -->

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## How to Test

#450 

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [ ] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [ ] Code follows the project's coding conventions
- [ ] I have updated relevant documentation
- [ ] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes

<!-- Add any other context, concerns, or notes for reviewers here -->
