### PR TITLE
fix(ci): generate admin passwords that pass complexity validation

### DIFF
--- a/backend/docs/authentication.md
+++ b/backend/docs/authentication.md
@@ -600,7 +600,7 @@ make secrets-generate-force   # writes the value to .secrets/admin-password
 make run-all                  # app startup seeds the admin user with this password
 ```
 
-If `APP_ADMIN_PASSWORD` is not set, `generate_secrets.sh` creates a random 24-byte base64 password saved to `.secrets/admin-password`:
+If `APP_ADMIN_PASSWORD` is not set, `generate_secrets.sh` creates a random 16-character password (upper, lower, digit, and punctuation) saved to `.secrets/admin-password`:
 
 ```bash
 cat .secrets/admin-password

--- a/backend/tools/generate_secrets.sh
+++ b/backend/tools/generate_secrets.sh
@@ -43,6 +43,19 @@ check_dependencies() {
     fi
 }
 
+# Generate a bootstrap admin password that satisfies validate_password_complexity:
+# at least 14 characters and 3 of 4 character classes (upper, lower, digit, other).
+# openssl rand -base64 can miss a class (~0.1% of the time), which flakes CI when
+# orchestrator-admin reset-password validates the secret.
+generate_admin_password() {
+    local upper lower digit punct
+    upper=$(openssl rand -base64 48 | tr -dc 'A-Z' | head -c 4)
+    lower=$(openssl rand -base64 48 | tr -dc 'a-z' | head -c 4)
+    digit=$(openssl rand -base64 48 | tr -dc '0-9' | head -c 4)
+    punct=$(openssl rand -base64 48 | tr -dc '!@#$%^&*+-=' | head -c 4)
+    echo -n "${upper}${lower}${digit}${punct}"
+}
+
 # Generate an ES256 (ECDSA P-256) key pair
 generate_key_pair() {
     local key_name="$1"
@@ -125,8 +138,8 @@ main() {
             echo -n "$APP_ADMIN_PASSWORD" > "$SECRETS_DIR/admin-password"
             info "  Using password from APP_ADMIN_PASSWORD env var"
         else
-            openssl rand -base64 24 > "$SECRETS_DIR/admin-password"
-            info "  Generated random password"
+            generate_admin_password > "$SECRETS_DIR/admin-password"
+            info "  Generated random password (complexity-compliant)"
         fi
         chmod 600 "$SECRETS_DIR/admin-password"
         info "  Password file: $SECRETS_DIR/admin-password"


### PR DESCRIPTION
## Description

merge-queue e2e failed on #543 because `make secrets-generate` wrote a random base64 admin password that did not satisfy `validate_password_complexity` (~0.1% of `openssl rand -base64` outputs miss a character class). the podman compose e2e job then died in **Initialize admin password** before playwright ran.

failed run: https://github.com/syntara-orchestration/syntara/actions/runs/34662580850/job/103468982678

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- [x] add `generate_admin_password()` in `backend/tools/generate_secrets.sh` that always includes upper, lower, digit, and punctuation (16 chars, 4 classes)
- [x] update auth docs to describe the new default password shape

## Out of Scope

- validating `APP_ADMIN_PASSWORD` when callers set it manually (still their responsibility)

## Related Issues

Related to #543

## How to Test

1. `cd backend && ./tools/generate_secrets.sh --force`
2. `cat .secrets/admin-password | uv run python -m syntara.orchestrator_admin reset-password -u admin --password-stdin --yes` against a running stack (or run the complexity check in a python shell)

## Backend Checklist

- [ ] I have run `make test` and all tests pass (in `backend/`)
- [ ] I have run `make lint` and code passes all checks
- [ ] I have run `make format` to ensure consistent formatting
- [ ] I have run `make typecheck` and all types are correct
- [ ] I have added tests for new functionality
- [ ] Database migrations are included if schema changed
- [x] No sensitive information (keys, passwords, etc.) is included

## Frontend Checklist

- [ ] I have run `npm test` and all tests pass (in `frontend/`)
- [ ] I have run `npm run lint` and code passes all checks
- [ ] I have run `npm run tsc` and there are no type errors
- [ ] I have added tests (unit / E2E) for new functionality
- [ ] Accessibility has been considered (semantic HTML, labels, keyboard navigation)
- [ ] Screenshots or screen recordings are attached for UI changes

## Visual Regression

> Visual regression does **not** run automatically on this PR. If your change affects UI that's covered by `e2e/visual-regression/page-registry.ts`, update baselines yourself before requesting review — otherwise the weekly baseline-refresh PR will pick up the drift and route it to the UI/UX team instead of you.

- [ ] If this PR intentionally changes covered UI: I have commented `/update-screenshots` on this PR and confirmed the regenerated baselines look correct in the Files changed tab
- [ ] If this PR adds a new page/route: I have added an entry to `page-registry.ts` and run `/update-screenshots` to generate its baseline

## General Checklist

- [x] Code follows the project's coding conventions
- [x] I have updated relevant documentation
- [x] No secrets or credentials are included in this PR
- [ ] Breaking changes are documented with migration steps

## Screenshots / Demo (if applicable)

<!-- Add screenshots or screen recordings to demonstrate UI or UX changes -->

## Additional Notes